### PR TITLE
avoid unexpected buffer consumption in pydantic encoder

### DIFF
--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -50,8 +50,10 @@ def prefect_json_object_encoder(obj: Any) -> Any:
     elif isinstance(obj, io.IOBase):
         return {
             "__class__": to_qualified_name(obj.__class__),
-            "__prefect_io_placeholder__": True,
-            "repr": repr(obj),
+            "data": (
+                f"<Prefect IOStream Placeholder: type={obj.__class__.__name__}, "
+                f"repr={repr(obj)} (original content not read)>"
+            ),
         }
     else:
         return {

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -12,6 +12,7 @@ bytes to an object respectively.
 """
 
 import base64
+import io
 from typing import Any, ClassVar, Generic, Optional, Union, overload
 
 from pydantic import (
@@ -46,6 +47,12 @@ def prefect_json_object_encoder(obj: Any) -> Any:
     """
     if isinstance(obj, BaseException):
         return {"__exc_type__": to_qualified_name(obj.__class__), "message": str(obj)}
+    elif isinstance(obj, io.IOBase):
+        return {
+            "__class__": to_qualified_name(obj.__class__),
+            "__prefect_io_placeholder__": True,
+            "repr": repr(obj),
+        }
     else:
         return {
             "__class__": to_qualified_name(obj.__class__),

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,7 +1,9 @@
 import base64
+import io
 import json
 import uuid
 from dataclasses import dataclass
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -168,7 +170,7 @@ class TestPickleSerializer:
         with pytest.raises(ValueError):
             PickleSerializer(picklelib=pickle)
 
-    def test_picklelib_is_used(self, monkeypatch):
+    def test_picklelib_is_used(self, monkeypatch: pytest.MonkeyPatch):
         dumps = MagicMock(return_value=b"test")
         loads = MagicMock(return_value="test")
         monkeypatch.setattr("pickle.dumps", dumps)
@@ -179,7 +181,7 @@ class TestPickleSerializer:
         serializer.loads(b"test")
         loads.assert_called_once_with(base64.decodebytes(b"test"))
 
-    def test_picklelib_must_implement_dumps(self, monkeypatch):
+    def test_picklelib_must_implement_dumps(self, monkeypatch: pytest.MonkeyPatch):
         import pickle
 
         monkeypatch.delattr(pickle, "dumps")
@@ -189,7 +191,7 @@ class TestPickleSerializer:
         ):
             PickleSerializer(picklelib="pickle")
 
-    def test_picklelib_must_implement_loads(self, monkeypatch):
+    def test_picklelib_must_implement_loads(self, monkeypatch: pytest.MonkeyPatch):
         import pickle
 
         monkeypatch.delattr(pickle, "loads")
@@ -202,13 +204,13 @@ class TestPickleSerializer:
 
 class TestJSONSerializer:
     @pytest.mark.parametrize("data", SERIALIZER_TEST_CASES)
-    def test_simple_roundtrip(self, data):
+    def test_simple_roundtrip(self, data: Any):
         serializer = JSONSerializer()
         serialized = serializer.dumps(data)
         assert serializer.loads(serialized) == data
 
     @pytest.mark.parametrize("data", EXCEPTION_TEST_CASES)
-    def test_exception_roundtrip(self, data):
+    def test_exception_roundtrip(self, data: Any):
         serializer = JSONSerializer()
         serialized = serializer.dumps(data)
         assert exceptions_equal(serializer.loads(serialized), data)
@@ -223,7 +225,7 @@ class TestJSONSerializer:
             {"key": complex_str.encode("ASCII")},
         ],
     )
-    def test_simple_roundtrip_with_complex_bytes(self, data):
+    def test_simple_roundtrip_with_complex_bytes(self, data: Any):
         serializer = JSONSerializer()
         serialized = serializer.dumps(data)
         assert serializer.loads(serialized) == data
@@ -236,7 +238,7 @@ class TestJSONSerializer:
         serialized = serializer.dumps("test")
         assert serializer.loads(serialized) == "test"
 
