### PR TITLE
Add work pool and queue tables

### DIFF
--- a/ui-v2/src/components/work-pools/work-pool-details-header.stories.tsx
+++ b/ui-v2/src/components/work-pools/work-pool-details-header.stories.tsx
@@ -1,0 +1,19 @@
+import { createFakeWorkPool } from "@/mocks/create-fake-work-pool";
+import { reactQueryDecorator, routerDecorator } from "@/storybook/utils";
+import type { Meta, StoryObj } from "@storybook/react";
+import { WorkPoolDetailsHeader } from "./work-pool-details-header";
+
+const meta: Meta<typeof WorkPoolDetailsHeader> = {
+  title: "Components/WorkPools/WorkPoolDetailsHeader",
+  component: WorkPoolDetailsHeader,
+  decorators: [routerDecorator, reactQueryDecorator],
+};
+export default meta;
+
+type Story = StoryObj<typeof WorkPoolDetailsHeader>;
+
+export const Default: Story = {
+  args: {
+    workPool: createFakeWorkPool(),
+  },
+};

--- a/ui-v2/src/components/work-pools/work-pool-details-header.tsx
+++ b/ui-v2/src/components/work-pools/work-pool-details-header.tsx
@@ -1,0 +1,51 @@
+import type { WorkPool } from "@/api/work-pools";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { WorkPoolPauseResumeToggle } from "./work-pool-card/components/work-pool-pause-resume-toggle";
+import { WorkPoolContextMenu } from "./work-pool-card/components/work-pool-context-menu";
+import { useDeleteWorkPool } from "@/api/work-pools";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+export type WorkPoolDetailsHeaderProps = {
+  workPool: WorkPool;
+};
+
+export const WorkPoolDetailsHeader = ({ workPool }: WorkPoolDetailsHeaderProps) => {
+  const { deleteWorkPool } = useDeleteWorkPool()
+
+  const handleDelete = () => {
+    deleteWorkPool(workPool.name, {
+      onSuccess: () => toast.success(`${workPool.name} deleted`),
+      onError: () => toast.error(`Failed to delete ${workPool.name}`),
+    })
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink to="/work-pools" className="text-xl font-semibold">
+              Work pools
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem className="text-xl font-semibold">
+            <BreadcrumbPage>{workPool.name}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <div className="flex items-center gap-2">
+        <WorkPoolPauseResumeToggle workPool={workPool} />
+        <WorkPoolContextMenu workPool={workPool} onDelete={handleDelete} />
+      </div>
+    </div>
+  )
+}

--- a/ui-v2/src/components/work-pools/work-pools-table/index.ts
+++ b/ui-v2/src/components/work-pools/work-pools-table/index.ts
@@ -1,0 +1,1 @@
+export { WorkPoolsDataTable } from './work-pools-data-table'

--- a/ui-v2/src/components/work-pools/work-pools-table/work-pools-data-table.stories.tsx
+++ b/ui-v2/src/components/work-pools/work-pools-table/work-pools-data-table.stories.tsx
@@ -1,0 +1,20 @@
+import { createFakeWorkPool } from '@/mocks'
+import { reactQueryDecorator } from '@/storybook/utils'
+import type { Meta, StoryObj } from '@storybook/react'
+import { WorkPoolsDataTable } from './work-pools-data-table'
+
+const meta: Meta<typeof WorkPoolsDataTable> = {
+  title: 'Components/WorkPools/WorkPoolsDataTable',
+  component: WorkPoolsDataTable,
+  decorators: [reactQueryDecorator],
+}
+export default meta
+
+type Story = StoryObj<typeof WorkPoolsDataTable>
+
+export const Default: Story = {
+  args: {
+    workPools: [createFakeWorkPool(), createFakeWorkPool(), createFakeWorkPool()],
+    totalCount: 3,
+  },
+}

