### PR TITLE
Fix error in setup for client compatibility tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -139,7 +139,7 @@ jobs:
         run: >
           uv run --isolated prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
 
-          ./scripts/wait-for-server.py
+          uv run --isolated ./scripts/wait-for-server.py
 
       - name: Verify the CLI isn't available in the active environment
         run: |


### PR DESCRIPTION
The client compability tests have been failing because of a missing `uv run`.