### PR TITLE
use correct secret in websocket subscription

### DIFF
--- a/flows/task_worker.py
+++ b/flows/task_worker.py
@@ -1,0 +1,82 @@
+"""
+Integration test verifying that a task served via `task.serve()`
+can connect to an ephemeral Prefect server that requires
+PREFECT_SERVER_API_AUTH_STRING authentication, especially when
+PREFECT_API_KEY is also (incorrectly) set on the client side.
+"""
+
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+import anyio
+
+from prefect import task
+from prefect.server.api.server import SubprocessASGIServer
+from prefect.settings import (
+    PREFECT_API_AUTH_STRING,
+    PREFECT_API_KEY,
+    PREFECT_API_URL,
+    PREFECT_SERVER_API_AUTH_STRING,
+    PREFECT_SERVER_CSRF_PROTECTION_ENABLED,
+    temporary_settings,
+)
+
+CLIENT_SECRET = SERVER_SECRET = "very-secret-server-auth-string"
+CLIENT_DUMMY_API_KEY = "dummy-key-should-be-ignored"
+STARTUP_TIMEOUT = 5
+CONNECTION_TIMEOUT = 5
+
+counter = 0
+
+
+@task
+def bump():
+    global counter
+    counter += 1
+
+
+@asynccontextmanager
+async def run_ephemeral_server_with_auth() -> AsyncGenerator[str, None]:
+    """Starts and stops an ephemeral server requiring auth string."""
+    server = None
+    try:
+        with temporary_settings(
+            updates={
+                PREFECT_SERVER_API_AUTH_STRING: SERVER_SECRET,
+                PREFECT_SERVER_CSRF_PROTECTION_ENABLED: "true",
+            }
+        ):
+            server = SubprocessASGIServer()
+            server.start(timeout=STARTUP_TIMEOUT)
+            yield server.api_url
+    finally:
+        if server and server.server_process:
+            server.stop()
+
+
+async def smoke_test_authed_task_worker():
+    async with run_ephemeral_server_with_auth() as api_url:
+        try:
+            with temporary_settings(
+                updates={
+                    PREFECT_API_URL: api_url,
+                    PREFECT_API_AUTH_STRING: CLIENT_SECRET,
+                    PREFECT_API_KEY: CLIENT_DUMMY_API_KEY,  # pass this as a regression for https://github.com/PrefectHQ/prefect/issues/17971
+                }
+            ):
+                bump.delay()
+
+                with anyio.move_on_after(CONNECTION_TIMEOUT):
+                    await bump.serve()
+
+                assert counter == 1
+
+            print("task worker connected successfully")
+
+        except Exception as e:
+            print(f"task worker failed to connect: {e!r}")
+            raise
+
+
+if __name__ == "__main__":
+    anyio.run(smoke_test_authed_task_worker)

