### PR TITLE
add aef index

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,9 +26,7 @@ docs: check-uv
 
 # Install development dependencies
 install: check-uv
-    echo "this solves prefect + integrations deps into a uv.lock, so the first install is slow, subsequent syncs are fast"
-    # TODO: commit the uv.lock file
-    uv sync --dev
+    uv sync --group perf
 
 # Clean up environment
 clean: check-uv

--- a/src/prefect/server/database/_migrations/versions/postgresql/2025_05_04_193249_1c9bb7f78263_add_scope_leader_idx_to_.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2025_05_04_193249_1c9bb7f78263_add_scope_leader_idx_to_.py
@@ -1,0 +1,27 @@
+"""add scope+leader idx to AutomationEventFollower
+
+Revision ID: 1c9bb7f78263
+Revises: 4160a4841eed
+Create Date: 2025-05-04 19:32:49.195966
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1c9bb7f78263"
+down_revision = "4160a4841eed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        index_name="ix_ae_follower_scope_leader",
+        table_name="automation_event_follower",
+        columns=["scope", "leader_event_id"],
+    )
+
+
+def downgrade():
+    op.drop_index(index_name="ix_ae_follower_scope_leader")

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_05_04_193544_3c841a1800a1_add_scope_leader_idx_to_.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_05_04_193544_3c841a1800a1_add_scope_leader_idx_to_.py
@@ -1,0 +1,27 @@
+"""add scope+leader idx to AutomationEventFollower
+
+Revision ID: 3c841a1800a1
+Revises: 7655f31c5157
+Create Date: 2025-05-04 19:35:44.726368
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3c841a1800a1"
+down_revision = "7655f31c5157"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        index_name="ix_ae_follower_scope_leader",
+        table_name="automation_event_follower",
+        columns=["scope", "leader_event_id"],
+    )
+
+
+def downgrade():
+    op.drop_index(index_name="ix_ae_follower_scope_leader")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1377,6 +1377,12 @@ class AutomationEventFollower(Base):
             "follower_event_id",
             unique=True,
         ),
+        # allows lookup on (scope, leader_event_id) to use an index-only instead of full table scan
+        sa.Index(
+            "ix_ae_follower_scope_leader",
+            "scope",
+            "leader_event_id",
+        ),
     )
     scope: Mapped[str] = mapped_column(default="", index=True)
     leader_event_id: Mapped[uuid.UUID] = mapped_column(index=True)


### PR DESCRIPTION
## this PR

adds a  **Composite index on `automation_event_follower(scope, leader_event_id)`**

   * `orm_models.py` declares `ix_ae_follower_scope_leader`.
   * Alembic migrations for **Postgres** and **SQLite** create / drop the index.


no runtime code paths changed in this PR

---

## 🩹 why it matters today

* The API hits

  ```sql
  SELECT follower
  FROM automation_event_follower
  WHERE scope=$1 AND leader_event_id=$2
  ```

  on **every** event to maintain causal ordering.
* When the table is empty (typical) that query devolves to a seq-scan and ends up taking the _second most_ `total_ms` 
* The composite index converts it to an index-only hit (sub-ms)

---

## 🗺️ TODO

* **Problem**: a multi-pod Prefect setup  will need the “skip-the-query”
  hints to be **global**, not per-process (I tried a TTL cache for kicks and it works on the single server setup and then realized it wont work for a multi-server setup)
* **Plan** (not included here): In the redis impl of `ordering.py`:

  * `W:<scope>` → Set of `leader_id`s that have waiters.
  * `P:<scope>` → Hash/Set mapping `follower_id → leader_id`.
  * `record_follower` adds to the sets; `forget_follower` removes.
  * Fast-path becomes a single `SISMEMBER` instead of a DB query.
* **Why not now?**

  * I don't want to introduce anything that's invalid for a multi server setup, this PR is limited to the benefits from adding the index
  * Keeps this patch minimal and non-invasive—no new runtime deps.
  * The index already drops per-call latency to <1 ms, which is fine until we
    actually deploy multiple pods.

---

## 🧪 test

```bash
# generate & apply
prefect server database upgrade

# verify
psql -c '\d automation_event_follower'  # should list ix_ae_follower_scope_leader
```

Run any load script (or your Logfire dashboard) and confirm the follower
SELECTs remain but their **avg\_ms ≈ 0.6** and they no longer dominate
`total_ms`.
