### PR TITLE
Early return bucket path to avoid duplicated prefix in GCS bucket

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/cloud_storage.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/cloud_storage.py
@@ -806,7 +806,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
         if self.bucket_folder != "" and bucket_path.startswith(self.bucket_folder):
             self.logger.info(
                 f"Bucket path {bucket_path!r} is already prefixed with "
-                f"bucket folder {self.bucket_folder!r}; is this intentional?"
+                f"bucket folder {self.bucket_folder!r}; returning unmodified path."
             )
             return bucket_path
 

--- a/src/integrations/prefect-gcp/prefect_gcp/cloud_storage.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/cloud_storage.py
@@ -808,6 +808,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
                 f"Bucket path {bucket_path!r} is already prefixed with "
                 f"bucket folder {self.bucket_folder!r}; is this intentional?"
             )
+            return bucket_path
 
         bucket_path = str(PurePosixPath(self.bucket_folder) / bucket_path)
         if bucket_path in ["", ".", "/"]:


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/18227