### PR TITLE
Vendor `uuid7` implementation

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
     "typing_extensions>=4.10.0,<5.0.0",
     "ujson>=5.8.0,<6.0.0",
     "uvicorn>=0.14.0,!=0.29.0",
-    "uuid7>=0.1.0",
     "websockets>=13.0,<16.0",
     "whenever>=0.7.3,<0.9.0; python_version>='3.13'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ dependencies = [
     "websockets>=13.0,<16.0",
     "whenever>=0.7.3,<0.9.0; python_version>='3.13'",
     "uv>=0.6.0",
-    "uuid7>=0.1.0",
 ]
 [project.urls]
 Changelog = "https://github.com/PrefectHQ/prefect/releases"

--- a/src/prefect/_internal/uuid7.py
+++ b/src/prefect/_internal/uuid7.py
@@ -1,11 +1,131 @@
-from typing import cast
-from uuid import UUID
+from __future__ import annotations
 
-from uuid_extensions import uuid7 as _uuid7  # pyright: ignore[reportMissingTypeStubs]
-
-
-def uuid7() -> UUID:
-    return cast(UUID, _uuid7())
+import os
+import time
+import uuid
+from typing import Callable, Optional, Union
 
 
-__all__ = ["uuid7"]
+def _time_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def uuid7(
+    ms: Optional[int] = None,
+    as_type: Optional[str] = None,
+    time_func: Callable[[], int] = _time_ms,
+) -> Union[uuid.UUID, str, int, bytes]:
+    """
+    UUID v7, following the proposed extension to RFC4122 described in
+    https://www.ietf.org/id/draft-peabody-dispatch-new-uuid-format-02.html.
+    All representations (string, byte array, int) sort chronologically,
+    with a potential time resolution of 50ns (if the system clock
+    supports this).
+
+    Parameters
+    ----------
+
+    ms      - Optional integer with the whole number of milliseconds
+                since Unix epoch, to set the "as of" timestamp.
+
+    as_type - Optional string to return the UUID in a different format.
+                A uuid.UUID (version 7, variant 0x10) is returned unless
+                this is one of 'str', 'int', 'hex' or 'bytes'.
+
+    time_func - Set the time function, which must return integer
+                milliseconds since the Unix epoch, midnight on 1-Jan-1970.
+                Defaults to time.time_ns()/1e6. This is exposed because
+                time.time_ns() may have a low resolution on Windows.
+
+    Returns
+    -------
+
+    A UUID object, or if as_type is specified, a string, int or
+    bytes of length 16.
+
+    Implementation notes
+    --------------------
+
+    The 128 bits in the UUID are allocated as follows:
+    - 36 bits of whole seconds
+    - 24 bits of fractional seconds, giving approx 50ns resolution
+    - 14 bits of sequential counter, if called repeatedly in same time tick
+    - 48 bits of randomness
+    plus, at locations defined by RFC4122, 4 bits for the
+    uuid version (0b111) and 2 bits for the uuid variant (0b10).
+
+     0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           unix_ts_ms                          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |          unix_ts_ms           |  ver  |       rand_a          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |var|                        rand_b                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                            rand_b                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+    Indicative timings:
+    - uuid.uuid4()            2.4us
+    - uuid7()                 3.7us
+    - uuid7(as_type='int')    1.6us
+    - uuid7(as_type='str')    2.5us
+
+    Examples
+    --------
+
+    >>> uuid7()
+    UUID('061cb26a-54b8-7a52-8000-2124e7041024')
+
+    >>> for fmt in ('bytes', 'hex', 'int', 'str', 'uuid', None):
+    ...     print(fmt, repr(uuid7(as_type=fmt)))
+    bytes b'\x06\x1c\xb8\xfe\x0f\x0b|9\x80\x00\tjt\x85\xb3\xbb'
+    hex '061cb8fe0f0b7c3980011863b956b758'
+    int 8124504378724980906989670469352026642
+    str '061cb8fe-0f0b-7c39-8003-d44a7ee0bdf6'
+    uuid UUID('061cb8fe-0f0b-7c39-8004-0489578299f6')
+    None UUID('061cb8fe-0f0f-7df2-8000-afd57c2bf446')
+    """
+    if ms is None:
+        ms = time_func()
+    else:
+        ms = int(ms)  # Fail fast if not an int
+
+    rand_a = int.from_bytes(os.urandom(2))
+    rand_b = int.from_bytes(os.urandom(8))
+    uuid_bytes = uuidfromvalues(ms, rand_a, rand_b)
+
+    uuid_int = int.from_bytes(uuid_bytes)
+    if as_type == "int":
+        return int.from_bytes(uuid_bytes)
+    elif as_type == "bin":
+        return bin(int.from_bytes(uuid_bytes))
+    elif as_type == "hex":
+        return f"{uuid_int:>032x}"
+    elif as_type == "bytes":
+        return uuid_int.to_bytes(16, "big")
+    elif as_type == "str":
+        return format_byte_array_as_uuid(uuid_bytes)
+    else:
+        return uuid.UUID(int=uuid_int)
+
+
+def uuidfromvalues(unix_ts_ms: int, rand_a: int, rand_b: int):
+    version = 0x07
+    var = 2
+    rand_a &= 0xFFF
+    rand_b &= 0x3FFFFFFFFFFFFFFF
+
+    final_bytes = unix_ts_ms.to_bytes(6)
+    final_bytes += ((version << 12) + rand_a).to_bytes(2)
+    final_bytes += ((var << 62) + rand_b).to_bytes(8)
+
+    return final_bytes
+
+
+def format_byte_array_as_uuid(arr: bytes):
+    return f"{arr[:4].hex()}-{arr[4:6].hex()}-{arr[6:8].hex()}-{arr[8:10].hex()}-{arr[10:].hex()}"
+
+
+__all__ = ("uuid7",)

