### PR TITLE
Run `prefect-client` smoke tests against local server

### DIFF
--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -44,6 +44,15 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
           activate-environment: true
 
+      - name: Start server
+        env:
+          PREFECT_API_URL: http://127.0.0.1:4200/api
+          PREFECT_SERVER_LOGGING_LEVEL: DEBUG
+        run: >
+          uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
+
+          ./scripts/wait-for-server.py
+  
       - name: Create a temp dir to stage our build
         run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
 
@@ -70,16 +79,6 @@ jobs:
           echo "prefect_client_version=$prefect_client_version" >> $GITHUB_OUTPUT
         working-directory: ${{ env.TMPDIR }}
         id: prefect_client_version
-
-      - name: Start server
-        env:
-          PREFECT_API_URL: http://127.0.0.1:4200/api
-          PREFECT_SERVER_LOGGING_LEVEL: DEBUG
-        run: >
-          uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
-
-          ./scripts/wait-for-server.py
-
 
       - name: Run the smoke test flow using the built client
         run: python client/client_flow.py

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -51,7 +51,7 @@ jobs:
         run: >
           uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
 
-          uv run ./scripts/wait-for-server.py
+          uv run --isolated ./scripts/wait-for-server.py
   
       - name: Create a temp dir to stage our build
         run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -71,19 +71,27 @@ jobs:
         working-directory: ${{ env.TMPDIR }}
         id: prefect_client_version
 
+      - name: Start server
+        env:
+          PREFECT_API_URL: http://127.0.0.1:4200/api
+          PREFECT_SERVER_LOGGING_LEVEL: DEBUG
+        run: >
+          uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
+
+          ./scripts/wait-for-server.py
+
+
       - name: Run the smoke test flow using the built client
         run: python client/client_flow.py
         working-directory: ${{ env.TMPDIR }}
         env:
-          PREFECT_API_KEY: ${{ secrets.PREFECT_CLIENT_SA_API_KEY }}
-          PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspaces/96bd3cf8-85c9-4545-9713-b4e3c3e03466" # sandbox, prefect-client workspace
+          PREFECT_API_URL: "http://127.0.0.1:4200/api"
 
       - name: Run deploy and execute smoke test using the built client
         run: python client/client_deploy.py
         working-directory: ${{ env.TMPDIR }}
         env:
-          PREFECT_API_KEY: ${{ secrets.PREFECT_CLIENT_SA_API_KEY }}
-          PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspaces/96bd3cf8-85c9-4545-9713-b4e3c3e03466" # sandbox, prefect-client workspace
+          PREFECT_API_URL: "http://127.0.0.1:4200/api"
 
 
       - name: Install prefect from source
@@ -106,8 +114,7 @@ jobs:
         run: uv run python client/client_flow.py
         working-directory: ${{ env.TMPDIR }}
         env:
-          PREFECT_API_KEY: ${{ secrets.PREFECT_CLIENT_SA_API_KEY }}
-          PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspaces/96bd3cf8-85c9-4545-9713-b4e3c3e03466" # sandbox, prefect-client workspace
+          PREFECT_API_URL: "http://127.0.0.1:4200/api"
 
       - name: Publish build artifacts
         if: ${{ inputs.upload-artifacts }}

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -51,7 +51,7 @@ jobs:
         run: >
           uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
 
-          ./scripts/wait-for-server.py
+          uv run ./scripts/wait-for-server.py
   
       - name: Create a temp dir to stage our build
         run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV

--- a/client/client_deploy.py
+++ b/client/client_deploy.py
@@ -9,11 +9,23 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from prefect import Flow, get_client
+from prefect.client.schemas.actions import WorkPoolCreate
 from prefect.runner.runner import Runner
+from prefect.server.exceptions import ObjectNotFoundError
 
 
 async def main():
     async with get_client() as client:
+        # Check if the smoke-test work pool exists
+        try:
+            await client.read_work_pool("smoke-test")
+        except ObjectNotFoundError:
+            # Create the work pool if it doesn't exist
+            await client.create_work_pool(
+                WorkPoolCreate(name="smoke-test", type="process")
+            )
+
+        # Deploy the flow
         smoke_test_flow = await Flow.afrom_source(
             source=Path(__file__).resolve().parent,
             entrypoint="client_flow.py:smoke_test_flow",
@@ -29,6 +41,7 @@ async def main():
 
         deployment_id = await coro
 
+        # Execute a run via a runner
         flow_run = await client.create_flow_run_from_deployment(
             deployment_id=deployment_id
         )

--- a/client/client_deploy.py
+++ b/client/client_deploy.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING
 
 from prefect import Flow, get_client
 from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.exceptions import ObjectNotFound
 from prefect.runner.runner import Runner
-from prefect.server.exceptions import ObjectNotFoundError
 
 
 async def main():
@@ -19,7 +19,7 @@ async def main():
         # Check if the smoke-test work pool exists
         try:
             await client.read_work_pool("smoke-test")
-        except ObjectNotFoundError:
+        except ObjectNotFound:
             # Create the work pool if it doesn't exist
             await client.create_work_pool(
                 WorkPoolCreate(name="smoke-test", type="process")

--- a/scripts/wait-for-server.py
+++ b/scripts/wait-for-server.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "anyio",
+#   "prefect",
+# ]
+# ///
 """
 Wait until the Prefect server returns a healthy response.
 


### PR DESCRIPTION
Removes the dependency on Prefect Cloud and allows these tests to run successfully from a forked repository.
