### PR TITLE
Add `pause_deployment` and `resume_deployment` client methods

### DIFF
--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from httpx import HTTPStatusError, RequestError
 
+from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
 from prefect.exceptions import ObjectNotFound
 
@@ -167,13 +168,29 @@ class DeploymentClient(BaseClient):
 
         return UUID(deployment_id)
 
-    def set_deployment_paused_state(self, deployment_id: UUID, paused: bool) -> None:
+    def _set_deployment_paused_state(self, deployment_id: UUID, paused: bool) -> None:
         self.request(
             "PATCH",
             "/deployments/{id}",
             path_params={"id": deployment_id},
             json={"paused": paused},
         )
+
+    @deprecated_callable(
+        start_date="Jun 2025",
+        help="Use pause_deployment or resume_deployment instead.",
+    )
+    def set_deployment_paused_state(self, deployment_id: UUID, paused: bool) -> None:
+        """
+        DEPRECATED: Use pause_deployment or resume_deployment instead.
+
+        Set the paused state of a deployment.
+
+        Args:
+            deployment_id: the deployment ID to update
+            paused: whether the deployment should be paused
+        """
+        self._set_deployment_paused_state(deployment_id, paused)
 
     def pause_deployment(self, deployment_id: Union[UUID, str]) -> None:
         """
@@ -193,7 +210,7 @@ class DeploymentClient(BaseClient):
                 raise ValueError(f"Invalid deployment ID: {deployment_id}")
 
         try:
-            self.set_deployment_paused_state(deployment_id, paused=True)
+            self._set_deployment_paused_state(deployment_id, paused=True)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ObjectNotFound(http_exc=e) from e
@@ -218,7 +235,7 @@ class DeploymentClient(BaseClient):
                 raise ValueError(f"Invalid deployment ID: {deployment_id}")
 
         try:
-            self.set_deployment_paused_state(deployment_id, paused=False)
+            self._set_deployment_paused_state(deployment_id, paused=False)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ObjectNotFound(http_exc=e) from e
@@ -810,7 +827,7 @@ class DeploymentAsyncClient(BaseAsyncClient):
 
         return UUID(deployment_id)
 
-    async def set_deployment_paused_state(
+    async def _set_deployment_paused_state(
         self, deployment_id: UUID, paused: bool
     ) -> None:
         await self.request(
@@ -819,6 +836,24 @@ class DeploymentAsyncClient(BaseAsyncClient):
             path_params={"id": deployment_id},
             json={"paused": paused},
         )
+
+    @deprecated_callable(
+        start_date="Jun 2025",
+        help="Use pause_deployment or resume_deployment instead.",
+    )
+    async def set_deployment_paused_state(
+        self, deployment_id: UUID, paused: bool
+    ) -> None:
+        """
+        DEPRECATED: Use pause_deployment or resume_deployment instead.
+
+        Set the paused state of a deployment.
+
+        Args:
+            deployment_id: the deployment ID to update
+            paused: whether the deployment should be paused
+        """
+        await self._set_deployment_paused_state(deployment_id, paused)
 
     async def pause_deployment(self, deployment_id: Union[UUID, str]) -> None:
         """
@@ -838,7 +873,7 @@ class DeploymentAsyncClient(BaseAsyncClient):
                 raise ValueError(f"Invalid deployment ID: {deployment_id}")
 
         try:
-            await self.set_deployment_paused_state(deployment_id, paused=True)
+            await self._set_deployment_paused_state(deployment_id, paused=True)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ObjectNotFound(http_exc=e) from e
@@ -863,7 +898,7 @@ class DeploymentAsyncClient(BaseAsyncClient):
                 raise ValueError(f"Invalid deployment ID: {deployment_id}")
 
         try:
-            await self.set_deployment_paused_state(deployment_id, paused=False)
+            await self._set_deployment_paused_state(deployment_id, paused=False)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ObjectNotFound(http_exc=e) from e

--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -175,6 +175,56 @@ class DeploymentClient(BaseClient):
             json={"paused": paused},
         )
 
