### PR TITLE
Attempt retries  when task returns a failed state

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -314,10 +314,13 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             raise RuntimeError("Engine has not started.")
         return self._client
 
-    def can_retry(self, exc: Exception) -> bool:
+    def can_retry(self, exc_or_state: Exception | State) -> bool:
         retry_condition: Optional[
             Callable[["Task[P, Coroutine[Any, Any, R]]", TaskRun, State], bool]
         ] = self.task.retry_condition_fn
+
+        failure_type = "exception" if isinstance(exc_or_state, Exception) else "state"
+
         if not self.task_run:
             raise ValueError("Task run is not set")
         try:
@@ -326,8 +329,8 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 f" {self.task.name!r}"
             )
             state = Failed(
-                data=exc,
-                message=f"Task run encountered unexpected exception: {repr(exc)}",
+                data=exc_or_state,
+                message=f"Task run encountered unexpected {failure_type}: {repr(exc_or_state)}",
             )
             if asyncio.iscoroutinefunction(retry_condition):
                 should_retry = run_coro_as_sync(
@@ -476,7 +479,15 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             # otherwise, return the exception
             return self._raised
 
-    def handle_success(self, result: R, transaction: Transaction) -> R:
+    def handle_success(
+        self, result: R, transaction: Transaction
+    ) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]:
+        # Handle the case where the task explicitly returns a failed state, in
+        # which case we should retry the task if it has retries left.
+        if isinstance(result, State) and result.is_failed():
+            if self.handle_retry(result):
+                return None
+
         if self.task.cache_expiration is not None:
             expiration = prefect.types._datetime.now("UTC") + self.task.cache_expiration
         else:
@@ -508,16 +519,16 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         self._return_value = result
 
         self._telemetry.end_span_on_success()
-        return result
 
-    def handle_retry(self, exc: Exception) -> bool:
+    def handle_retry(self, exc_or_state: Exception | State) -> bool:
         """Handle any task run retries.
 
         - If the task has retries left, and the retry condition is met, set the task to retrying and return True.
         - If the task has a retry delay, place in AwaitingRetry state with a delayed scheduled time.
         - If the task has no retries left, or the retry condition is not met, return False.
         """
-        if self.retries < self.task.retries and self.can_retry(exc):
+        failure_type = "exception" if isinstance(exc_or_state, Exception) else "state"
+        if self.retries < self.task.retries and self.can_retry(exc_or_state):
             if self.task.retry_delay_seconds:
                 delay = (
                     self.task.retry_delay_seconds[
@@ -535,8 +546,9 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 new_state = Retrying()
 
             self.logger.info(
-                "Task run failed with exception: %r - Retry %s/%s will start %s",
-                exc,
+                "Task run failed with %s: %r - Retry %s/%s will start %s",
+                failure_type,
+                exc_or_state,
                 self.retries + 1,
                 self.task.retries,
                 str(delay) + " second(s) from now" if delay else "immediately",
@@ -552,7 +564,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 else "No retries configured for this task."
             )
             self.logger.error(
-                f"Task run failed with exception: {exc!r} - {retry_message_suffix}",
+                f"Task run failed with {failure_type}: {exc_or_state!r} - {retry_message_suffix}",
                 exc_info=True,
             )
             return False
@@ -830,7 +842,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
     def call_task_fn(
         self, transaction: Transaction
-    ) -> Union[R, Coroutine[Any, Any, R]]:
+    ) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]:
         """
         Convenience method to call the task function. Returns a coroutine if the
         task is async.
@@ -855,10 +867,13 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             raise RuntimeError("Engine has not started.")
         return self._client
 
-    async def can_retry(self, exc: Exception) -> bool:
+    async def can_retry(self, exc_or_state: Exception | State) -> bool:
         retry_condition: Optional[
             Callable[["Task[P, Coroutine[Any, Any, R]]", TaskRun, State], bool]
         ] = self.task.retry_condition_fn
+
+        failure_type = "exception" if isinstance(exc_or_state, Exception) else "state"
+
         if not self.task_run:
             raise ValueError("Task run is not set")
         try:
@@ -867,8 +882,8 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 f" {self.task.name!r}"
             )
             state = Failed(
-                data=exc,
-                message=f"Task run encountered unexpected exception: {repr(exc)}",
+                data=exc_or_state,
+                message=f"Task run encountered unexpected {failure_type}: {repr(exc_or_state)}",
             )
             if asyncio.iscoroutinefunction(retry_condition):
                 should_retry = await retry_condition(self.task, self.task_run, state)
@@ -1031,7 +1046,13 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             # otherwise, return the exception
             return self._raised
 
-    async def handle_success(self, result: R, transaction: AsyncTransaction) -> R:
+    async def handle_success(
+        self, result: R, transaction: AsyncTransaction
+    ) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]:
+        if isinstance(result, State) and result.is_failed():
+            if await self.handle_retry(result):
+                return None
+
         if self.task.cache_expiration is not None:
             expiration = prefect.types._datetime.now("UTC") + self.task.cache_expiration
         else:
@@ -1064,14 +1085,16 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         return result
 
-    async def handle_retry(self, exc: Exception) -> bool:
+    async def handle_retry(self, exc_or_state: Exception | State) -> bool:
         """Handle any task run retries.
 
         - If the task has retries left, and the retry condition is met, set the task to retrying and return True.
         - If the task has a retry delay, place in AwaitingRetry state with a delayed scheduled time.
         - If the task has no retries left, or the retry condition is not met, return False.
         """
-        if self.retries < self.task.retries and await self.can_retry(exc):
+        failure_type = "exception" if isinstance(exc_or_state, Exception) else "state"
+
+        if self.retries < self.task.retries and await self.can_retry(exc_or_state):
             if self.task.retry_delay_seconds:
                 delay = (
                     self.task.retry_delay_seconds[
@@ -1089,8 +1112,9 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 new_state = Retrying()
 
             self.logger.info(
-                "Task run failed with exception: %r - Retry %s/%s will start %s",
-                exc,
+                "Task run failed with %s: %r - Retry %s/%s will start %s",
+                failure_type,
+                exc_or_state,
                 self.retries + 1,
                 self.task.retries,
                 str(delay) + " second(s) from now" if delay else "immediately",
@@ -1106,7 +1130,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 else "No retries configured for this task."
             )
             self.logger.error(
-                f"Task run failed with exception: {exc!r} - {retry_message_suffix}",
+                f"Task run failed with {failure_type}: {exc_or_state!r} - {retry_message_suffix}",
                 exc_info=True,
             )
             return False
@@ -1382,7 +1406,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
     async def call_task_fn(
         self, transaction: AsyncTransaction
-    ) -> Union[R, Coroutine[Any, Any, R]]:
+    ) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]:
         """
         Convenience method to call the task function. Returns a coroutine if the
         task is async.

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -314,9 +314,9 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             raise RuntimeError("Engine has not started.")
         return self._client
 
