### PR TITLE
lower bound pin uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
           )$
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.6.11
+    rev: 0.6.17
     hooks:
       - id: uv-lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install UV from official image - pin to specific version for build caching
-COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /bin/uv
 
 # Copy the repository in; requires full git history for versions to generate correctly
 COPY . ./
@@ -101,7 +101,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install UV from official image - pin to specific version for build caching
-COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /bin/uv
 
 # Install prefect from the sdist
 COPY --from=python-builder /opt/prefect/dist ./dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,6 +349,9 @@ ignore-words-list = [
 check-hidden = true
 
 
+[tool.uv]
+required-version = ">=0.6.15" # make sure upload_time is included to avoid churn (see https://github.com/dependabot/dependabot-core/issues/12127)
+
 [tool.uv.sources]
 prefect-aws = { path = "src/integrations/prefect-aws" }
 prefect-azure = { path = "src/integrations/prefect-azure" }


### PR DESCRIPTION
newer versions of `uv` add a `upload_time` field to all entries which causes a large diff.

this PR adds a bound so that devs don't accidentally cause churn by using a earlier uv version

see https://github.com/dependabot/dependabot-core/issues/12127