-    def test_uses_alternative_json_library(self, monkeypatch):
+    def test_uses_alternative_json_library(self, monkeypatch: pytest.MonkeyPatch):
         dumps_mock = MagicMock()
         loads_mock = MagicMock()
         monkeypatch.setattr("orjson.dumps", dumps_mock)
@@ -249,7 +251,46 @@ class TestJSONSerializer:
             "test", object_hook=prefect_json_object_decoder
         )
 
-    def test_allows_custom_encoder(self, monkeypatch):
+    def test_json_serializer_does_not_consume_iobase_objects(self):
+        serializer = JSONSerializer()
+        string_io_content = "hello world from unit test"
+        string_io = io.StringIO(string_io_content)
+        data_with_stream = {"my_stream": string_io, "other_data": 123}
+
+        string_io.seek(0)
+        assert string_io.tell() == 0, "Initial seek(0) failed"
+
+        serialized_data = serializer.dumps(data_with_stream)
+
+        assert string_io.tell() == 0, (
+            "Stream pointer should not have moved after dumps()"
+        )
+
+        assert string_io.read() == string_io_content, (
+            "Stream content changed or was consumed after dumps()"
+        )
+
+        string_io.seek(0)
+
+        deserialized_data = json.loads(serialized_data.decode())
+        assert isinstance(deserialized_data.get("my_stream"), dict), (
+            "Serialized 'my_stream' is not a dict"
+        )
+        assert (
+            deserialized_data["my_stream"].get("__prefect_io_placeholder__") is True
+        ), "Missing '__prefect_io_placeholder__'"
+        assert "repr" in deserialized_data["my_stream"], (
+            "Missing 'repr' in serialized stream placeholder"
+        )
+        assert string_io_content not in deserialized_data["my_stream"]["repr"], (
+            "Original content found in repr of placeholder"
+        )
+        assert "StringIO" in deserialized_data["my_stream"]["repr"], (
+            "'StringIO' not in repr of placeholder"
+        )
+        assert deserialized_data.get("other_data") == 123, "Other data was altered"
+
+    def test_allows_custom_encoder(self, monkeypatch: pytest.MonkeyPatch):
         fake_object_encoder = MagicMock(return_value="foobar!")
         prefect_object_encoder = MagicMock()
 
@@ -274,7 +315,7 @@ class TestJSONSerializer:
         prefect_object_encoder.assert_not_called()
         fake_object_encoder.assert_called_once_with(obj)
 
-    def test_allows_custom_decoder(self, monkeypatch):
+    def test_allows_custom_decoder(self, monkeypatch: pytest.MonkeyPatch):
         fake_object_decoder = MagicMock(return_value="test")
         prefect_object_decoder = MagicMock()
 
@@ -298,7 +339,7 @@ class TestJSONSerializer:
         fake_object_decoder.assert_called_once_with({"foo": "bar"})
         prefect_object_decoder.assert_not_called()
 
-    def test_allows_custom_kwargs(self, monkeypatch):
+    def test_allows_custom_kwargs(self, monkeypatch: pytest.MonkeyPatch):
         dumps_mock = MagicMock()
         loads_mock = MagicMock()
         monkeypatch.setattr("json.dumps", dumps_mock)
@@ -326,7 +367,7 @@ class TestJSONSerializer:
 
 class TestCompressedSerializer:
     @pytest.mark.parametrize("data", SERIALIZER_TEST_CASES)
-    def test_simple_roundtrip(self, data):
+    def test_simple_roundtrip(self, data: Any):
         serializer = CompressedSerializer(serializer="pickle")
         serialized = serializer.dumps(data)
         assert serializer.loads(serialized) == data
@@ -337,7 +378,9 @@ class TestCompressedSerializer:
         serialized = serializer.dumps("test")
         assert serializer.loads(serialized) == "test"
 
