### PR TITLE
Enables CSRF protection support on internal server requests

### DIFF
--- a/src/prefect/server/api/clients.py
+++ b/src/prefect/server/api/clients.py
@@ -18,7 +18,7 @@ from prefect.server.schemas.actions import DeploymentFlowRunCreate, StateCreate
 from prefect.server.schemas.core import WorkPool
 from prefect.server.schemas.filters import VariableFilter, VariableFilterName
 from prefect.server.schemas.responses import DeploymentResponse, OrchestrationResult
-from prefect.settings import PREFECT_SERVER_API_AUTH_STRING
+from prefect.settings import get_current_settings
 from prefect.types import StrictVariableValue
 
 if TYPE_CHECKING:
@@ -39,18 +39,19 @@ class BaseClient:
         # will point it to the the currently running server instance
         api_app = create_app()
 
-        # we pull the auth string from _server_ settings because this client is run on the server
-        auth_string = PREFECT_SERVER_API_AUTH_STRING.value()
+        settings = get_current_settings()
 
-        if auth_string:
-            token = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
-            additional_headers.setdefault("Authorization", f"Basic {token}")
+        # we pull the auth string from _server_ settings because this client is run on the server
+        if auth_string_secret := settings.api.auth_string:
+            if auth_string := auth_string_secret.get_secret_value():
+                token = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
+                additional_headers.setdefault("Authorization", f"Basic {token}")
 
         self._http_client = PrefectHttpxAsyncClient(
             transport=httpx.ASGITransport(app=api_app, raise_app_exceptions=False),
             headers={**additional_headers},
             base_url="http://prefect-in-memory/api",
-            enable_csrf_support=False,
+            enable_csrf_support=settings.server.api.csrf_protection_enabled,
             raise_on_all_errors=False,
         )
 

--- a/src/prefect/server/api/clients.py
+++ b/src/prefect/server/api/clients.py
@@ -42,7 +42,7 @@ class BaseClient:
         settings = get_current_settings()
 
         # we pull the auth string from _server_ settings because this client is run on the server
-        if auth_string_secret := settings.api.auth_string:
+        if auth_string_secret := settings.server.api.auth_string:
             if auth_string := auth_string_secret.get_secret_value():
                 token = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
                 additional_headers.setdefault("Authorization", f"Basic {token}")


### PR DESCRIPTION
To help keep system coupling lower, the automations subsystem uses an
in-memory client to make API calls to perform orchestration actions.
This client was aware of Prefect API auth, but not of CSRF protection.

Closes #18045

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
