### PR TITLE
add `--dry-run` flag to `prefect deploy`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ uv run pytest -n4              # Run tests in parallel
 uv run pytest tests/some_file.py -k test_name  # Run specific test
 prefect server start           # Start local server
 prefect config view            # Inspect configuration
+docker run -p 4200:4200 --rm -d prefecthq/prefect:3.4.7-python3.12 -- prefect server start --host 0.0.0.0 # Start local server in docker
 ```
 
 ## Tech Stack
@@ -35,6 +36,8 @@ prefect config view            # Inspect configuration
 - **PostgreSQL/SQLite** databases
 
 ## Development Guidelines
+
+Work from repo root.
 
 ### Code Conventions
 

--- a/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
+++ b/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
@@ -700,6 +700,29 @@ Each time a step runs, the following actions take place in order:
 
 To update a deployment, make any desired changes to the `prefect.yaml` file, and run `prefect deploy`. Running just this command will prompt you to select a deployment interactively, or you may specify the deployment to update with `--name your-deployment`.
 
+## Validate deployment definitions
+
+Before creating or updating deployments, you can use the `--dry-run` flag to validate your deployment configuration:
+
+```bash
+prefect deploy --all --dry-run
+```
+
+This flag validates your deployment without making any changes to the server. It performs several checks:
+
+- Validates that the flow entrypoint exists and can be loaded
+- Checks that the work pool exists (if specified)
+- Validates deployment and schedule parameters against the flow's parameter schema
+- Verifies build steps are properly configured
+
+Parameter validation ensures that any parameters provided in your deployment or schedule configuration match the expected types defined in your flow function. For example, if your flow expects an integer parameter but your deployment configuration provides a string, the dry run will catch this error before deployment creation.
+
+<Tip>
+**Parameter validation is enabled for all deployments by default**
+
+To skip parameter validation, set `enforce_parameter_schema: false` in your deployment configuration.
+</Tip>
+
 ## Further reading
 
 Now that you are familiar with creating deployments, you can explore infrastructure options for running your deployments:

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -989,12 +989,12 @@ async def _run_multi_deploy(
         app.console.print("[yellow]dry run mode - no changes will be made[/yellow]")
 
     if deploy_all:
-        action_word = "validating" if dry_run else "deploying"
+        action_word = "validating" if dry_run else "Deploying"
         app.console.print(
             f"{action_word} all flows with an existing deployment configuration..."
         )
     else:
-        action_word = "validating" if dry_run else "deploying"
+        action_word = "validating" if dry_run else "Deploying"
         app.console.print(
             f"{action_word} flows with selected deployment configurations..."
         )

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -5,6 +5,7 @@ Base `prefect` command-line application
 import asyncio
 import platform
 import sys
+from contextvars import ContextVar
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as import_version
 from typing import Any
@@ -28,6 +29,9 @@ from prefect.types._datetime import parse_datetime
 
 app: PrefectTyper = PrefectTyper(add_completion=True, no_args_is_help=True)
 
+# Context variable to control interactivity in dry run mode
+_dry_run_mode: ContextVar[bool] = ContextVar("dry_run_mode", default=False)
+
 
 def version_callback(value: bool) -> None:
     if value:
@@ -36,6 +40,9 @@ def version_callback(value: bool) -> None:
 
 
 def is_interactive() -> bool:
+    # Check if we're in dry run mode first
+    if _dry_run_mode.get():
+        return False
     return app.console.is_interactive
 
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -6210,10 +6210,7 @@ def hello_world():
                 invoke_and_assert,
                 command="deploy --all --dry-run",
                 expected_code=0,
-                expected_output_contains=[
-                    "DRY RUN: Would create/update deployment",
-                    "Dry run complete",
-                ],
+                expected_output_contains=["DRY RUN: Would create/update deployment"],
             )
 
             # Verify no deployment creation/update API calls were made
@@ -6287,7 +6284,6 @@ def hello_world():
                     expected_output_contains=[
                         "dry run mode",
                         "Would run 1 build step(s)",
-                        "Dry run complete",
                     ],
                 )
 
@@ -6426,10 +6422,7 @@ def typed_flow(count: int, items: List[str]):
                 invoke_and_assert,
                 command="deploy --all --dry-run",
                 expected_code=0,
-                expected_output_contains=[
-                    "DRY RUN: Would create/update deployment",
-                    "Dry run complete",
-                ],
+                expected_output_contains=["DRY RUN: Would create/update deployment"],
             )
 
     @pytest.mark.usefixtures("project_dir_with_single_deployment")


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17814


### problem
When deploying multiple flows with `prefect deploy --all`, configuration errors could leave deployments in a "half new, half old" state. Users needed a way to validate deployment configurations before making any changes.

### solution
Added a `--dry-run` flag that validates deployment configurations without making any API calls or resource changes.


### usage
```bash
# Validate single deployment
prefect deploy my_flow.py:my_function --dry-run

# Validate all deployments in project  
prefect deploy --all --dry-run

# Validate specific deployments
prefect deploy -n deployment1 -n deployment2 --dry-run
```


### notes
It's pretty unfortunate how much branching this adds, but without fully refactoring this file, it wasn't clear to me how else to do it.