### PR TITLE
omit nested venv from docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,8 +26,10 @@ ipython_config.py
 .python-version
 .env
 .venv
+**/.venv/
 env/
 venv/
+**/venv/
 
 # Documentation artifacts
 site/


### PR DESCRIPTION
notably, running `docker build` locally would scoop any .venv files from integrations, which would drastically increase build time and footprint

<img width="1457" alt="image" src="https://github.com/user-attachments/assets/0b5bfaf2-88b3-4c3e-9682-d00b76714349" />