### PR TITLE
Bugfix: Scatterplot pagination

### DIFF
--- a/ui/src/pages/Runs.vue
+++ b/ui/src/pages/Runs.vue
@@ -31,7 +31,6 @@
                       :end-date="flowRunsFilterRef.flowRuns?.expectedStartTimeBefore"
                       class="runs__scatter-plot"
                     />
-                    <!-- <p-pager v-model:page="flowRunsHistoryPage" :pages="flowRunsHistoryPages" /> -->
                   </p-card>
                 </template>
 

--- a/ui/src/pages/Runs.vue
+++ b/ui/src/pages/Runs.vue
@@ -200,7 +200,7 @@
   const taskRunsSort = useRouteQueryParam('task-runs-sort', TaskRunSortValuesSortParam, 'EXPECTED_START_TIME_DESC')
   const flowRunsPage = useRouteQueryParam('flow-runs-page', NumberRouteParam, 1)
 
-  const { value: limit } = useLocalStorage('workspace-runs-list-limit', 10)
+  const { value: limit } = useLocalStorage('workspace-runs-list-limit', 100)
 
   const flowRunsFilter: Getter<FlowRunsPaginationFilter> = () => {
     const filter = mapper.map('SavedSearchFilter', dashboardFilter, 'FlowRunsFilter')

--- a/ui/src/pages/Runs.vue
+++ b/ui/src/pages/Runs.vue
@@ -31,6 +31,7 @@
                       :end-date="flowRunsFilterRef.flowRuns?.expectedStartTimeBefore"
                       class="runs__scatter-plot"
                     />
+                    <!-- <p-pager v-model:page="flowRunsHistoryPage" :pages="flowRunsHistoryPages" /> -->
                   </p-card>
                 </template>
 
@@ -54,9 +55,10 @@
                   </template>
                 </p-list-header>
 
+                <p-pager v-model:limit="limit" v-model:page="flowRunsPage" :pages="flowRunPages" />
+
                 <template v-if="flowRunCount > 0">
                   <FlowRunList v-model:selected="selectedFlowRuns" :selectable="flowRunsAreSelectable" :flow-runs />
-                  <p-pager v-model:limit="limit" v-model:page="flowRunsPage" :pages="flowRunPages" />
                 </template>
 
                 <template v-else-if="!flowRunsSubscription.executed && flowRunsSubscription.loading">
@@ -103,8 +105,8 @@
                 </p-list-header>
 
                 <template v-if="taskRunCount > 0">
-                  <TaskRunList v-model:selected="selectedTaskRuns" :selectable="taskRunsAreSelectable" :task-runs="taskRuns" />
                   <p-pager v-model:limit="limit" v-model:page="taskRunsPage" :pages="taskRunsPages" />
+                  <TaskRunList v-model:selected="selectedTaskRuns" :selectable="taskRunsAreSelectable" :task-runs="taskRuns" />
                 </template>
 
                 <template v-else-if="!taskRunsSubscriptions.executed && taskRunsSubscriptions.loading">
@@ -246,7 +248,7 @@
       },
       sort: flowRunsSort.value,
       limit: limit.value,
-      page: flowRunsPage.value,
+      offset: (flowRunsPage.value - 1) * limit.value,
     })
   }
 


### PR DESCRIPTION
This PR fixes an issue where the flow run scatterplot query wasn't respecting pages because the endpoint works on an offset model instead of a paginated one. It also moves the pager to the top of the list and bumps the default number of items from 10 => 100. This means users will be able to paginate through the scatterplot and runs list at the same time, like so:


https://github.com/user-attachments/assets/a145edfd-f371-4786-8775-9f236eb0c547


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
