### PR TITLE
Add automations prefix to validate route

### DIFF
--- a/src/prefect/server/api/templates.py
+++ b/src/prefect/server/api/templates.py
@@ -8,11 +8,17 @@ from prefect.server.utilities.user_templates import (
     validate_user_template,
 )
 
-router: PrefectRouter = PrefectRouter(prefix="/templates", tags=["Automations"])
+router: PrefectRouter = PrefectRouter(tags=["Automations"])
 
 
+# deprecated and can be removed after the ui removes its dependency on it
+# use /templates/validate instead
 @router.post(
-    "/validate",
+    "/automations/templates/validate",
+    response_class=Response,
+)
+@router.post(
+    "/templates/validate",
     response_class=Response,
 )
 def validate_template(template: str = Body(default="")) -> Response:


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/17189
Supersedes https://github.com/PrefectHQ/prefect/pull/18259

It appears the UI is [still using the route with the `/automations` prefix](https://github.com/PrefectHQ/prefect-ui-library/blob/6564988eed300fd01df33b60e922e64ec7601bb5/src/services/WorkspaceAutomationsApi.ts#L36) so until that is updated we need to support both endpoints.