### PR TITLE
Allow `flow.sumbit` to be non-blocking for some infrastructure types

### DIFF
--- a/.github/workflows/k8s-integration-tests.yaml
+++ b/.github/workflows/k8s-integration-tests.yaml
@@ -32,10 +32,6 @@ jobs:
           python-version: "3.12"
           cache-dependency-glob: "src/integrations/prefect-kubernetes/integration_tests/pyproject.toml"
       
-
-      - name: Install dependencies
-        run: cd src/integrations/prefect-kubernetes/integration_tests && uv sync --active
-      
       - name: Set up Kind cluster
         uses: helm/kind-action@v1.12.0
         with:
@@ -68,14 +64,14 @@ jobs:
           PREFECT_API_URL: http://127.0.0.1:4200/api
           PREFECT_SERVER_LOGGING_LEVEL: DEBUG
         run: |
-          prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
-          python ./scripts/wait-for-server.py
+          uv run prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
+          uv run -s ./scripts/wait-for-server.py
 
       
       - name: Run integration tests
         run: |
-          cd src/integrations/prefect-kubernetes/integration_tests
           uv run pytest -s
+        working-directory: src/integrations/prefect-kubernetes/integration_tests
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
 

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -657,6 +657,28 @@ class ECSWorker(BaseWorker):
     _documentation_url = "https://docs.prefect.io/integrations/prefect-aws/"
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/d74b16fe84ce626345adf235a47008fea2869a60-225x225.png"  # noqa
 
