### PR TITLE
Uses UUIDv7 for the IDs of time-oriented objects

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "typing_extensions>=4.10.0,<5.0.0",
     "ujson>=5.8.0,<6.0.0",
     "uvicorn>=0.14.0,!=0.29.0",
+    "uuid7>=0.1.0",
     "websockets>=13.0,<16.0",
     "whenever>=0.7.3,<0.9.0; python_version>='3.13'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dependencies = [
     "websockets>=13.0,<16.0",
     "whenever>=0.7.3,<0.9.0; python_version>='3.13'",
     "uv>=0.6.0",
+    "uuid7>=0.1.0",
 ]
 [project.urls]
 Changelog = "https://github.com/PrefectHQ/prefect/releases"

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, Field
 from rich.repr import RichReprResult
 from typing_extensions import Self
+from uuid_extensions import uuid7
 
 from prefect.types._datetime import (
     DateTime,
@@ -100,13 +101,22 @@ class PrefectBaseModel(BaseModel):
 
 class IDBaseModel(PrefectBaseModel):
     """
-    A PrefectBaseModel with an auto-generated UUID ID value.
+    A PrefectBaseModel with a randomly-generated UUID ID value.
 
     The ID is reset on copy() and not included in equality comparisons.
     """
 
     _reset_fields: ClassVar[set[str]] = {"id"}
     id: UUID = Field(default_factory=uuid4)
+
+
+class TimeSeriesBaseModel(IDBaseModel):
+    """
+    A PrefectBaseModel with a time-oriented UUIDv7 ID value.  Used for models that
+    operate like timeseries, such as runs, states, and logs.
+    """
+
+    id: UUID = Field(default_factory=uuid7)
 
 
 class ObjectBaseModel(IDBaseModel):

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -9,8 +9,8 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, Field
 from rich.repr import RichReprResult
 from typing_extensions import Self
-from uuid_extensions import uuid7
 
+from prefect.types import uuid7
 from prefect.types._datetime import (
     DateTime,
     human_friendly_diff,

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from rich.repr import RichReprResult
 from typing_extensions import Self
 
-from prefect.types import uuid7
+from prefect._internal.uuid7 import uuid7
 from prefect.types._datetime import (
     DateTime,
     human_friendly_diff,

--- a/src/prefect/_internal/uuid7.py
+++ b/src/prefect/_internal/uuid7.py
@@ -1,0 +1,11 @@
+from typing import cast
+from uuid import UUID
+
+from uuid_extensions import uuid7 as _uuid7  # pyright: ignore[reportMissingTypeStubs]
+
+
+def uuid7() -> UUID:
+    return cast(UUID, _uuid7())
+
+
+__all__ = ["uuid7"]

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -52,6 +52,7 @@ from prefect._internal.schemas.validators import (
     validate_not_negative,
     validate_parent_and_ref_diff,
 )
+from prefect._internal.uuid7 import uuid7
 from prefect._result_records import ResultRecordMetadata
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.settings import PREFECT_CLOUD_API_URL, PREFECT_CLOUD_UI_URL
@@ -62,7 +63,6 @@ from prefect.types import (
     NonNegativeInteger,
     PositiveInteger,
     StrictVariableValue,
-    uuid7,
 )
 from prefect.types._datetime import DateTime, now
 from prefect.types.names import (

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -33,7 +33,6 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Literal, Self, TypeVar
-from uuid_extensions import uuid7
 
 from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.compatibility.migration import getattr_migration
@@ -63,6 +62,7 @@ from prefect.types import (
     NonNegativeInteger,
     PositiveInteger,
     StrictVariableValue,
+    uuid7,
 )
 from prefect.types._datetime import DateTime, now
 from prefect.types.names import (

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
     overload,
 )
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import orjson
 from pydantic import (
@@ -33,10 +33,15 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Literal, Self, TypeVar
+from uuid_extensions import uuid7
 
 from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.compatibility.migration import getattr_migration
-from prefect._internal.schemas.bases import ObjectBaseModel, PrefectBaseModel
+from prefect._internal.schemas.bases import (
+    ObjectBaseModel,
+    PrefectBaseModel,
+    TimeSeriesBaseModel,
+)
 from prefect._internal.schemas.fields import CreatedBy, UpdatedBy
 from prefect._internal.schemas.validators import (
     get_or_create_run_name,
@@ -184,7 +189,7 @@ def data_discriminator(x: Any) -> str:
     return "Any"
 
 
-class State(ObjectBaseModel, Generic[R]):
+class State(TimeSeriesBaseModel, ObjectBaseModel, Generic[R]):
     """
     The state of a run.
     """
@@ -415,7 +420,7 @@ class State(ObjectBaseModel, Generic[R]):
         """
         return self.model_copy(
             update={
-                "id": uuid4(),
+                "id": uuid7(),
                 "created": now("UTC"),
                 "updated": now("UTC"),
                 "timestamp": now("UTC"),
@@ -511,7 +516,7 @@ class FlowRunPolicy(PrefectBaseModel):
         return values
 
 
-class FlowRun(ObjectBaseModel):
+class FlowRun(TimeSeriesBaseModel, ObjectBaseModel):
     name: str = Field(
         default_factory=lambda: generate_slug(2),
         description=(
@@ -767,7 +772,7 @@ class Constant(TaskRunInput):
     type: str
 
 
-class TaskRun(ObjectBaseModel):
+class TaskRun(TimeSeriesBaseModel, ObjectBaseModel):
     name: str = Field(
         default_factory=lambda: generate_slug(2), examples=["my-task-run"]
     )
@@ -1307,7 +1312,7 @@ class SavedSearch(ObjectBaseModel):
     )
 
 
-class Log(ObjectBaseModel):
+class Log(TimeSeriesBaseModel, ObjectBaseModel):
     """An ORM representation of log data."""
 
     name: str = Field(default=..., description="The logger name.")

--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -13,7 +13,7 @@ from typing import (
     Tuple,
     Union,
 )
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from pydantic import (
     AfterValidator,
@@ -23,6 +23,7 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Annotated, Self
+from uuid_extensions import uuid7
 
 import prefect.types._datetime
 from prefect._internal.schemas.bases import PrefectBaseModel
@@ -135,7 +136,7 @@ class Event(PrefectBaseModel):
         description="An open-ended set of data describing what happened",
     )
     id: UUID = Field(
-        default_factory=uuid4,
+        default_factory=uuid7,
         description="The client-provided identifier of this event",
     )
     follows: Optional[UUID] = Field(

--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -23,7 +23,6 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Annotated, Self
-from uuid_extensions import uuid7
 
 import prefect.types._datetime
 from prefect._internal.schemas.bases import PrefectBaseModel
@@ -31,6 +30,7 @@ from prefect.logging import get_logger
 from prefect.settings import (
     PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE,
 )
+from prefect.types import uuid7
 
 from .labelling import Labelled
 

--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -26,11 +26,11 @@ from typing_extensions import Annotated, Self
 
 import prefect.types._datetime
 from prefect._internal.schemas.bases import PrefectBaseModel
+from prefect._internal.uuid7 import uuid7
 from prefect.logging import get_logger
 from prefect.settings import (
     PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE,
 )
-from prefect.types import uuid7
 
 from .labelling import Labelled
 

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -16,7 +16,6 @@ from fastapi import (
 )
 from packaging.version import Version
 from sqlalchemy.ext.asyncio import AsyncSession
-from uuid_extensions import uuid7
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
@@ -31,7 +30,7 @@ from prefect.server.models.work_queues import (
 from prefect.server.models.workers import emit_work_pool_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
 from prefect.server.utilities.server import PrefectRouter
-from prefect.types import DateTime
+from prefect.types import DateTime, uuid7
 from prefect.types._datetime import now
 
 if TYPE_CHECKING:

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect._internal.uuid7 import uuid7
 from prefect.server.api.validation import validate_job_variable_defaults_for_work_pool
 from prefect.server.database import PrefectDBInterface, provide_database_interface
 from prefect.server.models.deployments import mark_deployments_ready
@@ -30,7 +31,7 @@ from prefect.server.models.work_queues import (
 from prefect.server.models.workers import emit_work_pool_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
 from prefect.server.utilities.server import PrefectRouter
-from prefect.types import DateTime, uuid7
+from prefect.types import DateTime
 from prefect.types._datetime import now
 
 if TYPE_CHECKING:

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -3,7 +3,7 @@ Routes for interacting with work queue objects.
 """
 
 from typing import TYPE_CHECKING, List, Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import sqlalchemy as sa
 from fastapi import (
@@ -16,6 +16,7 @@ from fastapi import (
 )
 from packaging.version import Version
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_extensions import uuid7
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
@@ -184,7 +185,7 @@ async def create_work_pool(
             )
 
             await emit_work_pool_status_event(
-                event_id=uuid4(),
+                event_id=uuid7(),
                 occurred=now("UTC"),
                 pre_update_work_pool=None,
                 work_pool=model,

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -43,6 +43,7 @@ from pydantic import (
 )
 from typing_extensions import Self, TypeAlias
 
+from prefect._internal.uuid7 import uuid7
 from prefect.blocks.abstract import NotificationBlock, NotificationError
 from prefect.blocks.core import Block
 from prefect.blocks.webhook import Webhook
@@ -80,8 +81,8 @@ from prefect.server.utilities.user_templates import (
     render_user_template,
     validate_user_template,
 )
-from prefect.types import StrictVariableValue, uuid7
-from prefect.types._datetime import DateTime, now, parse_datetime
+from prefect.types import DateTime, StrictVariableValue
+from prefect.types._datetime import now, parse_datetime
 from prefect.utilities.schema_tools.hydration import (
     HydrationContext,
     HydrationError,

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -42,7 +42,6 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Self, TypeAlias
-from uuid_extensions import uuid7
 
 from prefect.blocks.abstract import NotificationBlock, NotificationError
 from prefect.blocks.core import Block
@@ -81,7 +80,7 @@ from prefect.server.utilities.user_templates import (
     render_user_template,
     validate_user_template,
 )
-from prefect.types import StrictVariableValue
+from prefect.types import StrictVariableValue, uuid7
 from prefect.types._datetime import DateTime, now, parse_datetime
 from prefect.utilities.schema_tools.hydration import (
     HydrationContext,

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -28,7 +28,7 @@ from typing import (
     Union,
     cast,
 )
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import jinja2
 import orjson
@@ -42,6 +42,7 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Self, TypeAlias
+from uuid_extensions import uuid7
 
 from prefect.blocks.abstract import NotificationBlock, NotificationError
 from prefect.blocks.core import Block
@@ -155,7 +156,7 @@ class Action(PrefectBaseModel, abc.ABC):
         )
 
         async with PrefectServerEventsClient() as events:
-            triggered_event_id = uuid4()
+            triggered_event_id = uuid7()
             await events.emit(
                 Event(
                     occurred=triggered_action.triggered,
@@ -178,7 +179,7 @@ class Action(PrefectBaseModel, abc.ABC):
                         **self._result_details,
                     },
                     follows=triggered_event_id,
-                    id=uuid4(),
+                    id=uuid7(),
                 )
             )
 
@@ -207,7 +208,7 @@ class Action(PrefectBaseModel, abc.ABC):
             resource["prefect.posture"] = automation.trigger.posture
 
         async with PrefectServerEventsClient() as events:
-            triggered_event_id = uuid4()
+            triggered_event_id = uuid7()
             await events.emit(
                 Event(
                     occurred=triggered_action.triggered,
@@ -240,7 +241,7 @@ class Action(PrefectBaseModel, abc.ABC):
                         **action_details,
                         **self._result_details,
                     },
-                    id=uuid4(),
+                    id=uuid7(),
                     follows=triggered_event_id,
                 )
             )

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -27,6 +27,7 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Self, TypeAlias
+from uuid_extensions import uuid7
 
 from prefect.logging import get_logger
 from prefect.server.events.actions import ServerActionTypes
@@ -153,7 +154,7 @@ class CompositeTrigger(Trigger, abc.ABC):
                     else None
                 ),
             },
-            id=uuid4(),
+            id=uuid7(),
         )
 
     def _set_parent(self, value: "Union[Trigger , Automation]"):
@@ -462,7 +463,7 @@ class EventTrigger(ResourceTrigger):
                     else None
                 ),
             },
-            id=uuid4(),
+            id=uuid7(),
         )
 
 
@@ -644,7 +645,7 @@ class AutomationSort(AutoEnum):
 class Firing(PrefectBaseModel):
     """Represents one instance of a trigger firing"""
 
-    id: UUID = Field(default_factory=uuid4)
+    id: UUID = Field(default_factory=uuid7)
 
     trigger: ServerTriggerTypes = Field(
         default=..., description="The trigger that is firing"
@@ -721,7 +722,7 @@ class TriggeredAction(PrefectBaseModel):
     )
 
     id: UUID = Field(
-        default_factory=uuid4,
+        default_factory=uuid7,
         description="A unique key representing a single triggering of an action",
     )
 

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -28,6 +28,7 @@ from pydantic import (
 )
 from typing_extensions import Self, TypeAlias
 
+from prefect._internal.uuid7 import uuid7
 from prefect.logging import get_logger
 from prefect.server.events.actions import ServerActionTypes
 from prefect.server.events.schemas.events import (
@@ -39,7 +40,7 @@ from prefect.server.events.schemas.events import (
 )
 from prefect.server.schemas.actions import ActionBaseModel
 from prefect.server.utilities.schemas import ORMBaseModel, PrefectBaseModel
-from prefect.types import DateTime, uuid7
+from prefect.types import DateTime
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -27,7 +27,6 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Self, TypeAlias
-from uuid_extensions import uuid7
 
 from prefect.logging import get_logger
 from prefect.server.events.actions import ServerActionTypes
@@ -40,7 +39,7 @@ from prefect.server.events.schemas.events import (
 )
 from prefect.server.schemas.actions import ActionBaseModel
 from prefect.server.utilities.schemas import ORMBaseModel, PrefectBaseModel
-from prefect.types import DateTime
+from prefect.types import DateTime, uuid7
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -16,7 +16,6 @@ from sqlalchemy import delete, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Select
-from uuid_extensions import uuid7
 
 from prefect.logging import get_logger
 from prefect.server import models, schemas
@@ -31,6 +30,7 @@ from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS,
     PREFECT_API_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME,
 )
+from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 
 T = TypeVar("T", bound=tuple[Any, ...])

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -17,6 +17,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Select
 
+from prefect._internal.uuid7 import uuid7
 from prefect.logging import get_logger
 from prefect.server import models, schemas
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
@@ -30,7 +31,6 @@ from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS,
     PREFECT_API_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME,
 )