+    def pause_deployment(self, deployment_id: Union[UUID, str]) -> None:
+        """
+        Pause a deployment by ID.
+
+        Args:
+            deployment_id: The deployment ID of interest (can be a UUID or a string).
+
+        Raises:
+            ObjectNotFound: If request returns 404
+            RequestError: If request fails
+        """
+        if not isinstance(deployment_id, UUID):
+            try:
+                deployment_id = UUID(deployment_id)
+            except ValueError:
+                raise ValueError(f"Invalid deployment ID: {deployment_id}")
+
+        try:
+            self.set_deployment_paused_state(deployment_id, paused=True)
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+    def resume_deployment(self, deployment_id: Union[UUID, str]) -> None:
+        """
+        Resume (unpause) a deployment by ID.
+
+        Args:
+            deployment_id: The deployment ID of interest (can be a UUID or a string).
+
+        Raises:
+            ObjectNotFound: If request returns 404
+            RequestError: If request fails
+        """
+        if not isinstance(deployment_id, UUID):
+            try:
+                deployment_id = UUID(deployment_id)
+            except ValueError:
+                raise ValueError(f"Invalid deployment ID: {deployment_id}")
+
+        try:
+            self.set_deployment_paused_state(deployment_id, paused=False)
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
     def update_deployment(
         self,
         deployment_id: UUID,
@@ -769,6 +819,56 @@ class DeploymentAsyncClient(BaseAsyncClient):
             path_params={"id": deployment_id},
             json={"paused": paused},
         )
+
+    async def pause_deployment(self, deployment_id: Union[UUID, str]) -> None:
+        """
+        Pause a deployment by ID.
+
+        Args:
+            deployment_id: The deployment ID of interest (can be a UUID or a string).
+
+        Raises:
+            ObjectNotFound: If request returns 404
+            RequestError: If request fails
+        """
+        if not isinstance(deployment_id, UUID):
+            try:
+                deployment_id = UUID(deployment_id)
+            except ValueError:
+                raise ValueError(f"Invalid deployment ID: {deployment_id}")
+
+        try:
+            await self.set_deployment_paused_state(deployment_id, paused=True)
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+    async def resume_deployment(self, deployment_id: Union[UUID, str]) -> None:
+        """
+        Resume (unpause) a deployment by ID.
+
+        Args:
+            deployment_id: The deployment ID of interest (can be a UUID or a string).
+
+        Raises:
+            ObjectNotFound: If request returns 404
+            RequestError: If request fails
+        """
+        if not isinstance(deployment_id, UUID):
+            try:
+                deployment_id = UUID(deployment_id)
+            except ValueError:
+                raise ValueError(f"Invalid deployment ID: {deployment_id}")
+
+        try:
+            await self.set_deployment_paused_state(deployment_id, paused=False)
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
 
     async def update_deployment(
         self,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -945,7 +945,7 @@ class Runner:
         """
         self._logger.info("Pausing all deployments...")
         for deployment_id in self._deployment_ids:
-            await self._client._set_deployment_paused_state(deployment_id, True)
+            await self._client.pause_deployment(deployment_id)
             self._logger.debug(f"Paused deployment '{deployment_id}'")
 
         self._logger.info("All deployments have been paused!")

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -945,7 +945,7 @@ class Runner:
         """
         self._logger.info("Pausing all deployments...")
         for deployment_id in self._deployment_ids:
-            await self._client.set_deployment_paused_state(deployment_id, True)
+            await self._client._set_deployment_paused_state(deployment_id, True)
             self._logger.debug(f"Paused deployment '{deployment_id}'")
 
         self._logger.info("All deployments have been paused!")


### PR DESCRIPTION
## Summary
This PR adds `pause_deployment` and `resume_deployment` methods to the Prefect client, addressing a user request from Slack where these methods were missing from the client API. It also deprecates the existing `set_deployment_paused_state` method in favor of the new, more intuitive methods.

## Changes
- Added `pause_deployment(deployment_id)` and `resume_deployment(deployment_id)` methods to both `DeploymentClient` and `DeploymentAsyncClient`
- Both methods accept either UUID or string deployment IDs for flexibility
- Include proper error handling:
  - `ValueError` for invalid deployment IDs
  - `ObjectNotFound` for non-existent deployments
- Deprecated `set_deployment_paused_state` method with a 6-month deprecation window (Jun 2025 - Dec 2025)
- Created private `_set_deployment_paused_state` method for internal use
- Added comprehensive tests for both sync and async clients

## Testing
Added tests that verify:
- Pausing an unpaused deployment
- Resuming a paused deployment  
- String ID handling
- Error cases (invalid IDs, non-existent deployments)
- Deprecation warning is properly shown

All tests pass successfully.

## Context
This addresses a user request where they needed to programmatically pause deployments but found the method was missing from the client. While `set_deployment_paused_state` exists, it was named like an implementation detail and didn't handle exceptions. The new methods provide a cleaner, more intuitive API.

🤖 Generated with [Claude Code](https://claude.ai/code)