### PR TITLE
Run integration tests against `prefect-client`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -103,6 +103,16 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+          
+      - name: Create a temp dir to stage our build
+        run: |
+          echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+
+      - name: Prepare files for prefect-client build (omit the local build)
+        run: sh client/build_client.sh
+        env:
+          TMPDIR: ${{ env.TMPDIR }}
+        
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -110,18 +120,19 @@ jobs:
           python-version: "3.10"
           cache-dependency-glob: "pyproject.toml"
           activate-environment: true
-
-      - name: Create a temp dir to stage our build
-        run: |
-          echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+          working-directory: ${{ env.TMPDIR }}
 
       - name: Install `prefect-client`
         run: |
-          sh client/build_client.sh
+          cat pyproject.toml
           uv build
           uv pip install dist/*.tar.gz
         env:
           TMPDIR: ${{ env.TMPDIR }}
+
+      - name: Verify the CLI isn't available in the active environment
+        run: |
+          prefect --help && { echo "Prefect CLI should not be available in the active environment"; exit 1; } || echo "Prefect CLI is not available in the active environment"
       - name: Start server
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
@@ -133,7 +144,7 @@ jobs:
 
       - name: Verify the CLI isn't available in the active environment
         run: |
-          prefect server start && { echo "Prefect CLI should not be available in the active environment"; exit 1; } || echo "Prefect CLI is not available in the active environment"
+          prefect --help && { echo "Prefect CLI should not be available in the active environment"; exit 1; } || echo "Prefect CLI is not available in the active environment"
 
       - name: Run integration flows
         env:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -131,6 +131,10 @@ jobs:
 
           ./scripts/wait-for-server.py
 
+      - name: Verify the CLI isn't available in the active environment
+        run: |
+          prefect server start && { echo "Prefect CLI should not be available in the active environment"; exit 1; } || echo "Prefect CLI is not available in the active environment"
+
       - name: Run integration flows
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -127,8 +127,7 @@ jobs:
           cat pyproject.toml
           uv build
           uv pip install dist/*.tar.gz
-        env:
-          TMPDIR: ${{ env.TMPDIR }}
+        working-directory: ${{ env.TMPDIR }}
 
       - name: Verify the CLI isn't available in the active environment
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -51,7 +51,6 @@ jobs:
           enable-cache: true
           python-version: "3.10"
           cache-dependency-glob: "pyproject.toml"
-          activate-environment: true
 
       - name: Start server@${{ matrix.server-version.version }}
         if: ${{ matrix.server-version.version != 'main' }}
@@ -93,6 +92,51 @@ jobs:
         run: |
           cat server.log || echo "No logs available"
           docker logs prefect-server || echo "No logs available"
+
+  prefect-client-compatibility-tests:
+    name: Prefect Client Compatibility Tests
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.10"
+          cache-dependency-glob: "pyproject.toml"
+          activate-environment: true
+
+      - name: Create a temp dir to stage our build
+        run: |
+          echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+
+      - name: Install `prefect-client`
+        run: |
+          sh client/build_client.sh
+          uv build
+          uv pip install dist/*.tar.gz
+        env:
+          TMPDIR: ${{ env.TMPDIR }}
+      - name: Start server
+        env:
+          PREFECT_API_URL: http://127.0.0.1:4200/api
+          PREFECT_SERVER_LOGGING_LEVEL: DEBUG
+        run: >
+          uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
+
+          ./scripts/wait-for-server.py
+
+      - name: Run integration flows
+        env:
+          PREFECT_API_URL: http://127.0.0.1:4200/api
+        run: >
+          ./scripts/run-integration-flows.py flows/
+        
 
   sqlite-3-24-0:
     name: Test SQLite 3.24.0 Compatibility

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,26 +45,13 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        id: setup_python
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
         with:
+          enable-cache: true
           python-version: "3.10"
-
-      - name: UV Cache
-        # Manually cache the uv cache directory
-        # until setup-python supports it:
-        # https://github.com/actions/setup-python/issues/822
-        uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-client.txt', 'requirements.txt', 'requirements-dev.txt') }}
-
-      - name: Install python packages
-        run: |
-          python -m pip install -U uv
-          uv pip install --upgrade --system .
+          cache-dependency-glob: "pyproject.toml"
+          activate-environment: true
 
       - name: Start server@${{ matrix.server-version.version }}
         if: ${{ matrix.server-version.version != 'main' }}
@@ -82,7 +69,7 @@ jobs:
             ${{ matrix.server-version.image }} \
             prefect server start --analytics-off --host 0.0.0.0
 
-          ./scripts/wait-for-server.py
+          uv run ./scripts/wait-for-server.py
 
       - name: Start server
         if: ${{ matrix.server-version.version == 'main' }}
@@ -90,16 +77,16 @@ jobs:
           PREFECT_API_URL: http://127.0.0.1:4200/api
           PREFECT_SERVER_LOGGING_LEVEL: DEBUG
         run: >
-          prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
+          uv run prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
 
-          ./scripts/wait-for-server.py
+          uv run ./scripts/wait-for-server.py
 
       - name: Run integration flows
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
           SERVER_VERSION: ${{ matrix.server-version.version }}
         run: >
-          ./scripts/run-integration-flows.py flows/
+          uv run ./scripts/run-integration-flows.py flows/
 
       - name: Show server logs
         if: always()

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -60,6 +60,10 @@ jobs:
         run: uv pip install dist/*.tar.gz
         working-directory: ${{ env.TMPDIR }}
 
+      - name: Verify the CLI isn't available in the active environment
+        run: |
+          prefect --help && { echo "Prefect CLI should not be available in the active environment"; exit 1; } || echo "Prefect CLI is not available in the active environment"
+
       - name: Get the version of built `prefect-client`
         run: |
           prefect_client_version=$(python -c "import prefect; print(prefect.__version__)")


### PR DESCRIPTION
This PR adds a job that runs compatibility tests against `prefect-client`. This seems like the lowest lift way to add coverage to `prefect-client` and avoid accidental breakage. 