### PR TITLE
Bugfix: Coalesce flow run start times with expected start times

### DIFF
--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional
 from uuid import UUID
 
 from pydantic import ConfigDict, Field
+from sqlalchemy.sql.functions import coalesce
 
 import prefect.server.schemas as schemas
 from prefect.server.utilities.database import db_injector
@@ -461,9 +462,15 @@ class FlowRunFilterStartTime(PrefectFilterBaseModel):
     ) -> Iterable[sa.ColumnExpressionArgument[bool]]:
         filters: list[sa.ColumnExpressionArgument[bool]] = []
         if self.before_ is not None:
-            filters.append(db.FlowRun.start_time <= self.before_)
+            filters.append(
+                coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time)
+                <= self.before_
+            )
         if self.after_ is not None:
-            filters.append(db.FlowRun.start_time >= self.after_)
+            filters.append(
+                coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time)
+                >= self.after_
+            )
         if self.is_null_ is not None:
             filters.append(
                 db.FlowRun.start_time.is_(None)

--- a/tests/server/models/test_flow_runs.py
+++ b/tests/server/models/test_flow_runs.py
@@ -634,7 +634,7 @@ class TestReadFlowRuns:
                 start_time=now_dt - datetime.timedelta(minutes=1),
                 state=schemas.states.State(
                     type="COMPLETED",
-                    name="My Completed State",
+                    name="My Completed State 1",
                 ),
             ),
         )
@@ -645,7 +645,7 @@ class TestReadFlowRuns:
                 start_time=now_dt,
                 state=schemas.states.State(
                     type="COMPLETED",
-                    name="My Completed State",
+                    name="My Completed State 2",
                 ),
             ),
         )
@@ -656,7 +656,7 @@ class TestReadFlowRuns:
                 start_time=now_dt + datetime.timedelta(minutes=1),
                 state=schemas.states.State(
                     type="COMPLETED",
-                    name="My Completed State",
+                    name="My Completed State 3",
                 ),
             ),
         )
@@ -666,7 +666,7 @@ class TestReadFlowRuns:
                 flow_id=flow.id,
                 state=schemas.states.State(
                     type="COMPLETED",
-                    name="My Completed State",
+                    name="My Completed State 4",
                 ),
             ),
         )
@@ -689,7 +689,11 @@ class TestReadFlowRuns:
                 start_time=schemas.filters.FlowRunFilterStartTime(after_=now_dt)
             ),
         )
-        assert {res.id for res in result} == {flow_run_2.id, flow_run_3.id}
+        assert {res.id for res in result} == {
+            flow_run_2.id,
+            flow_run_3.id,
+            flow_run_4.id,
+        }
 
         # before_ AND after_
         result = await models.flow_runs.read_flow_runs(

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -65,3 +65,23 @@ class TestFlowRunFilters:
         flow_run_filter = FlowRunFilter(end_time={"is_null_": True})
         sql_filter = flow_run_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.FlowRun.end_time.is_(None)))
+
+    def test_coalesces_start_time_and_expected_start_time_after_(self, db):
+        flow_run_filter = FlowRunFilter(start_time={"after_": NOW})
+        sql_filter = flow_run_filter.as_sql_filter()
+        assert sql_filter.compare(
+            sa.and_(
+                sa.func.coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time)
+                >= NOW
+            )
+        )
+
+    def test_coalesces_start_time_and_expected_start_time_before_(self, db):
+        flow_run_filter = FlowRunFilter(start_time={"before_": NOW})
+        sql_filter = flow_run_filter.as_sql_filter()
+        assert sql_filter.compare(
+            sa.and_(
+                sa.func.coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time)
+                <= NOW
+            )
+        )


### PR DESCRIPTION
This PR fixes an issue where scheduled runs weren't returned when using `start_time` filters by coalescing `start_time` and `expected_start_time` fields. This matches the behavior JS clients are expecting.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
