### PR TITLE
Subclassing to set the max_range per sandox environment (#18083)

### DIFF
--- a/src/prefect/server/utilities/user_templates.py
+++ b/src/prefect/server/utilities/user_templates.py
@@ -24,7 +24,7 @@ def _check_template_range(*args: int) -> range:
     if len(rng) > MAX_TEMPLATE_RANGE:
         raise OverflowError(
             "Range too big. The sandbox blocks ranges larger than"
-            f" MAX_RANGE ({MAX_TEMPLATE_RANGE})."
+            f" {MAX_TEMPLATE_RANGE=}."
         )
     return rng
 


### PR DESCRIPTION
closes #18083 

When prefect is imported, it sets a jinja.sandbox.MAX_RANGE globally. This affects all other processes that might use jinja, including dbt.  

Therefore, the change subclasses the environment to a new class so that the range can be set for just that class and thus dbt (and other jinja environments) can continue to use the default (100000).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes

