### PR TITLE
use kopf event for `occurred` in forwarded prefect events

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -18,10 +18,16 @@ from prefect import __version__, get_client
 from prefect.client.orchestration import PrefectClient
 from prefect.events import Event, RelatedResource
 from prefect.events.clients import EventsClient, get_events_client
-from prefect.events.filters import EventFilter, EventNameFilter, EventResourceFilter
+from prefect.events.filters import (
+    EventFilter,
+    EventNameFilter,
+    EventOccurredFilter,
+    EventResourceFilter,
+)
 from prefect.events.schemas.events import Resource
 from prefect.exceptions import ObjectNotFound
 from prefect.states import Crashed
+from prefect.types import DateTime
 from prefect.utilities.engine import propose_state
 from prefect.utilities.slugify import slugify
 from prefect_kubernetes.settings import KubernetesSettings
@@ -89,6 +95,17 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
 
     logger.debug(f"Pod event received - type: {event_type}, phase: {phase}, uid: {uid}")
 
+    # Extract the creation timestamp from the Kubernetes event
+    k8s_event_time = None
+    if isinstance(event, dict) and "object" in event:
+        obj = event["object"]
+        if isinstance(obj, dict) and "metadata" in obj:
+            metadata = obj["metadata"]
+            if "creationTimestamp" in metadata:
+                k8s_event_time = DateTime.fromisoformat(
+                    metadata["creationTimestamp"].replace("Z", "+00:00")
+                )
+
     # Create a deterministic event ID based on the pod's ID, phase, and restart count.
     # This ensures that the event ID is the same for the same pod in the same phase and restart count
     # and Prefect's event system will be able to deduplicate events.
@@ -110,15 +127,28 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
     if event_type is None:
         if orchestration_client is None:
             raise RuntimeError("Orchestration client not initialized")
+
+        # Use the Kubernetes event timestamp for the filter to avoid "Query time range is too large" error
+        event_filter = EventFilter(
+            event=EventNameFilter(name=[f"prefect.kubernetes.pod.{phase.lower()}"]),
+            resource=EventResourceFilter(
+                id=[f"prefect.kubernetes.pod.{uid}"],
+            ),
+            **(
+                {
+                    "occurred": EventOccurredFilter(
+                        since=k8s_event_time - timedelta(minutes=10)
+                    )
+                }
+                if k8s_event_time
+                else {}
+            ),
+        )
+
         response = await orchestration_client.request(
             "POST",
             "/events/filter",
-            json=EventFilter(
-                event=EventNameFilter(name=[f"prefect.kubernetes.pod.{phase.lower()}"]),
-                resource=EventResourceFilter(
-                    id=[f"prefect.kubernetes.pod.{uid}"],
-                ),
-            ).model_dump(exclude_unset=True),
+            json=event_filter.model_dump(exclude_unset=True),
         )
         # If the event already exists, we don't need to emit a new one.
         if response.json()["events"]:
@@ -139,12 +169,15 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
                 resource["kubernetes.reason"] = reason
                 break
 
+    # Create the Prefect event, using the K8s event timestamp as the occurred time if available
     prefect_event = Event(
         event=f"prefect.kubernetes.pod.{phase.lower()}",
-        resource=Resource(resource),
+        resource=Resource.model_validate(resource),
         id=event_id,
         related=_related_resources_from_labels(labels),
+        **({"occurred": k8s_event_time} if k8s_event_time else {}),
     )
+
     if (prev_event := _last_event_cache.get(event_id)) is not None:
         if (
             -timedelta(minutes=5)

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -146,7 +146,7 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
         response = await orchestration_client.request(
             "POST",
             "/events/filter",
-            json=event_filter.model_dump(exclude_unset=True),
+            json=event_filter.model_dump(exclude_unset=True, mode="json"),
         )
         # If the event already exists, we don't need to emit a new one.
         if response.json()["events"]:

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -135,11 +135,7 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
                 id=[f"prefect.kubernetes.pod.{uid}"],
             ),
             **(
-                {
-                    "occurred": EventOccurredFilter(
-                        since=k8s_event_time - timedelta(minutes=10)
-                    )
-                }
+                {"occurred": EventOccurredFilter(since=k8s_event_time)}
                 if k8s_event_time
                 else {}
             ),

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -5,7 +5,7 @@ import json
 import logging
 import threading
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import anyio
@@ -134,10 +134,12 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
             resource=EventResourceFilter(
                 id=[f"prefect.kubernetes.pod.{uid}"],
             ),
-            **(
-                {"occurred": EventOccurredFilter(since=k8s_event_time)}
-                if k8s_event_time
-                else {}
+            occurred=EventOccurredFilter(
+                since=(
+                    k8s_event_time
+                    if k8s_event_time
+                    else (datetime.now(timezone.utc) - timedelta(hours=1))
+                )
             ),
         )
 

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -258,6 +258,42 @@ class TestReplicatePodEvent:
         emitted_event = mock_events_client.emit.call_args[1]["event"]
         assert emitted_event.event == f"prefect.kubernetes.pod.{phase.lower()}"
 
+    async def test_kubernetes_event_timestamp_used(self, mock_events_client: AsyncMock):
+        """Test that Kubernetes event timestamp is extracted and used as occurred time"""
+        pod_id = uuid.uuid4()
+        flow_run_id = uuid.uuid4()
+        k8s_timestamp = "2023-05-15T10:30:00Z"
+
+        await _replicate_pod_event(
+            event={
+                "type": "ADDED",
+                "object": {
+                    "metadata": {
+                        "name": "test-pod",
+                        "creationTimestamp": k8s_timestamp,
+                    }
+                },
+            },
+            uid=str(pod_id),
+            name="test",
+            namespace="test",
+            labels={
+                "prefect.io/flow-run-id": str(flow_run_id),
+                "prefect.io/flow-run-name": "test-run",
+            },
+            status={"phase": "Running"},
+            logger=MagicMock(),
+        )
+
+        mock_events_client.emit.assert_called_once()
+        emitted_event = mock_events_client.emit.call_args[1]["event"]
+
+        # Verify the occurred time matches the K8s timestamp
+        from prefect.types import DateTime
+
+        expected_occurred = DateTime.fromisoformat(k8s_timestamp.replace("Z", "+00:00"))
+        assert emitted_event.occurred == expected_occurred
+
 
 class TestStartAndStopObserver:
     @pytest.mark.timeout(10)


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/18225

this PR makes 2 changes
- we restrict the `/events/filter` call to only look at things after the k8s event that triggers the handler
- we use the k8s event timestamp as the `occurred` of the prefect event