### PR TITLE
Parse docker image strings with digests

### DIFF
--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -516,9 +516,9 @@ def parse_image_tag(name: str) -> tuple[str, Optional[str]]:
     # - Example: simplename:latest or simplename@sha256:abc123
     if len(name_parts) == 1:
         if "@" in name_parts[0]:
-            image_name, tag = name_parts[0].split("@", 1)
+            image_name, tag = name_parts[0].split("@")
         elif ":" in name_parts[0]:
-            image_name, tag = name_parts[0].split(":", 1)
+            image_name, tag = name_parts[0].split(":")
 
         else:
             image_name = name_parts[0]
@@ -530,9 +530,9 @@ def parse_image_tag(name: str) -> tuple[str, Optional[str]]:
         image_path = "/".join(name_parts[1:])
 
         if "@" in image_path:
-            image_path, tag = image_path.split("@", 1)
+            image_path, tag = image_path.split("@")
         elif ":" in image_path:
-            image_path, tag = image_path.split(":", 1)
+            image_path, tag = image_path.split(":")
 
         image_name = f"{index_name}/{image_path}"
 

--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -495,10 +495,11 @@ def parse_image_tag(name: str) -> tuple[str, Optional[str]]:
     """
     Parse Docker Image String
 
-    - If a tag exists, this function parses and returns the image registry and tag,
+    - If a tag or digest exists, this function parses and returns the image registry and tag/digest,
       separately as a tuple.
       - Example 1: 'prefecthq/prefect:latest' -> ('prefecthq/prefect', 'latest')
       - Example 2: 'hostname.io:5050/folder/subfolder:latest' -> ('hostname.io:5050/folder/subfolder', 'latest')
+      - Example 3: 'prefecthq/prefect@sha256:abc123' -> ('prefecthq/prefect', 'sha256:abc123')
     - Supports parsing Docker Image strings that follow Docker Image Specification v1.1.0
       - Image building tools typically enforce this standard
 
@@ -506,26 +507,35 @@ def parse_image_tag(name: str) -> tuple[str, Optional[str]]:
         name (str): Name of Docker Image
 
     Return:
-        tuple: image registry, image tag
+        tuple: image registry, image tag/digest
     """
     tag = None
     name_parts = name.split("/")
-    # First handles the simplest image names (DockerHub-based, index-free, potentionally with a tag)
-    # - Example: simplename:latest
+
+    # First handles the simplest image names (DockerHub-based, index-free, potentially with a tag or digest)
+    # - Example: simplename:latest or simplename@sha256:abc123
     if len(name_parts) == 1:
-        if ":" in name_parts[0]:
-            image_name, tag = name_parts[0].split(":")
+        if "@" in name_parts[0]:
+            image_name, tag = name_parts[0].split("@", 1)
+        elif ":" in name_parts[0]:
+            image_name, tag = name_parts[0].split(":", 1)
+
         else:
             image_name = name_parts[0]
     else:
         # 1. Separates index (hostname.io or prefecthq) from path:tag (folder/subfolder:latest or prefect:latest)
-        # 2. Separates path and tag (if tag exists)
-        # 3. Reunites index and path (without tag) as image name
+        # 2. Separates path and tag/digest (if exists)
+        # 3. Reunites index and path (without tag/digest) as image name
         index_name = name_parts[0]
         image_path = "/".join(name_parts[1:])
-        if ":" in image_path:
-            image_path, tag = image_path.split(":")
+
+        if "@" in image_path:
+            image_path, tag = image_path.split("@", 1)
+        elif ":" in image_path:
+            image_path, tag = image_path.split(":", 1)
+
         image_name = f"{index_name}/{image_path}"
+
     return image_name, tag
 
 

--- a/tests/docker/test_image_parsing.py
+++ b/tests/docker/test_image_parsing.py
@@ -24,6 +24,10 @@ from prefect.utilities.dockerutils import (
             "hostname.io:5050/dir/subdir:latest",
             ("hostname.io:5050/dir/subdir", "latest"),
         ),
+        (
+            "prefecthq/prefect@sha256:abcdef1234567890",
+            ("prefecthq/prefect", "sha256:abcdef1234567890"),
+        ),
     ],
 )
 def test_parse_image_tag(value, expected):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Adds detection and parsing for Docker image strings containing digests.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