--- a/ui-v2/src/components/work-pools/work-pools-table/work-pools-data-table.tsx
+++ b/ui-v2/src/components/work-pools/work-pools-table/work-pools-data-table.tsx
@@ -1,0 +1,91 @@
+import type { WorkPool } from '@/api/work-pools'
+import { useDeleteWorkPool } from '@/api/work-pools'
+import { DataTable } from '@/components/ui/data-table'
+import { SearchInput } from '@/components/ui/input'
+import { StatusBadge } from '@/components/ui/status-badge'
+import { WorkPoolContextMenu } from '../work-pool-card/components/work-pool-context-menu'
+import { WorkPoolName } from '../work-pool-card/components/work-pool-name'
+import { WorkPoolPauseResumeToggle } from '../work-pool-card/components/work-pool-pause-resume-toggle'
+import { WorkPoolTypeBadge } from '../work-pool-card/components/work-pool-type-badge'
+import { pluralize } from '@/utils'
+import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import { useCallback, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+type WorkPoolsDataTableProps = {
+  workPools: WorkPool[]
+  totalCount: number
+}
+
+const columnHelper = createColumnHelper<WorkPool>()
+
+export const WorkPoolsDataTable = ({ workPools, totalCount }: WorkPoolsDataTableProps) => {
+  const { deleteWorkPool } = useDeleteWorkPool()
+  const [search, setSearch] = useState('')
+
+  const filteredWorkPools = useMemo(() => {
+    return workPools.filter(pool =>
+      [pool.name, pool.description, pool.type, pool.id].join(' ').toLowerCase().includes(search.toLowerCase()),
+    )
+  }, [workPools, search])
+
+  const handleDelete = useCallback(
+    (pool: WorkPool) => {
+      deleteWorkPool(pool.name, {
+        onSuccess: () => toast.success(`${pool.name} deleted`),
+        onError: () => toast.error(`Failed to delete ${pool.name}`),
+      })
+    },
+    [deleteWorkPool],
+  )
+
+  const columns = useMemo(
+    () => [
+      columnHelper.display({
+        id: 'name',
+        header: 'Name',
+        cell: ({ row }) => <WorkPoolName workPoolName={row.original.name} />,
+      }),
+      columnHelper.accessor('type', {
+        header: 'Type',
+        cell: info => <WorkPoolTypeBadge type={info.getValue()} />,
+      }),
+      columnHelper.accessor('concurrency_limit', {
+        header: 'Concurrency',
+        cell: info => info.getValue() ?? 'Unlimited',
+      }),
+      columnHelper.accessor('status', {
+        header: 'Status',
+        cell: info => info.getValue() && <StatusBadge status={info.getValue()} />,
+      }),
+      columnHelper.display({
+        id: 'actions',
+        cell: ({ row }) => (
+          <div className='flex items-center gap-2 justify-end'>
+            <WorkPoolPauseResumeToggle workPool={row.original} />
+            <WorkPoolContextMenu workPool={row.original} onDelete={() => handleDelete(row.original)} />
+          </div>
+        ),
+      }),
+    ],
+    [handleDelete],
+  )
+
+  const table = useReactTable({
+    data: filteredWorkPools,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <div>
+      <div className='flex items-end justify-between pb-4'>
+        <p className='text-sm text-muted-foreground'>
+          {totalCount} {pluralize(totalCount, 'work pool')}
+        </p>
+        <SearchInput placeholder='Search work pools...' value={search} onChange={e => setSearch(e.target.value)} />
+      </div>
+      <DataTable table={table} />
+    </div>
+  )
+}

--- a/ui-v2/src/components/work-pools/work-queue-details-header.stories.tsx
+++ b/ui-v2/src/components/work-pools/work-queue-details-header.stories.tsx
@@ -1,0 +1,20 @@
+import { createFakeWorkQueue } from "@/mocks/create-fake-work-queue";
+import { reactQueryDecorator, routerDecorator } from "@/storybook/utils";
+import type { Meta, StoryObj } from "@storybook/react";
+import { WorkQueueDetailsHeader } from "./work-queue-details-header";
+
+const meta: Meta<typeof WorkQueueDetailsHeader> = {
+  title: "Components/WorkPools/WorkQueueDetailsHeader",
+  component: WorkQueueDetailsHeader,
+  decorators: [routerDecorator, reactQueryDecorator],
+};
+export default meta;
+
+type Story = StoryObj<typeof WorkQueueDetailsHeader>;
+
+export const Default: Story = {
+  args: {
+    workPoolName: "my-pool",
+    workQueue: createFakeWorkQueue({ work_pool_name: "my-pool" }),
+  },
+};

--- a/ui-v2/src/components/work-pools/work-queue-details-header.tsx
+++ b/ui-v2/src/components/work-pools/work-queue-details-header.tsx
@@ -1,0 +1,47 @@
+import type { WorkQueue } from "@/api/work-queues";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { Link } from "@tanstack/react-router";
+
+export type WorkQueueDetailsHeaderProps = {
+  workPoolName: string;
+  workQueue: WorkQueue;
+};
+
+export const WorkQueueDetailsHeader = ({ workPoolName, workQueue }: WorkQueueDetailsHeaderProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink to="/work-pools" className="text-xl font-semibold">
+              Work pools
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink
+              to="/work-pools/work-pool/$workPoolName"
+              params={{ workPoolName }}
+              className="text-xl font-semibold"
+            >
+              {workPoolName}
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem className="text-xl font-semibold">
+            <BreadcrumbPage>{workQueue.name}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      {workQueue.status && <StatusBadge status={workQueue.status} />}
+    </div>
+  );
+};

--- a/ui-v2/src/components/work-pools/work-queues-table/index.ts
+++ b/ui-v2/src/components/work-pools/work-queues-table/index.ts
@@ -1,0 +1,1 @@
+export { WorkPoolQueuesDataTable } from './work-pool-queues-data-table'

--- a/ui-v2/src/components/work-pools/work-queues-table/work-pool-queues-data-table.stories.tsx
+++ b/ui-v2/src/components/work-pools/work-queues-table/work-pool-queues-data-table.stories.tsx
@@ -1,0 +1,20 @@
+import { createFakeWorkQueue } from '@/mocks'
+import { reactQueryDecorator } from '@/storybook/utils'
+import type { Meta, StoryObj } from '@storybook/react'
+import { WorkPoolQueuesDataTable } from './work-pool-queues-data-table'
+
+const meta: Meta<typeof WorkPoolQueuesDataTable> = {
+  title: 'Components/WorkPools/WorkPoolQueuesDataTable',
+  component: WorkPoolQueuesDataTable,
+  decorators: [reactQueryDecorator],
+}
+export default meta
+
+type Story = StoryObj<typeof WorkPoolQueuesDataTable>
+
+export const Default: Story = {
+  args: {
+    workPoolName: 'my-pool',
+    workQueues: [createFakeWorkQueue({ work_pool_name: 'my-pool' }), createFakeWorkQueue({ work_pool_name: 'my-pool' })],
+  },
+}

--- a/ui-v2/src/components/work-pools/work-queues-table/work-pool-queues-data-table.tsx
+++ b/ui-v2/src/components/work-pools/work-queues-table/work-pool-queues-data-table.tsx
@@ -1,0 +1,47 @@
+import type { WorkQueue } from '@/api/work-queues'
+import { DataTable } from '@/components/ui/data-table'
+import { StatusBadge } from '@/components/ui/status-badge'
+import { WorkQueueLink } from '../work-queue-link'
+import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import { useMemo } from 'react'
+
+type WorkPoolQueuesDataTableProps = {
+  workPoolName: string
+  workQueues: WorkQueue[]
+}
+
+const columnHelper = createColumnHelper<WorkQueue>()
+
+export const WorkPoolQueuesDataTable = ({ workPoolName, workQueues }: WorkPoolQueuesDataTableProps) => {
+  const columns = useMemo(
+    () => [
+      columnHelper.display({
+        id: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <WorkQueueLink workPoolName={workPoolName} workQueueName={row.original.name} />
+        ),
+      }),
+      columnHelper.accessor('priority', {
+        header: 'Priority',
+      }),
+      columnHelper.accessor('concurrency_limit', {
+        header: 'Concurrency',
+        cell: info => info.getValue() ?? 'Unlimited',
+      }),
+      columnHelper.accessor('status', {
+        header: 'Status',
+        cell: info => info.getValue() && <StatusBadge status={info.getValue()} />,
+      }),
+    ],
+    [workPoolName],
+  )
+
+  const table = useReactTable({
+    data: workQueues,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return <DataTable table={table} />
+}

--- a/ui-v2/src/routes/work-pools/index.tsx
+++ b/ui-v2/src/routes/work-pools/index.tsx
@@ -2,14 +2,11 @@ import {
 	buildCountWorkPoolsQuery,
 	buildFilterWorkPoolsQuery,
 } from "@/api/work-pools";
-import { SearchInput } from "@/components/ui/input";
 import { WorkPoolsEmptyState } from "@/components/work-pools/empty-state";
 import { WorkPoolsPageHeader } from "@/components/work-pools/header";
-import { WorkPoolCard } from "@/components/work-pools/work-pool-card/work-pool-card";
-import { pluralize } from "@/utils";
+import { WorkPoolsDataTable } from "@/components/work-pools/work-pools-table";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
 
 export const Route = createFileRoute("/work-pools/")({
 	component: RouteComponent,
@@ -26,7 +23,6 @@ export const Route = createFileRoute("/work-pools/")({
 });
 
 function RouteComponent() {
-	const [searchTerm, setSearchTerm] = useState("");
 
 	const { data: workPoolCount = 0 } = useSuspenseQuery(
 		buildCountWorkPoolsQuery(),
@@ -39,53 +35,14 @@ function RouteComponent() {
 		}),
 	);
 
-	const filteredWorkPools = useMemo(() => {
-		return workPools.filter((workPool) =>
-			[
-				workPool.name,
-				workPool.description,
-				workPool.type,
-				JSON.stringify(workPool.base_job_template),
-				workPool.id,
-				workPool.default_queue_id,
-				workPool.status,
-			]
-				.join(" ")
-				.toLowerCase()
-				.includes(searchTerm.toLowerCase()),
-		);
-	}, [workPools, searchTerm]);
-
-	const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-		setSearchTerm(event.target.value);
-	};
-
-	return (
-		<div className="flex flex-col gap-4">
-			<WorkPoolsPageHeader />
-			{workPoolCount < 1 ? (
-				<WorkPoolsEmptyState />
-			) : (
-				<>
-					<div className="flex items-end justify-between">
-						<div className="text-sm text-muted-foreground">
-							{workPoolCount} {pluralize(workPoolCount, "work pool")}
-						</div>
-						<div className="flex gap-2">
-							<SearchInput
-								placeholder="Search work pools..."
-								value={searchTerm}
-								onChange={handleSearchChange}
-							/>
-						</div>
-					</div>
-					<div className="flex flex-col gap-4">
-						{filteredWorkPools.map((workPool) => (
-							<WorkPoolCard key={workPool.id} workPool={workPool} />
-						))}
-					</div>
-				</>
-			)}
-		</div>
-	);
+        return (
+                <div className="flex flex-col gap-4">
+                        <WorkPoolsPageHeader />
+                        {workPoolCount < 1 ? (
+                                <WorkPoolsEmptyState />
+                        ) : (
+                                <WorkPoolsDataTable workPools={workPools} totalCount={workPoolCount} />
+                        )}
+                </div>
+        );
 }

--- a/ui-v2/src/routes/work-pools/work-pool.$workPoolName.queue.$workQueueName.tsx
+++ b/ui-v2/src/routes/work-pools/work-pool.$workPoolName.queue.$workQueueName.tsx
@@ -1,11 +1,87 @@
+import { buildFilterFlowRunsQuery } from "@/api/flow-runs";
+import { buildWorkQueueDetailsQuery } from "@/api/work-queues";
+import { WorkQueueDetailsHeader } from "@/components/work-pools/work-queue-details-header";
+import { FlowRunsList } from "@/components/flow-runs/flow-runs-list";
+import { Card } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { z } from "zod";
+
+const searchParams = z.object({ tab: z.string().optional() }).optional();
 
 export const Route = createFileRoute(
-	"/work-pools/work-pool/$workPoolName/queue/$workQueueName",
+  "/work-pools/work-pool/$workPoolName/queue/$workQueueName"
 )({
-	component: RouteComponent,
+  validateSearch: zodValidator(searchParams),
+  component: RouteComponent,
+  loader: async ({ context, params }) => {
+    const { workPoolName, workQueueName } = params;
+    await context.queryClient.ensureQueryData(
+      buildWorkQueueDetailsQuery(workPoolName, workQueueName)
+    );
+    await context.queryClient.ensureQueryData(
+      buildFilterFlowRunsQuery({
+        limit: 20,
+        offset: 0,
+        sort: "START_TIME_DESC",
+        work_pools: { name: [workPoolName] },
+        work_pool_queues: { name: [workQueueName] },
+      })
+    );
+  },
+  wrapInSuspense: true,
 });
 
 function RouteComponent() {
-	return "🚧🚧 Pardon our dust! 🚧🚧";
+  const { workPoolName, workQueueName } = Route.useParams();
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const tab = search?.tab ?? "details";
+
+  const { data: workQueue } = useSuspenseQuery(
+    buildWorkQueueDetailsQuery(workPoolName, workQueueName)
+  );
+  const { data: flowRuns } = useSuspenseQuery(
+    buildFilterFlowRunsQuery({
+      limit: 20,
+      offset: 0,
+      sort: "START_TIME_DESC",
+      work_pools: { name: [workPoolName] },
+      work_pool_queues: { name: [workQueueName] },
+    })
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <WorkQueueDetailsHeader workPoolName={workPoolName} workQueue={workQueue} />
+      <Tabs
+        value={tab}
+        onValueChange={(value) =>
+          navigate({ to: ".", search: (prev) => ({ ...prev, tab: value }) })
+        }
+      >
+        <TabsList>
+          <TabsTrigger value="details">Details</TabsTrigger>
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+        </TabsList>
+        <TabsContent value="details">
+          <Card className="p-4 space-y-2">
+            <div>
+              <span className="text-sm text-muted-foreground">Description</span>
+              <div>{workQueue.description}</div>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Priority</span>
+              <div>{workQueue.priority}</div>
+            </div>
+          </Card>
+        </TabsContent>
+        <TabsContent value="runs">
+          <FlowRunsList flowRuns={flowRuns} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }

--- a/ui-v2/src/routes/work-pools/work-pool.$workPoolName.tsx
+++ b/ui-v2/src/routes/work-pools/work-pool.$workPoolName.tsx
@@ -1,23 +1,92 @@
-import { buildGetWorkPoolQuery } from "@/api/work-pools/work-pools";
+import { buildFilterFlowRunsQuery } from "@/api/flow-runs";
+import { buildGetWorkPoolQuery } from "@/api/work-pools";
+import { buildFilterWorkPoolWorkQueuesQuery } from "@/api/work-queues";
+import { WorkPoolDetailsHeader } from "@/components/work-pools/work-pool-details-header";
+import { WorkPoolQueuesDataTable } from "@/components/work-pools/work-queues-table";
+import { FlowRunsList } from "@/components/flow-runs/flow-runs-list";
+import { Card } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { useNavigate } from "react-router-dom";
+import { z } from "zod";
+
+const searchParams = z.object({ tab: z.string().optional() }).optional();
 
 export const Route = createFileRoute("/work-pools/work-pool/$workPoolName")({
-	component: RouteComponent,
-	loader: async ({ context, params }) => {
-		const { workPoolName } = params;
-		return context.queryClient.ensureQueryData(
-			buildGetWorkPoolQuery(workPoolName),
-		);
-	},
-	wrapInSuspense: true,
+  validateSearch: zodValidator(searchParams),
+  component: RouteComponent,
+  loader: async ({ context, params }) => {
+    const { workPoolName } = params;
+    await context.queryClient.ensureQueryData(buildGetWorkPoolQuery(workPoolName));
+    await context.queryClient.ensureQueryData(
+      buildFilterWorkPoolWorkQueuesQuery({ work_pool_name: workPoolName })
+    );
+    await context.queryClient.ensureQueryData(
+      buildFilterFlowRunsQuery({
+        limit: 20,
+        offset: 0,
+        sort: "START_TIME_DESC",
+        work_pools: { name: [workPoolName] },
+      })
+    );
+  },
+  wrapInSuspense: true,
 });
 
 function RouteComponent() {
-	const { workPoolName } = Route.useParams();
-	const { data: workPool } = useSuspenseQuery(
-		buildGetWorkPoolQuery(workPoolName),
-	);
+  const { workPoolName } = Route.useParams();
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const tab = search?.tab ?? "details";
 
-	return <div>Work pool: {workPool.name}</div>;
+  const { data: workPool } = useSuspenseQuery(buildGetWorkPoolQuery(workPoolName));
+  const { data: queues } = useSuspenseQuery(
+    buildFilterWorkPoolWorkQueuesQuery({ work_pool_name: workPoolName })
+  );
+  const { data: flowRuns } = useSuspenseQuery(
+    buildFilterFlowRunsQuery({
+      limit: 20,
+      offset: 0,
+      sort: "START_TIME_DESC",
+      work_pools: { name: [workPoolName] },
+    })
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <WorkPoolDetailsHeader workPool={workPool} />
+      <Tabs
+        value={tab}
+        onValueChange={(value) =>
+          navigate({ to: ".", search: (prev) => ({ ...prev, tab: value }) })
+        }
+      >
+        <TabsList>
+          <TabsTrigger value="details">Details</TabsTrigger>
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+          <TabsTrigger value="queues">Work Queues</TabsTrigger>
+        </TabsList>
+        <TabsContent value="details">
+          <Card className="p-4 space-y-2">
+            <div>
+              <span className="text-sm text-muted-foreground">Description</span>
+              <div>{workPool.description}</div>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Type</span>
+              <div>{workPool.type}</div>
+            </div>
+          </Card>
+        </TabsContent>
+        <TabsContent value="runs">
+          <FlowRunsList flowRuns={flowRuns} />
+        </TabsContent>
+        <TabsContent value="queues">
+          <WorkPoolQueuesDataTable workPoolName={workPoolName} workQueues={queues} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add WorkPoolsDataTable and WorkPoolQueuesDataTable components with search and status columns
- integrate tables into work pools index and details pages
- enhance WorkPoolDetailsHeader with context menu and pause/resume toggle

## Testing
- `npm run format --silent` *(fails: biome not found)*