--- a/src/prefect/_internal/uuid7.py
+++ b/src/prefect/_internal/uuid7.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import time
 import uuid
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 
 def _time_ms() -> int:
@@ -12,9 +12,8 @@ def _time_ms() -> int:
 
 def uuid7(
     ms: Optional[int] = None,
-    as_type: Optional[str] = None,
     time_func: Callable[[], int] = _time_ms,
-) -> Union[uuid.UUID, str, int, bytes]:
+) -> uuid.UUID:
     """
     UUID v7, following the proposed extension to RFC4122 described in
     https://www.ietf.org/id/draft-peabody-dispatch-new-uuid-format-02.html.
@@ -92,23 +91,12 @@ def uuid7(
     else:
         ms = int(ms)  # Fail fast if not an int
 
-    rand_a = int.from_bytes(os.urandom(2))
-    rand_b = int.from_bytes(os.urandom(8))
+    rand_a = int.from_bytes(bytes=os.urandom(2), byteorder="big")
+    rand_b = int.from_bytes(bytes=os.urandom(8), byteorder="big")
     uuid_bytes = uuidfromvalues(ms, rand_a, rand_b)
 
-    uuid_int = int.from_bytes(uuid_bytes)
-    if as_type == "int":
-        return int.from_bytes(uuid_bytes)
-    elif as_type == "bin":
-        return bin(int.from_bytes(uuid_bytes))
-    elif as_type == "hex":
-        return f"{uuid_int:>032x}"
-    elif as_type == "bytes":
-        return uuid_int.to_bytes(16, "big")
-    elif as_type == "str":
-        return format_byte_array_as_uuid(uuid_bytes)
-    else:
-        return uuid.UUID(int=uuid_int)
+    uuid_int = int.from_bytes(bytes=uuid_bytes, byteorder="big")
+    return uuid.UUID(int=uuid_int)
 
 
 def uuidfromvalues(unix_ts_ms: int, rand_a: int, rand_b: int):

--- a/src/prefect/_internal/uuid7.py
+++ b/src/prefect/_internal/uuid7.py
@@ -105,9 +105,9 @@ def uuidfromvalues(unix_ts_ms: int, rand_a: int, rand_b: int):
     rand_a &= 0xFFF
     rand_b &= 0x3FFFFFFFFFFFFFFF
 
-    final_bytes = unix_ts_ms.to_bytes(6)
-    final_bytes += ((version << 12) + rand_a).to_bytes(2)
-    final_bytes += ((var << 62) + rand_b).to_bytes(8)
+    final_bytes = unix_ts_ms.to_bytes(length=6, byteorder="big")
+    final_bytes += ((version << 12) + rand_a).to_bytes(length=2, byteorder="big")
+    final_bytes += ((var << 62) + rand_b).to_bytes(length=8, byteorder="big")
 
     return final_bytes
 

--- a/tests/_internal/test_uuid.py
+++ b/tests/_internal/test_uuid.py
@@ -1,0 +1,44 @@
+import time
+
+from prefect._internal.uuid7 import format_byte_array_as_uuid, uuid7, uuidfromvalues
+
+
+def test_uuid7():
+    """
+    Some simple tests
+    """
+    # Note the sequence value increments by 1 between each of these uuid7(...) calls
+    ms = time.time_ns() // 1_000_000
+    out1 = str(uuid7(ms))
+    out2: str = uuid7(ms, as_type="str")  # type: ignore
+
+    assert out1[:13] == out2[:13]
+
+
+def test_monotonicity():
+    last = ""
+    for n in range(100_000):
+        i = str(uuid7())
+        if n > 0 and i <= last:
+            raise RuntimeError(f"UUIDs are not monotonic: {last} versus {i}")
+
+
+def test_vector():
+    # test vectors from
+    # https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-example-of-a-uuidv7-value
+
+    unix_ts_ms = 0x17F22E279B0
+    rand_a = 0xCC3
+    rand_b = 0x18C4DC0C0C07398F
+
+    expected = "017f22e279b07cc398c4dc0c0c07398f"
+    found = uuidfromvalues(unix_ts_ms, rand_a, rand_b).hex()
+    assert expected == found
+
+
+def test_formatting():
+    expected = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f"
+    found = format_byte_array_as_uuid(
+        b'\x01\x7f"\xe2y\xb0|\xc3\x98\xc4\xdc\x0c\x0c\x079\x8f'
+    )
+    assert expected == found

--- a/tests/_internal/test_uuid.py
+++ b/tests/_internal/test_uuid.py
@@ -10,7 +10,7 @@ def test_uuid7():
     # Note the sequence value increments by 1 between each of these uuid7(...) calls
     ms = time.time_ns() // 1_000_000
     out1 = str(uuid7(ms))
-    out2: str = uuid7(ms, as_type="str")  # type: ignore
+    out2 = str(uuid7(ms))
 
     assert out1[:13] == out2[:13]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3673,7 +3673,6 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
     { name = "ujson" },
-    { name = "uuid7" },
     { name = "uv" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -3888,7 +3887,6 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0,!=0.12.2,<0.16.0" },
     { name = "typing-extensions", specifier = ">=4.10.0,<5.0.0" },
     { name = "ujson", specifier = ">=5.8.0,<6.0.0" },
-    { name = "uuid7", specifier = ">=0.1.0" },
     { name = "uv", specifier = ">=0.6.0" },
     { name = "uvicorn", specifier = ">=0.14.0,!=0.29.0" },
     { name = "websockets", specifier = ">=13.0,<16.0" },
@@ -6728,15 +6726,6 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
-]
-
-[[package]]
-name = "uuid7"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR vendors the UUIDv7 implementation from `uuid7` to unblock Conda releases. Parts that we don't need are left out and I've made some modifications to improve the typing.