### PR TITLE
Fix bug where the runner would try to cancel a flow run that was not running

### DIFF
--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -968,16 +968,9 @@ class Runner:
 
         pid = process_map_entry.get("pid") if process_map_entry else None
         if not pid:
-            if flow_run.state:
-                await self._run_on_cancellation_hooks(flow_run, flow_run.state)
-            await self._mark_flow_run_as_cancelled(
-                flow_run,
-                state_updates={
-                    "message": (
-                        "Could not find process ID for flow run"
-                        " and cancellation cannot be guaranteed."
-                    )
-                },
+            self._logger.debug(
+                "Received cancellation request for flow run %s but no process was found.",
+                flow_run.id,
             )
             return
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -911,6 +911,48 @@ class TestRunner:
         assert resource["prefect.deployment.version-type"] == "githubulous"
         assert resource["prefect.deployment.version"] == "1.2.3.4.5.6"
 
+    async def test_runner_does_not_try_to_cancel_flow_run_if_no_process_id_is_found(
+        self, prefect_client: PrefectClient
+    ):
+        """
+        Regression test for https://github.com/PrefectHQ/prefect/issues/18106
+        """
+        runner_1 = Runner()
+        runner_2 = Runner()
+        runner_2._mark_flow_run_as_cancelled = AsyncMock()
+        runner_2._kill_process = AsyncMock()
+        deployment_id = await runner_1.add_deployment(
+            await tired_flow.to_deployment(__file__)
+        )
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        async with runner_1, runner_2:
+            execute_task = asyncio.create_task(runner_1.execute_flow_run(flow_run.id))
+
+            while True:
+                await anyio.sleep(0.5)
+                flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+                assert flow_run.state
+                if flow_run.state.is_running():
+                    break
+
+            await prefect_client.set_flow_run_state(
+                flow_run_id=flow_run.id,
+                state=flow_run.state.model_copy(
+                    update={"name": "Cancelling", "type": StateType.CANCELLING}
+                ),
+            )
+
+            await execute_task
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert flow_run.state.is_cancelled()
+        runner_2._mark_flow_run_as_cancelled.assert_not_called()
+        runner_2._kill_process.assert_not_called()
+
     @pytest.mark.usefixtures("use_hosted_api_server")
     async def test_runner_runs_on_cancellation_hooks_for_remotely_stored_flows(
         self,


### PR DESCRIPTION
This PR removes some code for `Runner` cancellation that is no longer necessary, but lead to the incorrect `Runner` cancelling a flow run when multiple instances are running for the same deployment or if multiple process workers are running in the same work pool.

Closes https://github.com/PrefectHQ/prefect/issues/18106