### PR TITLE
Move test workflows to how-to guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,8 +32,7 @@
                   "v3/develop/task-run-limits",
                   "v3/develop/global-concurrency-limits"
                 ]
-              },
-              "v3/develop/test-workflows"
+              }
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,7 +97,8 @@
               "v3/how-to-guides/workflows/visualize-workflow-structure",
               "v3/how-to-guides/workflows/run-background-tasks",
               "v3/how-to-guides/workflows/state-change-hooks",
-              "v3/how-to-guides/workflows/artifacts"
+              "v3/how-to-guides/workflows/artifacts",
+              "v3/how-to-guides/workflows/test-workflows"
             ]
           },
           { "group": "Configuration",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1647,6 +1647,10 @@
       "destination": "/v3/how-to-guides/configuration/manage-settings"
     },
     {
+      "source": "/v3/develop/test-workflows",
+      "destination": "/v3/how-to-guides/workflows/test-workflows"
+    },
+    {
       "source": "/v3/deploy/infrastructure-concepts/deploy-via-python",
       "destination": "/v3/how-to-guides/deployments/deploy-via-python"
     },

--- a/docs/v3/how-to-guides/workflows/test-workflows.mdx
+++ b/docs/v3/how-to-guides/workflows/test-workflows.mdx
@@ -1,7 +1,9 @@
 ---
-title: Test workflows
-description: Learn about writing tests for Prefect flows and tasks.
+title: How to test workflows
+sidebarTitle: Test workflows
 ---
+
+### Isolate tests with an ephemeral backend
 
 Prefect provides a simple context manager for unit tests that allows you to run flows and tasks against a temporary local SQLite database.
 
@@ -44,9 +46,10 @@ def test_my_favorite_flow():
 
 In this example, the fixture is scoped to run once for the entire test session. In most cases, you do not need a clean database for each test. Just isolate your test runs to a test database. Creating a new test database per test creates significant overhead, so we recommend scoping the fixture to the session. If you need to isolate some tests fully, use the test harness again to create a fresh database.
 </Note>
-## Unit testing tasks
 
-To test an individual task, access the original function using `.fn`:
+### Unit testing underlying functions
+
+To test the function decorated with `@task` or `@flow`, use `.fn` to call the wrapped function directly:
 
 ```python
 from prefect import flow, task
@@ -64,10 +67,7 @@ def test_my_favorite_task():
     assert my_favorite_task.fn() == 42
 ```
 
-<Tip>
-**Disable logger**
-
-If your task uses a logger, you can disable the logger to avoid the `RuntimeError` raised from a missing flow context.
+If your flow or task uses a logger, you can disable the logger to avoid the `RuntimeError` raised from a missing flow context.
     ```python
     from prefect.logging import disable_run_logger
 
@@ -75,4 +75,3 @@ If your task uses a logger, you can disable the logger to avoid the `RuntimeErro
         with disable_run_logger():
             assert my_favorite_task.fn() == 42
     ```
-</Tip>

--- a/docs/v3/how-to-guides/workflows/test-workflows.mdx
+++ b/docs/v3/how-to-guides/workflows/test-workflows.mdx
@@ -1,6 +1,7 @@
 ---
 title: How to test workflows
 sidebarTitle: Test workflows
+description: Learn about writing tests for Prefect flows and tasks.
 ---
 
 ### Isolate tests with an ephemeral backend


### PR DESCRIPTION
Stacked on https://github.com/PrefectHQ/prefect/pull/18123

This pull request updates the documentation for testing workflows in Prefect, reorganizing and improving the content for clarity and accessibility. The most important changes involve restructuring the file, adding new sections, and refining the language to better guide users.

### Documentation Restructuring and Updates:

* **File renamed and retitled:** The file `docs/v3/develop/test-workflows.mdx` was renamed to `docs/v3/how-to-guides/workflows/test-workflows.mdx` and retitled from "Test workflows" to "How to test workflows" to align with the "How-to guides" structure. A new `sidebarTitle` was also added for better navigation.

* **New section added:** A section titled "Isolate tests with an ephemeral backend" was introduced, explaining how to use a temporary local SQLite database for unit tests.

* **Improved task testing guidance:** The section on unit testing was renamed to "Unit testing underlying functions" and clarified to explain how to test functions decorated with `@task` or `@flow` using `.fn`.

* **Refined logger disabling instructions:** Simplified the explanation for disabling the logger when testing flows or tasks, removing unnecessary `<Tip>` formatting.

### Navigation and Redirection Updates:

* **Updated navigation links:** The `docs/docs.json` file was updated to move the "test-workflows" documentation under the "How-to guides" section, ensuring it appears in the correct category in the sidebar. [[1]](diffhunk://#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9L35-R35) [[2]](diffhunk://#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9L100-R100)

* **Added redirection rule:** A redirection was added to map the old URL `/v3/develop/test-workflows` to the new location `/v3/how-to-guides/workflows/test-workflows`.