### PR TITLE
centralize consumer name generation

### DIFF
--- a/src/prefect/server/events/services/actions.py
+++ b/src/prefect/server/events/services/actions.py
@@ -6,7 +6,9 @@ from typing import TYPE_CHECKING, NoReturn
 from prefect.logging import get_logger
 from prefect.server.events import actions
 from prefect.server.services.base import RunInAllServers, Service
-from prefect.server.utilities.messaging import Consumer, create_consumer
+from prefect.server.utilities.messaging import create_consumer
+from prefect.server.utilities.messaging._names import generate_consumer_name
+from prefect.settings import PREFECT_MESSAGING_BROKER
 from prefect.settings.context import get_current_settings
 from prefect.settings.models.server.services import ServicesBaseSetting
 
@@ -27,7 +29,11 @@ class Actions(RunInAllServers, Service):
 
     async def start(self) -> NoReturn:
         assert self.consumer_task is None, "Actions already started"
-        self.consumer: Consumer = create_consumer("actions")
+        consumer_kwargs = {}
+        if PREFECT_MESSAGING_BROKER.value() == "prefect_redis.messaging":
+            consumer_kwargs["name"] = generate_consumer_name()
+
+        self.consumer = create_consumer("actions", **consumer_kwargs)
 
         async with actions.consumer() as handler:
             self.consumer_task = asyncio.create_task(self.consumer.run(handler))

--- a/src/prefect/server/events/services/event_logger.py
+++ b/src/prefect/server/events/services/event_logger.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import rich
 
 from prefect.logging import get_logger
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.services.base import RunInAllServers, Service
-from prefect.server.utilities.messaging import Message, create_consumer
+from prefect.server.utilities.messaging import Consumer, Message, create_consumer
 from prefect.server.utilities.messaging._names import generate_consumer_name
-from prefect.settings import PREFECT_MESSAGING_BROKER
 from prefect.settings.context import get_current_settings
 from prefect.settings.models.server.services import ServicesBaseSetting
 from prefect.types._datetime import now
@@ -32,11 +31,14 @@ class EventLogger(RunInAllServers, Service):
 
     async def start(self) -> NoReturn:
         assert self.consumer_task is None, "Logger already started"
-        consumer_kwargs = {}
-        if PREFECT_MESSAGING_BROKER.value() == "prefect_redis.messaging":
+        consumer_kwargs: dict[str, Any] = {}
+        if (
+            get_current_settings().server.events.messaging_broker
+            == "prefect_redis.messaging"
+        ):
             consumer_kwargs["name"] = generate_consumer_name()
 
-        self.consumer = create_consumer("events", **consumer_kwargs)
+        self.consumer: Consumer = create_consumer("events", **consumer_kwargs)
 
         console = rich.console.Console()
 

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -20,12 +20,13 @@ from prefect.server.schemas.core import TaskRun
 from prefect.server.schemas.states import State
 from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities.messaging import (
-    Consumer,
     Message,
     MessageHandler,
     create_consumer,
 )
+from prefect.server.utilities.messaging._names import generate_consumer_name
 from prefect.server.utilities.messaging.memory import log_metrics_periodically
+from prefect.settings import PREFECT_MESSAGING_BROKER
 from prefect.settings.context import get_current_settings
 from prefect.settings.models.server.services import ServicesBaseSetting
 from prefect.types._datetime import now
@@ -243,7 +244,11 @@ class TaskRunRecorder(RunInAllServers, Service):
 
     async def start(self) -> NoReturn:
         assert self.consumer_task is None, "TaskRunRecorder already started"
-        self.consumer: Consumer = create_consumer("events")
+        consumer_kwargs = {}
+        if PREFECT_MESSAGING_BROKER.value() == "prefect_redis.messaging":
+            consumer_kwargs["name"] = generate_consumer_name()
+
+        self.consumer = create_consumer("events", **consumer_kwargs)
 
         async with consumer() as handler:
             self.consumer_task = asyncio.create_task(self.consumer.run(handler))

--- a/src/prefect/server/utilities/messaging/_names.py
+++ b/src/prefect/server/utilities/messaging/_names.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import socket
+from uuid import uuid4
+
+
+def generate_consumer_name() -> str:
+    """Return a unique name for Redis stream consumers."""
+    return f"{socket.gethostname()}-{uuid4().hex}"


### PR DESCRIPTION
This PR centralizes consumer name generation for event services and makes sure consumers have unique names

<details><summary>Details</summary>
- Added `generate_consumer_name` in a private messaging module.
- Updated event-related services to use this helper when Redis is enabled.
</details>

