### PR TITLE
Move generation hooks to pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+default_install_hook_types: 
+  - pre-commit
+  - pre-push
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.5
@@ -53,6 +57,8 @@ repos:
               scripts/generate_settings_ref.py|
               scripts/run_precommit_generation_scripts.py
           )$
+        stages:
+          - pre-push
       - id: check-ui-v2
         name: Check UI v2
         language: system
@@ -88,3 +94,5 @@ repos:
               ui-v2/package.json
           )$
         pass_filenames: false
+        stages:
+          - pre-push


### PR DESCRIPTION
These hooks take a while to run and are unnecessary on every commit. This change means they only run before pushing to a remote branch.

Note that contributors will need to run `pre-commit install` again to install the pre-push hooks.
