### PR TITLE
fix `config` validation for nested and constrained settings

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2041,6 +2041,30 @@ class TestProfile:
         ):
             profile.validate_settings()
 
+    def test_validate_settings_nested_field_constraints(self):
+        """
+        Test that nested field constraints are properly validated.
+        Regression test for issue #18258: PREFECT_RUNNER_HEARTBEAT_FREQUENCY validation.
+        """
+        from prefect.settings import PREFECT_RUNNER_HEARTBEAT_FREQUENCY
+
+        # Test invalid value (< 30)
+        profile = Profile(
+            name="test", settings={PREFECT_RUNNER_HEARTBEAT_FREQUENCY: "5"}
+        )
+        with pytest.raises(
+            ProfileSettingsValidationError,
+            match="Input should be greater than or equal to 30",
+        ):
+            profile.validate_settings()
+
+        # Test valid value (>= 30)
+        profile = Profile(
+            name="test", settings={PREFECT_RUNNER_HEARTBEAT_FREQUENCY: "40"}
+        )
+        # Should not raise
+        profile.validate_settings()
+
 
 class TestProfilesCollection:
     def test_init_stores_single_profile(self):


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/18258

**Problem:**
`prefect config set` was not validating field constraints for nested settings, allowing invalid values to be saved:

```bash
# This should fail but was succeeding
$ prefect config set PREFECT_RUNNER_HEARTBEAT_FREQUENCY=5
Set 'PREFECT_RUNNER_HEARTBEAT_FREQUENCY' to '5'.  # ❌ Should have failed (5 < 30)

# Then all subsequent prefect commands would crash
$ prefect config view
ValidationError: Input should be greater than or equal to 30
```

**Root Cause:**
`Profile.validate_settings()` was manually traversing nested models, losing pydantic field constraints like `ge=30` in the process.

**Solution:**
Updated the validation to use the same robust approach as `Settings.copy_with_update()`:
1. Build proper nested dict structure using setting accessors
2. Validate against the full `Settings` model to preserve all constraints
3. Map validation errors back to profile-specific errors

**Result:**
```bash
# Now correctly fails validation
$ prefect config set PREFECT_RUNNER_HEARTBEAT_FREQUENCY=5
Validation error(s) for setting PREFECT_RUNNER_HEARTBEAT_FREQUENCY
 - Input should be greater than or equal to 30

# Valid values still work
$ prefect config set PREFECT_RUNNER_HEARTBEAT_FREQUENCY=40
Set 'PREFECT_RUNNER_HEARTBEAT_FREQUENCY' to '40'.
```