--- a/flows/task_worker.py
+++ b/flows/task_worker.py
@@ -1,8 +1,5 @@
 """
-Integration test verifying that a task served via `task.serve()`
-can connect to an ephemeral Prefect server that requires
-PREFECT_SERVER_API_AUTH_STRING authentication, especially when
-PREFECT_API_KEY is also (incorrectly) set on the client side.
+Simple use of a task worker when PREFECT_API_AUTH_STRING is set.
 """
 
 from contextlib import asynccontextmanager

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -322,12 +322,16 @@ class PrefectClient(
         if api_version is None:
             api_version = SERVER_API_VERSION
         httpx_settings["headers"].setdefault("X-PREFECT-API-VERSION", api_version)
-        if api_key:
-            httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
-
+        # Prioritize auth_string if provided, otherwise use api_key
         if auth_string:
             token = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
-            httpx_settings["headers"].setdefault("Authorization", f"Basic {token}")
+            httpx_settings["headers"]["Authorization"] = (
+                f"Basic {token}"  # Overwrite if exists
+            )
+        elif api_key:
+            httpx_settings["headers"]["Authorization"] = (
+                f"Bearer {api_key}"  # Set if auth_string is not present
+            )
 
         # Context management
         self._context_stack: int = 0
@@ -1189,12 +1193,16 @@ class SyncPrefectClient(
         if api_version is None:
             api_version = SERVER_API_VERSION
         httpx_settings["headers"].setdefault("X-PREFECT-API-VERSION", api_version)
-        if api_key:
-            httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
-
+        # Prioritize auth_string if provided, otherwise use api_key
         if auth_string:
             token = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
-            httpx_settings["headers"].setdefault("Authorization", f"Basic {token}")
+            httpx_settings["headers"]["Authorization"] = (
+                f"Basic {token}"  # Overwrite if exists
+            )
+        elif api_key:
+            httpx_settings["headers"]["Authorization"] = (
+                f"Bearer {api_key}"  # Set if auth_string is not present
+            )
 
         # Context management
         self._context_stack: int = 0

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1551,7 +1551,7 @@ class Task(Generic[P, R]):
             validated_state=task_run.state,
         )
 
-        if task_run_url := url_for(task_run):
+        if get_current_settings().ui_url and (task_run_url := url_for(task_run)):
             logger.info(
                 f"Created task run {task_run.name!r}. View it in the UI at {task_run_url!r}"
             )

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -3,21 +3,17 @@ import signal
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
 import pytest
 from pydantic import BaseModel
 
-from prefect import Task, flow, task
+from prefect import flow, task
 from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectDistributedFuture
 from prefect.settings import (
-    PREFECT_API_AUTH_STRING,
-    PREFECT_API_KEY,
     PREFECT_API_URL,
-    PREFECT_SERVER_API_AUTH_STRING,
     PREFECT_UI_URL,
     temporary_settings,
 )
@@ -908,73 +904,3 @@ class TestTaskWorkerLimit:
 
         assert updated_task_run_1.state.is_completed()
         assert updated_task_run_2.state.is_scheduled()
-
-
-@pytest.mark.usefixtures("use_hosted_api_server")
-class TestTaskWorkerAuth:
-    @pytest.fixture
-    def auth_task(self):
-        @task
-        def my_auth_task() -> Any:
-            return "ok"
-
-        return my_auth_task
-
-    @pytest.mark.parametrize(
-        ("client_auth_string", "client_api_key", "expected_reason"),
-        [
-            (None, None, "Auth required but no token provided"),
-            ("wrong-secret", None, "Invalid token"),
-            (None, "some-api-key", "Invalid token"),
-        ],
-        ids=["no_creds", "wrong_auth_string", "only_api_key"],
-    )
-    async def test_fails_with_mismatched_or_missing_creds(
-        self,
-        auth_task: Task[[], Any],
-        client_auth_string: Optional[str],
-        client_api_key: Optional[str],
-        expected_reason: str,
-    ):
-        """
-        Tests that the TaskWorker fails to connect when the server requires
-        an auth string but the client provides invalid or no credentials.
-        """
-        server_secret = "test-server-secret"
-
-        with temporary_settings(
-            updates={
-                PREFECT_SERVER_API_AUTH_STRING: server_secret,
-                PREFECT_API_AUTH_STRING: client_auth_string,
-                PREFECT_API_KEY: client_api_key,
-            }
-        ):
-            task_worker = TaskWorker(auth_task)
-            with pytest.raises(
-                Exception, match=f"Unable to authenticate|{expected_reason}"
-            ):
-                with anyio.move_on_after(5):
-                    await task_worker._subscribe_to_task_scheduling()
-
-    async def test_connects_with_auth_string_and_api_key_set(
-        self, auth_task: Task[[], Any]
-    ):
-        """
-        Tests that the TaskWorker connects successfully when the server requires
-        an auth string and the client provides both the correct auth string
-        and an API key (auth string should be prioritized).
-        """
-        server_secret = "test-server-secret"
-        client_secret = server_secret
-
-        with temporary_settings(
-            updates={
-                PREFECT_SERVER_API_AUTH_STRING: server_secret,
-                PREFECT_API_AUTH_STRING: client_secret,
-                PREFECT_API_KEY: "some-irrelevant-api-key",  # Should be ignored
-            }
-        ):
-            with anyio.move_on_after(5):
-                task_worker = TaskWorker(auth_task)
-                async with task_worker:
-                    pass


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17971

the client subscription code should have been updated in https://github.com/PrefectHQ/prefect/pull/17741 but it wasn't, so we were indiscriminately trying to use `PREFECT_API_KEY`