### PR TITLE
add on-demand free-threaded ci

### DIFF
--- a/.github/workflows/free-threaded-tests.yaml
+++ b/.github/workflows/free-threaded-tests.yaml
@@ -1,0 +1,40 @@
+name: Free Threaded Python Tests
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  run-free-threaded-tests:
+    name: Free Threaded Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.13t"
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install packages
+        run: uv sync --locked
+
+      - name: Run free-threaded tests
+        run: |
+          uv run pytest tests/test_task_runners.py tests/test_task_worker.py tests/_internal/concurrency tests/concurrency tests/server/services \
+          --numprocesses auto \
+          --maxprocesses 6 \
+          --dist worksteal \
+          --disable-docker-image-builds \
+          --exclude-service kubernetes \
+          --exclude-service docker \
+          --durations 26 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -161,7 +161,7 @@ jobs:
           --disable-docker-image-builds \
           --exclude-service kubernetes \
           --exclude-service docker \
-          --durations 26 \
+          --durations 26
 
       - name: Check database container
         # Only applicable for Postgres, but we want this to run even when tests fail


### PR DESCRIPTION
i was curious if we have any incompatibilities with free-threaded versions like 3.13t and it appears we don't (by smoke testing most unit/integration tests locally)

didn't think it was worth the runtime to add a check when all the other tests run, but this subset of the unit tests would run on `workflow_dispatch` - i don't think its super important to add this, so if we want to hold off that's fine with me. just thought it'd be nice to run sometimes if necessary