### PR TITLE
Remove future garbage collection warning

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -94,7 +94,7 @@ from typing_extensions import ParamSpec
 
 from prefect.client.schemas.objects import State, TaskRunInput
 from prefect.futures import PrefectFuture, PrefectFutureList, PrefectWrappedFuture
-from prefect.logging.loggers import get_logger, get_run_logger
+from prefect.logging.loggers import get_logger
 from prefect.task_runners import TaskRunner
 from prefect.tasks import Task
 from prefect.utilities.asyncutils import run_coro_as_sync
@@ -144,18 +144,6 @@ class PrefectDaskFuture(PrefectWrappedFuture[R, distributed.Future]):
                 return future_result
 
         return self._final_state.result(raise_on_failure=raise_on_failure, _sync=True)
-
-    def __del__(self):
-        if self._final_state or self._wrapped_future.done():
-            return
-        try:
-            local_logger = get_run_logger()
-        except Exception:
-            local_logger = logger
-        local_logger.warning(
-            "A future was garbage collected before it resolved."
-            " Please call `.wait()` or `.result()` on futures to ensure they resolve.",
-        )
 
 
 class DaskTaskRunner(TaskRunner):

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -362,43 +362,6 @@ class TestDaskTaskRunner:
 
         assert test_flow().result() == 42
 
-    def test_warns_if_future_garbage_collection_before_resolving(
-        self, caplog: pytest.LogCaptureFixture
-    ):
-        task_runner = DaskTaskRunner(cluster_kwargs={"dashboard_address": None})
-
-        @task
-        def test_task():
-            return 42
-
-        @flow(task_runner=task_runner)
-        def test_flow():
-            for _ in range(10):
-                test_task.submit()
-
-        test_flow()
-
-        assert "A future was garbage collected before it resolved" in caplog.text
-
-    def test_does_not_warn_if_future_resolved_when_garbage_collected(
-        self, caplog: pytest.LogCaptureFixture
-    ):
-        task_runner = DaskTaskRunner(cluster_kwargs={"dashboard_address": None})
-
-        @task
-        def test_task():
-            return 42
-
-        @flow(task_runner=task_runner)
-        def test_flow():
-            futures = [test_task.submit() for _ in range(10)]
-            for future in futures:
-                future.wait()
-
-        test_flow()
-
-        assert "A future was garbage collected before it resolved" not in caplog.text
-
     async def test_successful_dataframe_flow_run(self, task_runner: DaskTaskRunner):
         @task
         def task_a():

--- a/src/integrations/prefect-ray/tests/test_task_runners.py
+++ b/src/integrations/prefect-ray/tests/test_task_runners.py
@@ -499,39 +499,6 @@ class TestRayTaskRunner:
 
         flow_with_dependent_tasks()
 
-    def test_warns_if_future_garbage_collection_before_resolving(
-        self, caplog, task_runner
-    ):
-        @task
-        def test_task():
-            return 42
-
-        @flow(task_runner=task_runner)
-        def test_flow():
-            for _ in range(10):
-                test_task.submit()
-
-        test_flow()
-
-        assert "A future was garbage collected before it resolved" in caplog.text
-
-    def test_does_not_warn_if_future_resolved_when_garbage_collected(
-        self, task_runner, caplog
-    ):
-        @task
-        def test_task():
-            return 42
-
-        @flow(task_runner=task_runner)
-        def test_flow():
-            futures = [test_task.submit() for _ in range(10)]
-            for future in futures:
-                future.wait()
-
-        test_flow()
-
-        assert "A future was garbage collected before it resolved" not in caplog.text
-
     def test_can_run_many_tasks_without_crashing(self, task_runner):
         """
         Regression test for https://github.com/PrefectHQ/prefect/issues/15539

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -14,7 +14,7 @@ from typing_extensions import NamedTuple, Self, TypeVar
 from prefect._waiters import FlowRunWaiter
 from prefect.client.orchestration import get_client
 from prefect.exceptions import ObjectNotFound
-from prefect.logging.loggers import get_logger, get_run_logger
+from prefect.logging.loggers import get_logger
 from prefect.states import Pending, State
 from prefect.task_runs import TaskRunWaiter
 from prefect.utilities.annotations import quote
@@ -223,19 +223,6 @@ class PrefectConcurrentFuture(PrefectWrappedFuture[R, concurrent.futures.Future[
             raise_on_failure=raise_on_failure, _sync=True
         )
         return _result
-
-    def __del__(self) -> None:
-        if self._final_state or self._wrapped_future.done():
-            return
-        try:
-            local_logger = get_run_logger()
-        except Exception:
-            local_logger = logger
-        local_logger.warning(
-            "A future was garbage collected before it resolved."
-            " Please call `.wait()` or `.result()` on futures to ensure they resolve."
-            "\nSee https://docs.prefect.io/latest/develop/task-runners for more details.",
-        )
 
 
 class PrefectDistributedFuture(PrefectTaskRunFuture[R]):

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -210,18 +210,6 @@ class TestPrefectConcurrentFuture:
         with pytest.raises(ValueError, match="oops"):
             future.result(raise_on_failure=True)
 
-    def test_warns_if_not_resolved_when_garbage_collected(self, caplog):
-        PrefectConcurrentFuture(uuid.uuid4(), Future())
-
-        assert "A future was garbage collected before it resolved" in caplog.text
-
-    def test_does_not_warn_if_resolved_when_garbage_collected(self, caplog):
-        wrapped_future = Future()
-        wrapped_future.set_result(Completed())
-        PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
-
-        assert "A future was garbage collected before it resolved" not in caplog.text
-
 
 class TestResolveFuturesToStates:
     async def test_resolve_futures_transforms_future(self):


### PR DESCRIPTION
Closes #17517 

This warning was originally intended to be a convenience for users migrating from 2.x -> 3.x, but it has come up more often as a confusion point and is no longer necessary.