### PR TITLE
Disable `kopf` scanning for `prefect-kubernetes` observer

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -37,6 +37,11 @@ orchestration_client: PrefectClient | None = None
 
 
 @kopf.on.startup()
+def configure(settings: kopf.OperatorSettings, **_):
+    settings.scanning.disabled = True
+
+
+@kopf.on.startup()
 async def initialize_clients(logger: kopf.Logger, **kwargs: Any):
     logger.info("Initializing clients")
     global events_client


### PR DESCRIPTION
This change disables `kopf` scanning for the `prefect-kubernetes` observer to avoid logging errors when the observer runs without the necessary permissions to discover namespaces and CRDs. That discovery isn't necessary for the observer to function, but it does log annoying errors.

Here's an exerpt from the setting docstring:

> If disabled or if enabled but the permission is not granted, then only the specific namespaces will be served, with namespace patterns ignored; and only the resources detected at startup will be served, with added CRDs or CRD versions being ignored, and the deleted CRDs causing failures.
> 
> The default mode is good enough for most cases, unless the strict (non-dynamic) mode is intended -- to prevent the warnings in the logs.


Closes https://github.com/PrefectHQ/prefect-helm/issues/485
