### PR TITLE
Update `Runner` to use a long-lived `EventsClient`

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -251,8 +251,8 @@ class EventsClient(abc.ABC):
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[Exception]],
-        exc_val: Optional[Exception],
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:
         del self._in_context
@@ -360,8 +360,8 @@ class PrefectEventsClient(EventsClient):
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[Exception]],
-        exc_val: Optional[Exception],
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:
         self._websocket = None


### PR DESCRIPTION
Giving the runner a long-lived `EventsClient` allows us to customize the rate events are emitted. Using a client with a low checkpoint should prevent heartbeat events from piling up client-side.

Closes https://github.com/PrefectHQ/prefect/issues/17958
