### PR TITLE
fix parsing for `PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS`

### DIFF
--- a/src/prefect/settings/models/tasks.py
+++ b/src/prefect/settings/models/tasks.py
@@ -1,9 +1,10 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar, Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 from pydantic_settings import SettingsConfigDict
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
+from prefect.types import TaskRetryDelaySeconds
 
 
 class TasksRunnerSettings(PrefectBaseSettings):
@@ -73,7 +74,7 @@ class TasksSettings(PrefectBaseSettings):
         ),
     )
 
-    default_retry_delay_seconds: Union[int, float, list[float]] = Field(
+    default_retry_delay_seconds: TaskRetryDelaySeconds = Field(
         default=0,
         description="This value sets the default retry delay seconds for all tasks.",
         validation_alias=AliasChoices(

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -218,6 +218,5 @@ __all__ = [
     "SecretDict",
     "StatusCode",
     "StrictVariableValue",
-    # parse_retry_delay_input is internal, no need to add to __all__
-    "TaskRetryDelaySeconds",  # Ensure TaskRetryDelaySeconds is in __all__ if it wasn't (it likely was)
+    "TaskRetryDelaySeconds",
 ]

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -173,7 +173,7 @@ def parse_retry_delay_input(value: Any) -> Any:
 
 
 TaskRetryDelaySeconds = Annotated[
-    Union[int, float, list[float], None],
+    Union[str, int, float, list[float], None],
     BeforeValidator(parse_retry_delay_input),
 ]
 

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Annotated, Any, Optional, TypeVar, Union, cast
-from uuid import UUID
+from typing import Annotated, Any, Optional, TypeVar, Union
 from typing_extensions import Literal
 import orjson
 import pydantic
@@ -132,6 +131,52 @@ ClientRetryExtraCodes = Annotated[
     BeforeValidator(partial(validate_set_T_from_delim_string, type_=StatusCode)),
 ]
 
+
+def parse_retry_delay_input(value: Any) -> Any:
+    """
+    Parses various inputs (string, int, float, list) into a format suitable
+    for TaskRetryDelaySeconds (int, float, list[float], or None).
+    Handles comma-separated strings for lists of delays.
+    """
+    if isinstance(value, str):
+        stripped_value = value.strip()
+        if not stripped_value:
+            return None  # Treat empty or whitespace-only string as None
+
+        delim = ","
+        # Split and filter empty strings that result from multiple commas (e.g., "10,,20")
+        parts = [s.strip() for s in stripped_value.split(delim) if s.strip()]
+
+        if not parts:  # e.g., value was just "," or " , "
+            return None
+
+        def _parse_num_part(part_str: str) -> Union[float, int]:
+            try:
+                # Prefer float to align with list[float] in TaskRetryDelaySeconds
+                return TypeAdapter(float).validate_strings(part_str)
+            except pydantic.ValidationError:
+                try:
+                    return TypeAdapter(int).validate_strings(part_str)
+                except pydantic.ValidationError as e_int:
+                    raise ValueError(
+                        f"Invalid number format '{part_str}' for retry delay."
+                    ) from e_int
+
+        if len(parts) == 1:
+            return _parse_num_part(parts[0])
+        else:
+            return [_parse_num_part(p) for p in parts]
+
+    # For non-string inputs (int, float, list, None, etc.), pass them through.
+    # Pydantic will then validate them against Union[int, float, list[float], None].
+    return value
+
+
+TaskRetryDelaySeconds = Annotated[
+    Union[int, float, list[float], None],
+    BeforeValidator(parse_retry_delay_input),
+]
+
 LogLevel = Annotated[
     Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     BeforeValidator(lambda x: x.upper()),
@@ -173,4 +218,6 @@ __all__ = [
     "SecretDict",
     "StatusCode",
     "StrictVariableValue",
+    # parse_retry_delay_input is internal, no need to add to __all__
+    "TaskRetryDelaySeconds",  # Ensure TaskRetryDelaySeconds is in __all__ if it wasn't (it likely was)
 ]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,6 +40,7 @@ from prefect.settings import (
     PREFECT_SERVER_API_PORT,
     PREFECT_SERVER_DATABASE_CONNECTION_URL,
     PREFECT_SERVER_LOGGING_LEVEL,
+    PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
     PREFECT_TEST_MODE,
     PREFECT_TEST_SETTING,
     PREFECT_UI_API_URL,
@@ -971,6 +972,22 @@ class TestSettingAccess:
         with pytest.raises(ValueError):
             with temporary_settings({PREFECT_CLIENT_RETRY_EXTRA_CODES: extra_codes}):
                 PREFECT_CLIENT_RETRY_EXTRA_CODES.value()
+
+    def test_default_task_retry_delay_seconds(self):
+        sample_values_and_expected = (
+            (None, None),
+            ("", None),
+            ("10", 10.0),
+            ("10,20,30", [10.0, 20.0, 30.0]),
+            ("10.0", 10.0),
+            (10, 10.0),
+            ([10, 20, 30], [10.0, 20.0, 30.0]),
+        )
+        for retry_delay_plaintext_value, expected in sample_values_and_expected:
+            with temporary_settings(
+                {PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS: retry_delay_plaintext_value}
+            ):
+                assert PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS.value() == expected
 
     def test_deprecated_ENV_VAR_attribute_access(self):
         settings = Settings()


### PR DESCRIPTION
uses a similar idea to `validate_set_T_from_delim_string` but its an unhashable `list` (order matters for retry delays), maybe there's some more general function to write for all these `BeforeValidator`s, but this seemed fine for now

motivated by https://github.com/PrefectHQ/prefect/pull/18041