### PR TITLE
disable client smoke test for PRs from forks

### DIFF
--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -29,6 +29,7 @@ on:
 jobs:
   prefect-client-smoke-test:
     name: Build and run prefect-client
+    if: ${{ !(github.event.pull_request.head.repo.fork) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
for PRs from forks, the client build smoke test will reliably fail because its needs repo secrets, perhaps we should make it so that this runs against a prefect server in the future