+    async def initiate_run(
+        self,
+        flow_run: "FlowRun",
+        configuration: ECSJobConfiguration,
+    ):
+        """
+        Initiates a flow run on AWS ECS. This method does not wait for the flow run to complete.
+        """
+        ecs_client = await run_sync_in_worker_thread(
+            self._get_client, configuration, "ecs"
+        )
+
+        logger = self.get_flow_run_logger(flow_run)
+
+        await run_sync_in_worker_thread(
+            self._create_task_and_wait_for_start,
+            logger,
+            ecs_client,
+            configuration,
+            flow_run,
+        )
+
     async def run(
         self,
         flow_run: "FlowRun",

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -657,7 +657,7 @@ class ECSWorker(BaseWorker):
     _documentation_url = "https://docs.prefect.io/integrations/prefect-aws/"
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/d74b16fe84ce626345adf235a47008fea2869a60-225x225.png"  # noqa
 
-    async def initiate_run(
+    async def _initiate_run(
         self,
         flow_run: "FlowRun",
         configuration: ECSJobConfiguration,

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -430,6 +430,48 @@ async def test_default(aws_credentials: AwsCredentials, flow_run: FlowRun):
 
 
 @pytest.mark.usefixtures("ecs_mocks")
+async def test_initiate_run_does_not_wait_for_task_completion(
+    aws_credentials: AwsCredentials, flow_run: FlowRun
+):
+    """
+    This test ensures that `initiate_run` does not wait for the task to complete.
+    """
+    configuration = await construct_configuration(
+        aws_credentials=aws_credentials, command="echo test"
+    )
+
+    session = aws_credentials.get_boto3_session()
+    ecs_client = session.client("ecs")
+
+    async with ECSWorker(work_pool_name="test") as worker:
+        await worker.initiate_run(flow_run=flow_run, configuration=configuration)
+
+    clusters = ecs_client.list_clusters()["clusterArns"]
+    assert len(clusters) == 1
+
+    tasks = ecs_client.list_tasks(cluster=clusters[0])["taskArns"]
+    assert len(tasks) == 1
+
+    task = describe_task(ecs_client, tasks[0])
+    assert task["lastStatus"] == "RUNNING"
+
+    task_definition = describe_task_definition(ecs_client, task)
+    assert task_definition["containerDefinitions"] == [
+        {
+            "name": ECS_DEFAULT_CONTAINER_NAME,
+            "image": get_prefect_image_name(),
+            "cpu": 0,
+            "memory": 0,
+            "portMappings": [],
+            "essential": True,
+            "environment": [],
+            "mountPoints": [],
+            "volumesFrom": [],
+        }
+    ]
+
+
+@pytest.mark.usefixtures("ecs_mocks")
 async def test_image(aws_credentials: AwsCredentials, flow_run: FlowRun):
     configuration = await construct_configuration(
         aws_credentials=aws_credentials, image="prefecthq/prefect-dev:main-python3.9"

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -434,7 +434,7 @@ async def test_initiate_run_does_not_wait_for_task_completion(
     aws_credentials: AwsCredentials, flow_run: FlowRun
 ):
     """
-    This test ensures that `initiate_run` does not wait for the task to complete.
+    This test ensures that `_initiate_run` does not wait for the task to complete.
     """
     configuration = await construct_configuration(
         aws_credentials=aws_credentials, command="echo test"
@@ -444,7 +444,7 @@ async def test_initiate_run_does_not_wait_for_task_completion(
     ecs_client = session.client("ecs")
 
     async with ECSWorker(work_pool_name="test") as worker:
-        await worker.initiate_run(flow_run=flow_run, configuration=configuration)
+        await worker._initiate_run(flow_run=flow_run, configuration=configuration)
 
     clusters = ecs_client.list_clusters()["clusterArns"]
     assert len(clusters) == 1

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -432,6 +432,16 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
 
         return await super().setup()
 
+    async def initiate_run(
+        self,
+        flow_run: "FlowRun",
+        configuration: DockerWorkerJobConfiguration,
+    ):
+        """
+        Initiates a flow run within a Docker container. This method does not wait for the flow run to complete.
+        """
+        await run_sync_in_worker_thread(self._create_and_start_container, configuration)
+
     async def run(
         self,
         flow_run: "FlowRun",
@@ -697,7 +707,13 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
             self._pull_image(docker_client, configuration)
 
         try:
+            self._logger.info(
+                f"Creating Docker container {container_settings['name']!r}..."
+            )
             container = self._create_container(docker_client, **container_settings)
+            self._logger.info(
+                f"Docker container {container.name!r} created successfully."
+            )
         except Exception as exc:
             self._emit_container_creation_failed_event(configuration)
             raise exc

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -432,7 +432,7 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
 
         return await super().setup()
 
-    async def initiate_run(
+    async def _initiate_run(
         self,
         flow_run: "FlowRun",
         configuration: DockerWorkerJobConfiguration,

--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -119,7 +119,7 @@ async def test_initiate_run_does_not_wait_for_container_completion(
 ):
     default_docker_worker_job_configuration.prepare_for_flow_run(flow_run)
     async with DockerWorker(work_pool_name="test") as worker:
-        await worker.initiate_run(
+        await worker._initiate_run(
             flow_run=flow_run, configuration=default_docker_worker_job_configuration
         )
         mock_docker_client.containers.create.assert_called_once()

--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -114,6 +114,18 @@ async def registry_credentials():
     return block
 
 
+async def test_initiate_run_does_not_wait_for_container_completion(
+    mock_docker_client, flow_run, default_docker_worker_job_configuration
+):
+    default_docker_worker_job_configuration.prepare_for_flow_run(flow_run)
+    async with DockerWorker(work_pool_name="test") as worker:
+        await worker.initiate_run(
+            flow_run=flow_run, configuration=default_docker_worker_job_configuration
+        )
+        mock_docker_client.containers.create.assert_called_once()
+        mock_docker_client.containers.get.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "requested_name,container_name",
     [

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -416,7 +416,7 @@ class VertexAIWorker(
     _documentation_url = "https://docs.prefect.io/integrations/prefect-gcp"  # noqa
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/10424e311932e31c477ac2b9ef3d53cefbaad708-250x250.png"  # noqa
 
-    async def initiate_run(
+    async def _initiate_run(
         self,
         flow_run: "FlowRun",
         configuration: VertexAIWorkerJobConfiguration,

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -416,6 +416,30 @@ class VertexAIWorker(
     _documentation_url = "https://docs.prefect.io/integrations/prefect-gcp"  # noqa
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/10424e311932e31c477ac2b9ef3d53cefbaad708-250x250.png"  # noqa
 
+    async def initiate_run(
+        self,
+        flow_run: "FlowRun",
+        configuration: VertexAIWorkerJobConfiguration,
+    ):
+        """
+        Initiates a flow run on Vertex AI. This method does not wait for the flow run to complete.
+        """
+        logger = self.get_flow_run_logger(flow_run)
+
+        job_name = configuration.job_name
+        job_spec = self._build_job_spec(configuration)
+        job_service_async_client = (
+            configuration.credentials.get_job_service_async_client()
+        )
+
+        await self._create_and_begin_job(
+            job_name,
+            job_spec,
+            job_service_async_client,
+            configuration,
+            logger,
+        )
+
     async def run(
         self,
         flow_run: "FlowRun",

--- a/src/integrations/prefect-gcp/tests/test_vertex_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_vertex_worker.py
@@ -168,7 +168,7 @@ class TestVertexAIWorker:
     ):
         async with VertexAIWorker("test-pool") as worker:
             job_config.prepare_for_flow_run(flow_run, None, None)
-            await worker.initiate_run(flow_run=flow_run, configuration=job_config)
+            await worker._initiate_run(flow_run=flow_run, configuration=job_config)
 
             job_config.credentials.job_service_async_client.create_custom_job.assert_called_once()
             # The worker doesn't wait for the job to complete, so the get_custom_job call should not have been made

--- a/src/integrations/prefect-gcp/tests/test_vertex_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_vertex_worker.py
@@ -163,6 +163,17 @@ class TestVertexAIWorker:
                 status_code=0, identifier="mock_display_name"
             )
 
+    async def test_initiate_run_does_not_wait_for_completion(
+        self, flow_run, job_config
+    ):
+        async with VertexAIWorker("test-pool") as worker:
+            job_config.prepare_for_flow_run(flow_run, None, None)
+            await worker.initiate_run(flow_run=flow_run, configuration=job_config)
+
+            job_config.credentials.job_service_async_client.create_custom_job.assert_called_once()
+            # The worker doesn't wait for the job to complete, so the get_custom_job call should not have been made
+            job_config.credentials.job_service_async_client.get_custom_job.assert_not_called()
+
     async def test_missing_scheduling(self, flow_run, job_config):
         job_config.job_spec["scheduling"] = None
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -676,6 +676,27 @@ class KubernetesWorker(
             tuple[str, str], KubernetesWorkerJobConfiguration
         ] = {}
 
+    async def initiate_run(
+        self,
+        flow_run: "FlowRun",
+        configuration: KubernetesWorkerJobConfiguration,
+    ) -> None:
+        """
+        Creates a Kubernetes job to start flow run execution. This method does not
+        wait for the job to complete.
+
+        Args:
+            flow_run: The flow run to execute
+            configuration: The configuration to use when executing the flow run
+            task_status: The task status object for the current flow run. If provided,
+                the task will be marked as started.
+        """
+        logger = self.get_flow_run_logger(flow_run)
+        async with self._get_configured_kubernetes_client(configuration) as client:
+            logger.info("Creating Kubernetes job...")
+
+            await self._create_job(configuration, client)
+
     async def run(
         self,
         flow_run: "FlowRun",

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -676,7 +676,7 @@ class KubernetesWorker(
             tuple[str, str], KubernetesWorkerJobConfiguration
         ] = {}
 
-    async def initiate_run(
+    async def _initiate_run(
         self,
         flow_run: "FlowRun",
         configuration: KubernetesWorkerJobConfiguration,

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -1438,7 +1438,7 @@ class TestKubernetesWorker:
         default_configuration.prepare_for_flow_run(flow_run)
         expected_manifest = default_configuration.job_manifest
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
-            await k8s_worker.initiate_run(
+            await k8s_worker._initiate_run(
                 flow_run=flow_run, configuration=default_configuration
             )
             mock_core_client.return_value.list_namespaced_pod.assert_not_called()

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -697,13 +697,23 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             "Workers must implement a method for running submitted flow runs"
         )
 
-    async def initiate_run(
+    async def _initiate_run(
         self,
         flow_run: "FlowRun",
         configuration: C,
     ) -> None:
+        """
+        This method is called by the worker to initiate a flow run and should return as
+        soon as possible.
+
+        This method is used in `.submit` to allow non-blocking submission of flows. For
+        workers that wait for completion in their `run` method, this method should be
+        implemented to return immediately.
+
+        If this method is not implemented, `.submit` will fall back to the `.run` method.
+        """
         raise NotImplementedError(
-            "This worker has not implemented `initiate_run`. Please use `run` instead."
+            "This worker has not implemented `_initiate_run`. Please use `run` instead."
         )
 
     async def submit(
@@ -876,7 +886,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             # Call the implementation-specific run method with the constructed configuration. This is where the
             # rubber meets the road.
             try:
-                await self.initiate_run(flow_run, configuration)
+                await self._initiate_run(flow_run, configuration)
             except NotImplementedError:
                 result = await self.run(flow_run, configuration)
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2536,7 +2536,7 @@ class TestSubmit:
                 run_spy()
                 return BaseWorkerResult(identifier="test", status_code=0)
 
-            async def initiate_run(
+            async def _initiate_run(
                 self,
                 flow_run: FlowRun,
                 configuration: BaseJobConfiguration,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2508,6 +2508,75 @@ class TestSubmit:
         # Return value is hardcoded in the FakeResultStorage to ensure it is used as expected
         assert future.result() == "Here you go chief!"
 
+    @pytest.mark.usefixtures("mock_run_process")
+    async def test_submit_calls_initiate_run_if_implemented(
+        self,
+        work_pool: WorkPool,
+        prefect_client: PrefectClient,
+    ):
+        @flow
+        def a_garden_variety_flow():
+            pass
+
+        run_spy = AsyncMock()
+        initiate_run_spy = AsyncMock()
+
+        class WorkerThatImplementsInitiateRun(
+            BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]
+        ):
+            type = "worker-that-implements-initiate-run"
+            job_configuration = BaseJobConfiguration
+
+            async def run(
+                self,
+                flow_run: FlowRun,
+                configuration: BaseJobConfiguration,
+                task_status: anyio.abc.TaskStatus[int] | None = None,
+            ):
+                run_spy()
+                return BaseWorkerResult(identifier="test", status_code=0)
+
+            async def initiate_run(
+                self,
+                flow_run: FlowRun,
+                configuration: BaseJobConfiguration,
+            ):
+                initiate_run_spy(
+                    flow_run=flow_run,
+                    configuration=configuration,
+                )
+
+        async with WorkerThatImplementsInitiateRun(
+            work_pool_name=work_pool.name, name="test-worker"
+        ) as worker:
+            with pytest.warns(FutureWarning):
+                future = await worker.submit(a_garden_variety_flow)
+                assert isinstance(future, PrefectFlowRunFuture)
+
+        assert run_spy.call_count == 0
+
+        flow_run = await prefect_client.read_flow_run(future.flow_run_id)
+        assert flow_run.work_pool_name == work_pool.name
+
+        expected_configuration = await BaseJobConfiguration.from_template_and_values(
+            work_pool.base_job_template,
+            flow_run.job_variables or {},
+        )
+
+        expected_configuration.prepare_for_flow_run(
+            flow_run=flow_run,
+            flow=Flow(id=flow_run.flow_id, name=a_garden_variety_flow.name, labels={}),
+            work_pool=work_pool,
+            worker_name="test-worker",
+        )
+
+        initiate_run_spy.assert_called_once_with(
+            flow_run=flow_run,
+            configuration=expected_configuration,
+        )
+
+        assert initiate_run_spy.call_count == 1
+
 
 class TestBackwardsCompatibility:
     async def test_backwards_compatibility_with_old_prepare_for_flow_run(


### PR DESCRIPTION
The `initiate_run` method is a new method used to create infrastructure for a flow run, but not watch the created infrastructure or wait for the flow run to complete.

`initiate_run` will be used (if implemented) within `.submit` to allow `flow.submit` to be a non-blocking way to submit runs to remote infrastructure.

This PR also implements `initiate_run` for the following workers:
- Kubernetes
- ECS
- Vertex AI
- Docker

This PR doesn't implement `initiate_run` for the Cloud Run or Azure Container Instances workers because those workers both have clean-up steps after a run has completed. A non-blocking approach will need to remove the clean-up requirement and will be addressed in another PR.

Related to https://github.com/PrefectHQ/prefect/issues/17194
