### PR TITLE
Task worker hygiene

### DIFF
--- a/src/prefect/_internal/compatibility/blocks.py
+++ b/src/prefect/_internal/compatibility/blocks.py
@@ -1,0 +1,27 @@
+import inspect
+from typing import Any
+
+from prefect.filesystems import NullFileSystem, WritableFileSystem
+
+
+async def _call_explicitly_async_block_method(
+    block: WritableFileSystem | NullFileSystem,
+    method: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """
+    TODO: remove this once we have explicit async methods on all storage blocks
+
+    see https://github.com/PrefectHQ/prefect/issues/15008
+    """
+    if hasattr(block, f"a{method}"):  # explicit async method
+        return await getattr(block, f"a{method}")(*args, **kwargs)
+    elif hasattr(getattr(block, method, None), "aio"):  # sync_compatible
+        return await getattr(block, method).aio(block, *args, **kwargs)
+    else:  # should not happen in prefect, but users can override impls
+        maybe_coro = getattr(block, method)(*args, **kwargs)
+        if inspect.isawaitable(maybe_coro):
+            return await maybe_coro
+        else:
+            return maybe_coro

--- a/src/prefect/_internal/compatibility/blocks.py
+++ b/src/prefect/_internal/compatibility/blocks.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from prefect.filesystems import NullFileSystem, WritableFileSystem
 
 
-async def _call_explicitly_async_block_method(
+async def _call_explicitly_async_block_method(  # pyright: ignore[reportUnusedFunction]
     block: Union[WritableFileSystem, NullFileSystem],
     method: str,
     args: tuple[Any, ...],

--- a/src/prefect/_internal/compatibility/blocks.py
+++ b/src/prefect/_internal/compatibility/blocks.py
@@ -1,11 +1,11 @@
 import inspect
-from typing import Any
+from typing import Any, Union
 
 from prefect.filesystems import NullFileSystem, WritableFileSystem
 
 
 async def _call_explicitly_async_block_method(
-    block: WritableFileSystem | NullFileSystem,
+    block: Union[WritableFileSystem, NullFileSystem],
     method: str,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],

--- a/src/prefect/_internal/compatibility/blocks.py
+++ b/src/prefect/_internal/compatibility/blocks.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from prefect.filesystems import NullFileSystem, WritableFileSystem
 
 
-async def _call_explicitly_async_block_method(  # pyright: ignore[reportUnusedFunction]
+async def call_explicitly_async_block_method(
     block: Union[WritableFileSystem, NullFileSystem],
     method: str,
     args: tuple[Any, ...],

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -34,7 +34,7 @@ from typing_extensions import ParamSpec, Self
 import prefect
 import prefect.types._datetime
 from prefect._internal.compatibility.async_dispatch import async_dispatch
-from prefect._internal.compatibility.blocks import _call_explicitly_async_block_method
+from prefect._internal.compatibility.blocks import call_explicitly_async_block_method
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._result_records import R, ResultRecord, ResultRecordMetadata
@@ -484,7 +484,7 @@ class ResultStore(BaseModel):
             # TODO: Add an `exists` method to commonly used storage blocks
             # so the entire payload doesn't need to be read
             try:
-                metadata_content = await _call_explicitly_async_block_method(
+                metadata_content = await call_explicitly_async_block_method(
                     self.metadata_storage, "read_path", (key,), {}
                 )
                 if metadata_content is None:
@@ -495,7 +495,7 @@ class ResultStore(BaseModel):
                 return False
         else:
             try:
-                content = await _call_explicitly_async_block_method(
+                content = await call_explicitly_async_block_method(
                     self.result_storage, "read_path", (key,), {}
                 )
                 if content is None:
@@ -580,7 +580,7 @@ class ResultStore(BaseModel):
             self.result_storage = await aget_default_result_storage()
 
         if self.metadata_storage is not None:
-            metadata_content = await _call_explicitly_async_block_method(
+            metadata_content = await call_explicitly_async_block_method(
                 self.metadata_storage,
                 "read_path",
                 (key,),
@@ -590,7 +590,7 @@ class ResultStore(BaseModel):
             assert metadata.storage_key is not None, (
                 "Did not find storage key in metadata"
             )
-            result_content = await _call_explicitly_async_block_method(
+            result_content = await call_explicitly_async_block_method(
                 self.result_storage,
                 "read_path",
                 (metadata.storage_key,),
@@ -603,7 +603,7 @@ class ResultStore(BaseModel):
             )
             await emit_result_read_event(self, resolved_key_path)
         else:
-            content = await _call_explicitly_async_block_method(
+            content = await call_explicitly_async_block_method(
                 self.result_storage,
                 "read_path",
                 (key,),
@@ -785,13 +785,13 @@ class ResultStore(BaseModel):
 
         # If metadata storage is configured, write result and metadata separately
         if self.metadata_storage is not None:
-            await _call_explicitly_async_block_method(
+            await call_explicitly_async_block_method(
                 self.result_storage,
                 "write_path",
                 (result_record.metadata.storage_key,),
                 {"content": result_record.serialize_result()},
             )
-            await _call_explicitly_async_block_method(
+            await call_explicitly_async_block_method(
                 self.metadata_storage,
                 "write_path",
                 (base_key,),
@@ -800,7 +800,7 @@ class ResultStore(BaseModel):
             await emit_result_write_event(self, result_record.metadata.storage_key)
         # Otherwise, write the result metadata and result together
         else:
-            await _call_explicitly_async_block_method(
+            await call_explicitly_async_block_method(
                 self.result_storage,
                 "write_path",
                 (result_record.metadata.storage_key,),
@@ -991,7 +991,7 @@ class ResultStore(BaseModel):
             ),
         )
 
-        await _call_explicitly_async_block_method(
+        await call_explicitly_async_block_method(
             self.result_storage,
             "write_path",
             (f"parameters/{identifier}",),
@@ -1010,7 +1010,7 @@ class ResultStore(BaseModel):
                 "Result store is not configured - must have a result storage block to read parameters"
             )
         record: ResultRecord[Any] = ResultRecord[Any].deserialize(
-            await _call_explicitly_async_block_method(
+            await call_explicitly_async_block_method(
                 self.result_storage,
                 "read_path",
                 (f"parameters/{identifier}",),

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -22,7 +22,7 @@ from websockets.exceptions import InvalidStatus
 
 import prefect.types._datetime
 from prefect import Task
-from prefect._internal.compatibility.blocks import _call_explicitly_async_block_method
+from prefect._internal.compatibility.blocks import call_explicitly_async_block_method
 from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.cache_policies import DEFAULT, NO_CACHE
 from prefect.client.orchestration import get_client
@@ -540,7 +540,7 @@ async def store_parameters(
         ),
     )
 
-    await _call_explicitly_async_block_method(
+    await call_explicitly_async_block_method(
         result_store.result_storage,
         "write_path",
         (f"parameters/{identifier}",),
@@ -565,7 +565,7 @@ async def read_parameters(
             "Result store is not configured - must have a result storage block to read parameters"
         )
     record: ResultRecord[Any] = ResultRecord[Any].deserialize(
-        await _call_explicitly_async_block_method(
+        await call_explicitly_async_block_method(
             result_store.result_storage,
             "read_path",
             (f"parameters/{identifier}",),

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -521,7 +521,7 @@ async def serve(
 
 async def store_parameters(
     result_store: ResultStore, identifier: UUID, parameters: dict[str, Any]
-):
+) -> None:
     """Store parameters for a task run in the result store.
 
     Args:

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -22,17 +22,20 @@ from websockets.exceptions import InvalidStatus
 
 import prefect.types._datetime
 from prefect import Task
+from prefect._internal.compatibility.blocks import _call_explicitly_async_block_method
 from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.cache_policies import DEFAULT, NO_CACHE
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import TaskRun
 from prefect.client.subscriptions import Subscription
 from prefect.logging.loggers import get_logger
-from prefect.results import ResultStore, get_or_create_default_task_scheduling_storage
-from prefect.settings import (
-    PREFECT_API_URL,
-    PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS,
+from prefect.results import (
+    ResultRecord,
+    ResultRecordMetadata,
+    ResultStore,
+    get_or_create_default_task_scheduling_storage,
 )
+from prefect.settings import get_current_settings
 from prefect.states import Pending
 from prefect.task_engine import run_task_async, run_task_sync
 from prefect.types import DateTime
@@ -43,6 +46,7 @@ from prefect.utilities.processutils import (
     _register_signal,  # pyright: ignore[reportPrivateUsage]
 )
 from prefect.utilities.services import start_client_metrics_server
+from prefect.utilities.timeout import timeout_async
 from prefect.utilities.urls import url_for
 
 if TYPE_CHECKING:
@@ -170,9 +174,13 @@ class TaskWorker:
         sys.exit(0)
 
     @sync_compatible
-    async def start(self) -> None:
+    async def start(self, timeout: Optional[float] = None) -> None:
         """
         Starts a task worker, which runs the tasks provided in the constructor.
+
+        Args:
+            timeout: If provided, the task worker will exit after the given number of
+                seconds. Defaults to None, meaning the task worker will run indefinitely.
         """
         _register_signal(signal.SIGTERM, self.handle_sigterm)
 
@@ -181,14 +189,16 @@ class TaskWorker:
         async with asyncnullcontext() if self.started else self:
             logger.info("Starting task worker...")
             try:
-                await self._subscribe_to_task_scheduling()
+                with timeout_async(timeout):
+                    await self._subscribe_to_task_scheduling()
             except InvalidStatus as exc:
                 if exc.response.status_code == 403:
                     logger.error(
                         "403: Could not establish a connection to the `/task_runs/subscriptions/scheduled`"
-                        f" endpoint found at:\n\n {PREFECT_API_URL.value()}"
-                        "\n\nPlease double-check the values of your"
-                        " `PREFECT_API_URL` and `PREFECT_API_KEY` environment variables."
+                        f" endpoint found at:\n\n {get_current_settings().api.url}"
+                        "\n\nPlease double-check the values of"
+                        " `PREFECT_API_AUTH_STRING` and `PREFECT_SERVER_API_AUTH_STRING` if running a Prefect server "
+                        "or `PREFECT_API_URL` and `PREFECT_API_KEY` environment variables if using Prefect Cloud."
                     )
                 else:
                     raise
@@ -228,7 +238,7 @@ class TaskWorker:
         return True
 
     async def _subscribe_to_task_scheduling(self):
-        base_url = PREFECT_API_URL.value()
+        base_url = get_current_settings().api.url
         if base_url is None:
             raise ValueError(
                 "`PREFECT_API_URL` must be set to use the task worker. "
@@ -282,7 +292,7 @@ class TaskWorker:
         task = next((t for t in self.tasks if t.task_key == task_run.task_key), None)
 
         if not task:
-            if PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS:
+            if get_current_settings().task_scheduling.delete_failed_submissions:
                 logger.warning(
                     f"Task {task_run.name!r} not found in task worker registry."
                 )
@@ -312,7 +322,7 @@ class TaskWorker:
                     f"Failed to read parameters for task run {task_run.id!r}",
                     exc_info=exc,
                 )
-                if PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS.value():
+                if get_current_settings().task_scheduling.delete_failed_submissions:
                     logger.info(
                         f"Deleting task run {task_run.id!r} because it failed to submit"
                     )
@@ -421,6 +431,7 @@ async def serve(
     *tasks: Task[P, R],
     limit: Optional[int] = 10,
     status_server_port: Optional[int] = None,
+    timeout: Optional[float] = None,
 ):
     """Serve the provided tasks so that their runs may be submitted to
     and executed in the engine. Tasks do not need to be within a flow run context to be
@@ -434,6 +445,8 @@ async def serve(
         - status_server_port: An optional port on which to start an HTTP server
             exposing status information about the task worker. If not provided, no
             status server will run.
+        - timeout: If provided, the task worker will exit after the given number of
+            seconds. Defaults to None, meaning the task worker will run indefinitely.
 
     Example:
         ```python
@@ -469,7 +482,13 @@ async def serve(
         status_server_task = loop.create_task(server.serve())
 
     try:
-        await task_worker.start()
+        await task_worker.start(timeout=timeout)
+
+    except TimeoutError:
+        if timeout is not None:
+            logger.info(f"Task worker timed out after {timeout} seconds. Exiting...")
+        else:
+            raise
 
     except BaseExceptionGroup as exc:  # novermin
         exceptions = exc.exceptions
@@ -492,3 +511,59 @@ async def serve(
                 await status_server_task
             except asyncio.CancelledError:
                 pass
+
+
+async def store_parameters(
+    result_store: ResultStore, identifier: UUID, parameters: dict[str, Any]
+):
+    """Store parameters for a task run in the result store.
+
+    Args:
+        result_store: The result store to store the parameters in.
+        identifier: The identifier of the task run.
+        parameters: The parameters to store.
+    """
+    if result_store.result_storage is None:
+        raise ValueError(
+            "Result store is not configured - must have a result storage block to store parameters"
+        )
+    record = ResultRecord(
+        result=parameters,
+        metadata=ResultRecordMetadata(
+            serializer=result_store.serializer, storage_key=str(identifier)
+        ),
+    )
+
+    await _call_explicitly_async_block_method(
+        result_store.result_storage,
+        "write_path",
+        (f"parameters/{identifier}",),
+        {"content": record.serialize()},
+    )
+
+
+async def read_parameters(
+    result_store: ResultStore, identifier: UUID
+) -> dict[str, Any]:
+    """Read parameters for a task run from the result store.
+
+    Args:
+        result_store: The result store to read the parameters from.
+        identifier: The identifier of the task run.
+
+    Returns:
+        The parameters for the task run.
+    """
+    if result_store.result_storage is None:
+        raise ValueError(
+            "Result store is not configured - must have a result storage block to read parameters"
+        )
+    record: ResultRecord[Any] = ResultRecord[Any].deserialize(
+        await _call_explicitly_async_block_method(
+            result_store.result_storage,
+            "read_path",
+            (f"parameters/{identifier}",),
+            {},
+        )
+    )
+    return record.result

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -810,6 +810,8 @@ class Task(Generic[P, R]):
             # store parameters for background tasks so that task worker
             # can retrieve them at runtime
             if deferred and (parameters or wait_for):
+                from prefect.task_worker import store_parameters
+
                 parameters_id = uuid4()
                 state.state_details.task_parameters_id = parameters_id
 
@@ -825,7 +827,7 @@ class Task(Generic[P, R]):
                     data["parameters"] = parameters
                 if wait_for:
                     data["wait_for"] = wait_for
-                await store.store_parameters(parameters_id, data)
+                await store_parameters(store, parameters_id, data)
 
             # collect task inputs
             task_inputs = {
@@ -911,6 +913,8 @@ class Task(Generic[P, R]):
             # store parameters for background tasks so that task worker
             # can retrieve them at runtime
             if deferred and (parameters or wait_for):
+                from prefect.task_worker import store_parameters
+
                 parameters_id = uuid4()
                 state.state_details.task_parameters_id = parameters_id
 
@@ -926,7 +930,7 @@ class Task(Generic[P, R]):
                     data["parameters"] = parameters
                 if wait_for:
                     data["wait_for"] = wait_for
-                await store.store_parameters(parameters_id, data)
+                await store_parameters(store, parameters_id, data)
 
             # collect task inputs
             task_inputs = {

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator, Iterable, Tuple
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Iterable, Tuple
 from unittest import mock
 
 import pytest
@@ -19,20 +19,21 @@ from prefect.settings import (
     PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
     temporary_settings,
 )
+from prefect.task_worker import read_parameters
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
 
 
-async def result_store_from_task(task) -> ResultStore:
+async def result_store_from_task(task: Task[..., Any]) -> ResultStore:
     return await ResultStore(
         result_storage=await get_or_create_default_task_scheduling_storage()
     ).update_for_task(task)
 
 
 @pytest.fixture
-def local_filesystem(tmp_path):
-    block = LocalFileSystem(basepath=tmp_path)
+def local_filesystem(tmp_path: Path) -> LocalFileSystem:
+    block = LocalFileSystem(basepath=str(tmp_path))
     block.save("test-fs", overwrite=True)
     return block
 
@@ -52,7 +53,7 @@ async def clear_cached_filesystems():
 
 
 @pytest.fixture
-def foo_task() -> Task:
+def foo_task() -> Task[..., int]:
     @task
     def foo(x: int) -> int:
         print(x)
@@ -62,7 +63,7 @@ def foo_task() -> Task:
 
 
 @pytest.fixture
-def async_foo_task() -> Task:
+def async_foo_task() -> Task[..., int]:
     @task
     async def async_foo(x: int) -> int:
         print(x)
@@ -72,35 +73,42 @@ def async_foo_task() -> Task:
 
 
 @pytest.fixture
-def foo_task_with_result_storage(foo_task, local_filesystem):
+def foo_task_with_result_storage(
+    foo_task: Task[..., int], local_filesystem: LocalFileSystem
+) -> Task[..., int]:
     return foo_task.with_options(result_storage=local_filesystem)
 
 
 @pytest.fixture
-def async_foo_task_with_result_storage(async_foo_task, local_filesystem):
+def async_foo_task_with_result_storage(
+    async_foo_task: Task[..., int], local_filesystem: LocalFileSystem
+) -> Task[..., int]:
     return async_foo_task.with_options(result_storage=local_filesystem)
 
 
 async def test_task_submission_with_parameters_uses_default_storage(
-    foo_task, prefect_client
+    foo_task: Task[..., int], prefect_client: "PrefectClient"
 ):
     foo_task_without_result_storage = foo_task.with_options(result_storage=None)
     task_run_future = foo_task_without_result_storage.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
     result_store = await result_store_from_task(foo_task)
-    await result_store.read_parameters(task_run.state.state_details.task_parameters_id)
+    assert task_run.state is not None
+    assert task_run.state.state_details is not None
+    assert task_run.state.state_details.task_parameters_id is not None
+    await read_parameters(result_store, task_run.state.state_details.task_parameters_id)
 
 
 async def test_task_submission_with_parameters_reuses_default_storage_block(
-    foo_task: Task, tmp_path: Path, prefect_client
+    foo_task: Task[..., int], tmp_path: Path, prefect_client: "PrefectClient"
 ):
     with temporary_settings(
         {
             PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK: "local-file-system/my-tasks",
         }
     ):
-        block = LocalFileSystem(basepath=tmp_path / "some-storage")
+        block = LocalFileSystem(basepath=str(tmp_path / "some-storage"))
         await block.save("my-tasks", overwrite=True)
 
         foo_task_without_result_storage = foo_task.with_options(result_storage=None)
@@ -119,47 +127,50 @@ async def test_task_submission_with_parameters_reuses_default_storage_block(
         result_store = await result_store_from_task(foo_task)
         task_run_a = await prefect_client.read_task_run(task_run_future_a.task_run_id)
         task_run_b = await prefect_client.read_task_run(task_run_future_b.task_run_id)
-        assert await result_store.read_parameters(
-            task_run_a.state.state_details.task_parameters_id
+        assert await read_parameters(
+            result_store, task_run_a.state.state_details.task_parameters_id
         ) == {"parameters": {"x": 42}, "context": mock.ANY}
-        assert await result_store.read_parameters(
-            task_run_b.state.state_details.task_parameters_id
+        assert await read_parameters(
+            result_store, task_run_b.state.state_details.task_parameters_id
         ) == {"parameters": {"x": 24}, "context": mock.ANY}
 
 
 async def test_task_submission_creates_a_scheduled_task_run(
-    foo_task_with_result_storage, prefect_client
+    foo_task_with_result_storage: Task[..., int], prefect_client: "PrefectClient"
 ):
     task_run_future = foo_task_with_result_storage.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
+    assert task_run.state is not None
     assert task_run.state.is_scheduled()
     assert task_run.state.state_details.deferred is True
 
     result_store = await result_store_from_task(foo_task_with_result_storage)
 
-    parameters = await result_store.read_parameters(
-        task_run.state.state_details.task_parameters_id
+    parameters = await read_parameters(
+        result_store, task_run.state.state_details.task_parameters_id
     )
 
     assert parameters == {"parameters": {"x": 42}, "context": mock.ANY}
 
 
-async def test_sync_task_not_awaitable_in_async_context(foo_task, prefect_client):
+async def test_sync_task_not_awaitable_in_async_context(
+    foo_task: Task[..., int], prefect_client: "PrefectClient"
+):
     task_run_future = foo_task.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
     assert task_run.state.is_scheduled()
 
     result_store = await result_store_from_task(foo_task)
 
-    parameters = await result_store.read_parameters(
-        task_run.state.state_details.task_parameters_id
+    parameters = await read_parameters(
+        result_store, task_run.state.state_details.task_parameters_id
     )
 
     assert parameters == {"parameters": {"x": 42}, "context": mock.ANY}
 
 
 async def test_async_task_submission_creates_a_scheduled_task_run(
-    async_foo_task_with_result_storage, prefect_client
+    async_foo_task_with_result_storage: Task[..., int], prefect_client: "PrefectClient"
 ):
     task_run_future = async_foo_task_with_result_storage.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
@@ -167,17 +178,17 @@ async def test_async_task_submission_creates_a_scheduled_task_run(
 
     result_store = await result_store_from_task(async_foo_task_with_result_storage)
 
-    parameters = await result_store.read_parameters(
-        task_run.state.state_details.task_parameters_id
+    parameters = await read_parameters(
+        result_store, task_run.state.state_details.task_parameters_id
     )
 
     assert parameters == {"parameters": {"x": 42}, "context": mock.ANY}
 
 
 async def test_scheduled_tasks_are_enqueued_server_side(
-    foo_task_with_result_storage: Task,
+    foo_task_with_result_storage: Task[..., int],
     in_memory_prefect_client: "PrefectClient",
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     # Need to mock `get_client` to return the in-memory client because we are directly inspecting
     # changes in the server-side task queue. Ideally, we'd be able to inspect the task queue via
@@ -215,7 +226,7 @@ async def test_scheduled_tasks_are_enqueued_server_side(
 
 
 async def test_tasks_are_not_enqueued_server_side_when_executed_directly(
-    foo_task: Task,
+    foo_task: Task[..., int],
 ):
     # Regression test for https://github.com/PrefectHQ/prefect/issues/13674
     # where executing a task would cause it to be enqueue server-side
@@ -233,12 +244,12 @@ async def prefect_client() -> AsyncGenerator["PrefectClient", None]:
 
 
 class TestCall:
-    async def test_call(self, async_foo_task):
+    async def test_call(self, async_foo_task: Task[..., int]):
         result = await async_foo_task(42)
 
         assert result == 42
 
-    async def test_call_with_return_state(self, async_foo_task):
+    async def test_call_with_return_state(self, async_foo_task: Task[..., int]):
         state = await async_foo_task(42, return_state=True)
 
         assert state.is_completed()
@@ -247,7 +258,7 @@ class TestCall:
 
 
 class TestMap:
-    async def test_map(self, async_foo_task):
+    async def test_map(self, async_foo_task: Task[..., int]):
         task_runs = async_foo_task.map([1, 2, 3], deferred=True)
 
         assert len(task_runs) == 3
@@ -256,8 +267,8 @@ class TestMap:
 
         for i, task_run in enumerate(task_runs):
             assert task_run.state.is_scheduled()
-            assert await result_store.read_parameters(
-                task_run.state.state_details.task_parameters_id
+            assert await read_parameters(
+                result_store, task_run.state.state_details.task_parameters_id
             ) == {"parameters": {"x": i + 1}, "context": mock.ANY}
 
     async def test_map_with_implicitly_unmapped_kwargs(self):
@@ -273,8 +284,10 @@ class TestMap:
 
         for i, task_run in enumerate(task_runs):
             assert task_run.state.is_scheduled()
-            assert await result_store.read_parameters(
-                task_run.state.state_details.task_parameters_id
+            assert task_run.state.state_details is not None
+            assert task_run.state.state_details.task_parameters_id is not None
+            assert await read_parameters(
+                result_store, task_run.state.state_details.task_parameters_id
             ) == {"parameters": {"x": i + 1, "unmappable": 42}, "context": mock.ANY}
 
     async def test_async_map_with_implicitly_unmapped_kwargs(self):
@@ -290,13 +303,15 @@ class TestMap:
 
         for i, task_run in enumerate(task_runs):
             assert task_run.state.is_scheduled()
-            assert await result_store.read_parameters(
-                task_run.state.state_details.task_parameters_id
+            assert task_run.state.state_details is not None
+            assert task_run.state.state_details.task_parameters_id is not None
+            assert await read_parameters(
+                result_store, task_run.state.state_details.task_parameters_id
             ) == {"parameters": {"x": i + 1, "unmappable": 42}, "context": mock.ANY}
 
     async def test_map_with_explicit_unmapped_kwargs(self):
         @task
-        def bar(x: int, mappable: Iterable) -> Tuple[int, Iterable]:
+        def bar(x: int, mappable: Iterable[str]) -> Tuple[int, Iterable[str]]:
             return (x, mappable)
 
         task_runs = bar.map(
@@ -309,8 +324,10 @@ class TestMap:
 
         for i, task_run in enumerate(task_runs):
             assert task_run.state.is_scheduled()
-            assert await result_store.read_parameters(
-                task_run.state.state_details.task_parameters_id
+            assert task_run.state.state_details is not None
+            assert task_run.state.state_details.task_parameters_id is not None
+            assert await read_parameters(
+                result_store, task_run.state.state_details.task_parameters_id
             ) == {
                 "parameters": {"x": i + 1, "mappable": ["some", "iterable"]},
                 "context": mock.ANY,
@@ -318,7 +335,7 @@ class TestMap:
 
     async def test_async_map_with_explicit_unmapped_kwargs(self):
         @task
-        async def bar(x: int, mappable: Iterable) -> Tuple[int, Iterable]:
+        async def bar(x: int, mappable: Iterable[str]) -> Tuple[int, Iterable[str]]:
             return (x, mappable)
 
         task_runs = bar.map(
@@ -331,8 +348,10 @@ class TestMap:
 
         for i, task_run in enumerate(task_runs):
             assert task_run.state.is_scheduled()
-            assert await result_store.read_parameters(
-                task_run.state.state_details.task_parameters_id
+            assert task_run.state.state_details is not None
+            assert task_run.state.state_details.task_parameters_id is not None
+            assert await read_parameters(
+                result_store, task_run.state.state_details.task_parameters_id
             ) == {
                 "parameters": {"x": i + 1, "mappable": ["some", "iterable"]},
                 "context": mock.ANY,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -61,6 +61,7 @@ from prefect.settings import (
     temporary_settings,
 )
 from prefect.states import State
+from prefect.task_worker import read_parameters
 from prefect.tasks import Task, task, task_input_hash
 from prefect.testing.utilities import exceptions_equal
 from prefect.transactions import (
@@ -76,23 +77,23 @@ from prefect.utilities.collections import quote
 from prefect.utilities.engine import get_state_for_result
 
 
-def comparable_inputs(d):
+def comparable_inputs(d: dict[str, Any]) -> dict[str, Any]:
     return {k: set(v) for k, v in d.items()}
 
 
 @pytest.fixture
-def timeout_test_flow():
+def timeout_test_flow() -> Any:
     @task(timeout_seconds=0.1)
-    def times_out(x):
+    def times_out(x: int) -> int:
         time.sleep(2)
         return x
 
     @task
-    def depends(x):
+    def depends(x: int) -> int:
         return x
 
     @task
-    def independent():
+    def independent() -> int:
         return 42
 
     @flow
@@ -105,11 +106,13 @@ def timeout_test_flow():
     return test_flow
 
 
-async def get_background_task_run_parameters(task, parameters_id):
+async def get_background_task_run_parameters(
+    task: Task[..., Any], parameters_id: UUID
+) -> Any:
     store = await ResultStore(
         result_storage=await get_or_create_default_task_scheduling_storage()
     ).update_for_task(task)
-    return await store.read_parameters(parameters_id)
+    return await read_parameters(store, parameters_id)
 
 
 class TestTaskName:
@@ -167,7 +170,7 @@ class TestTaskRunName:
 
     def test_invalid_run_name(self):
         class InvalidTaskRunNameArg:
-            def format(*args, **kwargs):
+            def format(*args: Any, **kwargs: Any) -> Any:
                 pass
 
         with pytest.raises(
@@ -184,7 +187,7 @@ class TestTaskRunName:
 
     def test_invalid_runtime_run_name(self):
         class InvalidTaskRunNameArg:
-            def format(*args, **kwargs):
+            def format(*args: Any, **kwargs: Any) -> Any:
                 pass
 
         @task

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -107,7 +107,7 @@ def timeout_test_flow() -> Any:
 
 
 async def get_background_task_run_parameters(
-    task: Task[..., Any], parameters_id: UUID
+    task: Task[Any, Any], parameters_id: UUID
 ) -> Any:
     store = await ResultStore(
         result_storage=await get_or_create_default_task_scheduling_storage()


### PR DESCRIPTION
- moves `read_parameters` and `store_parameters` out of `results.py` and into `task_worker.py` as functions, deprecating the methods on `ResultStore`
- moves block method compat code into `_internal` module (was already private)
- updates error message upon 403 when connecting to subscription per https://github.com/PrefectHQ/prefect/pull/17975