### PR TITLE
Add tags support to Automation objects

### DIFF
--- a/src/prefect/events/schemas/automations.py
+++ b/src/prefect/events/schemas/automations.py
@@ -416,6 +416,10 @@ class AutomationCore(PrefectBaseModel, extra="ignore"):  # type: ignore[call-arg
     enabled: bool = Field(
         default=True, description="Whether this automation will be evaluated"
     )
+    tags: List[str] = Field(
+        default_factory=list,
+        description="A list of tags associated with this automation",
+    )
 
     trigger: TriggerTypes = Field(
         default=...,

--- a/src/prefect/server/database/_migrations/versions/postgresql/2025_06_12_144500_add_automation_tags_aa1234567890.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2025_06_12_144500_add_automation_tags_aa1234567890.py
@@ -1,0 +1,34 @@
+"""Add tags column to automation table
+
+Revision ID: aa1234567890
+Revises: 1c9bb7f78263
+Create Date: 2025-06-12 14:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "aa1234567890"
+down_revision = "1c9bb7f78263"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "automation",
+        sa.Column(
+            "tags",
+            prefect.server.utilities.database.JSON(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("automation", "tags")

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_06_12_144500_add_automation_tags_bb2345678901.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_06_12_144500_add_automation_tags_bb2345678901.py
@@ -1,0 +1,34 @@
+"""Add tags column to automation table
+
+Revision ID: bb2345678901
+Revises: 3c841a1800a1
+Create Date: 2025-06-12 14:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "bb2345678901"
+down_revision = "3c841a1800a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "automation",
+        sa.Column(
+            "tags",
+            prefect.server.utilities.database.JSON(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("automation", "tags")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1254,6 +1254,7 @@ class Automation(Base):
     description: Mapped[str] = mapped_column(default="")
 
     enabled: Mapped[bool] = mapped_column(server_default="1", default=True)
+    tags: Mapped[list[str]] = mapped_column(JSON, server_default="[]", default=list)
 
     trigger: Mapped[ServerTriggerTypes] = mapped_column(Pydantic(ServerTriggerTypes))
 

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -485,6 +485,10 @@ class AutomationCore(PrefectBaseModel, extra="ignore"):
     enabled: bool = Field(
         default=True, description="Whether this automation will be evaluated"
     )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="A list of tags associated with this automation",
+    )
 
     trigger: ServerTriggerTypes = Field(
         default=...,

--- a/tests/events/server/test_automations_api.py
+++ b/tests/events/server/test_automations_api.py
@@ -1261,3 +1261,117 @@ async def test_infrastructure_error_inside_create(
         )
         assert response.status_code == 422, response.content
         assert "Error creating automation: Something is wrong" in response.text
+
+
+async def test_create_automation_with_tags(
+    client: AsyncClient,
+    automations_url: str,
+    automation_to_create: AutomationCreate,
+) -> None:
+    """Test creating an automation with tags"""
+    automation_to_create.tags = ["test", "db", "critical"]
+
+    response = await client.post(
+        f"{automations_url}/",
+        json=automation_to_create.model_dump(mode="json"),
+    )
+    assert response.status_code == 201, response.content
+
+    created_automation = Automation.model_validate_json(response.content)
+    assert created_automation.tags == ["test", "db", "critical"]
+
+
+async def test_create_automation_with_empty_tags(
+    client: AsyncClient,
+    automations_url: str,
+    automation_to_create: AutomationCreate,
+) -> None:
+    """Test creating an automation with empty tags list"""
+    automation_to_create.tags = []
+
+    response = await client.post(
+        f"{automations_url}/",
+        json=automation_to_create.model_dump(mode="json"),
+    )
+    assert response.status_code == 201, response.content
+
+    created_automation = Automation.model_validate_json(response.content)
+    assert created_automation.tags == []
+
+
+async def test_create_automation_without_tags_defaults_to_empty(
+    client: AsyncClient,
+    automations_url: str,
+    automation_to_create: AutomationCreate,
+) -> None:
+    """Test creating an automation without specifying tags defaults to empty list"""
+    # Don't set tags - should default to empty list
+
+    response = await client.post(
+        f"{automations_url}/",
+        json=automation_to_create.model_dump(mode="json"),
+    )
+    assert response.status_code == 201, response.content
+
+    created_automation = Automation.model_validate_json(response.content)
+    assert created_automation.tags == []
+
+
+async def test_update_automation_tags(
+    client: AsyncClient,
+    automations_url: str,
+    existing_automation: Automation,
+) -> None:
+    """Test updating an automation's tags"""
+    automation_update = AutomationUpdate(
+        **existing_automation.model_dump(exclude={"id", "created", "updated"}),
+        tags=["new", "updated", "tags"],
+    )
+
+    response = await client.put(
+        f"{automations_url}/{existing_automation.id}",
+        json=automation_update.model_dump(mode="json"),
+    )
+    assert response.status_code == 204, response.content
+
+    # Verify the update
+    response = await client.get(f"{automations_url}/{existing_automation.id}")
+    assert response.status_code == 200, response.content
+
+    updated_automation = Automation.model_validate_json(response.content)
+    assert updated_automation.tags == ["new", "updated", "tags"]
+
+
+async def test_patch_automation_does_not_affect_tags_when_not_specified(
+    client: AsyncClient,
+    automations_url: str,
+    existing_automation: Automation,
+) -> None:
+    """Test that partial updates don't affect tags when not specified"""
+    # First, set some tags on the automation
+    automation_update = AutomationUpdate(
+        **existing_automation.model_dump(exclude={"id", "created", "updated"}),
+        tags=["original", "tags"],
+    )
+
+    response = await client.put(
+        f"{automations_url}/{existing_automation.id}",
+        json=automation_update.model_dump(mode="json"),
+    )
+    assert response.status_code == 204, response.content
+
+    # Now patch only the enabled field
+    patch_data = AutomationPartialUpdate(enabled=False)
+    response = await client.patch(
+        f"{automations_url}/{existing_automation.id}",
+        json=patch_data.model_dump(mode="json"),
+    )
+    assert response.status_code == 204, response.content
+
+    # Verify tags are preserved
+    response = await client.get(f"{automations_url}/{existing_automation.id}")
+    assert response.status_code == 200, response.content
+
+    updated_automation = Automation.model_validate_json(response.content)
+    assert updated_automation.tags == ["original", "tags"]
+    assert updated_automation.enabled is False


### PR DESCRIPTION
## Summary
First part of #16771

- Add tags field to client and server automation schemas
- Add tags column to automation database model with JSON type
- Create database migrations for PostgreSQL and SQLite
- Add comprehensive tests for automation tags functionality
- Support tags in create, update, and partial update operations

🤖 Generated with [Claude Code](https://claude.ai/code)