### PR TITLE
Fix: Use quotes for dbt cli path handling (fixes 18026)

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -374,10 +374,10 @@ class DbtCoreOperation(ShellOperation):
 
         commands = []
         for command in self.commands:
-            command += f" --profiles-dir {profiles_dir}"
+            command += f' --profiles-dir "{profiles_dir}"'
             if project_dir is not None:
                 project_dir = Path(project_dir).expanduser()
-                command += f" --project-dir {project_dir}"
+                command += f' --project-dir "{project_dir}"'
             commands.append(command)
         return commands
 

--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -563,7 +563,7 @@ class TestDbtCoreOperation:
         mock_write = mock_named_temporary_file.return_value.write
         assert (
             mock_write.call_args_list[0][0][0]
-            == f"dbt debug --profiles-dir {tmp_path} --project-dir {tmp_path}".encode()
+            == f'dbt debug --profiles-dir "{tmp_path}" --project-dir "{tmp_path}'.encode()
         )
 
 


### PR DESCRIPTION
Closes #18026: As per #18026 the project and profiles dir can not currently handle spaces in the path. Adding quotes should solve this issue across platforms. 

Unit test has also been adjusted to reflect the change.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