-    def can_retry(self, exc_or_state: Exception | State) -> bool:
+    def can_retry(self, exc_or_state: Exception | State[R]) -> bool:
         retry_condition: Optional[
-            Callable[["Task[P, Coroutine[Any, Any, R]]", TaskRun, State], bool]
+            Callable[["Task[P, Coroutine[Any, Any, R]]", TaskRun, State[R]], bool]
         ] = self.task.retry_condition_fn
 
         failure_type = "exception" if isinstance(exc_or_state, Exception) else "state"
@@ -481,7 +481,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
     def handle_success(
         self, result: R, transaction: Transaction
-    ) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]:
+    ) -> Union[ResultRecord[R], None, Coroutine[Any, Any, R], R]:
         # Handle the case where the task explicitly returns a failed state, in
         # which case we should retry the task if it has retries left.
         if isinstance(result, State) and result.is_failed():
@@ -520,7 +520,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         self._telemetry.end_span_on_success()
 
-    def handle_retry(self, exc_or_state: Exception | State) -> bool:
+    def handle_retry(self, exc_or_state: Exception | State[R]) -> bool:
         """Handle any task run retries.
 
         - If the task has retries left, and the retry condition is met, set the task to retrying and return True.
@@ -867,9 +867,9 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             raise RuntimeError("Engine has not started.")
         return self._client
 
-    async def can_retry(self, exc_or_state: Exception | State) -> bool:
+    async def can_retry(self, exc_or_state: Exception | State[R]) -> bool:
         retry_condition: Optional[
-            Callable[["Task[P, Coroutine[Any, Any, R]]", TaskRun, State], bool]
+            Callable[["Task[P, Coroutine[Any, Any, R]]", TaskRun, State[R]], bool]
         ] = self.task.retry_condition_fn
 
         failure_type = "exception" if isinstance(exc_or_state, Exception) else "state"
@@ -1048,7 +1048,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
     async def handle_success(
         self, result: R, transaction: AsyncTransaction
-    ) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]:
+    ) -> Union[ResultRecord[R], None, Coroutine[Any, Any, R], R]:
         if isinstance(result, State) and result.is_failed():
             if await self.handle_retry(result):
                 return None
@@ -1085,7 +1085,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         return result
 
-    async def handle_retry(self, exc_or_state: Exception | State) -> bool:
+    async def handle_retry(self, exc_or_state: Exception | State[R]) -> bool:
         """Handle any task run retries.
 
         - If the task has retries left, and the retry condition is met, set the task to retrying and return True.


### PR DESCRIPTION
This updates the task run engine to retry tasks that explicitly return a failed state. Consider this flow/task:

```python
from prefect import flow, task, get_run_logger
from prefect.states import Failed

RUNS = 0

def condition(task, task_run, state):
    try:
        state.result()
    except Exception:
        return "please_retry" in state.message


@task(retries=1, retry_condition_fn=condition)
def task_a():
    global RUNS
    RUNS += 1
    logger = get_run_logger()
    logger.info("Inside task_a")

    if RUNS < 2:
        return Failed(message="please_retry")
    else:
        return "success"


@flow()
def generic_flow():
    task_a()


if __name__ == "__main__":
    generic_flow()
```

`task_a` will now be retried:

```
11:59:39.997 | INFO    | Flow run 'misty-shrew' - Beginning flow run 'misty-shrew' for flow 'generic-flow'
11:59:40.006 | INFO    | Flow run 'misty-shrew' - View at https://app.stg.prefect.dev/account/7eb347db-a59f-4bb6-a811-514c11282a80/workspace/d3a6209b-65a4-465e-b018-8b2433f657be/runs/flow-run/06841bee-b24a-7b94-8000-518940f744d1
11:59:40.050 | INFO    | Task run 'task_a-f85' - Inside task_a
11:59:40.052 | INFO    | Task run 'task_a-f85' - Task run failed with state: Failed(message='please_retry', type=FAILED, result=None) - Retry 1/1 will start immediately
11:59:40.055 | INFO    | Task run 'task_a-f85' - Inside task_a
11:59:40.057 | INFO    | Task run 'task_a-f85' - Finished in state Completed()
11:59:40.246 | INFO    | Flow run 'misty-shrew' - Finished in state Completed()
```

Closes https://github.com/PrefectHQ/prefect/issues/15826