### PR TITLE
begin "dependent settings" refactor

### DIFF
--- a/src/prefect/settings/models/_defaults.py
+++ b/src/prefect/settings/models/_defaults.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import SecretStr
+
+if TYPE_CHECKING:
+    from prefect.settings.models.root import Settings
+
+
+def calculate_default_profiles_path(values: dict[str, Any]) -> Path:
+    """Calculate default profiles_path based on home directory."""
+    home = values.get("home")
+    if not isinstance(home, Path):
+        # Fallback if home isn't a Path (should be validated earlier)
+        home = Path("~/.prefect").expanduser()
+    return home / "profiles.toml"
+
+
+def calculate_default_local_storage_path(values: dict[str, Any]) -> Path:
+    """Calculate default local_storage_path based on home directory."""
+    home = values.get("home")
+    if not isinstance(home, Path):
+        home = Path("~/.prefect").expanduser()
+    return home / "storage"
+
+
+def calculate_default_memo_store_path(values: dict[str, Any]) -> Path:
+    """Calculate default memo_store_path based on home directory."""
+    home = values.get("home")
+    if not isinstance(home, Path):
+        home = Path("~/.prefect").expanduser()
+    return home / "memo_store.toml"
+
+
+def calculate_default_logging_config_path(values: dict[str, Any]) -> Path:
+    """Calculate default logging_config_path based on home directory."""
+    home = values.get("home")
+    if not isinstance(home, Path):
+        home = Path("~/.prefect").expanduser()
+    return home / "logging.yml"
+
+
+def calculate_default_database_connection_url(settings: "Settings") -> SecretStr:
+    value: str = f"sqlite+aiosqlite:///{settings.home}/prefect.db"
+    if settings.server.database.driver == "postgresql+asyncpg":
+        required = [
+            "host",
+            "user",
+            "name",
+            "password",
+        ]
+        missing = [
+            attr for attr in required if getattr(settings.server.database, attr) is None
+        ]
+        if missing:
+            raise ValueError(
+                f"Missing required database connection settings: {', '.join(missing)}"
+            )
+
+        from sqlalchemy import URL
+
+        value = URL(
+            drivername=settings.server.database.driver,
+            host=settings.server.database.host,
+            port=settings.server.database.port or 5432,
+            username=settings.server.database.user,
+            password=(
+                settings.server.database.password.get_secret_value()
+                if settings.server.database.password
+                else None
+            ),
+            database=settings.server.database.name,
+            query=[],  # type: ignore
+        ).render_as_string(hide_password=False)
+
+    elif settings.server.database.driver == "sqlite+aiosqlite":
+        if settings.server.database.name:
+            value = (
+                f"{settings.server.database.driver}:///{settings.server.database.name}"
+            )
+        else:
+            value = f"sqlite+aiosqlite:///{settings.home}/prefect.db"
+
+    elif settings.server.database.driver:
+        raise ValueError(
+            f"Unsupported database driver: {settings.server.database.driver}"
+        )
+    return SecretStr(value)
+
+
+def calculate_default_ui_url(settings: "Settings") -> str | None:
+    value = settings.ui_url
+    if value is not None:
+        return value
+
+    # Otherwise, infer a value from the API URL
+    ui_url = api_url = settings.api.url
+
+    if not api_url:
+        return None
+    assert ui_url is not None
+
+    cloud_url = settings.cloud.api_url
+    cloud_ui_url = settings.cloud.ui_url
+    if api_url.startswith(cloud_url) and cloud_ui_url:
+        ui_url = ui_url.replace(cloud_url, cloud_ui_url)
+
+    if ui_url.endswith("/api"):
+        # Handles open-source APIs
+        ui_url = ui_url[:-4]
+
+    # Handles Cloud APIs with content after `/api`
+    ui_url = ui_url.replace("/api/", "/")
+
+    # Update routing
+    ui_url = ui_url.replace("/accounts/", "/account/")
+    ui_url = ui_url.replace("/workspaces/", "/workspace/")
+
+    return ui_url

--- a/src/prefect/settings/models/logging.py
+++ b/src/prefect/settings/models/logging.py
@@ -1,6 +1,6 @@
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, ClassVar, Literal, Optional, Union
+from typing import Annotated, Any, ClassVar, Literal, Union
 
 from pydantic import (
     AliasChoices,
@@ -14,6 +14,8 @@ from typing_extensions import Self
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
 from prefect.types import LogLevel, validate_set_T_from_delim_string
+
+from ._defaults import calculate_default_logging_config_path
 
 
 def max_log_size_smaller_than_batch_size(values: dict[str, Any]) -> dict[str, Any]:
@@ -95,9 +97,9 @@ class LoggingSettings(PrefectBaseSettings):
         description="The default logging level for Prefect loggers.",
     )
 
