### PR TITLE
organize types

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -23750,7 +23750,7 @@
                         "type": "string",
                         "maxLength": 255,
                         "title": "Name",
-                        "description": "Variable name",
+                        "description": "The name of the variable",
                         "examples": [
                             "my_variable"
                         ]
@@ -23983,7 +23983,7 @@
                             {
                                 "type": "string",
                                 "maxLength": 255,
-                                "description": "Variable name",
+                                "description": "The name of the variable",
                                 "examples": [
                                     "my_variable"
                                 ]

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -23750,9 +23750,9 @@
                         "type": "string",
                         "maxLength": 255,
                         "title": "Name",
-                        "description": "The name of the variable",
+                        "description": "Variable name",
                         "examples": [
-                            "my-variable"
+                            "my_variable"
                         ]
                     },
                     "value": {
@@ -23982,17 +23982,17 @@
                         "anyOf": [
                             {
                                 "type": "string",
-                                "maxLength": 255
+                                "maxLength": 255,
+                                "description": "Variable name",
+                                "examples": [
+                                    "my_variable"
+                                ]
                             },
                             {
                                 "type": "null"
                             }
                         ],
-                        "title": "Name",
-                        "description": "The name of the variable",
-                        "examples": [
-                            "my-variable"
-                        ]
+                        "title": "Name"
                     },
                     "value": {
                         "anyOf": [

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -10983,7 +10983,8 @@
                     "name": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "string",
+                                "pattern": "^[^/%&><]+$"
                             },
                             {
                                 "type": "null"
@@ -25287,8 +25288,15 @@
                         "description": "The work pool with which the queue is associated."
                     },
                     "last_heartbeat_time": {
-                        "type": "string",
-                        "format": "date-time",
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Last Heartbeat Time",
                         "description": "The last time the worker process sent a heartbeat."
                     },

--- a/src/prefect/_internal/schemas/validators.py
+++ b/src/prefect/_internal/schemas/validators.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import datetime
 import os
-import re
 import urllib.parse
 import warnings
 from collections.abc import Iterable, Mapping, MutableMapping
@@ -34,60 +33,6 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 M = TypeVar("M", bound=Mapping[str, Any])
 MM = TypeVar("MM", bound=MutableMapping[str, Any])
-
-
-LOWERCASE_LETTERS_NUMBERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
-LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX = "^[a-z0-9_]*$"
-SLUG_REGEX = "^[a-z0-9]+([_-]+[a-z0-9]+)*$"
-
-
-@overload
-def raise_on_name_alphanumeric_dashes_only(
-    value: str, field_name: str = ...
-) -> str: ...
-
-
-@overload
-def raise_on_name_alphanumeric_dashes_only(
-    value: None, field_name: str = ...
-) -> None: ...
-
-
-def raise_on_name_alphanumeric_dashes_only(
-    value: Optional[str], field_name: str = "value"
-) -> Optional[str]:
-    if value is not None and not bool(
-        re.match(LOWERCASE_LETTERS_NUMBERS_AND_DASHES_ONLY_REGEX, value)
-    ):
-        raise ValueError(
-            f"{field_name} must only contain lowercase letters, numbers, and dashes."
-        )
-    return value
-
-
-@overload
-def raise_on_name_alphanumeric_underscores_only(
-    value: str, field_name: str = ...
-) -> str: ...
-
-
-@overload
-def raise_on_name_alphanumeric_underscores_only(
-    value: None, field_name: str = ...
-) -> None: ...
-
-
-def raise_on_name_alphanumeric_underscores_only(
-    value: Optional[str], field_name: str = "value"
-) -> Optional[str]:
-    if value is not None and not re.match(
-        LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX, value
-    ):
-        raise ValueError(
-            f"{field_name} must only contain lowercase letters, numbers, and"
-            " underscores."
-        )
-    return value
 
 
 def validate_values_conform_to_schema(
@@ -611,50 +556,3 @@ def validate_working_dir(v: Optional[Path | str]) -> Optional[Path]:
     if isinstance(v, str):
         return relative_path_to_current_platform(v)
     return v
-
-
-### UNCATEGORIZED VALIDATORS ###
-
-# the above categories seem to be getting a bit unwieldy, so this is a temporary
-# catch-all for validators until we organize these into files
-
-
-@overload
-def validate_block_document_name(value: str) -> str: ...
-
-
-@overload
-def validate_block_document_name(value: None) -> None: ...
-
-
-def validate_block_document_name(value: Optional[str]) -> Optional[str]:
-    if value is not None:
-        raise_on_name_alphanumeric_dashes_only(value, field_name="Block document name")
-    return value
-
-
-def validate_artifact_key(value: str) -> str:
-    raise_on_name_alphanumeric_dashes_only(value, field_name="Artifact key")
-    return value
-
-
-@overload
-def validate_variable_name(value: str) -> str: ...
-
-
-@overload
-def validate_variable_name(value: None) -> None: ...
-
-
-def validate_variable_name(value: Optional[str]) -> Optional[str]:
-    if value is not None:
-        if not bool(re.match(SLUG_REGEX, value)):
-            raise ValueError(
-                "Variable name must only contain lowercase letters, numbers, dashes, and underscores"
-            )
-    return value
-
-
-def validate_block_type_slug(value: str):
-    raise_on_name_alphanumeric_dashes_only(value, field_name="Block type slug")
-    return value

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -30,7 +30,6 @@ from prefect.client.schemas.schedules import (
 from prefect.schedules import Schedule
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
 from prefect.types import (
-    MAX_VARIABLE_NAME_LENGTH,
     DateTime,
     KeyValueLabelsField,
     Name,
@@ -831,12 +830,7 @@ class ArtifactUpdate(ActionBaseModel):
 class VariableCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a Variable."""
 
-    name: VariableName = Field(
-        default=...,
-        description="The name of the variable",
-        examples=["my_variable"],
-        max_length=MAX_VARIABLE_NAME_LENGTH,
-    )
+    name: VariableName = Field(default=...)
     value: StrictVariableValue = Field(
         default=...,
         description="The value of the variable",
@@ -848,12 +842,7 @@ class VariableCreate(ActionBaseModel):
 class VariableUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a Variable."""
 
-    name: Optional[VariableName] = Field(
-        default=None,
-        description="The name of the variable",
-        examples=["my_variable"],
-        max_length=MAX_VARIABLE_NAME_LENGTH,
-    )
+    name: Optional[VariableName] = Field(default=None)
     value: StrictVariableValue = Field(
         default=None,
         description="The value of the variable",

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -12,12 +12,8 @@ from prefect._internal.schemas.bases import ActionBaseModel
 from prefect._internal.schemas.validators import (
     convert_to_strings,
     remove_old_deployment_fields,
-    validate_artifact_key,
-    validate_block_document_name,
-    validate_block_type_slug,
     validate_name_present_on_nonanonymous_blocks,
     validate_schedule_max_scheduled_runs,
-    validate_variable_name,
 )
 from prefect.client.schemas.objects import (
     StateDetails,
@@ -44,6 +40,12 @@ from prefect.types import (
     NonNegativeInteger,
     PositiveInteger,
     StrictVariableValue,
+)
+from prefect.types.names import (
+    ArtifactKey,
+    BlockDocumentName,
+    BlockTypeSlug,
+    VariableName,
 )
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.pydantic import get_class_fields_only
@@ -216,7 +218,7 @@ class DeploymentCreate(ActionBaseModel):
     flow_id: UUID = Field(..., description="The ID of the flow to deploy.")
     paused: Optional[bool] = Field(default=None)
     schedules: list[DeploymentScheduleCreate] = Field(
-        default_factory=list,
+        default_factory=lambda: [],
         description="A list of schedules for the deployment.",
     )
     concurrency_limit: Optional[int] = Field(
@@ -537,7 +539,7 @@ class SavedSearchCreate(ActionBaseModel):
 
     name: str = Field(default=..., description="The name of the saved search.")
     filters: list[objects.SavedSearchFilter] = Field(
-        default_factory=list, description="The filter set for the saved search."
+        default_factory=lambda: [], description="The filter set for the saved search."
     )
 
 
@@ -585,7 +587,7 @@ class BlockTypeCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a block type."""
 
     name: str = Field(default=..., description="A block type's name")
-    slug: str = Field(default=..., description="A block type's slug")
+    slug: BlockTypeSlug = Field(default=..., description="A block type's slug")
     logo_url: Optional[objects.HttpUrl] = Field(
         default=None, description="Web URL for the block type's logo"
     )
@@ -600,9 +602,6 @@ class BlockTypeCreate(ActionBaseModel):
         default=None,
         description="A code snippet demonstrating use of the corresponding block",
     )
-
-    # validators
-    _validate_slug_format = field_validator("slug")(validate_block_type_slug)
 
 
 class BlockTypeUpdate(ActionBaseModel):
@@ -638,7 +637,7 @@ class BlockSchemaCreate(ActionBaseModel):
 class BlockDocumentCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a block document."""
 
-    name: Optional[Name] = Field(
+    name: Optional[BlockDocumentName] = Field(
         default=None, description="The name of the block document"
     )
     data: dict[str, Any] = Field(
@@ -657,8 +656,6 @@ class BlockDocumentCreate(ActionBaseModel):
             " Prefect automatically)"
         ),
     )
-
-    _validate_name_format = field_validator("name")(validate_block_document_name)
 
     @model_validator(mode="before")
     def validate_name_is_present_if_not_anonymous(
@@ -814,15 +811,13 @@ class WorkQueueUpdate(ActionBaseModel):
 class ArtifactCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create an artifact."""
 
-    key: Optional[str] = Field(default=None)
+    key: Optional[ArtifactKey] = Field(default=None)
     type: Optional[str] = Field(default=None)
     description: Optional[str] = Field(default=None)
     data: Optional[Union[dict[str, Any], Any]] = Field(default=None)
     metadata_: Optional[dict[str, str]] = Field(default=None)
     flow_run_id: Optional[UUID] = Field(default=None)
     task_run_id: Optional[UUID] = Field(default=None)
-
-    _validate_artifact_format = field_validator("key")(validate_artifact_key)
 
 
 class ArtifactUpdate(ActionBaseModel):
@@ -836,7 +831,7 @@ class ArtifactUpdate(ActionBaseModel):
 class VariableCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a Variable."""
 
-    name: str = Field(
+    name: VariableName = Field(
         default=...,
         description="The name of the variable",
         examples=["my_variable"],
@@ -848,15 +843,12 @@ class VariableCreate(ActionBaseModel):
         examples=["my-value"],
     )
     tags: Optional[list[str]] = Field(default=None)
-
-    # validators
-    _validate_name_format = field_validator("name")(validate_variable_name)
 
 
 class VariableUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a Variable."""
 
-    name: Optional[str] = Field(
+    name: Optional[VariableName] = Field(
         default=None,
         description="The name of the variable",
         examples=["my_variable"],
@@ -868,9 +860,6 @@ class VariableUpdate(ActionBaseModel):
         examples=["my-value"],
     )
     tags: Optional[list[str]] = Field(default=None)
-
-    # validators
-    _validate_name_format = field_validator("name")(validate_variable_name)
 
 
 class GlobalConcurrencyLimitCreate(ActionBaseModel):

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -33,7 +33,6 @@ from prefect.server.utilities.schemas import get_class_fields_only
 from prefect.server.utilities.schemas.bases import PrefectBaseModel
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
 from prefect.types import (
-    MAX_VARIABLE_NAME_LENGTH,
     DateTime,
     KeyValueLabels,
     Name,
@@ -1038,22 +1037,15 @@ class ArtifactUpdate(ActionBaseModel):
 
     data: Optional[Union[Dict[str, Any], Any]] = Field(None)
     description: Optional[str] = Field(None)
-    metadata_: Optional[Dict[str, str]] = Field(None)
-
-    _validate_metadata_length = field_validator("metadata_")(
-        validate_max_metadata_length
-    )
+    metadata_: Optional[
+        Annotated[dict[str, str], AfterValidator(validate_max_metadata_length)]
+    ] = Field(None)
 
 
 class VariableCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a Variable."""
 
-    name: VariableName = Field(
-        default=...,
-        description="The name of the variable",
-        examples=["my-variable"],
-        max_length=MAX_VARIABLE_NAME_LENGTH,
-    )
+    name: VariableName = Field(default=...)
     value: StrictVariableValue = Field(
         default=...,
         description="The value of the variable",
@@ -1069,12 +1061,7 @@ class VariableCreate(ActionBaseModel):
 class VariableUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a Variable."""
 
-    name: Optional[VariableName] = Field(
-        default=None,
-        description="The name of the variable",
-        examples=["my-variable"],
-        max_length=MAX_VARIABLE_NAME_LENGTH,
-    )
+    name: Optional[VariableName] = Field(default=None)
     value: StrictVariableValue = Field(
         default=None,
         description="The value of the variable",

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -6,15 +6,20 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Annotated, Any, ClassVar, Dict, List, Optional, Union
 from uuid import UUID, uuid4
 
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 import prefect.server.schemas as schemas
 from prefect._internal.schemas.validators import (
     get_or_create_run_name,
-    raise_on_name_alphanumeric_dashes_only,
     remove_old_deployment_fields,
     validate_cache_key_length,
     validate_max_metadata_length,
@@ -23,7 +28,6 @@ from prefect._internal.schemas.validators import (
     validate_parameters_conform_to_schema,
     validate_parent_and_ref_diff,
     validate_schedule_max_scheduled_runs,
-    validate_variable_name,
 )
 from prefect.server.utilities.schemas import get_class_fields_only
 from prefect.server.utilities.schemas.bases import PrefectBaseModel
@@ -40,25 +44,14 @@ from prefect.types import (
     StrictVariableValue,
 )
 from prefect.types._datetime import now
+from prefect.types.names import (
+    ArtifactKey,
+    BlockDocumentName,
+    BlockTypeSlug,
+    VariableName,
+)
 from prefect.utilities.names import generate_slug
 from prefect.utilities.templating import find_placeholders
-
-
-def validate_block_type_slug(value: str) -> str:
-    raise_on_name_alphanumeric_dashes_only(value, field_name="Block type slug")
-    return value
-
-
-def validate_block_document_name(value: str | None) -> str | None:
-    if value is not None:
-        raise_on_name_alphanumeric_dashes_only(value, field_name="Block document name")
-    return value
-
-
-def validate_artifact_key(value: str | None) -> str | None:
-    if value is not None:
-        raise_on_name_alphanumeric_dashes_only(value, field_name="Artifact key")
-    return value
 
 
 class ActionBaseModel(PrefectBaseModel):
@@ -166,8 +159,8 @@ class DeploymentCreate(ActionBaseModel):
     paused: bool = Field(
         default=False, description="Whether or not the deployment is paused."
     )
-    schedules: List[DeploymentScheduleCreate] = Field(
-        default_factory=list,
+    schedules: list[DeploymentScheduleCreate] = Field(
+        default_factory=lambda: [],
         description="A list of schedules for the deployment.",
     )
     concurrency_limit: Optional[PositiveInteger] = Field(
@@ -296,8 +289,8 @@ class DeploymentUpdate(ActionBaseModel):
     paused: bool = Field(
         default=False, description="Whether or not the deployment is paused."
     )
-    schedules: List[DeploymentScheduleUpdate] = Field(
-        default_factory=list,
+    schedules: list[DeploymentScheduleUpdate] = Field(
+        default_factory=lambda: [],
         description="A list of schedules for the deployment.",
     )
     concurrency_limit: Optional[PositiveInteger] = Field(
@@ -684,8 +677,8 @@ class SavedSearchCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a saved search."""
 
     name: str = Field(default=..., description="The name of the saved search.")
-    filters: List[schemas.core.SavedSearchFilter] = Field(
-        default_factory=list, description="The filter set for the saved search."
+    filters: list[schemas.core.SavedSearchFilter] = Field(
+        default_factory=lambda: [], description="The filter set for the saved search."
     )
 
 
@@ -733,7 +726,7 @@ class BlockTypeCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a block type."""
 
     name: Name = Field(default=..., description="A block type's name")
-    slug: str = Field(default=..., description="A block type's slug")
+    slug: BlockTypeSlug = Field(default=..., description="A block type's slug")
     logo_url: Optional[str] = Field(  # TODO: HttpUrl
         default=None, description="Web URL for the block type's logo"
     )
@@ -748,9 +741,6 @@ class BlockTypeCreate(ActionBaseModel):
         default=None,
         description="A code snippet demonstrating use of the corresponding block",
     )
-
-    # validators
-    _validate_slug_format = field_validator("slug")(validate_block_type_slug)
 
 
 class BlockTypeUpdate(ActionBaseModel):
@@ -769,7 +759,7 @@ class BlockTypeUpdate(ActionBaseModel):
 class BlockSchemaCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a block schema."""
 
-    fields: Dict[str, Any] = Field(
+    fields: dict[str, Any] = Field(
         default_factory=dict, description="The block schema's field schema"
     )
     block_type_id: UUID = Field(default=..., description="A block type ID")
@@ -787,7 +777,7 @@ class BlockSchemaCreate(ActionBaseModel):
 class BlockDocumentCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a block document."""
 
-    name: Optional[str] = Field(
+    name: Optional[BlockDocumentName] = Field(
         default=None,
         description=(
             "The block document's name. Not required for anonymous block documents."
@@ -808,10 +798,10 @@ class BlockDocumentCreate(ActionBaseModel):
         ),
     )
 
-    _validate_name_format = field_validator("name")(validate_block_document_name)
-
     @model_validator(mode="before")
-    def validate_name_is_present_if_not_anonymous(cls, values):
+    def validate_name_is_present_if_not_anonymous(
+        cls, values: dict[str, Any]
+    ) -> dict[str, Any]:
         return validate_name_present_on_nonanonymous_blocks(values)
 
 
@@ -988,7 +978,7 @@ class WorkQueueUpdate(ActionBaseModel):
 class ArtifactCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create an artifact."""
 
-    key: Optional[str] = Field(
+    key: Optional[ArtifactKey] = Field(
         default=None, description="An optional unique reference key for this artifact."
     )
     type: Optional[str] = Field(
@@ -1008,7 +998,9 @@ class ArtifactCreate(ActionBaseModel):
             " the artifact type."
         ),
     )
-    metadata_: Optional[Dict[str, str]] = Field(
+    metadata_: Optional[
+        Annotated[dict[str, str], AfterValidator(validate_max_metadata_length)]
+    ] = Field(
         default=None,
         description=(
             "User-defined artifact metadata. Content must be string key and value"
@@ -1040,12 +1032,6 @@ class ArtifactCreate(ActionBaseModel):
 
         return cls(data=data, **artifact_info)
 
-    _validate_metadata_length = field_validator("metadata_")(
-        validate_max_metadata_length
-    )
-
-    _validate_artifact_format = field_validator("key")(validate_artifact_key)
-
 
 class ArtifactUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update an artifact."""
@@ -1062,7 +1048,7 @@ class ArtifactUpdate(ActionBaseModel):
 class VariableCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a Variable."""
 
-    name: str = Field(
+    name: VariableName = Field(
         default=...,
         description="The name of the variable",
         examples=["my-variable"],
@@ -1073,20 +1059,17 @@ class VariableCreate(ActionBaseModel):
         description="The value of the variable",
         examples=["my-value"],
     )
-    tags: List[str] = Field(
+    tags: list[str] = Field(
         default_factory=list,
         description="A list of variable tags",
         examples=[["tag-1", "tag-2"]],
     )
 
-    # validators
-    _validate_name_format = field_validator("name")(validate_variable_name)
-
 
 class VariableUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a Variable."""
 
-    name: Optional[str] = Field(
+    name: Optional[VariableName] = Field(
         default=None,
         description="The name of the variable",
         examples=["my-variable"],
@@ -1097,11 +1080,8 @@ class VariableUpdate(ActionBaseModel):
         description="The value of the variable",
         examples=["my-value"],
     )
-    tags: Optional[List[str]] = Field(
+    tags: Optional[list[str]] = Field(
         default=None,
         description="A list of variable tags",
         examples=[["tag-1", "tag-2"]],
     )
-
-    # validators
-    _validate_name_format = field_validator("name")(validate_variable_name)

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -5,10 +5,21 @@ Full schemas of Prefect REST API objects.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Type,
+    Union,
+)
 from uuid import UUID
 
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
@@ -23,7 +34,6 @@ from typing_extensions import Literal, Self
 
 from prefect._internal.schemas.validators import (
     get_or_create_run_name,
-    raise_on_name_alphanumeric_dashes_only,
     set_run_policy_deprecated_fields,
     validate_cache_key_length,
     validate_default_queue_id_not_none,
@@ -52,6 +62,7 @@ from prefect.types import (
     StrictVariableValue,
 )
 from prefect.types._datetime import now
+from prefect.types.names import raise_on_name_alphanumeric_dashes_only
 from prefect.utilities.collections import (
     AutoEnum,
     dict_to_flatdict,
@@ -579,8 +590,9 @@ class Deployment(ORMBaseModel):
     paused: bool = Field(
         default=False, description="Whether or not the deployment is paused."
     )
-    schedules: List[DeploymentSchedule] = Field(
-        default_factory=list, description="A list of schedules for the deployment."
+    schedules: list[DeploymentSchedule] = Field(
+        default_factory=lambda: [],
+        description="A list of schedules for the deployment.",
     )
     concurrency_limit: Optional[NonNegativeInteger] = Field(
         default=None, description="The concurrency limit for the deployment."
@@ -679,8 +691,8 @@ class ConcurrencyLimit(ORMBaseModel):
         default=..., description="A tag the concurrency limit is applied to."
     )
     concurrency_limit: int = Field(default=..., description="The concurrency limit.")
-    active_slots: List[UUID] = Field(
-        default_factory=list,
+    active_slots: list[UUID] = Field(
+        default_factory=lambda: [],
         description="A list of active run ids using a concurrency slot",
     )
 
@@ -879,7 +891,9 @@ class BlockDocumentReference(ORMBaseModel):
     )
 
     @model_validator(mode="before")
-    def validate_parent_and_ref_are_different(cls, values):
+    def validate_parent_and_ref_are_different(
+        cls, values: dict[str, Any]
+    ) -> dict[str, Any]:
         return validate_parent_and_ref_diff(values)
 
 
@@ -911,8 +925,9 @@ class SavedSearch(ORMBaseModel):
     """An ORM representation of saved search data. Represents a set of filter criteria."""
 
     name: str = Field(default=..., description="The name of the saved search.")
-    filters: List[SavedSearchFilter] = Field(
-        default_factory=list, description="The filter set for the saved search."
+    filters: list[SavedSearchFilter] = Field(
+        default_factory=lambda: [],
+        description="The filter set for the saved search.",
     )
 
 
@@ -934,11 +949,11 @@ class Log(ORMBaseModel):
 class QueueFilter(PrefectBaseModel):
     """Filter criteria definition for a work queue."""
 
-    tags: Optional[List[str]] = Field(
+    tags: Optional[list[str]] = Field(
         default=None,
         description="Only include flow runs with these tags in the work queue.",
     )
-    deployment_ids: Optional[List[UUID]] = Field(
+    deployment_ids: Optional[list[UUID]] = Field(
         default=None,
         description="Only include flow runs from these deployments in the work queue.",
     )
@@ -1141,7 +1156,7 @@ class Worker(ORMBaseModel):
     work_pool_id: UUID = Field(
         description="The work pool with which the queue is associated."
     )
-    last_heartbeat_time: datetime.datetime = Field(
+    last_heartbeat_time: Optional[datetime.datetime] = Field(
         None, description="The last time the worker process sent a heartbeat."
     )
     heartbeat_interval_seconds: Optional[int] = Field(
@@ -1274,15 +1289,11 @@ class Variable(ORMBaseModel):
 
 class FlowRunInput(ORMBaseModel):
     flow_run_id: UUID = Field(description="The flow run ID associated with the input.")
-    key: str = Field(description="The key of the input.")
+    key: Annotated[str, AfterValidator(raise_on_name_alphanumeric_dashes_only)] = Field(
+        description="The key of the input."
+    )
     value: str = Field(description="The value of the input.")
     sender: Optional[str] = Field(default=None, description="The sender of the input.")
-
-    @field_validator("key", check_fields=False)
-    @classmethod
-    def validate_name_characters(cls, v: str) -> str:
-        raise_on_name_alphanumeric_dashes_only(v)
-        return v
 
 
 class CsrfToken(ORMBaseModel):

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -14,6 +14,7 @@ from .names import (
     NonEmptyishName,
     BANNED_CHARACTERS,
     WITHOUT_BANNED_CHARACTERS,
+    MAX_VARIABLE_NAME_LENGTH,
 )
 from pydantic import (
     BeforeValidator,
@@ -28,7 +29,6 @@ from zoneinfo import available_timezones
 
 T = TypeVar("T")
 
-MAX_VARIABLE_NAME_LENGTH = 255
 MAX_VARIABLE_VALUE_LENGTH = 5000
 
 NonNegativeInteger = Annotated[int, Field(ge=0)]

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Annotated, Any, Dict, List, Optional, Set, TypeVar, Union
+from typing import Annotated, Any, Optional, TypeVar, Union
 from typing_extensions import Literal
 import orjson
 import pydantic
@@ -52,8 +52,8 @@ VariableValue = Union[
     StrictBool,
     StrictFloat,
     None,
-    Dict[str, Any],
-    List[Any],
+    dict[str, Any],
+    list[Any],
 ]
 
 
@@ -84,24 +84,24 @@ def cast_none_to_empty_dict(value: Any) -> dict[str, Any]:
 
 
 KeyValueLabels = Annotated[
-    Dict[str, Union[StrictBool, StrictInt, StrictFloat, str]],
+    dict[str, Union[StrictBool, StrictInt, StrictFloat, str]],
     BeforeValidator(cast_none_to_empty_dict),
 ]
 
 
 ListOfNonEmptyStrings = Annotated[
-    List[str],
+    list[str],
     BeforeValidator(lambda x: [str(s) for s in x if str(s).strip()]),
 ]
 
 
-class SecretDict(pydantic.Secret[Dict[str, Any]]):
+class SecretDict(pydantic.Secret[dict[str, Any]]):
     pass
 
 
 def validate_set_T_from_delim_string(
-    value: Union[str, T, Set[T], None], type_: type[T], delim: str | None = None
-) -> Set[T]:
+    value: Union[str, T, set[T], None], type_: Any, delim: str | None = None
+) -> set[T]:
     """
     "no-info" before validator useful in scooping env vars
 
@@ -115,20 +115,20 @@ def validate_set_T_from_delim_string(
     delim = delim or ","
     if isinstance(value, str):
         return {T_adapter.validate_strings(s.strip()) for s in value.split(delim)}
-    errors = []
+    errors: list[pydantic.ValidationError] = []
     try:
         return {T_adapter.validate_python(value)}
     except pydantic.ValidationError as e:
         errors.append(e)
     try:
-        return TypeAdapter(Set[type_]).validate_python(value)
+        return TypeAdapter(set[type_]).validate_python(value)
     except pydantic.ValidationError as e:
         errors.append(e)
     raise ValueError(f"Invalid set[{type_}]: {errors}")
 
 
 ClientRetryExtraCodes = Annotated[
-    Union[str, StatusCode, Set[StatusCode], None],
+    Union[str, StatusCode, set[StatusCode], None],
     BeforeValidator(partial(validate_set_T_from_delim_string, type_=StatusCode)),
 ]
 
@@ -154,11 +154,15 @@ KeyValueLabelsField = Annotated[
 
 
 __all__ = [
+    "BANNED_CHARACTERS",
+    "WITHOUT_BANNED_CHARACTERS",
     "ClientRetryExtraCodes",
     "Date",
     "DateTime",
     "LogLevel",
     "KeyValueLabelsField",
+    "MAX_VARIABLE_NAME_LENGTH",
+    "MAX_VARIABLE_VALUE_LENGTH",
     "NonNegativeInteger",
     "PositiveInteger",
     "ListOfNonEmptyStrings",

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -8,6 +8,13 @@ import pydantic
 
 
 from ._datetime import DateTime, Date
+from .names import (
+    Name,
+    NameOrEmpty,
+    NonEmptyishName,
+    BANNED_CHARACTERS,
+    WITHOUT_BANNED_CHARACTERS,
+)
 from pydantic import (
     BeforeValidator,
     Field,
@@ -36,29 +43,6 @@ TimeZone = Annotated[
             [z for z in sorted(available_timezones()) if "localtime" not in z]
         ),
     ),
-]
-
-
-BANNED_CHARACTERS = ["/", "%", "&", ">", "<"]
-
-WITHOUT_BANNED_CHARACTERS = r"^[^" + "".join(BANNED_CHARACTERS) + "]+$"
-Name = Annotated[str, Field(pattern=WITHOUT_BANNED_CHARACTERS)]
-
-WITHOUT_BANNED_CHARACTERS_EMPTY_OK = r"^[^" + "".join(BANNED_CHARACTERS) + "]*$"
-NameOrEmpty = Annotated[str, Field(pattern=WITHOUT_BANNED_CHARACTERS_EMPTY_OK)]
-
-
-def non_emptyish(value: str) -> str:
-    if not value.strip("' \""):
-        raise ValueError("name cannot be an empty string")
-
-    return value
-
-
-NonEmptyishName = Annotated[
-    str,
-    Field(pattern=WITHOUT_BANNED_CHARACTERS),
-    BeforeValidator(non_emptyish),
 ]
 
 

--- a/src/prefect/types/names.py
+++ b/src/prefect/types/names.py
@@ -118,7 +118,7 @@ VariableName = Annotated[
     ),
     Field(
         max_length=MAX_VARIABLE_NAME_LENGTH,
-        description="Variable name",
+        description="The name of the variable",
         examples=["my_variable"],
     ),
 ]

--- a/src/prefect/types/names.py
+++ b/src/prefect/types/names.py
@@ -108,9 +108,17 @@ ArtifactKey = Annotated[
     ),
 ]
 
+MAX_VARIABLE_NAME_LENGTH = 255
+
+
 VariableName = Annotated[
     str,
     AfterValidator(
         partial(raise_on_name_alphanumeric_underscores_only, field_name="Variable name")
+    ),
+    Field(
+        max_length=MAX_VARIABLE_NAME_LENGTH,
+        description="Variable name",
+        examples=["my_variable"],
     ),
 ]

--- a/src/prefect/types/names.py
+++ b/src/prefect/types/names.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import re
+from functools import partial
+from typing import Annotated, overload
+
+from pydantic import AfterValidator, BeforeValidator, Field
+
+LOWERCASE_LETTERS_NUMBERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
+LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX = "^[a-z0-9_]*$"
+
+
+@overload
+def raise_on_name_alphanumeric_dashes_only(
+    value: str, field_name: str = ...
+) -> str: ...
+
+
+@overload
+def raise_on_name_alphanumeric_dashes_only(
+    value: None, field_name: str = ...
+) -> None: ...
+
+
+def raise_on_name_alphanumeric_dashes_only(
+    value: str | None, field_name: str = "value"
+) -> str | None:
+    if value is not None and not bool(
+        re.match(LOWERCASE_LETTERS_NUMBERS_AND_DASHES_ONLY_REGEX, value)
+    ):
+        raise ValueError(
+            f"{field_name} must only contain lowercase letters, numbers, and dashes."
+        )
+    return value
+
+
+@overload
+def raise_on_name_alphanumeric_underscores_only(
+    value: str, field_name: str = ...
+) -> str: ...
+
+
+@overload
+def raise_on_name_alphanumeric_underscores_only(
+    value: None, field_name: str = ...
+) -> None: ...
+
+
+def raise_on_name_alphanumeric_underscores_only(
+    value: str | None, field_name: str = "value"
+) -> str | None:
+    if value is not None and not re.match(
+        LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX, value
+    ):
+        raise ValueError(
+            f"{field_name} must only contain lowercase letters, numbers, and"
+            " underscores."
+        )
+    return value
+
+
+BANNED_CHARACTERS = ["/", "%", "&", ">", "<"]
+
+WITHOUT_BANNED_CHARACTERS = r"^[^" + "".join(BANNED_CHARACTERS) + "]+$"
+Name = Annotated[str, Field(pattern=WITHOUT_BANNED_CHARACTERS)]
+
+WITHOUT_BANNED_CHARACTERS_EMPTY_OK = r"^[^" + "".join(BANNED_CHARACTERS) + "]*$"
+NameOrEmpty = Annotated[str, Field(pattern=WITHOUT_BANNED_CHARACTERS_EMPTY_OK)]
+
+
+def non_emptyish(value: str) -> str:
+    if not value.strip("' \""):
+        raise ValueError("name cannot be an empty string")
+
+    return value
+
+
+NonEmptyishName = Annotated[
+    str,
+    Field(pattern=WITHOUT_BANNED_CHARACTERS),
+    BeforeValidator(non_emptyish),
+]
+
+
+### specific names
+
+BlockDocumentName = Annotated[
+    Name,
+    AfterValidator(
+        partial(
+            raise_on_name_alphanumeric_dashes_only, field_name="Block document name"
+        )
+    ),
+]
+
+
+BlockTypeSlug = Annotated[
+    str,
+    AfterValidator(
+        partial(raise_on_name_alphanumeric_dashes_only, field_name="Block type slug")
+    ),
+]
+
+ArtifactKey = Annotated[
+    str,
+    AfterValidator(
+        partial(raise_on_name_alphanumeric_dashes_only, field_name="Artifact key")
+    ),
+]
+
+VariableName = Annotated[
+    str,
+    AfterValidator(
+        partial(raise_on_name_alphanumeric_underscores_only, field_name="Variable name")
+    ),
+]

--- a/src/prefect/types/names.py
+++ b/src/prefect/types/names.py
@@ -8,6 +8,7 @@ from pydantic import AfterValidator, BeforeValidator, Field
 
 LOWERCASE_LETTERS_NUMBERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
 LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX = "^[a-z0-9_]*$"
+LOWERCASE_LETTERS_NUMBERS_AND_DASHES_OR_UNDERSCORES_REGEX = "^[a-z0-9-_]*$"
 
 
 @overload
@@ -55,6 +56,17 @@ def raise_on_name_alphanumeric_underscores_only(
         raise ValueError(
             f"{field_name} must only contain lowercase letters, numbers, and"
             " underscores."
+        )
+    return value
+
+
+def raise_on_name_alphanumeric_dashes_underscores_only(
+    value: str, field_name: str = "value"
+) -> str:
+    if not re.match(LOWERCASE_LETTERS_NUMBERS_AND_DASHES_OR_UNDERSCORES_REGEX, value):
+        raise ValueError(
+            f"{field_name} must only contain lowercase letters, numbers, and"
+            " dashes or underscores."
         )
     return value
 
@@ -114,7 +126,10 @@ MAX_VARIABLE_NAME_LENGTH = 255
 VariableName = Annotated[
     str,
     AfterValidator(
-        partial(raise_on_name_alphanumeric_underscores_only, field_name="Variable name")
+        partial(
+            raise_on_name_alphanumeric_dashes_underscores_only,
+            field_name="Variable name",
+        )
     ),
     Field(
         max_length=MAX_VARIABLE_NAME_LENGTH,

--- a/tests/server/orchestration/api/test_variables.py
+++ b/tests/server/orchestration/api/test_variables.py
@@ -109,6 +109,28 @@ class TestCreateVariable:
 
         assert res["value"] == value
 
+    @pytest.mark.parametrize("variable_name", ["my-variable", "my_variable"])
+    async def test_variable_name_may_contain_dashes_or_underscores(
+        self,
+        client: AsyncClient,
+        variable_name: str,
+    ):
+        response = await client.post(
+            "/variables/",
+            json={"name": variable_name, "value": "my-value"},
+        )
+        assert response
+        assert response.status_code == 201
+
+        res = response.json()
+        assert res["id"]
+        assert res["created"]
+        assert res["updated"]
+
+        assert res["name"] == variable_name
+        assert res["value"] == "my-value"
+        assert res["tags"] == []
+
     @pytest.mark.parametrize("variable_name", ["MY_VARIABLE", "my variable", "!@#$%"])
     async def test_name_constraints(
         self,
@@ -122,7 +144,7 @@ class TestCreateVariable:
         assert res
         assert res.status_code == 422
         assert (
-            "Variable name must only contain lowercase letters, numbers, dashes, and underscores"
+            "Variable name must only contain lowercase letters, numbers, and dashes or underscores."
             in res.json()["exception_detail"][0]["msg"]
         )
 

--- a/tests/server/orchestration/api/test_variables.py
+++ b/tests/server/orchestration/api/test_variables.py
@@ -556,7 +556,7 @@ class TestUpdateVariable:
         )
         assert res
         assert res.status_code == 422
-        assert "String should have at most" in res.json()["exception_detail"][0]["msg"]
+        assert "Value should have at most" in res.json()["exception_detail"][0]["msg"]
 
     async def test_value_max_length(
         self,
@@ -687,7 +687,7 @@ class TestUpdateVariableByName:
         )
         assert res
         assert res.status_code == 422
-        assert "String should have at most" in res.json()["exception_detail"][0]["msg"]
+        assert "Value should have at most" in res.json()["exception_detail"][0]["msg"]
 
     async def test_value_max_length(
         self,

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -9209,7 +9209,7 @@ export interface components {
         VariableCreate: {
             /**
              * Name
-             * @description Variable name
+             * @description The name of the variable
              */
             name: string;
             /**

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -9209,7 +9209,7 @@ export interface components {
         VariableCreate: {
             /**
              * Name
-             * @description The name of the variable
+             * @description Variable name
              */
             name: string;
             /**
@@ -9301,10 +9301,7 @@ export interface components {
          * @description Data used by the Prefect REST API to update a Variable.
          */
         VariableUpdate: {
-            /**
-             * Name
-             * @description The name of the variable
-             */
+            /** Name */
             name?: string | null;
             /**
              * Value

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -9887,10 +9887,9 @@ export interface components {
             work_pool_id: string;
             /**
              * Last Heartbeat Time
-             * Format: date-time
              * @description The last time the worker process sent a heartbeat.
              */
-            last_heartbeat_time?: string;
+            last_heartbeat_time?: string | null;
             /**
              * Heartbeat Interval Seconds
              * @description The number of seconds to expect between heartbeats sent by the worker.


### PR DESCRIPTION
strict refactor, deleting as much as possible from the internal validators module and moving it into `types` in cases where we only are checking some `re.Pattern`, which allows us to just define these once for use in client/server schemas and avoid extra encapsulation like we had in the internal validators module

moves naming related types into a new `prefect.types.names`

to merge after https://github.com/PrefectHQ/prefect/pull/17995, which doesn't attempt the consolidation im going for here

<details>

### copilot

This pull request introduces several updates to improve schema validation, simplify code, and enhance maintainability. Key changes include replacing custom validators with type annotations, updating JSON schema definitions, and replacing default list initializations with `lambda` functions for consistency.

### Schema Validation Updates:
* Updated `docs/v3/api-ref/rest-api/server/schema.json` to include stricter validation for variable names using regex patterns and improved descriptions and examples for clarity. (`[[1]](diffhunk://#diff-cf5a87210428d7bd0c474807042c28dd7a425625be29cc2252ae2a72c6ebc96eL10986-R10987)`, `[[2]](diffhunk://#diff-cf5a87210428d7bd0c474807042c28dd7a425625be29cc2252ae2a72c6ebc96eL23752-R23755)`, `[[3]](diffhunk://#diff-cf5a87210428d7bd0c474807042c28dd7a425625be29cc2252ae2a72c6ebc96eL23984-R23995)`)
* Replaced custom validation functions (e.g., `raise_on_name_alphanumeric_dashes_only`) with type annotations such as `BlockDocumentName`, `ArtifactKey`, and `VariableName` in `src/prefect/client/schemas/actions.py` and `src/prefect/client/schemas/objects.py`. (`[[1]](diffhunk://#diff-a91c42027554e27d0bd3239f5e9a05f49b24c7f23da10743b06b25a2bd9cf4d8L588-R589)`, `[[2]](diffhunk://#diff-a91c42027554e27d0bd3239f5e9a05f49b24c7f23da10743b06b25a2bd9cf4d8L817-L826)`, `[[3]](diffhunk://#diff-ef5a2fbfd2a049d62f31acff73d7cb79c7f0c5532f167854b1d1be16452105c6L1647-R1652)`)

### Code Simplification:
* Removed redundant validators and regex constants from `src/prefect/_internal/schemas/validators.py`, consolidating validation logic into type definitions. (`[[1]](diffhunk://#diff-d5290028f31a09df4fb8228220522848f9d547517fab86aa896a614c0d2faa90L39-L91)`, `[[2]](diffhunk://#diff-d5290028f31a09df4fb8228220522848f9d547517fab86aa896a614c0d2faa90L613-L656)`)
* Replaced `default_factory=list` with `default_factory=lambda: []` for list fields in Pydantic models to ensure consistent initialization. (`[[1]](diffhunk://#diff-a91c42027554e27d0bd3239f5e9a05f49b24c7f23da10743b06b25a2bd9cf4d8L219-R220)`, `[[2]](diffhunk://#diff-ef5a2fbfd2a049d62f31acff73d7cb79c7f0c5532f167854b1d1be16452105c6L1136-R1138)`, `[[3]](diffhunk://#diff-ef5a2fbfd2a049d62f31acff73d7cb79c7f0c5532f167854b1d1be16452105c6L1222-R1224)`)

### JSON Schema Enhancements:
* Updated `last_heartbeat_time` in `docs/v3/api-ref/rest-api/server/schema.json` to allow `null` values in addition to `date-time` strings for better flexibility. (`[docs/v3/api-ref/rest-api/server/schema.jsonR25291-R25299](diffhunk://#diff-cf5a87210428d7bd0c474807042c28dd7a425625be29cc2252ae2a72c6ebc96eR25291-R25299)`)

These changes collectively improve the robustness, readability, and maintainability of the codebase.

</details>