-    def test_uses_alternative_compression_library(self, monkeypatch):
+    def test_uses_alternative_compression_library(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         compress_mock = MagicMock(return_value=b"test")
         decompress_mock = MagicMock(return_value=PickleSerializer().dumps("test"))
         monkeypatch.setattr("zlib.compress", compress_mock)
@@ -348,7 +391,7 @@ class TestCompressedSerializer:
         compress_mock.assert_called_once()
         decompress_mock.assert_called_once()
 
-    def test_uses_given_serializer(self, monkeypatch):
+    def test_uses_given_serializer(self, monkeypatch: pytest.MonkeyPatch):
         compress_mock = MagicMock(return_value=b"test")
         decompress_mock = MagicMock(return_value=JSONSerializer().dumps("test"))
         monkeypatch.setattr("zlib.compress", compress_mock)


### PR DESCRIPTION
Addresses an issue where `io.StringIO`/`BytesIO` objects passed as task parameters were consumed before task execution, appearing empty to user code. This was a regression from Prefect 2.

**Cause:**
The `prefect_json_object_encoder` (used by `JSONSerializer` for logging/events) inadvertently read `io.IOBase` objects during its serialization process.

**Solution:**
`prefect_json_object_encoder` now explicitly checks for `io.IOBase` instances. Instead of reading them, it returns a standardized dictionary placeholder (e.g., `{"__class__": "...", "data": "<Prefect IOStream Placeholder...>"}`). This keeps the stream unread for the task.



<details>

### original report

from slack

```python
from io import StringIO

import prefect
from prefect import flow, task, get_run_logger


@task
def main_task(stream):
    logger = get_run_logger()
    logger.info("|" + stream.read() + "|")
    stream.seek(0)
    logger.info("|" + stream.read() + "|")


@flow
def main_flow():
    logger = get_run_logger()
    logger.info("Version: " + prefect.__version__)

    main_task(StringIO("Hello world"))

main_flow()
```

prefect 3
```python
14:37:09.429 | INFO    | Flow run 'banana-hound' - Beginning flow run 'banana-hound' for flow 'main-flow'
14:37:09.434 | INFO    | Flow run 'banana-hound' - View at http://127.0.0.1:4200/runs/flow-run/8bdf7a74-9b22-4522-ae1e-bebac8c75970
14:37:09.435 | INFO    | Flow run 'banana-hound' - Version: 3.3.7
14:37:09.515 | INFO    | Task run 'main_task-981' - ||
14:37:09.517 | INFO    | Task run 'main_task-981' - |Hello world|
14:37:09.524 | INFO    | Task run 'main_task-981' - Finished in state Completed()
14:37:09.724 | INFO    | Flow run 'banana-hound' - Finished in state Completed()
```


prefect 2
```python
14:49:00.531 | INFO    | prefect.engine - Created flow run 'aquamarine-corgi' for flow 'main-flow'
14:49:00.539 | INFO    | Flow run 'aquamarine-corgi' - View at http://127.0.0.1:4200/flow-runs/flow-run/8d543e70-c019-4e59-9cd7-35cfcb6da9a5
14:49:00.692 | INFO    | Flow run 'aquamarine-corgi' - Version: 2.20.18
14:49:00.823 | INFO    | Flow run 'aquamarine-corgi' - Created task run 'main_task-0' for task 'main_task'
14:49:00.825 | INFO    | Flow run 'aquamarine-corgi' - Executing 'main_task-0' immediately...
14:49:00.965 | INFO    | Task run 'main_task-0' - |Hello world|
14:49:00.967 | INFO    | Task run 'main_task-0' - |Hello world|
14:49:01.032 | INFO    | Task run 'main_task-0' - Finished in state Completed()
14:49:01.112 | INFO    | Flow run 'aquamarine-corgi' - Finished in state Completed('All states completed.')
```

</details>

my choice of placeholder format was pretty arbitrary, i was more or less following the `__class__` and `data` key precedent and then trying to give a semantically informative placeholder, but open to suggestions