-    config_path: Optional[Path] = Field(
-        default=None,
-        description="The path to a custom YAML logging configuration file.",
+    config_path: Path = Field(
+        default_factory=calculate_default_logging_config_path,
+        description="A path to a logging configuration file. Defaults to <home>/logging.yml",
         validation_alias=AliasChoices(
             AliasPath("config_path"),
             "prefect_logging_config_path",

--- a/src/prefect/settings/models/results.py
+++ b/src/prefect/settings/models/results.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import ClassVar, Optional
 
@@ -5,6 +7,8 @@ from pydantic import AliasChoices, AliasPath, Field
 from pydantic_settings import SettingsConfigDict
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
+
+from ._defaults import calculate_default_local_storage_path
 
 
 class ResultsSettings(PrefectBaseSettings):
@@ -34,9 +38,9 @@ class ResultsSettings(PrefectBaseSettings):
         ),
     )
 
-    local_storage_path: Optional[Path] = Field(
-        default=None,
-        description="The path to a directory to store results in.",
+    local_storage_path: Path = Field(
+        default_factory=calculate_default_local_storage_path,
+        description="The default location for locally persisted results. Defaults to <home>/storage.",
         validation_alias=AliasChoices(
             AliasPath("local_storage_path"),
             "prefect_results_local_storage_path",

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -21,6 +21,11 @@ from prefect.settings.models.testing import TestingSettings
 from prefect.settings.models.worker import WorkerSettings
 from prefect.utilities.collections import deep_merge_dicts, set_in_dict
 
+from ._defaults import (
+    calculate_default_database_connection_url,
+    calculate_default_profiles_path,
+    calculate_default_ui_url,
+)
 from .api import APISettings
 from .cli import CLISettings
 from .client import ClientSettings
@@ -52,9 +57,9 @@ class Settings(PrefectBaseSettings):
         description="The path to the Prefect home directory. Defaults to ~/.prefect",
     )
 
-    profiles_path: Optional[Path] = Field(
-        default=None,
-        description="The path to a profiles configuration file.",
+    profiles_path: Path = Field(
+        default_factory=calculate_default_profiles_path,
+        description="The path to a profiles configuration file. Defaults to <home>/profiles.toml.",
     )
 
     debug_mode: bool = Field(
@@ -182,7 +187,7 @@ class Settings(PrefectBaseSettings):
         post-hoc default assignments to keep set/unset fields correct after instantiation.
         """
         if self.ui_url is None:
-            self.ui_url = _default_ui_url(self)
+            self.ui_url = calculate_default_ui_url(self)
             self.__pydantic_fields_set__.remove("ui_url")
         if self.server.ui.api_url is None:
             if self.api.url:
@@ -193,27 +198,17 @@ class Settings(PrefectBaseSettings):
                     f"http://{self.server.api.host}:{self.server.api.port}/api"
                 )
                 self.server.ui.__pydantic_fields_set__.remove("api_url")
-        if self.profiles_path is None or "PREFECT_HOME" in str(self.profiles_path):
-            self.profiles_path = Path(f"{self.home}/profiles.toml")
-            self.__pydantic_fields_set__.remove("profiles_path")
-        if self.results.local_storage_path is None:
-            self.results.local_storage_path = Path(f"{self.home}/storage")
-            self.results.__pydantic_fields_set__.remove("local_storage_path")
-        if self.server.memo_store_path is None:
-            self.server.memo_store_path = Path(f"{self.home}/memo_store.toml")
-            self.server.__pydantic_fields_set__.remove("memo_store_path")
         if self.debug_mode or self.testing.test_mode:
             self.logging.level = "DEBUG"
             self.internal.logging_level = "DEBUG"
             self.logging.__pydantic_fields_set__.remove("level")
             self.internal.__pydantic_fields_set__.remove("logging_level")
 
-        if self.logging.config_path is None:
-            self.logging.config_path = Path(f"{self.home}/logging.yml")
-            self.logging.__pydantic_fields_set__.remove("config_path")
         # Set default database connection URL if not provided
         if self.server.database.connection_url is None:
-            self.server.database.connection_url = _default_database_connection_url(self)
+            self.server.database.connection_url = (
+                calculate_default_database_connection_url(self)
+            )
             self.server.database.__pydantic_fields_set__.remove("connection_url")
         db_url = self.server.database.connection_url.get_secret_value()
         if (
@@ -330,37 +325,6 @@ class Settings(PrefectBaseSettings):
         return str(hash(tuple((key, value) for key, value in env_variables.items())))
 
 
-def _default_ui_url(settings: "Settings") -> Optional[str]:
-    value = settings.ui_url
-    if value is not None:
-        return value
-
-    # Otherwise, infer a value from the API URL
-    ui_url = api_url = settings.api.url
-
-    if not api_url:
-        return None
-    assert ui_url is not None
-
-    cloud_url = settings.cloud.api_url
-    cloud_ui_url = settings.cloud.ui_url
-    if api_url.startswith(cloud_url) and cloud_ui_url:
-        ui_url = ui_url.replace(cloud_url, cloud_ui_url)
-
-    if ui_url.endswith("/api"):
-        # Handles open-source APIs
-        ui_url = ui_url[:-4]
-
-    # Handles Cloud APIs with content after `/api`
-    ui_url = ui_url.replace("/api/", "/")
-
-    # Update routing
-    ui_url = ui_url.replace("/accounts/", "/account/")
-    ui_url = ui_url.replace("/workspaces/", "/workspace/")
-
-    return ui_url
-
-
 def _warn_on_misconfigured_api_url(settings: "Settings"):
     """
     Validator for settings warning if the API URL is misconfigured.
@@ -402,54 +366,6 @@ def _warn_on_misconfigured_api_url(settings: "Settings"):
             warnings.warn("\n".join(warnings_list), stacklevel=2)
 
     return settings
-
-
-def _default_database_connection_url(settings: "Settings") -> SecretStr:
-    value: str = f"sqlite+aiosqlite:///{settings.home}/prefect.db"
-    if settings.server.database.driver == "postgresql+asyncpg":
-        required = [
-            "host",
-            "user",
-            "name",
-            "password",
-        ]
-        missing = [
-            attr for attr in required if getattr(settings.server.database, attr) is None
-        ]
-        if missing:
-            raise ValueError(
-                f"Missing required database connection settings: {', '.join(missing)}"
-            )
-
-        from sqlalchemy import URL
-
-        value = URL(
-            drivername=settings.server.database.driver,
-            host=settings.server.database.host,
-            port=settings.server.database.port or 5432,
-            username=settings.server.database.user,
-            password=(
-                settings.server.database.password.get_secret_value()
-                if settings.server.database.password
-                else None
-            ),
-            database=settings.server.database.name,
-            query=[],  # type: ignore
-        ).render_as_string(hide_password=False)
-
-    elif settings.server.database.driver == "sqlite+aiosqlite":
-        if settings.server.database.name:
-            value = (
-                f"{settings.server.database.driver}:///{settings.server.database.name}"
-            )
-        else:
-            value = f"sqlite+aiosqlite:///{settings.home}/prefect.db"
-
-    elif settings.server.database.driver:
-        raise ValueError(
-            f"Unsupported database driver: {settings.server.database.driver}"
-        )
-    return SecretStr(value)
 
 
 def canonical_environment_prefix(settings: "Settings") -> str:

--- a/src/prefect/settings/models/server/root.py
+++ b/src/prefect/settings/models/server/root.py
@@ -1,5 +1,7 @@
+from __future__ import annotations  # Ensure this is at the top
+
 from pathlib import Path
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from pydantic import AliasChoices, AliasPath, Field
 from pydantic_settings import SettingsConfigDict
@@ -7,6 +9,8 @@ from pydantic_settings import SettingsConfigDict
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
 from prefect.types import LogLevel
 
+# Import the default function, using .. to go up one directory level
+from .._defaults import calculate_default_memo_store_path
 from .api import ServerAPISettings
 from .database import ServerDatabaseSettings
 from .deployments import ServerDeploymentsSettings
@@ -83,9 +87,9 @@ class ServerSettings(PrefectBaseSettings):
         ),
     )
 
-    memo_store_path: Optional[Path] = Field(
-        default=None,
-        description="The path to the memo store file.",
+    memo_store_path: Path = Field(
+        default_factory=calculate_default_memo_store_path,
+        description="Path to the memo store file. Defaults to <home>/memo_store.toml",
         validation_alias=AliasChoices(
             AliasPath("memo_store_path"),
             "prefect_server_memo_store_path",


### PR DESCRIPTION
given https://github.com/pydantic/pydantic/pull/10678 is implemented, we can stop using the dunder methods in the model_validator of the settings object to manage "set" fields

this PR starts that process for the `PREFECT_HOME` dependent settings to get a feel for it

this will also require a lower bound bump to 2.10