-from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 
 T = TypeVar("T", bound=tuple[Any, ...])

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -9,13 +9,14 @@ import datetime
 import logging
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy import delete, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Select
+from uuid_extensions import uuid7
 
 from prefect.logging import get_logger
 from prefect.server import models, schemas
@@ -752,7 +753,7 @@ async def _generate_scheduled_flow_runs(
         for date in dates:
             runs.append(
                 {
-                    "id": uuid4(),
+                    "id": uuid7(),
                     "flow_id": deployment.flow_id,
                     "deployment_id": deployment_id,
                     "deployment_version": deployment.version,
@@ -825,7 +826,7 @@ async def _insert_scheduled_flow_runs(
 
     # insert flow run states that correspond to the newly-insert rows
     insert_flow_run_states: list[dict[str, Any]] = [
-        {"id": uuid4(), "flow_run_id": r["id"], **r["state"]}
+        {"id": uuid7(), "flow_run_id": r["id"], **r["state"]}
         for r in runs
         if r["id"] in inserted_flow_run_ids
     ]

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from cachetools import TTLCache
 from sqlalchemy.ext.asyncio import AsyncSession
-from uuid_extensions import uuid7
 
 from prefect.server import models, schemas
 from prefect.server.database.orm_models import (
@@ -21,6 +20,7 @@ from prefect.server.events.schemas.events import Event
 from prefect.server.models import deployments
 from prefect.server.schemas.statuses import DeploymentStatus
 from prefect.settings import PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL
+from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 from prefect.utilities.text import truncated_to
 

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from cachetools import TTLCache
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect._internal.uuid7 import uuid7
 from prefect.server import models, schemas
 from prefect.server.database.orm_models import (
     ORMDeployment,
@@ -20,7 +21,6 @@ from prefect.server.events.schemas.events import Event
 from prefect.server.models import deployments
 from prefect.server.schemas.statuses import DeploymentStatus
 from prefect.settings import PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL
-from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 from prefect.utilities.text import truncated_to
 

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, MutableMapping, Optional, Set, Union
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from cachetools import TTLCache
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_extensions import uuid7
 
 from prefect.server import models, schemas
 from prefect.server.database.orm_models import (
@@ -356,7 +357,7 @@ async def deployment_status_event(
             "prefect.resource.name": f"{deployment.name}",
         },
         related=related_work_queue_and_pool_info,
-        id=uuid4(),
+        id=uuid7(),
     )
 
 
@@ -392,7 +393,7 @@ async def work_queue_status_event(
             "prefect.resource.role": "work-queue",
         },
         related=related_work_pool_info,
-        id=uuid4(),
+        id=uuid7(),
     )
 
 

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -20,13 +20,13 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.schemas as schemas
+from prefect._internal.uuid7 import uuid7
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
 from prefect.server.events.clients import PrefectServerEventsClient
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.events import work_pool_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
 from prefect.server.utilities.database import UUID as PrefectUUID
-from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 
 DEFAULT_AGENT_WORK_POOL_NAME = "default-agent-pool"

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -13,11 +13,12 @@ from typing import (
     Sequence,
     Union,
 )
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_extensions import uuid7
 
 import prefect.server.schemas as schemas
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
@@ -239,7 +240,7 @@ async def update_work_pool(
                 update_data["status"] = schemas.statuses.WorkPoolStatus.NOT_READY
 
     if "status" in update_data:
-        update_data["last_status_event_id"] = uuid4()
+        update_data["last_status_event_id"] = uuid7()
         update_data["last_transitioned_status_at"] = now("UTC")
 
     update_stmt = (

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -18,7 +18,6 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from uuid_extensions import uuid7
 
 import prefect.server.schemas as schemas
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
@@ -27,6 +26,7 @@ from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.events import work_pool_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
 from prefect.server.utilities.database import UUID as PrefectUUID
+from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 
 DEFAULT_AGENT_WORK_POOL_NAME = "default-agent-pool"

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -48,6 +48,7 @@ from prefect.server.schemas.statuses import WorkPoolStatus
 from prefect.server.utilities.schemas.bases import (
     ORMBaseModel,
     PrefectBaseModel,
+    TimeSeriesBaseModel,
 )
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
 from prefect.types import (
@@ -175,7 +176,7 @@ class ConcurrencyOptions(BaseModel):
     collision_strategy: ConcurrencyLimitStrategy
 
 
-class FlowRun(ORMBaseModel):
+class FlowRun(TimeSeriesBaseModel, ORMBaseModel):
     """An ORM representation of flow run data."""
 
     name: str = Field(
@@ -414,7 +415,7 @@ class Constant(TaskRunInput):
     type: str
 
 
-class TaskRun(ORMBaseModel):
+class TaskRun(TimeSeriesBaseModel, ORMBaseModel):
     """An ORM representation of task run data."""
 
     name: str = Field(
@@ -931,7 +932,7 @@ class SavedSearch(ORMBaseModel):
     )
 
 
-class Log(ORMBaseModel):
+class Log(TimeSeriesBaseModel, ORMBaseModel):
     """An ORM representation of log data."""
 
     name: str = Field(default=..., description="The logger name.")

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -14,13 +14,17 @@ from typing import (
     Union,
     overload,
 )
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from pydantic import ConfigDict, Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Self
+from uuid_extensions import uuid7
 
 from prefect.client.schemas import objects
-from prefect.server.utilities.schemas.bases import IDBaseModel, PrefectBaseModel
+from prefect.server.utilities.schemas.bases import (
+    PrefectBaseModel,
+    TimeSeriesBaseModel,
+)
 from prefect.types._datetime import DateTime, now
 from prefect.utilities.collections import AutoEnum
 
@@ -96,7 +100,7 @@ class StateDetails(PrefectBaseModel):
     traceparent: Optional[str] = None
 
 
-class StateBaseModel(IDBaseModel):
+class StateBaseModel(TimeSeriesBaseModel):
     def orm_dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """
         This method is used as a convenience method for constructing fixtues by first
@@ -212,7 +216,7 @@ class State(StateBaseModel):
         """
         return self.model_copy(
             update={
-                "id": uuid4(),
+                "id": uuid7(),
                 "created": now("UTC"),
                 "updated": now("UTC"),
                 "timestamp": now("UTC"),

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -19,12 +19,12 @@ from uuid import UUID
 from pydantic import ConfigDict, Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Self
 
+from prefect._internal.uuid7 import uuid7
 from prefect.client.schemas import objects
 from prefect.server.utilities.schemas.bases import (
     PrefectBaseModel,
     TimeSeriesBaseModel,
 )
-from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 from prefect.utilities.collections import AutoEnum
 

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -18,13 +18,13 @@ from uuid import UUID
 
 from pydantic import ConfigDict, Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Self
-from uuid_extensions import uuid7
 
 from prefect.client.schemas import objects
 from prefect.server.utilities.schemas.bases import (
     PrefectBaseModel,
     TimeSeriesBaseModel,
 )
+from prefect.types import uuid7
 from prefect.types._datetime import DateTime, now
 from prefect.utilities.collections import AutoEnum
 

--- a/src/prefect/server/utilities/schemas/__init__.py
+++ b/src/prefect/server/utilities/schemas/__init__.py
@@ -4,6 +4,7 @@ from .bases import (
     ORMBaseModel,
     PrefectBaseModel,
     PrefectDescriptorBase,
+    TimeSeriesBaseModel,
     get_class_fields_only,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "ORMBaseModel",
     "PrefectBaseModel",
     "PrefectDescriptorBase",
+    "TimeSeriesBaseModel",
     "get_class_fields_only",
 ]

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic.config import JsonDict
 from typing_extensions import Self
 
-from prefect.types import uuid7
+from prefect._internal.uuid7 import uuid7
 from prefect.types._datetime import DateTime, human_friendly_diff
 
 if TYPE_CHECKING:

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -7,8 +7,8 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.config import JsonDict
 from typing_extensions import Self
-from uuid_extensions import uuid7
 
+from prefect.types import uuid7
 from prefect.types._datetime import DateTime, human_friendly_diff
 
 if TYPE_CHECKING:

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.config import JsonDict
 from typing_extensions import Self
+from uuid_extensions import uuid7
 
 from prefect.types._datetime import DateTime, human_friendly_diff
 
@@ -201,6 +202,15 @@ class IDBaseModel(PrefectBaseModel):
 
     _reset_fields: ClassVar[set[str]] = {"id"}
     id: UUID = Field(default_factory=uuid4)
+
+
+class TimeSeriesBaseModel(IDBaseModel):
+    """
+    A PrefectBaseModel with a time-oriented UUIDv7 ID value.  Used for models that
+    operate like timeseries, such as runs, states, and logs.
+    """
+
+    id: UUID = Field(default_factory=uuid7)
 
 
 class ORMBaseModel(IDBaseModel):

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -20,7 +20,6 @@ from typing import (
 )
 
 from typing_extensions import ParamSpec, Self, TypeVar
-from uuid_extensions import uuid7
 
 from prefect.client.schemas.objects import TaskRunInput
 from prefect.exceptions import MappingLengthMismatch, MappingMissingIterable
@@ -32,6 +31,7 @@ from prefect.futures import (
 )
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.settings import PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS
+from prefect.types import uuid7
 from prefect.utilities.annotations import allow_failure, quote, unmapped
 from prefect.utilities.callables import (
     collapse_variadic_parameters,

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -20,6 +20,7 @@ from typing import (
 )
 
 from typing_extensions import ParamSpec, Self, TypeVar
+from uuid_extensions import uuid7
 
 from prefect.client.schemas.objects import TaskRunInput
 from prefect.exceptions import MappingLengthMismatch, MappingMissingIterable
@@ -290,7 +291,7 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture[R]]):
         from prefect.context import FlowRunContext
         from prefect.task_engine import run_task_async, run_task_sync
 
-        task_run_id = uuid.uuid4()
+        task_run_id = uuid7()
         cancel_event = threading.Event()
         self._cancel_events[task_run_id] = cancel_event
         context = copy_context()

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -21,6 +21,7 @@ from typing import (
 
 from typing_extensions import ParamSpec, Self, TypeVar
 
+from prefect._internal.uuid7 import uuid7
 from prefect.client.schemas.objects import TaskRunInput
 from prefect.exceptions import MappingLengthMismatch, MappingMissingIterable
 from prefect.futures import (
@@ -31,7 +32,6 @@ from prefect.futures import (
 )
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.settings import PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS
-from prefect.types import uuid7
 from prefect.utilities.annotations import allow_failure, quote, unmapped
 from prefect.utilities.callables import (
     collapse_variadic_parameters,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -30,6 +30,7 @@ from typing import (
 from uuid import UUID, uuid4
 
 from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypeIs
+from uuid_extensions import uuid7
 
 import prefect.states
 from prefect.cache_policies import DEFAULT, NO_CACHE, CachePolicy
@@ -953,7 +954,7 @@ class Task(Generic[P, R]):
                 if flow_run_context and flow_run_context.flow_run
                 else None
             )
-            task_run_id = id or uuid4()
+            task_run_id = id or uuid7()
             state = prefect.states.Pending(
                 state_details=StateDetails(
                     task_run_id=task_run_id,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -32,6 +32,7 @@ from uuid import UUID, uuid4
 from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypeIs
 
 import prefect.states
+from prefect._internal.uuid7 import uuid7
 from prefect.cache_policies import DEFAULT, NO_CACHE, CachePolicy
 from prefect.client.orchestration import get_client
 from prefect.client.schemas import TaskRun
@@ -57,7 +58,6 @@ from prefect.results import (
 )
 from prefect.settings.context import get_current_settings
 from prefect.states import Pending, Scheduled, State
-from prefect.types import uuid7
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import run_coro_as_sync, sync_compatible
 from prefect.utilities.callables import (

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -30,7 +30,6 @@ from typing import (
 from uuid import UUID, uuid4
 
 from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypeIs
-from uuid_extensions import uuid7
 
 import prefect.states
 from prefect.cache_policies import DEFAULT, NO_CACHE, CachePolicy
@@ -58,6 +57,7 @@ from prefect.results import (
 )
 from prefect.settings.context import get_current_settings
 from prefect.states import Pending, Scheduled, State
+from prefect.types import uuid7
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import run_coro_as_sync, sync_compatible
 from prefect.utilities.callables import (

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Annotated, Any, Optional, TypeVar, Union
+from typing import Annotated, Any, Optional, TypeVar, Union, cast
+from uuid import UUID
 from typing_extensions import Literal
 import orjson
 import pydantic
-
+from uuid_extensions import uuid7 as _uuid7  # pyright: ignore[reportMissingTypeStubs]
 
 from ._datetime import DateTime, Date
 from .names import (
@@ -153,6 +154,10 @@ KeyValueLabelsField = Annotated[
 ]
 
 
+def uuid7() -> UUID:
+    return cast(UUID, _uuid7())
+
+
 __all__ = [
     "BANNED_CHARACTERS",
     "WITHOUT_BANNED_CHARACTERS",
@@ -173,4 +178,5 @@ __all__ = [
     "SecretDict",
     "StatusCode",
     "StrictVariableValue",
+    "uuid7",
 ]

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from typing_extensions import Literal
 import orjson
 import pydantic
-from uuid_extensions import uuid7 as _uuid7  # pyright: ignore[reportMissingTypeStubs]
 
 from ._datetime import DateTime, Date
 from .names import (
@@ -154,10 +153,6 @@ KeyValueLabelsField = Annotated[
 ]
 
 
-def uuid7() -> UUID:
-    return cast(UUID, _uuid7())
-
-
 __all__ = [
     "BANNED_CHARACTERS",
     "WITHOUT_BANNED_CHARACTERS",
@@ -178,5 +173,4 @@ __all__ = [
     "SecretDict",
     "StatusCode",
     "StrictVariableValue",
-    "uuid7",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3647,6 +3647,7 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
     { name = "ujson" },
+    { name = "uuid7" },
     { name = "uv" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -3861,6 +3862,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0,!=0.12.2,<0.16.0" },
     { name = "typing-extensions", specifier = ">=4.10.0,<5.0.0" },
     { name = "ujson", specifier = ">=5.8.0,<6.0.0" },
+    { name = "uuid7", specifier = ">=0.1.0" },
     { name = "uv", specifier = ">=0.6.0" },
     { name = "uvicorn", specifier = ">=0.14.0,!=0.29.0" },
     { name = "websockets", specifier = ">=13.0,<16.0" },
@@ -6686,6 +6688,15 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
+]
+
+[[package]]
+name = "uuid7"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477 },
 ]
 
 [[package]]


### PR DESCRIPTION
[UUIDv7](https://uuid7.com/) is a UUID generation mechanism that
guarantees that UUIDs are both random/unique, but also sequential in
time.  This makes them ideal for storing any time-oriented rows in
databases, since they'll have great data locality.

We've made this change to Prefect Cloud, and have seen some significant
improvements in write throughput, overall I/O, and in page cache hit
ratios.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
