### PR TITLE
Remove robots.txt file

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
I want `docs-2.prefect.io` to be removed from search results, and it seems that in the past we had both:
- [a meta tag for noindex and nofollow](https://github.com/PrefectHQ/prefect/blob/2.x/docs/overrides/main.html#L4)
- [a `robots.txt` file instructing agents to not explore the site](https://github.com/PrefectHQ/prefect/blob/2.x/docs/robots.txt) 

Having both is an anti-pattern: the `robots.txt` file prevents bots from discovering the meta tag (and `robots.txt` doesn't prevent indexing due to cross-linking from other sites)! And the meta tag is [the recommended most robust way to delist a site](https://support.google.com/webmasters/answer/9689846?sjid=5781052515740160538-NC#make_permanent).

So with all that, this PR removes `robots.txt`.