### PR TITLE
add some api-ref examples and avoid right hand nav pollution

### DIFF
--- a/docs/v3/api-ref/python/prefect-artifacts.mdx
+++ b/docs/v3/api-ref/python/prefect-artifacts.mdx
@@ -12,7 +12,7 @@ Interface for creating and reading artifacts.
 
 ## Functions
 
-### `create_link_artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L399" target="_blank">↗</a></sup>
+### `create_link_artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L399"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_link_artifact(link: str, link_text: str | None = None, key: str | None = None, description: str | None = None, client: 'PrefectClient | None' = None) -> UUID
@@ -33,7 +33,7 @@ The key must only contain lowercase letters, numbers, and dashes.
 - The table artifact ID.
 
 
-### `create_markdown_artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L461" target="_blank">↗</a></sup>
+### `create_markdown_artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L478"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_markdown_artifact(markdown: str, key: str | None = None, description: str | None = None) -> UUID
@@ -53,7 +53,7 @@ The key must only contain lowercase letters, numbers, and dashes.
 - The table artifact ID.
 
 
-### `create_table_artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L519" target="_blank">↗</a></sup>
+### `create_table_artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L552"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_table_artifact(table: dict[str, list[Any]] | list[dict[str, Any]] | list[list[Any]], key: str | None = None, description: str | None = None) -> UUID
@@ -73,7 +73,7 @@ The key must only contain lowercase letters, numbers, and dashes.
 - The table artifact ID.
 
 
-### `create_progress_artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L578" target="_blank">↗</a></sup>
+### `create_progress_artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L627"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_progress_artifact(progress: float, key: str | None = None, description: str | None = None) -> UUID
@@ -93,7 +93,7 @@ The key must only contain lowercase letters, numbers, and dashes.
 - The progress artifact ID.
 
 
-### `update_progress_artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L649" target="_blank">↗</a></sup>
+### `update_progress_artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L698"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_progress_artifact(artifact_id: UUID, progress: float, description: str | None = None, client: 'PrefectClient | None' = None) -> UUID
@@ -111,7 +111,7 @@ Update a progress artifact.
 - The progress artifact ID.
 
 
-### `create_image_artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L720" target="_blank">↗</a></sup>
+### `create_image_artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L769"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_image_artifact(image_url: str, key: str | None = None, description: str | None = None) -> UUID
@@ -133,7 +133,7 @@ The key must only contain lowercase letters, numbers, and dashes.
 
 ## Classes
 
-### `Artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L34" target="_blank">↗</a></sup>
+### `Artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 An artifact is a piece of data that is created by a flow or task run.
@@ -149,7 +149,7 @@ The key must only contain lowercase letters, numbers, and dashes.
 
 **Methods:**
 
-#### `create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L85" target="_blank">↗</a></sup>
+#### `create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create(self: Self, client: 'PrefectClient | None' = None) -> 'ArtifactResponse'
@@ -161,10 +161,10 @@ A method to create an artifact.
 - `client`: The PrefectClient
 
 **Returns:**
-- - The created artifact.
+- The created artifact.
 
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L153" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L153"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(cls, key: str | None = None, client: 'PrefectClient | None' = None) -> 'ArtifactResponse | None'
@@ -180,7 +180,7 @@ A method to get an artifact.
 - The artifact (if found).
 
 
-#### `get_or_create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L212" target="_blank">↗</a></sup>
+#### `get_or_create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L212"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_or_create(cls, key: str | None = None, description: str | None = None, data: dict[str, Any] | Any | None = None, client: 'PrefectClient | None' = None, **kwargs: Any) -> tuple['ArtifactResponse', bool]
@@ -199,53 +199,53 @@ A method to get or create an artifact.
 - The artifact, either retrieved or created.
 
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L249" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L249"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self) -> str | float | int | dict[str, Any]
 ```
 
-### `LinkArtifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L253" target="_blank">↗</a></sup>
+### `LinkArtifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L253"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L269" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L269"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self) -> str
 ```
 
-### `MarkdownArtifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L273" target="_blank">↗</a></sup>
+### `MarkdownArtifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L273"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L281" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L281"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self) -> str
 ```
 
-### `TableArtifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L285" target="_blank">↗</a></sup>
+### `TableArtifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L285"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L310" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L310"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self) -> str
 ```
 
-### `ProgressArtifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L314" target="_blank">↗</a></sup>
+### `ProgressArtifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L314"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L335" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L335"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self) -> float
 ```
 
-### `ImageArtifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L339" target="_blank">↗</a></sup>
+### `ImageArtifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L339"><Icon icon="github" size="14" /></a></sup>
 
 
 An artifact that will display an image from a publicly accessible URL in the UI.
@@ -256,7 +256,7 @@ An artifact that will display an image from a publicly accessible URL in the UI.
 
 **Methods:**
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/artifacts.py#L354" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/artifacts.py#L354"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self) -> str

--- a/docs/v3/api-ref/python/prefect-assets-core.mdx
+++ b/docs/v3/api-ref/python/prefect-assets-core.mdx
@@ -7,7 +7,7 @@ sidebarTitle: core
 
 ## Functions
 
-### `add_asset_metadata` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/assets/core.py#L65" target="_blank">↗</a></sup>
+### `add_asset_metadata` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/assets/core.py#L65"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_asset_metadata(asset: str | Asset, metadata: dict[str, Any]) -> None
@@ -15,13 +15,13 @@ add_asset_metadata(asset: str | Asset, metadata: dict[str, Any]) -> None
 
 ## Classes
 
-### `AssetProperties` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/assets/core.py#L11" target="_blank">↗</a></sup>
+### `AssetProperties` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/assets/core.py#L11"><Icon icon="github" size="14" /></a></sup>
 
 
 Metadata properties to configure on an Asset
 
 
-### `Asset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/assets/core.py#L32" target="_blank">↗</a></sup>
+### `Asset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/assets/core.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 
 Assets are objects that represent materialized data,
@@ -30,7 +30,7 @@ providing a way to track lineage and dependencies.
 
 **Methods:**
 
-#### `add_metadata` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/assets/core.py#L53" target="_blank">↗</a></sup>
+#### `add_metadata` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/assets/core.py#L53"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_metadata(self, metadata: dict[str, Any]) -> None

--- a/docs/v3/api-ref/python/prefect-assets-materialize.mdx
+++ b/docs/v3/api-ref/python/prefect-assets-materialize.mdx
@@ -7,7 +7,7 @@ sidebarTitle: materialize
 
 ## Functions
 
-### `materialize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/assets/materialize.py#L17" target="_blank">↗</a></sup>
+### `materialize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/assets/materialize.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 materialize(*assets: Union[str, Asset], **task_kwargs: Unpack[TaskOptions]) -> Callable[[Callable[P, R]], MaterializingTask[P, R]]

--- a/docs/v3/api-ref/python/prefect-automations.mdx
+++ b/docs/v3/api-ref/python/prefect-automations.mdx
@@ -7,11 +7,11 @@ sidebarTitle: automations
 
 ## Classes
 
-### `Automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L78" target="_blank">↗</a></sup>
+### `Automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L111" target="_blank">↗</a></sup>
+#### `create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L111"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create(self: Self) -> Self
@@ -40,7 +40,7 @@ created_automation = auto_to_create.create()
 ```
 
 
-#### `update` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L160" target="_blank">↗</a></sup>
+#### `update` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L160"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update(self: Self)
@@ -58,7 +58,7 @@ auto.update()
 ```
 
 
-#### `read` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L236" target="_blank">↗</a></sup>
+#### `read` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L236"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 read(cls, id: Optional[UUID] = None, name: Optional[str] = None) -> Self
@@ -77,7 +77,7 @@ automation = Automation.read(id=UUID("b3514963-02b1-47a5-93d1-6eeb131041cb"))
 ```
 
 
-#### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L297" target="_blank">↗</a></sup>
+#### `delete` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L297"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 delete(self: Self) -> bool
@@ -93,7 +93,7 @@ auto.delete()
 ```
 
 
-#### `disable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L347" target="_blank">↗</a></sup>
+#### `disable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L347"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 disable(self: Self) -> bool
@@ -112,7 +112,7 @@ auto.disable()
 ```
 
 
-#### `enable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/automations.py#L401" target="_blank">↗</a></sup>
+#### `enable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/automations.py#L401"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enable(self: Self) -> bool

--- a/docs/v3/api-ref/python/prefect-blocks-abstract.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-abstract.mdx
@@ -7,7 +7,7 @@ sidebarTitle: abstract
 
 ## Classes
 
-### `CredentialsBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L37" target="_blank">↗</a></sup>
+### `CredentialsBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 
 Stores credentials for an external system and exposes a client for interacting
@@ -19,7 +19,7 @@ interacting with the corresponding external system.
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L47" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter
@@ -34,7 +34,7 @@ Else, it returns a default logger labeled with the class's name.
 - The run logger or a default logger with the class's name.
 
 
-#### `get_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L63" target="_blank">↗</a></sup>
+#### `get_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_client(self, *args: Any, **kwargs: Any) -> Any
@@ -47,13 +47,13 @@ a `client_type` keyword argument to get the desired client
 within the service.
 
 
-### `NotificationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L73" target="_blank">↗</a></sup>
+### `NotificationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised if a notification block fails to send a notification.
 
 
-### `NotificationBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L80" target="_blank">↗</a></sup>
+### `NotificationBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L80"><Icon icon="github" size="14" /></a></sup>
 
 
 Block that represents a resource in an external system that is able to send notifications.
@@ -61,7 +61,7 @@ Block that represents a resource in an external system that is able to send noti
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L89" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter
@@ -76,7 +76,7 @@ Else, it returns a default logger labeled with the class's name.
 - The run logger or a default logger with the class's name.
 
 
-#### `raise_on_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L117" target="_blank">↗</a></sup>
+#### `raise_on_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_on_failure(self) -> Generator[None, None, None]
@@ -86,7 +86,7 @@ Context manager that, while active, causes the block to raise errors if it
 encounters a failure sending notifications.
 
 
-### `JobRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L129" target="_blank">↗</a></sup>
+### `JobRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L129"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a job run in an external system. Allows waiting
@@ -95,7 +95,7 @@ for the job run's completion and fetching its results.
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L136" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter
@@ -110,7 +110,7 @@ Else, it returns a default logger labeled with the class's name.
 - The run logger or a default logger with the class's name.
 
 
-### `JobBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L164" target="_blank">↗</a></sup>
+### `JobBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L164"><Icon icon="github" size="14" /></a></sup>
 
 
 Block that represents an entity in an external service
@@ -119,7 +119,7 @@ that can trigger a long running execution.
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L171" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L171"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter
@@ -134,7 +134,7 @@ Else, it returns a default logger labeled with the class's name.
 - The run logger or a default logger with the class's name.
 
 
-### `DatabaseBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L199" target="_blank">↗</a></sup>
+### `DatabaseBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 
 An abstract block type that represents a database and
@@ -152,7 +152,7 @@ implementations is recommended.
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L215" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L215"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter
@@ -167,7 +167,7 @@ Else, it returns a default logger labeled with the class's name.
 - The run logger or a default logger with the class's name.
 
 
-### `ObjectStorageBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L361" target="_blank">↗</a></sup>
+### `ObjectStorageBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L361"><Icon icon="github" size="14" /></a></sup>
 
 
 Block that represents a resource in an external service that can store
@@ -176,7 +176,7 @@ objects.
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L368" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L368"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter
@@ -191,7 +191,7 @@ Else, it returns a default logger labeled with the class's name.
 - The run logger or a default logger with the class's name.
 
 
-### `SecretBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L494" target="_blank">↗</a></sup>
+### `SecretBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L494"><Icon icon="github" size="14" /></a></sup>
 
 
 Block that represents a resource that can store and retrieve secrets.
@@ -199,7 +199,7 @@ Block that represents a resource that can store and retrieve secrets.
 
 **Methods:**
 
-#### `logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/abstract.py#L500" target="_blank">↗</a></sup>
+#### `logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/abstract.py#L500"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logger(self) -> LoggerOrAdapter

--- a/docs/v3/api-ref/python/prefect-blocks-core.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-core.mdx
@@ -7,7 +7,7 @@ sidebarTitle: core
 
 ## Functions
 
-### `block_schema_to_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L82" target="_blank">↗</a></sup>
+### `block_schema_to_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L82"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_schema_to_key(schema: BlockSchema) -> str
@@ -17,7 +17,7 @@ block_schema_to_key(schema: BlockSchema) -> str
 Defines the unique key used to lookup the Block class for a given schema.
 
 
-### `schema_extra` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L238" target="_blank">↗</a></sup>
+### `schema_extra` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L238"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 schema_extra(schema: dict[str, Any], model: type['Block']) -> None
@@ -29,27 +29,27 @@ Customizes Pydantic's schema generation feature to add blocks related informatio
 
 ## Classes
 
-### `InvalidBlockRegistration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L91" target="_blank">↗</a></sup>
+### `InvalidBlockRegistration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised on attempted registration of the base Block
 class or a Block interface class
 
 
-### `UnknownBlockType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L98" target="_blank">↗</a></sup>
+### `UnknownBlockType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a block type is not found in the registry.
 
 
-### `BlockNotSavedError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L229" target="_blank">↗</a></sup>
+### `BlockNotSavedError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L229"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a given block is not saved and an operation that requires
 the block to be saved is attempted.
 
 
-### `Block` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L289" target="_blank">↗</a></sup>
+### `Block` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L289"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for implementing a block that wraps an external service.
@@ -69,31 +69,31 @@ initialization.
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L325" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L325"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-#### `ser_model` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L368" target="_blank">↗</a></sup>
+#### `ser_model` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L368"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ser_model(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> Any
 ```
 
-#### `get_block_type_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L395" target="_blank">↗</a></sup>
+#### `get_block_type_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L395"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_type_name(cls) -> str
 ```
 
-#### `get_block_type_slug` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L399" target="_blank">↗</a></sup>
+#### `get_block_type_slug` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L399"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_type_slug(cls) -> str
 ```
 
-#### `get_block_capabilities` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L403" target="_blank">↗</a></sup>
+#### `get_block_capabilities` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L403"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_capabilities(cls) -> FrozenSet[str]
@@ -103,13 +103,13 @@ Returns the block capabilities for this Block. Recursively collects all block
 capabilities of all parent classes into a single frozenset.
 
 
-#### `get_block_schema_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L433" target="_blank">↗</a></sup>
+#### `get_block_schema_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L433"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_schema_version(cls) -> str
 ```
 
-#### `get_description` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L611" target="_blank">↗</a></sup>
+#### `get_description` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L611"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_description(cls) -> Optional[str]
@@ -119,7 +119,7 @@ Returns the description for the current block. Attempts to parse
 description from class docstring if an override is not defined.
 
 
-#### `get_code_example` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L634" target="_blank">↗</a></sup>
+#### `get_code_example` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L634"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_code_example(cls) -> Optional[str]
@@ -129,7 +129,7 @@ Returns the code example for the given block. Attempts to parse
 code example from the class docstring if an override is not provided.
 
 
-#### `get_block_class_from_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L779" target="_blank">↗</a></sup>
+#### `get_block_class_from_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L779"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_class_from_schema(cls: type[Self], schema: BlockSchema) -> type[Self]
@@ -138,7 +138,7 @@ get_block_class_from_schema(cls: type[Self], schema: BlockSchema) -> type[Self]
 Retrieve the block class implementation given a schema.
 
 
-#### `get_block_class_from_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L786" target="_blank">↗</a></sup>
+#### `get_block_class_from_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L786"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_class_from_key(cls: type[Self], key: str) -> type[Self]
@@ -147,7 +147,7 @@ get_block_class_from_key(cls: type[Self], key: str) -> type[Self]
 Retrieve the block class implementation given a key.
 
 
-#### `load` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1005" target="_blank">↗</a></sup>
+#### `load` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1005"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load(cls, name: str, validate: bool = True, client: Optional['PrefectClient'] = None) -> 'Self'
@@ -229,19 +229,19 @@ loaded_block.save("my-custom-message", overwrite=True)
 ```
 
 
-#### `is_block_class` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1227" target="_blank">↗</a></sup>
+#### `is_block_class` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1227"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_block_class(block: Any) -> TypeGuard[type['Block']]
 ```
 
-#### `annotation_refers_to_block_class` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1231" target="_blank">↗</a></sup>
+#### `annotation_refers_to_block_class` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1231"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 annotation_refers_to_block_class(annotation: Any) -> bool
 ```
 
-#### `get_block_placeholder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1484" target="_blank">↗</a></sup>
+#### `get_block_placeholder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1484"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_block_placeholder(self) -> str
@@ -260,7 +260,7 @@ templating.
 If a block has not been saved, the return value will be `None`.
 
 
-#### `model_json_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1507" target="_blank">↗</a></sup>
+#### `model_json_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1507"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_json_schema(cls, by_alias: bool = True, ref_template: str = '#/definitions/{model}', schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema, mode: Literal['validation', 'serialization'] = 'validation') -> dict[str, Any]
@@ -269,13 +269,13 @@ model_json_schema(cls, by_alias: bool = True, ref_template: str = '#/definitions
 TODO\: stop overriding this method - use GenerateSchema in ConfigDict instead?
 
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1527" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1527"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: type[Self], obj: dict[str, Any] | Any) -> Self
 ```
 
-#### `model_dump` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/core.py#L1552" target="_blank">↗</a></sup>
+#### `model_dump` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/core.py#L1552"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_dump(self) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-blocks-notifications.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-notifications.mdx
@@ -7,7 +7,7 @@ sidebarTitle: notifications
 
 ## Classes
 
-### `AbstractAppriseNotificationBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L20" target="_blank">↗</a></sup>
+### `AbstractAppriseNotificationBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L20"><Icon icon="github" size="14" /></a></sup>
 
 
 An abstract class for sending notifications using Apprise.
@@ -15,19 +15,19 @@ An abstract class for sending notifications using Apprise.
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L59" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `AppriseNotificationBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L78" target="_blank">↗</a></sup>
+### `AppriseNotificationBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for sending notifications using Apprise, through webhook URLs.
 
 
-### `SlackWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L116" target="_blank">↗</a></sup>
+### `SlackWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L116"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via a provided Slack webhook.
@@ -43,7 +43,7 @@ slack_webhook_block.notify("Hello from Prefect!")
 ```
 
 
-### `MicrosoftTeamsWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L146" target="_blank">↗</a></sup>
+### `MicrosoftTeamsWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L146"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via a provided Microsoft Teams webhook.
@@ -60,7 +60,7 @@ teams_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L187" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L187"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
@@ -69,7 +69,7 @@ block_initialization(self) -> None
 see https://github.com/caronc/apprise/pull/1172
 
 
-### `PagerDutyWebHook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L204" target="_blank">↗</a></sup>
+### `PagerDutyWebHook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L204"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via a provided PagerDuty webhook.
@@ -88,13 +88,13 @@ pagerduty_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L296" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L296"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `TwilioSMS` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L344" target="_blank">↗</a></sup>
+### `TwilioSMS` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L344"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via Twilio SMS.
@@ -112,13 +112,13 @@ twilio_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L396" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L396"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `OpsgenieWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L417" target="_blank">↗</a></sup>
+### `OpsgenieWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L417"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via a provided Opsgenie webhook.
@@ -137,13 +137,13 @@ opsgenie_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L505" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L505"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `MattermostWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L541" target="_blank">↗</a></sup>
+### `MattermostWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L541"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via a provided Mattermost webhook.
@@ -163,13 +163,13 @@ mattermost_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L609" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L609"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `DiscordWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L634" target="_blank">↗</a></sup>
+### `DiscordWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L634"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via a provided Discord webhook.
@@ -189,13 +189,13 @@ discord_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L714" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L714"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `CustomWebhookNotificationBlock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L738" target="_blank">↗</a></sup>
+### `CustomWebhookNotificationBlock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L738"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via any custom webhook.
@@ -218,13 +218,13 @@ custom_webhook_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L842" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L842"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-### `SendgridEmail` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L875" target="_blank">↗</a></sup>
+### `SendgridEmail` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L875"><Icon icon="github" size="14" /></a></sup>
 
 
 Enables sending notifications via any sendgrid account.
@@ -244,7 +244,7 @@ sendgrid_block.notify("Hello from Prefect!")
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L920" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/notifications.py#L920"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None

--- a/docs/v3/api-ref/python/prefect-blocks-redis.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-redis.mdx
@@ -7,7 +7,7 @@ sidebarTitle: redis
 
 ## Classes
 
-### `RedisStorageContainer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/redis.py#L23" target="_blank">↗</a></sup>
+### `RedisStorageContainer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/redis.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 
 Block used to interact with Redis as a filesystem
@@ -15,13 +15,13 @@ Block used to interact with Redis as a filesystem
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/redis.py#L66" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/redis.py#L66"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None
 ```
 
-#### `from_host` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/redis.py#L121" target="_blank">↗</a></sup>
+#### `from_host` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/redis.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_host(cls, host: str, port: int = 6379, db: int = 0, username: None | str | SecretStr = None, password: None | str | SecretStr = None) -> Self
@@ -39,7 +39,7 @@ Create block from hostname, username and password
 - `RedisStorageContainer` instance
 
 
-#### `from_connection_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/redis.py#L147" target="_blank">↗</a></sup>
+#### `from_connection_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/redis.py#L147"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_connection_string(cls, connection_string: str | SecretStr) -> Self

--- a/docs/v3/api-ref/python/prefect-blocks-system.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-system.mdx
@@ -7,25 +7,25 @@ sidebarTitle: system
 
 ## Classes
 
-### `JSON` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/system.py#L34" target="_blank">↗</a></sup>
+### `JSON` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/system.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 A block that represents JSON. Deprecated, please use Variables to store JSON data instead.
 
 
-### `String` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/system.py#L63" target="_blank">↗</a></sup>
+### `String` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/system.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 
 A block that represents a string. Deprecated, please use Variables to store string data instead.
 
 
-### `DateTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/system.py#L92" target="_blank">↗</a></sup>
+### `DateTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/system.py#L92"><Icon icon="github" size="14" /></a></sup>
 
 
 A block that represents a datetime. Deprecated, please use Variables to store datetime data instead.
 
 
-### `Secret` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/system.py#L120" target="_blank">↗</a></sup>
+### `Secret` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/system.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 
 A block that represents a secret value. The value stored in this block will be obfuscated when
@@ -34,13 +34,13 @@ this block is viewed or edited in the UI.
 
 **Methods:**
 
-#### `validate_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/system.py#L158" target="_blank">↗</a></sup>
+#### `validate_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/system.py#L158"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_value(cls, value: Union[T, SecretStr, PydanticSecret[T]]) -> Union[SecretStr, PydanticSecret[T]]
 ```
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/system.py#L166" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/system.py#L166"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(self) -> T | str

--- a/docs/v3/api-ref/python/prefect-blocks-webhook.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-webhook.mdx
@@ -7,7 +7,7 @@ sidebarTitle: webhook
 
 ## Classes
 
-### `Webhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/webhook.py#L19" target="_blank">↗</a></sup>
+### `Webhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/webhook.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 
 Block that enables calling webhooks.
@@ -15,7 +15,7 @@ Block that enables calling webhooks.
 
 **Methods:**
 
-#### `block_initialization` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/webhook.py#L55" target="_blank">↗</a></sup>
+#### `block_initialization` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/blocks/webhook.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_initialization(self) -> None

--- a/docs/v3/api-ref/python/prefect-cache_policies.mdx
+++ b/docs/v3/api-ref/python/prefect-cache_policies.mdx
@@ -7,7 +7,7 @@ sidebarTitle: cache_policies
 
 ## Classes
 
-### `CachePolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L46" target="_blank">↗</a></sup>
+### `CachePolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for all cache policies.
@@ -15,7 +15,7 @@ Base class for all cache policies.
 
 **Methods:**
 
-#### `from_cache_key_fn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L60" target="_blank">↗</a></sup>
+#### `from_cache_key_fn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_cache_key_fn(cls, cache_key_fn: Callable[['TaskRunContext', Dict[str, Any]], Optional[str]]) -> 'CacheKeyFnPolicy'
@@ -24,7 +24,7 @@ from_cache_key_fn(cls, cache_key_fn: Callable[['TaskRunContext', Dict[str, Any]]
 Given a function generates a key policy.
 
 
-#### `configure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L68" target="_blank">↗</a></sup>
+#### `configure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 configure(self, key_storage: Union['WritableFileSystem', str, Path, None] = None, lock_manager: Optional['LockManager'] = None, isolation_level: Union[Literal['READ_COMMITTED', 'SERIALIZABLE'], 'IsolationLevel', None] = None) -> Self
@@ -44,13 +44,13 @@ the current isolation level will be used.
 - A new cache policy with the given key storage, lock manager, and isolation level.
 
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L99" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L99"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: dict[str, Any], flow_parameters: dict[str, Any], **kwargs: Any) -> Optional[str]
 ```
 
-### `CacheKeyFnPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L155" target="_blank">↗</a></sup>
+### `CacheKeyFnPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L155"><Icon icon="github" size="14" /></a></sup>
 
 
 This policy accepts a custom function with signature f(task_run_context, task_parameters, flow_parameters) -> str
@@ -59,13 +59,13 @@ and uses it to compute a task run cache key.
 
 **Methods:**
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L166" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L166"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: dict[str, Any], flow_parameters: dict[str, Any], **kwargs: Any) -> Optional[str]
 ```
 
-### `CompoundCachePolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L178" target="_blank">↗</a></sup>
+### `CompoundCachePolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 
 This policy is constructed from two or more other cache policies and works by computing the keys
@@ -76,13 +76,13 @@ Any keys that return `None` will be ignored.
 
 **Methods:**
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L205" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L205"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: dict[str, Any], flow_parameters: dict[str, Any], **kwargs: Any) -> Optional[str]
 ```
 
-### `TaskSource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L278" target="_blank">↗</a></sup>
+### `TaskSource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L278"><Icon icon="github" size="14" /></a></sup>
 
 
 Policy for computing a cache key based on the source code of the task.
@@ -92,13 +92,13 @@ This policy only considers raw lines of code in the task, and not the source cod
 
 **Methods:**
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L285" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L285"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: Optional[dict[str, Any]], flow_parameters: Optional[dict[str, Any]], **kwargs: Any) -> Optional[str]
 ```
 
-### `FlowParameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L307" target="_blank">↗</a></sup>
+### `FlowParameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L307"><Icon icon="github" size="14" /></a></sup>
 
 
 Policy that computes the cache key based on a hash of the flow parameters.
@@ -106,13 +106,13 @@ Policy that computes the cache key based on a hash of the flow parameters.
 
 **Methods:**
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L312" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: dict[str, Any], flow_parameters: dict[str, Any], **kwargs: Any) -> Optional[str]
 ```
 
-### `RunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L325" target="_blank">↗</a></sup>
+### `RunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L325"><Icon icon="github" size="14" /></a></sup>
 
 
 Returns either the prevailing flow run ID, or if not found, the prevailing task
@@ -121,13 +121,13 @@ run ID.
 
 **Methods:**
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L331" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L331"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: dict[str, Any], flow_parameters: dict[str, Any], **kwargs: Any) -> Optional[str]
 ```
 
-### `Inputs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L347" target="_blank">↗</a></sup>
+### `Inputs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L347"><Icon icon="github" size="14" /></a></sup>
 
 
 Policy that computes a cache key based on a hash of the runtime inputs provided to the task..
@@ -135,7 +135,7 @@ Policy that computes a cache key based on a hash of the runtime inputs provided 
 
 **Methods:**
 
-#### `compute_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cache_policies.py#L354" target="_blank">↗</a></sup>
+#### `compute_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cache_policies.py#L354"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_key(self, task_ctx: TaskRunContext, inputs: dict[str, Any], flow_parameters: dict[str, Any], **kwargs: Any) -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-cli-block.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-block.mdx
@@ -12,25 +12,25 @@ Command line interface for working with blocks.
 
 ## Functions
 
-### `display_block` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/block.py#L45" target="_blank">↗</a></sup>
+### `display_block` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/block.py#L45"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 display_block(block_document: 'BlockDocument') -> Table
 ```
 
-### `display_block_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/block.py#L63" target="_blank">↗</a></sup>
+### `display_block_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/block.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 display_block_type(block_type: 'BlockType') -> Table
 ```
 
-### `display_block_schema_properties` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/block.py#L85" target="_blank">↗</a></sup>
+### `display_block_schema_properties` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/block.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 display_block_schema_properties(block_schema_fields: dict[str, Any]) -> Table
 ```
 
-### `display_block_schema_extra_definitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/block.py#L110" target="_blank">↗</a></sup>
+### `display_block_schema_extra_definitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/block.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 display_block_schema_extra_definitions(block_schema_definitions: dict[str, Any]) -> Table

--- a/docs/v3/api-ref/python/prefect-cli-cloud-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-cloud-__init__.mdx
@@ -12,37 +12,37 @@ Command line interface for interacting with Prefect Cloud
 
 ## Functions
 
-### `set_login_api_ready_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L71" target="_blank">↗</a></sup>
+### `set_login_api_ready_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_login_api_ready_event() -> None
 ```
 
-### `receive_login` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L115" target="_blank">↗</a></sup>
+### `receive_login` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 receive_login(payload: LoginSuccess) -> None
 ```
 
-### `receive_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L121" target="_blank">↗</a></sup>
+### `receive_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 receive_failure(payload: LoginFailed) -> None
 ```
 
-### `confirm_logged_in` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L163" target="_blank">↗</a></sup>
+### `confirm_logged_in` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L163"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 confirm_logged_in() -> None
 ```
 
-### `get_current_workspace` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L172" target="_blank">↗</a></sup>
+### `get_current_workspace` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_current_workspace(workspaces: Iterable[Workspace]) -> Workspace | None
 ```
 
-### `prompt_select_from_list` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L197" target="_blank">↗</a></sup>
+### `prompt_select_from_list` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L197"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prompt_select_from_list(console: Console, prompt: str, options: list[str] | list[tuple[T, str]]) -> str | T
@@ -63,10 +63,10 @@ key will be returned.
 
 ## Classes
 
-### `LoginSuccess` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L97" target="_blank">↗</a></sup>
+### `LoginSuccess` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L97"><Icon icon="github" size="14" /></a></sup>
 
-### `LoginFailed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L101" target="_blank">↗</a></sup>
+### `LoginFailed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L101"><Icon icon="github" size="14" /></a></sup>
 
-### `LoginResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L105" target="_blank">↗</a></sup>
+### `LoginResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L105"><Icon icon="github" size="14" /></a></sup>
 
-### `ServerExit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L110" target="_blank">↗</a></sup>
+### `ServerExit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/__init__.py#L110"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-cli-cloud-ip_allowlist.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-cloud-ip_allowlist.mdx
@@ -7,7 +7,7 @@ sidebarTitle: ip_allowlist
 
 ## Functions
 
-### `require_access_to_ip_allowlisting` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/ip_allowlist.py#L28" target="_blank">↗</a></sup>
+### `require_access_to_ip_allowlisting` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/ip_allowlist.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 require_access_to_ip_allowlisting(ctx: typer.Context) -> None
@@ -17,7 +17,7 @@ require_access_to_ip_allowlisting(ctx: typer.Context) -> None
 Enforce access to IP allowlisting for all subcommands.
 
 
-### `parse_ip_network_argument` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/ip_allowlist.py#L104" target="_blank">↗</a></sup>
+### `parse_ip_network_argument` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/ip_allowlist.py#L104"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parse_ip_network_argument(val: str) -> IPNetworkArg
@@ -25,4 +25,4 @@ parse_ip_network_argument(val: str) -> IPNetworkArg
 
 ## Classes
 
-### `IPNetworkArg` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/cloud/ip_allowlist.py#L99" target="_blank">↗</a></sup>
+### `IPNetworkArg` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/cloud/ip_allowlist.py#L99"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-cli-config.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-config.mdx
@@ -12,7 +12,7 @@ Command line interface for working with profiles
 
 ## Functions
 
-### `set_` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/config.py#L39" target="_blank">↗</a></sup>
+### `set_` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/config.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_(settings: list[str])
@@ -22,7 +22,7 @@ set_(settings: list[str])
 Change the value for a setting by setting the value in the current profile.
 
 
-### `validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/config.py#L85" target="_blank">↗</a></sup>
+### `validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/config.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate()
@@ -35,7 +35,7 @@ Deprecated settings will be automatically converted to new names unless both are
 set.
 
 
-### `unset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/config.py#L102" target="_blank">↗</a></sup>
+### `unset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/config.py#L102"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unset(setting_names: list[str], confirm: bool = typer.Option(False, '--yes', '-y'))
@@ -47,7 +47,7 @@ Restore the default value for a setting.
 Removes the setting from the current profile.
 
 
-### `view` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/config.py#L173" target="_blank">↗</a></sup>
+### `view` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/config.py#L173"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 view(show_defaults: bool = typer.Option(False, '--show-defaults/--hide-defaults', help=show_defaults_help), show_sources: bool = typer.Option(True, '--show-sources/--hide-sources', help=show_sources_help), show_secrets: bool = typer.Option(False, '--show-secrets/--hide-secrets', help='Toggle display of secrets setting values.'))

--- a/docs/v3/api-ref/python/prefect-cli-deployment.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-deployment.mdx
@@ -12,7 +12,7 @@ Command line interface for working with deployments.
 
 ## Functions
 
-### `str_presenter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L59" target="_blank">↗</a></sup>
+### `str_presenter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/deployment.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 str_presenter(dumper: yaml.Dumper | yaml.representer.SafeRepresenter, data: str) -> yaml.ScalarNode
@@ -23,7 +23,7 @@ configures yaml for dumping multiline strings
 Ref: https://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data
 
 
-### `assert_deployment_name_format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L85" target="_blank">↗</a></sup>
+### `assert_deployment_name_format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/deployment.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_deployment_name_format(name: str) -> None
@@ -31,11 +31,11 @@ assert_deployment_name_format(name: str) -> None
 
 ## Classes
 
-### `RichTextIO` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L206" target="_blank">↗</a></sup>
+### `RichTextIO` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/deployment.py#L206"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `write` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L211" target="_blank">↗</a></sup>
+#### `write` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/deployment.py#L211"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 write(self, content: str) -> None

--- a/docs/v3/api-ref/python/prefect-cli-dev.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-dev.mdx
@@ -12,13 +12,13 @@ Command line interface for working with Prefect Server
 
 ## Functions
 
-### `exit_with_error_if_not_editable_install` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/dev.py#L43" target="_blank">↗</a></sup>
+### `exit_with_error_if_not_editable_install` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/dev.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exit_with_error_if_not_editable_install() -> None
 ```
 
-### `build_docs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/dev.py#L57" target="_blank">↗</a></sup>
+### `build_docs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/dev.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_docs(schema_path: Optional[str] = None)
@@ -28,13 +28,13 @@ build_docs(schema_path: Optional[str] = None)
 Builds REST API reference documentation for static display.
 
 
-### `build_ui` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/dev.py#L86" target="_blank">↗</a></sup>
+### `build_ui` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/dev.py#L86"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_ui(no_install: bool = False)
 ```
 
-### `build_image` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/dev.py#L227" target="_blank">↗</a></sup>
+### `build_image` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/dev.py#L227"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_image(arch: str = typer.Option(None, help=f'The architecture to build the container for. Defaults to the architecture of the host Python. [default: {platform.machine()}]'), python_version: str = typer.Option(None, help=f'The Python version to build the container for. Defaults to the version of the host Python. [default: {python_version_minor()}]'), flavor: str = typer.Option(None, help="An alternative flavor to build, for example 'conda'. Defaults to the standard Python base image"), dry_run: bool = False)
@@ -44,7 +44,7 @@ build_image(arch: str = typer.Option(None, help=f'The architecture to build the 
 Build a docker image for development.
 
 
-### `container` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/dev.py#L296" target="_blank">↗</a></sup>
+### `container` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/dev.py#L296"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 container(bg: bool = False, name = 'prefect-dev', api: bool = True, tag: Optional[str] = None)

--- a/docs/v3/api-ref/python/prefect-cli-events.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Functions
 
-### `handle_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L77" target="_blank">↗</a></sup>
+### `handle_error` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/events.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_error(exc: Exception) -> None
@@ -15,4 +15,4 @@ handle_error(exc: Exception) -> None
 
 ## Classes
 
-### `StreamFormat` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L22" target="_blank">↗</a></sup>
+### `StreamFormat` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/events.py#L22"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-cli-global_concurrency_limit.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-global_concurrency_limit.mdx
@@ -7,4 +7,4 @@ sidebarTitle: global_concurrency_limit
 
 ## Classes
 
-### `OutputFormat` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/global_concurrency_limit.py#L33" target="_blank">↗</a></sup>
+### `OutputFormat` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/global_concurrency_limit.py#L33"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-cli-profile.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-profile.mdx
@@ -12,7 +12,7 @@ Command line interface for working with profiles.
 
 ## Functions
 
-### `ls` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L39" target="_blank">↗</a></sup>
+### `ls` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ls()
@@ -22,7 +22,7 @@ ls()
 List profile names.
 
 
-### `create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L61" target="_blank">↗</a></sup>
+### `create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L61"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create(name: str, from_name: str = typer.Option(None, '--from', help='Copy an existing profile.'))
@@ -32,7 +32,7 @@ create(name: str, from_name: str = typer.Option(None, '--from', help='Copy an ex
 Create a new profile.
 
 
-### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L183" target="_blank">↗</a></sup>
+### `delete` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L183"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 delete(name: str)
@@ -42,7 +42,7 @@ delete(name: str)
 Delete the given profile.
 
 
-### `rename` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L209" target="_blank">↗</a></sup>
+### `rename` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L209"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 rename(name: str, new_name: str)
@@ -52,7 +52,7 @@ rename(name: str, new_name: str)
 Change the name of a profile.
 
 
-### `inspect` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L239" target="_blank">↗</a></sup>
+### `inspect` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L239"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 inspect(name: Optional[str] = typer.Argument(None, help='Name of profile to inspect; defaults to active profile.'))
@@ -62,13 +62,13 @@ inspect(name: Optional[str] = typer.Argument(None, help='Name of profile to insp
 Display settings from a given profile; defaults to active.
 
 
-### `show_profile_changes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L265" target="_blank">↗</a></sup>
+### `show_profile_changes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L265"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 show_profile_changes(user_profiles: ProfilesCollection, default_profiles: ProfilesCollection) -> bool
 ```
 
-### `populate_defaults` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L293" target="_blank">↗</a></sup>
+### `populate_defaults` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L293"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 populate_defaults()
@@ -80,4 +80,4 @@ Populate the profiles configuration with default base profiles, preserving exist
 
 ## Classes
 
-### `ConnectionStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/profile.py#L339" target="_blank">↗</a></sup>
+### `ConnectionStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/profile.py#L339"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-cli-root.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-root.mdx
@@ -12,25 +12,25 @@ Base `prefect` command-line application
 
 ## Functions
 
-### `version_callback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py#L32" target="_blank">↗</a></sup>
+### `version_callback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/root.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 version_callback(value: bool) -> None
 ```
 
-### `is_interactive` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py#L38" target="_blank">↗</a></sup>
+### `is_interactive` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/root.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_interactive() -> bool
 ```
 
-### `main` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py#L44" target="_blank">↗</a></sup>
+### `main` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/root.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 main(ctx: typer.Context, version: bool = typer.Option(None, '--version', '-v', callback=version_callback, help='Display the current version.', is_eager=True), profile: str = typer.Option(None, '--profile', '-p', help='Select a profile for this CLI run.', is_eager=True), prompt: bool = SettingsOption(prefect.settings.PREFECT_CLI_PROMPT, help='Force toggle prompts for this CLI run.'))
 ```
 
-### `get_prefect_integrations` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py#L149" target="_blank">↗</a></sup>
+### `get_prefect_integrations` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/root.py#L149"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_prefect_integrations() -> dict[str, str]
@@ -40,7 +40,7 @@ get_prefect_integrations() -> dict[str, str]
 Get information about installed Prefect integrations.
 
 
-### `display` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py#L168" target="_blank">↗</a></sup>
+### `display` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/root.py#L168"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 display(object: dict[str, Any], nesting: int = 0) -> None

--- a/docs/v3/api-ref/python/prefect-cli-server.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-server.mdx
@@ -12,13 +12,13 @@ Command line interface for working with the Prefect API and server.
 
 ## Functions
 
-### `generate_welcome_blurb` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/server.py#L77" target="_blank">↗</a></sup>
+### `generate_welcome_blurb` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/server.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_welcome_blurb(base_url: str, ui_enabled: bool) -> str
 ```
 
-### `prestart_check` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/server.py#L127" target="_blank">↗</a></sup>
+### `prestart_check` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/server.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prestart_check(base_url: str) -> None
@@ -31,7 +31,7 @@ Check if `PREFECT_API_URL` is set in the current profile. If not, prompt the use
 - `base_url`: The base URL the server will be running on
 
 
-### `start` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/server.py#L226" target="_blank">↗</a></sup>
+### `start` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/server.py#L226"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start(host: str = SettingsOption(PREFECT_SERVER_API_HOST), port: int = SettingsOption(PREFECT_SERVER_API_PORT), keep_alive_timeout: int = SettingsOption(PREFECT_SERVER_API_KEEPALIVE_TIMEOUT), log_level: str = SettingsOption(PREFECT_SERVER_LOGGING_LEVEL), scheduler: bool = SettingsOption(PREFECT_API_SERVICES_SCHEDULER_ENABLED), analytics: bool = SettingsOption(PREFECT_SERVER_ANALYTICS_ENABLED, '--analytics-on/--analytics-off'), late_runs: bool = SettingsOption(PREFECT_API_SERVICES_LATE_RUNS_ENABLED), ui: bool = SettingsOption(PREFECT_UI_ENABLED), no_services: bool = typer.Option(False, '--no-services', help='Only run the webserver API and UI'), background: bool = typer.Option(False, '--background', '-b', help='Run the server in the background'))
@@ -41,7 +41,7 @@ start(host: str = SettingsOption(PREFECT_SERVER_API_HOST), port: int = SettingsO
 Start a Prefect server instance
 
 
-### `run_manager_process` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/server.py#L570" target="_blank">↗</a></sup>
+### `run_manager_process` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/server.py#L570"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_manager_process()
@@ -54,7 +54,7 @@ Users do not call this directly.
 We do everything in sync so that the child won't exit until the user kills it.
 
 
-### `list_services` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/server.py#L592" target="_blank">↗</a></sup>
+### `list_services` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/server.py#L592"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 list_services()
@@ -64,7 +64,7 @@ list_services()
 List all available services and their status.
 
 
-### `start_services` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/server.py#L615" target="_blank">↗</a></sup>
+### `start_services` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/server.py#L615"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start_services(background: bool = typer.Option(False, '--background', '-b', help='Run the services in the background'))

--- a/docs/v3/api-ref/python/prefect-cli-shell.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-shell.mdx
@@ -14,7 +14,7 @@ with options for logging output, scheduling, and deployment customization.
 
 ## Functions
 
-### `output_stream` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/shell.py#L34" target="_blank">↗</a></sup>
+### `output_stream` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/shell.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 output_stream(pipe: IO[str], logger_function: Callable[[str], None]) -> None
@@ -28,7 +28,7 @@ Read from a pipe line by line and log using the provided logging function.
 - `logger_function`: A logging function from the logger.
 
 
-### `output_collect` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/shell.py#L47" target="_blank">↗</a></sup>
+### `output_collect` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/shell.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 output_collect(pipe: IO[str], container: list[str]) -> None
@@ -42,7 +42,7 @@ Collects output from a subprocess pipe and stores it in a container list.
 - `container`: A list to store the collected output lines.
 
 
-### `run_shell_process` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/shell.py#L60" target="_blank">↗</a></sup>
+### `run_shell_process` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/shell.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_shell_process(command: str, log_output: bool = True, stream_stdout: bool = False, log_stderr: bool = False, popen_kwargs: Optional[Dict[str, Any]] = None)

--- a/docs/v3/api-ref/python/prefect-cli-variable.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-variable.mdx
@@ -7,7 +7,7 @@ sidebarTitle: variable
 
 ## Functions
 
-### `parse_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/variable.py#L104" target="_blank">↗</a></sup>
+### `parse_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/variable.py#L104"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parse_value(value: str) -> Union[str, int, float, bool, None, Dict[str, Any], List[str]]

--- a/docs/v3/api-ref/python/prefect-cli-work_pool.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-work_pool.mdx
@@ -12,13 +12,13 @@ Command line interface for working with work queues.
 
 ## Functions
 
-### `set_work_pool_as_default` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/work_pool.py#L54" target="_blank">↗</a></sup>
+### `set_work_pool_as_default` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/work_pool.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_work_pool_as_default(name: str) -> None
 ```
 
-### `has_provisioner_for_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/work_pool.py#L68" target="_blank">↗</a></sup>
+### `has_provisioner_for_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/work_pool.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 has_provisioner_for_type(work_pool_type: str) -> bool

--- a/docs/v3/api-ref/python/prefect-cli-worker.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-worker.mdx
@@ -7,4 +7,4 @@ sidebarTitle: worker
 
 ## Classes
 
-### `InstallPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/worker.py#L37" target="_blank">↗</a></sup>
+### `InstallPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/cli/worker.py#L37"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-client-base.mdx
+++ b/docs/v3/api-ref/python/prefect-client-base.mdx
@@ -7,7 +7,7 @@ sidebarTitle: base
 
 ## Functions
 
-### `determine_server_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L637" target="_blank">↗</a></sup>
+### `determine_server_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L637"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 determine_server_type() -> ServerType
@@ -26,9 +26,9 @@ not enabled
 
 ## Classes
 
-### `ASGIApp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L57" target="_blank">↗</a></sup>
+### `ASGIApp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L57"><Icon icon="github" size="14" /></a></sup>
 
-### `PrefectResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L145" target="_blank">↗</a></sup>
+### `PrefectResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect wrapper for the `httpx.Response` class.
@@ -38,7 +38,7 @@ Provides more informative error messages.
 
 **Methods:**
 
-#### `raise_for_status` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L152" target="_blank">↗</a></sup>
+#### `raise_for_status` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_for_status(self) -> Response
@@ -50,7 +50,7 @@ The `PrefectHTTPStatusError` contains useful additional information that
 is not contained in the `HTTPStatusError`.
 
 
-#### `from_httpx_response` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L165" target="_blank">↗</a></sup>
+#### `from_httpx_response` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L165"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_httpx_response(cls: type[Self], response: httpx.Response) -> Response
@@ -63,7 +63,7 @@ resolution order to look for methods defined in PrefectResponse, while leaving
 everything else about the original Response instance intact.
 
 
-### `PrefectHttpxAsyncClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L178" target="_blank">↗</a></sup>
+### `PrefectHttpxAsyncClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect wrapper for the async httpx client with support for retry-after headers
@@ -75,7 +75,7 @@ For more details on rate limit headers, see:
 [Configuring Cloudflare Rate Limiting](https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Rate-Limiting-from-UI)
 
 
-### `PrefectHttpxSyncClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L404" target="_blank">↗</a></sup>
+### `PrefectHttpxSyncClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L404"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect wrapper for the async httpx client with support for retry-after headers
@@ -89,7 +89,7 @@ For more details on rate limit headers, see:
 
 **Methods:**
 
-#### `send` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L543" target="_blank">↗</a></sup>
+#### `send` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L543"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 send(self, request: Request, *args: Any, **kwargs: Any) -> Response
@@ -105,4 +105,4 @@ Send a request with automatic retry behavior for the following status codes:
 - Any additional status codes provided in `PREFECT_CLIENT_RETRY_EXTRA_CODES`
 
 
-### `ServerType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L630" target="_blank">↗</a></sup>
+### `ServerType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/base.py#L630"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-client-cloud.mdx
+++ b/docs/v3/api-ref/python/prefect-client-cloud.mdx
@@ -7,7 +7,7 @@ sidebarTitle: cloud
 
 ## Functions
 
-### `get_cloud_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/cloud.py#L38" target="_blank">↗</a></sup>
+### `get_cloud_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/cloud.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_cloud_client(host: Optional[str] = None, api_key: Optional[str] = None, httpx_settings: Optional[dict[str, Any]] = None, infer_cloud_url: bool = False) -> 'CloudClient'
@@ -19,23 +19,23 @@ Needs a docstring.
 
 ## Classes
 
-### `CloudUnauthorizedError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/cloud.py#L66" target="_blank">↗</a></sup>
+### `CloudUnauthorizedError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/cloud.py#L66"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the CloudClient receives a 401 or 403 from the Cloud API.
 
 
-### `CloudClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/cloud.py#L72" target="_blank">↗</a></sup>
+### `CloudClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/cloud.py#L72"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `account_base_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/cloud.py#L101" target="_blank">↗</a></sup>
+#### `account_base_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/cloud.py#L101"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 account_base_url(self) -> str
 ```
 
-#### `workspace_base_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/cloud.py#L108" target="_blank">↗</a></sup>
+#### `workspace_base_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/cloud.py#L108"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 workspace_base_url(self) -> str

--- a/docs/v3/api-ref/python/prefect-client-collections.mdx
+++ b/docs/v3/api-ref/python/prefect-client-collections.mdx
@@ -7,7 +7,7 @@ sidebarTitle: collections
 
 ## Functions
 
-### `get_collections_metadata_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/collections.py#L17" target="_blank">↗</a></sup>
+### `get_collections_metadata_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/collections.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_collections_metadata_client(httpx_settings: Optional[Dict[str, Any]] = None) -> 'CollectionsMetadataClient'
@@ -23,4 +23,4 @@ to Prefect Cloud, otherwise will return an `OrchestrationClient`.
 
 ## Classes
 
-### `CollectionsMetadataClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/collections.py#L9" target="_blank">↗</a></sup>
+### `CollectionsMetadataClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/collections.py#L9"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-client-orchestration-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-client-orchestration-__init__.mdx
@@ -7,7 +7,7 @@ sidebarTitle: __init__
 
 ## Functions
 
-### `get_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L184" target="_blank">↗</a></sup>
+### `get_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L184"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_client(httpx_settings: Optional[dict[str, Any]] = None, sync_client: bool = False) -> Union['SyncPrefectClient', 'PrefectClient']
@@ -33,7 +33,7 @@ with get_client(sync_client=True) as client:
 
 ## Classes
 
-### `PrefectClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L265" target="_blank">↗</a></sup>
+### `PrefectClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L265"><Icon icon="github" size="14" /></a></sup>
 
 
 An asynchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
@@ -62,7 +62,7 @@ Examples:
 
 **Methods:**
 
-#### `api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L469" target="_blank">↗</a></sup>
+#### `api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L469"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 api_url(self) -> httpx.URL
@@ -71,19 +71,19 @@ api_url(self) -> httpx.URL
 Get the base URL for the API.
 
 
-#### `client_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1025" target="_blank">↗</a></sup>
+#### `client_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1025"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_version(self) -> str
 ```
 
-#### `loop` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1029" target="_blank">↗</a></sup>
+#### `loop` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1029"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 loop(self) -> asyncio.AbstractEventLoop | None
 ```
 
-### `SyncPrefectClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1130" target="_blank">↗</a></sup>
+### `SyncPrefectClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1130"><Icon icon="github" size="14" /></a></sup>
 
 
 A synchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
@@ -112,7 +112,7 @@ Examples:
 
 **Methods:**
 
-#### `api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1313" target="_blank">↗</a></sup>
+#### `api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1313"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 api_url(self) -> httpx.URL
@@ -121,7 +121,7 @@ api_url(self) -> httpx.URL
 Get the base URL for the API.
 
 
-#### `api_healthcheck` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1360" target="_blank">↗</a></sup>
+#### `api_healthcheck` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1360"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 api_healthcheck(self) -> Optional[Exception]
@@ -133,7 +133,7 @@ successful.
 If successful, returns `None`.
 
 
-#### `hello` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1373" target="_blank">↗</a></sup>
+#### `hello` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1373"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 hello(self) -> httpx.Response
@@ -142,31 +142,31 @@ hello(self) -> httpx.Response
 Send a GET request to /hello for testing purposes.
 
 
-#### `api_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1379" target="_blank">↗</a></sup>
+#### `api_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1379"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 api_version(self) -> str
 ```
 
-#### `client_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1383" target="_blank">↗</a></sup>
+#### `client_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1383"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_version(self) -> str
 ```
 
-#### `raise_for_api_version_mismatch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1386" target="_blank">↗</a></sup>
+#### `raise_for_api_version_mismatch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1386"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_for_api_version_mismatch(self) -> None
 ```
 
-#### `set_task_run_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1416" target="_blank">↗</a></sup>
+#### `set_task_run_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1416"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_task_run_name(self, task_run_id: UUID, name: str) -> httpx.Response
 ```
 
-#### `create_task_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1423" target="_blank">↗</a></sup>
+#### `create_task_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1423"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_task_run(self, task: 'TaskObject[P, R]', flow_run_id: Optional[UUID], dynamic_key: str, id: Optional[UUID] = None, name: Optional[str] = None, extra_tags: Optional[Iterable[str]] = None, state: Optional[prefect.states.State[R]] = None, task_inputs: Optional[dict[str, list[Union[TaskRunResult, FlowRunResult, Parameter, Constant]]]] = None) -> TaskRun
@@ -191,7 +191,7 @@ addition to `task.tags`
 - The created task run.
 
 
-#### `read_task_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1498" target="_blank">↗</a></sup>
+#### `read_task_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1498"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 read_task_run(self, task_run_id: UUID) -> TaskRun
@@ -206,7 +206,7 @@ Query the Prefect API for a task run by id.
 - a Task Run model representation of the task run
 
 
-#### `read_task_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1517" target="_blank">↗</a></sup>
+#### `read_task_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1517"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 read_task_runs(self) -> list[TaskRun]
@@ -229,7 +229,7 @@ be returned.
 of the task runs
 
 
-#### `set_task_run_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1565" target="_blank">↗</a></sup>
+#### `set_task_run_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1565"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_task_run_state(self, task_run_id: UUID, state: prefect.states.State[Any], force: bool = False) -> OrchestrationResult[Any]
@@ -247,7 +247,7 @@ forcing the Prefect API to accept the state
 - an OrchestrationResult model representation of state orchestration output
 
 
-#### `read_task_run_states` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1594" target="_blank">↗</a></sup>
+#### `read_task_run_states` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/__init__.py#L1594"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 read_task_run_states(self, task_run_id: UUID) -> list[prefect.states.State]

--- a/docs/v3/api-ref/python/prefect-client-orchestration-base.mdx
+++ b/docs/v3/api-ref/python/prefect-client-orchestration-base.mdx
@@ -7,14 +7,14 @@ sidebarTitle: base
 
 ## Classes
 
-### `BaseClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/base.py#L16" target="_blank">↗</a></sup>
+### `BaseClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/base.py#L16"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `request` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/base.py#L22" target="_blank">↗</a></sup>
+#### `request` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/base.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 request(self, method: HTTP_METHODS, path: 'ServerRoutes', params: dict[str, Any] | None = None, path_params: dict[str, Any] | None = None, **kwargs: Any) -> 'Response'
 ```
 
-### `BaseAsyncClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/orchestration/base.py#L36" target="_blank">↗</a></sup>
+### `BaseAsyncClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/orchestration/base.py#L36"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-client-schemas-actions.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-actions.mdx
@@ -7,57 +7,57 @@ sidebarTitle: actions
 
 ## Classes
 
-### `StateCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L58" target="_blank">↗</a></sup>
+### `StateCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L58"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a new state.
 
 
-### `FlowCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L70" target="_blank">↗</a></sup>
+### `FlowCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L70"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a flow.
 
 
-### `FlowUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L85" target="_blank">↗</a></sup>
+### `FlowUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a flow.
 
 
-### `DeploymentScheduleCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L95" target="_blank">↗</a></sup>
+### `DeploymentScheduleCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L95"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_active` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L117" target="_blank">↗</a></sup>
+#### `validate_active` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_active(cls, v: Any, handler: Callable[[Any], Any]) -> bool
 ```
 
-#### `validate_max_scheduled_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L127" target="_blank">↗</a></sup>
+#### `validate_max_scheduled_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_max_scheduled_runs(cls, v: Optional[int]) -> Optional[int]
 ```
 
-#### `from_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L133" target="_blank">↗</a></sup>
+#### `from_schedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L133"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_schedule(cls, schedule: Schedule) -> 'DeploymentScheduleCreate'
 ```
 
-### `DeploymentScheduleUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L172" target="_blank">↗</a></sup>
+### `DeploymentScheduleUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_max_scheduled_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L195" target="_blank">↗</a></sup>
+#### `validate_max_scheduled_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_max_scheduled_runs(cls, v: Optional[int]) -> Optional[int]
 ```
 
-### `DeploymentCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L201" target="_blank">↗</a></sup>
+### `DeploymentCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L201"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a deployment.
@@ -65,19 +65,19 @@ Data used by the Prefect REST API to create a deployment.
 
 **Methods:**
 
-#### `remove_old_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L206" target="_blank">↗</a></sup>
+#### `remove_old_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L206"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 remove_old_fields(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `convert_to_strings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L211" target="_blank">↗</a></sup>
+#### `convert_to_strings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L211"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 convert_to_strings(cls, values: Optional[Union[str, list[str]]]) -> Union[str, list[str]]
 ```
 
-#### `check_valid_configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L279" target="_blank">↗</a></sup>
+#### `check_valid_configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L279"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_valid_configuration(self, base_job_template: dict[str, Any]) -> None
@@ -87,7 +87,7 @@ Check that the combination of base_job_template defaults
 and job_variables conforms to the specified schema.
 
 
-### `DeploymentUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L299" target="_blank">↗</a></sup>
+### `DeploymentUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L299"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a deployment.
@@ -95,13 +95,13 @@ Data used by the Prefect REST API to update a deployment.
 
 **Methods:**
 
-#### `remove_old_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L304" target="_blank">↗</a></sup>
+#### `remove_old_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L304"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 remove_old_fields(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `check_valid_configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L355" target="_blank">↗</a></sup>
+#### `check_valid_configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L355"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_valid_configuration(self, base_job_template: dict[str, Any]) -> None
@@ -111,41 +111,41 @@ Check that the combination of base_job_template defaults
 and job_variables conforms to the specified schema.
 
 
-### `DeploymentBranch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L376" target="_blank">↗</a></sup>
+### `DeploymentBranch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L376"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_branch_length` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L389" target="_blank">↗</a></sup>
+#### `validate_branch_length` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L389"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_branch_length(cls, v: str) -> str
 ```
 
-### `FlowRunUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L395" target="_blank">↗</a></sup>
+### `FlowRunUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L395"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a flow run.
 
 
-### `TaskRunCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L409" target="_blank">↗</a></sup>
+### `TaskRunCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L409"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a task run
 
 
-### `TaskRunUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L454" target="_blank">↗</a></sup>
+### `TaskRunUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L454"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a task run
 
 
-### `FlowRunCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L460" target="_blank">↗</a></sup>
+### `FlowRunCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L460"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a flow run.
 
 
-### `DeploymentFlowRunCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L492" target="_blank">↗</a></sup>
+### `DeploymentFlowRunCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L492"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a flow run from a deployment.
@@ -153,43 +153,43 @@ Data used by the Prefect REST API to create a flow run from a deployment.
 
 **Methods:**
 
-#### `convert_parameters_to_plain_data` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L523" target="_blank">↗</a></sup>
+#### `convert_parameters_to_plain_data` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L523"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 convert_parameters_to_plain_data(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `SavedSearchCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L537" target="_blank">↗</a></sup>
+### `SavedSearchCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L537"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a saved search.
 
 
-### `ConcurrencyLimitCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L546" target="_blank">↗</a></sup>
+### `ConcurrencyLimitCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L546"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a concurrency limit.
 
 
-### `ConcurrencyLimitV2Create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L555" target="_blank">↗</a></sup>
+### `ConcurrencyLimitV2Create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L555"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a v2 concurrency limit.
 
 
-### `ConcurrencyLimitV2Update` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L575" target="_blank">↗</a></sup>
+### `ConcurrencyLimitV2Update` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L575"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a v2 concurrency limit.
 
 
-### `BlockTypeCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L586" target="_blank">↗</a></sup>
+### `BlockTypeCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L586"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a block type.
 
 
-### `BlockTypeUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L607" target="_blank">↗</a></sup>
+### `BlockTypeUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L607"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a block type.
@@ -197,19 +197,19 @@ Data used by the Prefect REST API to update a block type.
 
 **Methods:**
 
-#### `updatable_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L616" target="_blank">↗</a></sup>
+#### `updatable_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L616"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 updatable_fields(cls) -> set[str]
 ```
 
-### `BlockSchemaCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L620" target="_blank">↗</a></sup>
+### `BlockSchemaCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L620"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a block schema.
 
 
-### `BlockDocumentCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L637" target="_blank">↗</a></sup>
+### `BlockDocumentCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L637"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a block document.
@@ -217,25 +217,25 @@ Data used by the Prefect REST API to create a block document.
 
 **Methods:**
 
-#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L661" target="_blank">↗</a></sup>
+#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L661"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_name_is_present_if_not_anonymous(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `BlockDocumentUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L667" target="_blank">↗</a></sup>
+### `BlockDocumentUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L667"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a block document.
 
 
-### `BlockDocumentReferenceCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L682" target="_blank">↗</a></sup>
+### `BlockDocumentReferenceCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L682"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used to create block document reference.
 
 
-### `LogCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L697" target="_blank">↗</a></sup>
+### `LogCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L697"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a log.
@@ -243,7 +243,7 @@ Data used by the Prefect REST API to create a log.
 
 **Methods:**
 
-#### `model_dump` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L708" target="_blank">↗</a></sup>
+#### `model_dump` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L708"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]
@@ -253,61 +253,61 @@ The worker_id field is only included in logs sent to Prefect Cloud.
 If it's unset, we should not include it in the log payload.
 
 
-### `WorkPoolCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L719" target="_blank">↗</a></sup>
+### `WorkPoolCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L719"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a work pool.
 
 
-### `WorkPoolUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L746" target="_blank">↗</a></sup>
+### `WorkPoolUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L746"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a work pool.
 
 
-### `WorkQueueCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L759" target="_blank">↗</a></sup>
+### `WorkQueueCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L759"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a work queue.
 
 
-### `WorkQueueUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L788" target="_blank">↗</a></sup>
+### `WorkQueueUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L788"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a work queue.
 
 
-### `ArtifactCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L811" target="_blank">↗</a></sup>
+### `ArtifactCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L811"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create an artifact.
 
 
-### `ArtifactUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L823" target="_blank">↗</a></sup>
+### `ArtifactUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L823"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update an artifact.
 
 
-### `VariableCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L831" target="_blank">↗</a></sup>
+### `VariableCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L831"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a Variable.
 
 
-### `VariableUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L843" target="_blank">↗</a></sup>
+### `VariableUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L843"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a Variable.
 
 
-### `GlobalConcurrencyLimitCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L855" target="_blank">↗</a></sup>
+### `GlobalConcurrencyLimitCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L855"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a global concurrency limit.
 
 
-### `GlobalConcurrencyLimitUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/actions.py#L882" target="_blank">↗</a></sup>
+### `GlobalConcurrencyLimitUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/actions.py#L882"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a global concurrency limit.

--- a/docs/v3/api-ref/python/prefect-client-schemas-filters.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-filters.mdx
@@ -12,488 +12,488 @@ Schemas that define Prefect REST API filtering operations.
 
 ## Classes
 
-### `Operator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L16" target="_blank">↗</a></sup>
+### `Operator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L16"><Icon icon="github" size="14" /></a></sup>
 
 
 Operators for combining filter criteria.
 
 
-### `OperatorMixin` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L23" target="_blank">↗</a></sup>
+### `OperatorMixin` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 
 Base model for Prefect filters that combines criteria with a user-provided operator
 
 
-### `FlowFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L32" target="_blank">↗</a></sup>
+### `FlowFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Flow.id`.
 
 
-### `FlowFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L40" target="_blank">↗</a></sup>
+### `FlowFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Flow.name`.
 
 
-### `FlowFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L60" target="_blank">↗</a></sup>
+### `FlowFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Flow.tags`.
 
 
-### `FlowFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L76" target="_blank">↗</a></sup>
+### `FlowFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for flows. Only flows matching all criteria will be returned.
 
 
-### `FlowRunFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L90" target="_blank">↗</a></sup>
+### `FlowRunFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L90"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by FlowRun.id.
 
 
-### `FlowRunFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L101" target="_blank">↗</a></sup>
+### `FlowRunFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L101"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.name`.
 
 
-### `FlowRunFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L121" target="_blank">↗</a></sup>
+### `FlowRunFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.tags`.
 
 
-### `FlowRunFilterDeploymentId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L142" target="_blank">↗</a></sup>
+### `FlowRunFilterDeploymentId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L142"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.deployment_id`.
 
 
-### `FlowRunFilterWorkQueueName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L154" target="_blank">↗</a></sup>
+### `FlowRunFilterWorkQueueName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L154"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.work_queue_name`.
 
 
-### `FlowRunFilterStateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L168" target="_blank">↗</a></sup>
+### `FlowRunFilterStateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L168"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.state_type`.
 
 
-### `FlowRunFilterStateName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L179" target="_blank">↗</a></sup>
+### `FlowRunFilterStateName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L179"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunFilterState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L188" target="_blank">↗</a></sup>
+### `FlowRunFilterState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L188"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunFilterFlowVersion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L197" target="_blank">↗</a></sup>
+### `FlowRunFilterFlowVersion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L197"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.flow_version`.
 
 
-### `FlowRunFilterStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L205" target="_blank">↗</a></sup>
+### `FlowRunFilterStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L205"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.start_time`.
 
 
-### `FlowRunFilterExpectedStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L221" target="_blank">↗</a></sup>
+### `FlowRunFilterExpectedStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L221"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.expected_start_time`.
 
 
-### `FlowRunFilterNextScheduledStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L234" target="_blank">↗</a></sup>
+### `FlowRunFilterNextScheduledStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L234"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.next_scheduled_start_time`.
 
 
-### `FlowRunFilterParentFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L253" target="_blank">↗</a></sup>
+### `FlowRunFilterParentFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L253"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for subflows of the given flow runs
 
 
-### `FlowRunFilterParentTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L261" target="_blank">↗</a></sup>
+### `FlowRunFilterParentTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L261"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.parent_task_run_id`.
 
 
-### `FlowRunFilterIdempotencyKey` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L273" target="_blank">↗</a></sup>
+### `FlowRunFilterIdempotencyKey` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L273"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by FlowRun.idempotency_key.
 
 
-### `FlowRunFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L284" target="_blank">↗</a></sup>
+### `FlowRunFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L284"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter flow runs. Only flow runs matching all criteria will be returned
 
 
-### `TaskRunFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L329" target="_blank">↗</a></sup>
+### `TaskRunFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L329"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.flow_run_id`.
 
 
-### `TaskRunFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L342" target="_blank">↗</a></sup>
+### `TaskRunFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L342"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.id`.
 
 
-### `TaskRunFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L350" target="_blank">↗</a></sup>
+### `TaskRunFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L350"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.name`.
 
 
-### `TaskRunFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L370" target="_blank">↗</a></sup>
+### `TaskRunFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L370"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.tags`.
 
 
-### `TaskRunFilterStateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L386" target="_blank">↗</a></sup>
+### `TaskRunFilterStateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L386"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.state_type`.
 
 
-### `TaskRunFilterStateName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L394" target="_blank">↗</a></sup>
+### `TaskRunFilterStateName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L394"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskRunFilterState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L400" target="_blank">↗</a></sup>
+### `TaskRunFilterState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L400"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskRunFilterSubFlowRuns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L405" target="_blank">↗</a></sup>
+### `TaskRunFilterSubFlowRuns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L405"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.subflow_run`.
 
 
-### `TaskRunFilterStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L417" target="_blank">↗</a></sup>
+### `TaskRunFilterStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L417"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.start_time`.
 
 
-### `TaskRunFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L433" target="_blank">↗</a></sup>
+### `TaskRunFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L433"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter task runs. Only task runs matching all criteria will be returned
 
 
-### `DeploymentFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L459" target="_blank">↗</a></sup>
+### `DeploymentFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L459"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.id`.
 
 
-### `DeploymentFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L470" target="_blank">↗</a></sup>
+### `DeploymentFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L470"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.name`.
 
 
-### `DeploymentFilterWorkQueueName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L490" target="_blank">↗</a></sup>
+### `DeploymentFilterWorkQueueName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L490"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.work_queue_name`.
 
 
-### `DeploymentFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L500" target="_blank">↗</a></sup>
+### `DeploymentFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L500"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.tags`.
 
 
-### `DeploymentFilterConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L521" target="_blank">↗</a></sup>
+### `DeploymentFilterConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L521"><Icon icon="github" size="14" /></a></sup>
 
 
 DEPRECATED: Prefer `Deployment.concurrency_limit_id` over `Deployment.concurrency_limit`.
 
 
-### `DeploymentFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L538" target="_blank">↗</a></sup>
+### `DeploymentFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L538"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for deployments. Only deployments matching all criteria will be returned.
 
 
-### `LogFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L560" target="_blank">↗</a></sup>
+### `LogFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L560"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.name`.
 
 
-### `LogFilterLevel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L570" target="_blank">↗</a></sup>
+### `LogFilterLevel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L570"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.level`.
 
 
-### `LogFilterTimestamp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L586" target="_blank">↗</a></sup>
+### `LogFilterTimestamp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L586"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.timestamp`.
 
 
-### `LogFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L599" target="_blank">↗</a></sup>
+### `LogFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L599"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.flow_run_id`.
 
 
-### `LogFilterTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L607" target="_blank">↗</a></sup>
+### `LogFilterTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L607"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.task_run_id`.
 
 
-### `LogFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L615" target="_blank">↗</a></sup>
+### `LogFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L615"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter logs. Only logs matching all criteria will be returned
 
 
-### `FilterSet` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L632" target="_blank">↗</a></sup>
+### `FilterSet` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L632"><Icon icon="github" size="14" /></a></sup>
 
 
 A collection of filters for common objects
 
 
-### `BlockTypeFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L650" target="_blank">↗</a></sup>
+### `BlockTypeFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L650"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockType.name`
 
 
-### `BlockTypeFilterSlug` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L664" target="_blank">↗</a></sup>
+### `BlockTypeFilterSlug` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L664"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockType.slug`
 
 
-### `BlockTypeFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L672" target="_blank">↗</a></sup>
+### `BlockTypeFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L672"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter BlockTypes
 
 
-### `BlockSchemaFilterBlockTypeId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L684" target="_blank">↗</a></sup>
+### `BlockSchemaFilterBlockTypeId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L684"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockSchema.block_type_id`.
 
 
-### `BlockSchemaFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L692" target="_blank">↗</a></sup>
+### `BlockSchemaFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L692"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by BlockSchema.id
 
 
-### `BlockSchemaFilterCapabilities` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L700" target="_blank">↗</a></sup>
+### `BlockSchemaFilterCapabilities` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L700"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockSchema.capabilities`
 
 
-### `BlockSchemaFilterVersion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L713" target="_blank">↗</a></sup>
+### `BlockSchemaFilterVersion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L713"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockSchema.capabilities`
 
 
-### `BlockSchemaFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L723" target="_blank">↗</a></sup>
+### `BlockSchemaFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L723"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter BlockSchemas
 
 
-### `BlockDocumentFilterIsAnonymous` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L740" target="_blank">↗</a></sup>
+### `BlockDocumentFilterIsAnonymous` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L740"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.is_anonymous`.
 
 
-### `BlockDocumentFilterBlockTypeId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L751" target="_blank">↗</a></sup>
+### `BlockDocumentFilterBlockTypeId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L751"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.block_type_id`.
 
 
-### `BlockDocumentFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L759" target="_blank">↗</a></sup>
+### `BlockDocumentFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L759"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.id`.
 
 
-### `BlockDocumentFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L767" target="_blank">↗</a></sup>
+### `BlockDocumentFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L767"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.name`.
 
 
-### `BlockDocumentFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L783" target="_blank">↗</a></sup>
+### `BlockDocumentFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L783"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter BlockDocuments. Only BlockDocuments matching all criteria will be returned
 
 
-### `WorkQueueFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L805" target="_blank">↗</a></sup>
+### `WorkQueueFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L805"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkQueue.id`.
 
 
-### `WorkQueueFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L814" target="_blank">↗</a></sup>
+### `WorkQueueFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L814"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkQueue.name`.
 
 
-### `WorkQueueFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L834" target="_blank">↗</a></sup>
+### `WorkQueueFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L834"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter work queues. Only work queues matching all criteria will be
 returned
 
 
-### `WorkPoolFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L847" target="_blank">↗</a></sup>
+### `WorkPoolFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L847"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkPool.id`.
 
 
-### `WorkPoolFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L855" target="_blank">↗</a></sup>
+### `WorkPoolFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L855"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkPool.name`.
 
 
-### `WorkPoolFilterType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L863" target="_blank">↗</a></sup>
+### `WorkPoolFilterType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L863"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkPool.type`.
 
 
-### `WorkPoolFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L871" target="_blank">↗</a></sup>
+### `WorkPoolFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L871"><Icon icon="github" size="14" /></a></sup>
 
-### `WorkerFilterWorkPoolId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L883" target="_blank">↗</a></sup>
+### `WorkerFilterWorkPoolId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L883"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.worker_config_id`.
 
 
-### `WorkerFilterLastHeartbeatTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L891" target="_blank">↗</a></sup>
+### `WorkerFilterLastHeartbeatTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L891"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.last_heartbeat_time`.
 
 
-### `WorkerFilterStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L908" target="_blank">↗</a></sup>
+### `WorkerFilterStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L908"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.status`.
 
 
-### `WorkerFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L919" target="_blank">↗</a></sup>
+### `WorkerFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L919"><Icon icon="github" size="14" /></a></sup>
 
-### `ArtifactFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L933" target="_blank">↗</a></sup>
+### `ArtifactFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L933"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.id`.
 
 
-### `ArtifactFilterKey` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L941" target="_blank">↗</a></sup>
+### `ArtifactFilterKey` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L941"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.key`.
 
 
-### `ArtifactFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L966" target="_blank">↗</a></sup>
+### `ArtifactFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L966"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.flow_run_id`.
 
 
-### `ArtifactFilterTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L974" target="_blank">↗</a></sup>
+### `ArtifactFilterTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L974"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.task_run_id`.
 
 
-### `ArtifactFilterType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L982" target="_blank">↗</a></sup>
+### `ArtifactFilterType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L982"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.type`.
 
 
-### `ArtifactFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L993" target="_blank">↗</a></sup>
+### `ArtifactFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L993"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter artifacts. Only artifacts matching all criteria will be returned
 
 
-### `ArtifactCollectionFilterLatestId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1013" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterLatestId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1013"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.latest_id`.
 
 
-### `ArtifactCollectionFilterKey` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1021" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterKey` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1021"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.key`.
 
 
-### `ArtifactCollectionFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1047" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1047"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.flow_run_id`.
 
 
-### `ArtifactCollectionFilterTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1055" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1055"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.task_run_id`.
 
 
-### `ArtifactCollectionFilterType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1063" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1063"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.type`.
 
 
-### `ArtifactCollectionFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1074" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1074"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter artifact collections. Only artifact collections matching all criteria will be returned
 
 
-### `VariableFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1094" target="_blank">↗</a></sup>
+### `VariableFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1094"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Variable.id`.
 
 
-### `VariableFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1102" target="_blank">↗</a></sup>
+### `VariableFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1102"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Variable.name`.
 
 
-### `VariableFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1118" target="_blank">↗</a></sup>
+### `VariableFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1118"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Variable.tags`.
 
 
-### `VariableFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/filters.py#L1134" target="_blank">↗</a></sup>
+### `VariableFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/filters.py#L1134"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter variables. Only variables matching all criteria will be returned

--- a/docs/v3/api-ref/python/prefect-client-schemas-objects.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-objects.mdx
@@ -7,7 +7,7 @@ sidebarTitle: objects
 
 ## Functions
 
-### `data_discriminator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L200" target="_blank">↗</a></sup>
+### `data_discriminator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L200"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 data_discriminator(x: Any) -> str
@@ -15,15 +15,15 @@ data_discriminator(x: Any) -> str
 
 ## Classes
 
-### `RunType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L84" target="_blank">↗</a></sup>
+### `RunType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L84"><Icon icon="github" size="14" /></a></sup>
 
-### `StateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L89" target="_blank">↗</a></sup>
+### `StateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of state types.
 
 
-### `WorkPoolStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L111" target="_blank">↗</a></sup>
+### `WorkPoolStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L111"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of work pool statuses.
@@ -31,59 +31,59 @@ Enumeration of work pool statuses.
 
 **Methods:**
 
-#### `display_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L119" target="_blank">↗</a></sup>
+#### `display_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 display_name(self) -> str
 ```
 
-### `WorkerStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L123" target="_blank">↗</a></sup>
+### `WorkerStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L123"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of worker statuses.
 
 
-### `DeploymentStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L130" target="_blank">↗</a></sup>
+### `DeploymentStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L130"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of deployment statuses.
 
 
-### `WorkQueueStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L137" target="_blank">↗</a></sup>
+### `WorkQueueStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L137"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of work queue statuses.
 
 
-### `ConcurrencyLimitStrategy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L145" target="_blank">↗</a></sup>
+### `ConcurrencyLimitStrategy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of concurrency limit strategies.
 
 
-### `ConcurrencyOptions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L152" target="_blank">↗</a></sup>
+### `ConcurrencyOptions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 
 Class for storing the concurrency config in database.
 
 
-### `ConcurrencyLimitConfig` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L160" target="_blank">↗</a></sup>
+### `ConcurrencyLimitConfig` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L160"><Icon icon="github" size="14" /></a></sup>
 
 
 Class for storing the concurrency limit config in database.
 
 
-### `StateDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L169" target="_blank">↗</a></sup>
+### `StateDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L169"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `to_run_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L189" target="_blank">↗</a></sup>
+#### `to_run_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_run_result(self, run_type: RunType) -> Optional[Union[FlowRunResult, TaskRunResult]]
 ```
 
-### `State` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L206" target="_blank">↗</a></sup>
+### `State` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L206"><Icon icon="github" size="14" /></a></sup>
 
 
 The state of a run.
@@ -91,25 +91,25 @@ The state of a run.
 
 **Methods:**
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L262" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L262"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self: 'State[R]', raise_on_failure: Literal[True] = ..., retry_result_failure: bool = ...) -> R
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L269" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L269"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self: 'State[R]', raise_on_failure: Literal[False] = False, retry_result_failure: bool = ...) -> Union[R, Exception]
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L276" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L276"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self: 'State[R]', raise_on_failure: bool = ..., retry_result_failure: bool = ...) -> Union[R, Exception]
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L283" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L283"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: bool = True, retry_result_failure: bool = True) -> Union[R, Exception]
@@ -169,7 +169,7 @@ Get the result with `raise_on_failure` from a flow run in a different memory spa
 >>> await flow_run.state.result(raise_on_failure=True) # Raises `ValueError("oh no!")`
 
 
-#### `default_name_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L362" target="_blank">↗</a></sup>
+#### `default_name_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L362"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_name_from_type(self) -> Self
@@ -178,79 +178,79 @@ default_name_from_type(self) -> Self
 If a name is not provided, use the type
 
 
-#### `default_scheduled_start_time` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L372" target="_blank">↗</a></sup>
+#### `default_scheduled_start_time` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L372"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_scheduled_start_time(self) -> Self
 ```
 
-#### `set_unpersisted_results_to_none` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L379" target="_blank">↗</a></sup>
+#### `set_unpersisted_results_to_none` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L379"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_unpersisted_results_to_none(self) -> Self
 ```
 
-#### `is_scheduled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L384" target="_blank">↗</a></sup>
+#### `is_scheduled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L384"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_scheduled(self) -> bool
 ```
 
-#### `is_pending` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L387" target="_blank">↗</a></sup>
+#### `is_pending` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L387"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_pending(self) -> bool
 ```
 
-#### `is_running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L390" target="_blank">↗</a></sup>
+#### `is_running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L390"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_running(self) -> bool
 ```
 
-#### `is_completed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L393" target="_blank">↗</a></sup>
+#### `is_completed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L393"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_completed(self) -> bool
 ```
 
-#### `is_failed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L396" target="_blank">↗</a></sup>
+#### `is_failed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L396"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_failed(self) -> bool
 ```
 
-#### `is_crashed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L399" target="_blank">↗</a></sup>
+#### `is_crashed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L399"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_crashed(self) -> bool
 ```
 
-#### `is_cancelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L402" target="_blank">↗</a></sup>
+#### `is_cancelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L402"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_cancelled(self) -> bool
 ```
 
-#### `is_cancelling` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L405" target="_blank">↗</a></sup>
+#### `is_cancelling` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L405"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_cancelling(self) -> bool
 ```
 
-#### `is_final` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L408" target="_blank">↗</a></sup>
+#### `is_final` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L408"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_final(self) -> bool
 ```
 
-#### `is_paused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L411" target="_blank">↗</a></sup>
+#### `is_paused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L411"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_paused(self) -> bool
 ```
 
-#### `model_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L414" target="_blank">↗</a></sup>
+#### `model_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L414"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_copy(self) -> Self
@@ -260,7 +260,7 @@ Copying API models should return an object that could be inserted into the
 database again. The 'timestamp' is reset using the default factory.
 
 
-#### `fresh_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L427" target="_blank">↗</a></sup>
+#### `fresh_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L427"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 fresh_copy(self, **kwargs: Any) -> Self
@@ -269,7 +269,7 @@ fresh_copy(self, **kwargs: Any) -> Self
 Return a fresh copy of the state with a new ID.
 
 
-### `FlowRunPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L488" target="_blank">↗</a></sup>
+### `FlowRunPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L488"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines of how a flow run should be orchestrated.
@@ -277,23 +277,23 @@ Defines of how a flow run should be orchestrated.
 
 **Methods:**
 
-#### `populate_deprecated_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L523" target="_blank">↗</a></sup>
+#### `populate_deprecated_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L523"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 populate_deprecated_fields(cls, values: Any) -> Any
 ```
 
-### `FlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L529" target="_blank">↗</a></sup>
+### `FlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L529"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `set_default_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L687" target="_blank">↗</a></sup>
+#### `set_default_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L687"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_default_name(cls, name: Optional[str]) -> str
 ```
 
-### `TaskRunPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L691" target="_blank">↗</a></sup>
+### `TaskRunPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L691"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines of how a task run should retry.
@@ -301,7 +301,7 @@ Defines of how a task run should retry.
 
 **Methods:**
 
-#### `populate_deprecated_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L720" target="_blank">↗</a></sup>
+#### `populate_deprecated_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L720"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 populate_deprecated_fields(self)
@@ -311,56 +311,56 @@ If deprecated fields are provided, populate the corresponding new fields
 to preserve orchestration behavior.
 
 
-#### `validate_configured_retry_delays` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L740" target="_blank">↗</a></sup>
+#### `validate_configured_retry_delays` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L740"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_configured_retry_delays(cls, v: Optional[int | float | list[int] | list[float]]) -> Optional[int | float | list[int] | list[float]]
 ```
 
-#### `validate_jitter_factor` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L747" target="_blank">↗</a></sup>
+#### `validate_jitter_factor` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L747"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_jitter_factor(cls, v: Optional[float]) -> Optional[float]
 ```
 
-### `RunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L751" target="_blank">↗</a></sup>
+### `RunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L751"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for classes that represent inputs to task runs, which
 could include, constants, parameters, or other task runs.
 
 
-### `TaskRunResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L764" target="_blank">↗</a></sup>
+### `TaskRunResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L764"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a task run result input to another task run.
 
 
-### `FlowRunResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L771" target="_blank">↗</a></sup>
+### `FlowRunResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L771"><Icon icon="github" size="14" /></a></sup>
 
-### `Parameter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L776" target="_blank">↗</a></sup>
+### `Parameter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L776"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a parameter input to a task run.
 
 
-### `Constant` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L783" target="_blank">↗</a></sup>
+### `Constant` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L783"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents constant input value to a task run.
 
 
-### `TaskRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L790" target="_blank">↗</a></sup>
+### `TaskRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L790"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `set_default_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L900" target="_blank">↗</a></sup>
+#### `set_default_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L900"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_default_name(cls, name: Optional[str]) -> Name
 ```
 
-### `Workspace` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L904" target="_blank">↗</a></sup>
+### `Workspace` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L904"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Cloud workspace.
@@ -370,7 +370,7 @@ Expected payload for each workspace returned by the `me/workspaces` route.
 
 **Methods:**
 
-#### `handle` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L921" target="_blank">↗</a></sup>
+#### `handle` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L921"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle(self) -> str
@@ -379,7 +379,7 @@ handle(self) -> str
 The full handle of the workspace as `account_handle` / `workspace_handle`
 
 
-#### `api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L927" target="_blank">↗</a></sup>
+#### `api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L927"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 api_url(self) -> str
@@ -388,7 +388,7 @@ api_url(self) -> str
 Generate the API URL for accessing this workspace
 
 
-#### `ui_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L937" target="_blank">↗</a></sup>
+#### `ui_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L937"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ui_url(self) -> str
@@ -397,9 +397,9 @@ ui_url(self) -> str
 Generate the UI URL for accessing this workspace
 
 
-### `IPAllowlistEntry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L951" target="_blank">↗</a></sup>
+### `IPAllowlistEntry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L951"><Icon icon="github" size="14" /></a></sup>
 
-### `IPAllowlist` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L963" target="_blank">↗</a></sup>
+### `IPAllowlist` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L963"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Cloud IP allowlist.
@@ -407,25 +407,25 @@ A Prefect Cloud IP allowlist.
 Expected payload for an IP allowlist from the Prefect Cloud API.
 
 
-### `IPAllowlistMyAccessResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L973" target="_blank">↗</a></sup>
+### `IPAllowlistMyAccessResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L973"><Icon icon="github" size="14" /></a></sup>
 
 
 Expected payload for an IP allowlist access response from the Prefect Cloud API.
 
 
-### `BlockType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L980" target="_blank">↗</a></sup>
+### `BlockType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L980"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block type
 
 
-### `BlockSchema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1004" target="_blank">↗</a></sup>
+### `BlockSchema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1004"><Icon icon="github" size="14" /></a></sup>
 
 
 A representation of a block schema.
 
 
-### `BlockDocument` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1025" target="_blank">↗</a></sup>
+### `BlockDocument` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1025"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block document.
@@ -433,51 +433,51 @@ An ORM representation of a block document.
 
 **Methods:**
 
-#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1059" target="_blank">↗</a></sup>
+#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1059"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_name_is_present_if_not_anonymous(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `serialize_data` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1065" target="_blank">↗</a></sup>
+#### `serialize_data` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1065"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize_data(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> Any
 ```
 
-### `Flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1076" target="_blank">↗</a></sup>
+### `Flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1076"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of flow data.
 
 
-### `DeploymentSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1090" target="_blank">↗</a></sup>
+### `DeploymentSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1090"><Icon icon="github" size="14" /></a></sup>
 
-### `VersionInfo` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1115" target="_blank">↗</a></sup>
+### `VersionInfo` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1115"><Icon icon="github" size="14" /></a></sup>
 
-### `BranchingScheduleHandling` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1120" target="_blank">↗</a></sup>
+### `BranchingScheduleHandling` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1120"><Icon icon="github" size="14" /></a></sup>
 
-### `DeploymentBranchingOptions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1126" target="_blank">↗</a></sup>
+### `DeploymentBranchingOptions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1126"><Icon icon="github" size="14" /></a></sup>
 
-### `Deployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1133" target="_blank">↗</a></sup>
+### `Deployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1133"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of deployment data.
 
 
-### `ConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1238" target="_blank">↗</a></sup>
+### `ConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1238"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a concurrency limit.
 
 
-### `BlockSchemaReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1251" target="_blank">↗</a></sup>
+### `BlockSchemaReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1251"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block schema reference.
 
 
-### `BlockDocumentReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1271" target="_blank">↗</a></sup>
+### `BlockDocumentReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1271"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block document reference.
@@ -485,53 +485,53 @@ An ORM representation of a block document reference.
 
 **Methods:**
 
-#### `validate_parent_and_ref_are_different` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1292" target="_blank">↗</a></sup>
+#### `validate_parent_and_ref_are_different` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1292"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_parent_and_ref_are_different(cls, values: Any) -> Any
 ```
 
-### `Configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1298" target="_blank">↗</a></sup>
+### `Configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1298"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of account info.
 
 
-### `SavedSearchFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1305" target="_blank">↗</a></sup>
+### `SavedSearchFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1305"><Icon icon="github" size="14" /></a></sup>
 
 
 A filter for a saved search model. Intended for use by the Prefect UI.
 
 
-### `SavedSearch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1322" target="_blank">↗</a></sup>
+### `SavedSearch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1322"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of saved search data. Represents a set of filter criteria.
 
 
-### `Log` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1332" target="_blank">↗</a></sup>
+### `Log` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1332"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of log data.
 
 
-### `QueueFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1347" target="_blank">↗</a></sup>
+### `QueueFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1347"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter criteria definition for a work queue.
 
 
-### `WorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1360" target="_blank">↗</a></sup>
+### `WorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1360"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a work queue
 
 
-### `WorkQueueHealthPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1397" target="_blank">↗</a></sup>
+### `WorkQueueHealthPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1397"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `evaluate_health_status` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1413" target="_blank">↗</a></sup>
+#### `evaluate_health_status` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1413"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 evaluate_health_status(self, late_runs_count: int, last_polled: datetime.datetime | None = None) -> bool
@@ -547,21 +547,21 @@ Given empirical information about the state of the work queue, evaluate its heal
 - whether or not the work queue is healthy.
 
 
-### `WorkQueueStatusDetail` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1444" target="_blank">↗</a></sup>
+### `WorkQueueStatusDetail` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1444"><Icon icon="github" size="14" /></a></sup>
 
-### `Agent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1460" target="_blank">↗</a></sup>
+### `Agent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1460"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of an agent
 
 
-### `WorkPoolStorageConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1478" target="_blank">↗</a></sup>
+### `WorkPoolStorageConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1478"><Icon icon="github" size="14" /></a></sup>
 
 
 A work pool storage configuration
 
 
-### `WorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1493" target="_blank">↗</a></sup>
+### `WorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1493"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a work pool
@@ -569,49 +569,49 @@ An ORM representation of a work pool
 
 **Methods:**
 
-#### `is_push_pool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1531" target="_blank">↗</a></sup>
+#### `is_push_pool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1531"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_push_pool(self) -> bool
 ```
 
-#### `is_managed_pool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1535" target="_blank">↗</a></sup>
+#### `is_managed_pool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1535"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_managed_pool(self) -> bool
 ```
 
-#### `helpful_error_for_missing_default_queue_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1540" target="_blank">↗</a></sup>
+#### `helpful_error_for_missing_default_queue_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1540"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 helpful_error_for_missing_default_queue_id(cls, v: Optional[UUID]) -> UUID
 ```
 
-### `Worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1544" target="_blank">↗</a></sup>
+### `Worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1544"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a worker
 
 
-### `Artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1570" target="_blank">↗</a></sup>
+### `Artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1570"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_metadata_length` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1608" target="_blank">↗</a></sup>
+#### `validate_metadata_length` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1608"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_metadata_length(cls, v: Optional[dict[str, str]]) -> Optional[dict[str, str]]
 ```
 
-### `ArtifactCollection` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1614" target="_blank">↗</a></sup>
+### `ArtifactCollection` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1614"><Icon icon="github" size="14" /></a></sup>
 
-### `Variable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1651" target="_blank">↗</a></sup>
+### `Variable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1651"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1670" target="_blank">↗</a></sup>
+### `FlowRunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1670"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `decoded_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1679" target="_blank">↗</a></sup>
+#### `decoded_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1679"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 decoded_value(self) -> Any
@@ -623,21 +623,21 @@ Decode the value of the input.
 - the decoded value
 
 
-### `GlobalConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1689" target="_blank">↗</a></sup>
+### `GlobalConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1689"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a global concurrency limit
 
 
-### `CsrfToken` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1716" target="_blank">↗</a></sup>
+### `CsrfToken` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1716"><Icon icon="github" size="14" /></a></sup>
 
-### `Integration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1732" target="_blank">↗</a></sup>
+### `Integration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1732"><Icon icon="github" size="14" /></a></sup>
 
 
 A representation of an installed Prefect integration.
 
 
-### `WorkerMetadata` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/objects.py#L1739" target="_blank">↗</a></sup>
+### `WorkerMetadata` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/objects.py#L1739"><Icon icon="github" size="14" /></a></sup>
 
 
 Worker metadata.

--- a/docs/v3/api-ref/python/prefect-client-schemas-responses.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-responses.mdx
@@ -7,71 +7,71 @@ sidebarTitle: responses
 
 ## Classes
 
-### `SetStateStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L21" target="_blank">↗</a></sup>
+### `SetStateStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L21"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumerates return statuses for setting run states.
 
 
-### `StateAcceptDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L30" target="_blank">↗</a></sup>
+### `StateAcceptDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L30"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with an ACCEPT state transition.
 
 
-### `StateRejectDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L42" target="_blank">↗</a></sup>
+### `StateRejectDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L42"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with a REJECT state transition.
 
 
-### `StateAbortDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L57" target="_blank">↗</a></sup>
+### `StateAbortDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with an ABORT state transition.
 
 
-### `StateWaitDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L72" target="_blank">↗</a></sup>
+### `StateWaitDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L72"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with a WAIT state transition.
 
 
-### `HistoryResponseState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L94" target="_blank">↗</a></sup>
+### `HistoryResponseState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L94"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a single state's history over an interval.
 
 
-### `HistoryResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L116" target="_blank">↗</a></sup>
+### `HistoryResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L116"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a history of aggregation states over an interval
 
 
-### `OrchestrationResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L135" target="_blank">↗</a></sup>
+### `OrchestrationResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L135"><Icon icon="github" size="14" /></a></sup>
 
 
 A container for the output of state orchestration.
 
 
-### `WorkerFlowRunResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L145" target="_blank">↗</a></sup>
+### `WorkerFlowRunResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L145"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L153" target="_blank">↗</a></sup>
+### `FlowRunResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L153"><Icon icon="github" size="14" /></a></sup>
 
-### `DeploymentResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L309" target="_blank">↗</a></sup>
+### `DeploymentResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L309"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `as_related_resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L446" target="_blank">↗</a></sup>
+#### `as_related_resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L446"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_related_resource(self, role: str = 'deployment') -> 'RelatedResource'
 ```
 
-### `MinimalConcurrencyLimitResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L472" target="_blank">↗</a></sup>
+### `MinimalConcurrencyLimitResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L472"><Icon icon="github" size="14" /></a></sup>
 
-### `GlobalConcurrencyLimitResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/responses.py#L480" target="_blank">↗</a></sup>
+### `GlobalConcurrencyLimitResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/responses.py#L480"><Icon icon="github" size="14" /></a></sup>
 
 
 A response object for global concurrency limits.

--- a/docs/v3/api-ref/python/prefect-client-schemas-schedules.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-schedules.mdx
@@ -12,7 +12,7 @@ Schedule schemas
 
 ## Functions
 
-### `is_valid_timezone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L29" target="_blank">↗</a></sup>
+### `is_valid_timezone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_valid_timezone(v: str) -> bool
@@ -25,13 +25,13 @@ Unfortunately this list is slightly different from the list of valid
 timezones we use for cron and interval timezone validation.
 
 
-### `is_schedule_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L333" target="_blank">↗</a></sup>
+### `is_schedule_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L333"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_schedule_type(obj: Any) -> TypeGuard[SCHEDULE_TYPES]
 ```
 
-### `construct_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L337" target="_blank">↗</a></sup>
+### `construct_schedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L337"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 construct_schedule(interval: Optional[Union[int, float, datetime.timedelta]] = None, anchor_date: Optional[Union[datetime.datetime, str]] = None, cron: Optional[str] = None, rrule: Optional[str] = None, timezone: Optional[str] = None) -> SCHEDULE_TYPES
@@ -51,7 +51,7 @@ or a timedelta object. If a number is given, it will be interpreted as seconds.
 
 ## Classes
 
-### `IntervalSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L46" target="_blank">↗</a></sup>
+### `IntervalSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 
 A schedule formed by adding `interval` increments to an `anchor_date`. If no
@@ -83,13 +83,13 @@ if not provided, the current timestamp will be used
 
 **Methods:**
 
-#### `validate_timezone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L85" target="_blank">↗</a></sup>
+#### `validate_timezone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_timezone(self)
 ```
 
-### `CronSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L100" target="_blank">↗</a></sup>
+### `CronSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 
 Cron schedule
@@ -116,19 +116,19 @@ behaves like fcron and enables you to e.g. define a job that executes each
 
 **Methods:**
 
-#### `valid_timezone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L138" target="_blank">↗</a></sup>
+#### `valid_timezone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L138"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 valid_timezone(cls, v: Optional[str]) -> Optional[str]
 ```
 
-#### `valid_cron_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L143" target="_blank">↗</a></sup>
+#### `valid_cron_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 valid_cron_string(cls, v: str) -> str
 ```
 
-### `RRuleSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L168" target="_blank">↗</a></sup>
+### `RRuleSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L168"><Icon icon="github" size="14" /></a></sup>
 
 
 RRule schedule, based on the iCalendar standard
@@ -151,19 +151,19 @@ a 9am daily schedule with a UTC start date will maintain a 9am UTC time.
 
 **Methods:**
 
-#### `validate_rrule_str` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L197" target="_blank">↗</a></sup>
+#### `validate_rrule_str` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L197"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_rrule_str(cls, v: str) -> str
 ```
 
-#### `from_rrule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L201" target="_blank">↗</a></sup>
+#### `from_rrule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L201"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_rrule(cls, rrule: Union[dateutil.rrule.rrule, dateutil.rrule.rruleset]) -> 'RRuleSchedule'
 ```
 
-#### `to_rrule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L250" target="_blank">↗</a></sup>
+#### `to_rrule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L250"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_rrule(self) -> Union[dateutil.rrule.rrule, dateutil.rrule.rruleset]
@@ -173,7 +173,7 @@ Since rrule doesn't properly serialize/deserialize timezones, we localize dates
 here
 
 
-#### `valid_timezone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L308" target="_blank">↗</a></sup>
+#### `valid_timezone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L308"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 valid_timezone(cls, v: Optional[str]) -> str
@@ -185,4 +185,4 @@ Unfortunately this list is slightly different from the list of valid
 timezones we use for cron and interval timezone validation.
 
 
-### `NoSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/schedules.py#L324" target="_blank">↗</a></sup>
+### `NoSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/schedules.py#L324"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-client-schemas-sorting.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-sorting.mdx
@@ -7,61 +7,61 @@ sidebarTitle: sorting
 
 ## Classes
 
-### `FlowRunSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L4" target="_blank">↗</a></sup>
+### `FlowRunSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L4"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines flow run sorting options.
 
 
-### `TaskRunSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L18" target="_blank">↗</a></sup>
+### `TaskRunSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L18"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines task run sorting options.
 
 
-### `AutomationSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L30" target="_blank">↗</a></sup>
+### `AutomationSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L30"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines automation sorting options.
 
 
-### `LogSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L39" target="_blank">↗</a></sup>
+### `LogSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines log sorting options.
 
 
-### `FlowSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L46" target="_blank">↗</a></sup>
+### `FlowSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines flow sorting options.
 
 
-### `DeploymentSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L55" target="_blank">↗</a></sup>
+### `DeploymentSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines deployment sorting options.
 
 
-### `ArtifactSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L66" target="_blank">↗</a></sup>
+### `ArtifactSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L66"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines artifact sorting options.
 
 
-### `ArtifactCollectionSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L76" target="_blank">↗</a></sup>
+### `ArtifactCollectionSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines artifact collection sorting options.
 
 
-### `VariableSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L86" target="_blank">↗</a></sup>
+### `VariableSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L86"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines variables sorting options.
 
 
-### `BlockDocumentSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/schemas/sorting.py#L95" target="_blank">↗</a></sup>
+### `BlockDocumentSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/schemas/sorting.py#L95"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines block document sorting options.

--- a/docs/v3/api-ref/python/prefect-client-subscriptions.mdx
+++ b/docs/v3/api-ref/python/prefect-client-subscriptions.mdx
@@ -7,11 +7,11 @@ sidebarTitle: subscriptions
 
 ## Classes
 
-### `Subscription` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/subscriptions.py#L23" target="_blank">↗</a></sup>
+### `Subscription` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/subscriptions.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `websocket` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/subscriptions.py#L49" target="_blank">↗</a></sup>
+#### `websocket` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/subscriptions.py#L49"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 websocket(self) -> websockets.asyncio.client.ClientConnection

--- a/docs/v3/api-ref/python/prefect-client-utilities.mdx
+++ b/docs/v3/api-ref/python/prefect-client-utilities.mdx
@@ -12,7 +12,7 @@ Utilities for working with clients.
 
 ## Functions
 
-### `get_or_create_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/utilities.py#L31" target="_blank">↗</a></sup>
+### `get_or_create_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/utilities.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_or_create_client(client: Optional['PrefectClient'] = None) -> tuple['PrefectClient', bool]
@@ -28,13 +28,13 @@ Returns provided client, infers a client from context if available, or creates a
 - - tuple: a tuple of the client and a boolean indicating if the client was inferred from context
 
 
-### `client_injector` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/utilities.py#L63" target="_blank">↗</a></sup>
+### `client_injector` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/utilities.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_injector(func: Callable[Concatenate['PrefectClient', P], Coroutine[Any, Any, R]]) -> Callable[P, Coroutine[Any, Any, R]]
 ```
 
-### `inject_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/utilities.py#L74" target="_blank">↗</a></sup>
+### `inject_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/client/utilities.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 inject_client(fn: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, Coroutine[Any, Any, R]]

--- a/docs/v3/api-ref/python/prefect-concurrency-context.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-context.mdx
@@ -7,4 +7,4 @@ sidebarTitle: context
 
 ## Classes
 
-### `ConcurrencyContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/context.py#L10" target="_blank">↗</a></sup>
+### `ConcurrencyContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/context.py#L10"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-concurrency-services.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-services.mdx
@@ -7,4 +7,4 @@ sidebarTitle: services
 
 ## Classes
 
-### `ConcurrencySlotAcquisitionService` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/services.py#L21" target="_blank">↗</a></sup>
+### `ConcurrencySlotAcquisitionService` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/services.py#L21"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-concurrency-sync.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-sync.mdx
@@ -7,7 +7,7 @@ sidebarTitle: sync
 
 ## Functions
 
-### `concurrency` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/sync.py#L49" target="_blank">↗</a></sup>
+### `concurrency` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/sync.py#L49"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 concurrency(names: Union[str, list[str]], occupy: int = 1, timeout_seconds: Optional[float] = None, max_retries: Optional[int] = None, strict: bool = False) -> Generator[None, None, None]
@@ -44,7 +44,7 @@ def main():
 ```
 
 
-### `rate_limit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/sync.py#L109" target="_blank">↗</a></sup>
+### `rate_limit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/sync.py#L109"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 rate_limit(names: Union[str, list[str]], occupy: int = 1, timeout_seconds: Optional[float] = None, strict: bool = False) -> None

--- a/docs/v3/api-ref/python/prefect-concurrency-v1-context.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-v1-context.mdx
@@ -7,4 +7,4 @@ sidebarTitle: context
 
 ## Classes
 
-### `ConcurrencyContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/v1/context.py#L11" target="_blank">↗</a></sup>
+### `ConcurrencyContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/v1/context.py#L11"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-concurrency-v1-services.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-v1-services.mdx
@@ -7,10 +7,10 @@ sidebarTitle: services
 
 ## Classes
 
-### `ConcurrencySlotAcquisitionServiceError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/v1/services.py#L21" target="_blank">↗</a></sup>
+### `ConcurrencySlotAcquisitionServiceError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/v1/services.py#L21"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when an error occurs while acquiring concurrency slots.
 
 
-### `ConcurrencySlotAcquisitionService` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/v1/services.py#L25" target="_blank">↗</a></sup>
+### `ConcurrencySlotAcquisitionService` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/v1/services.py#L25"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-concurrency-v1-sync.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-v1-sync.mdx
@@ -7,7 +7,7 @@ sidebarTitle: sync
 
 ## Functions
 
-### `concurrency` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/concurrency/v1/sync.py#L19" target="_blank">↗</a></sup>
+### `concurrency` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/concurrency/v1/sync.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 concurrency(names: Union[str, list[str]], task_run_id: UUID, timeout_seconds: Optional[float] = None) -> Generator[None, None, None]

--- a/docs/v3/api-ref/python/prefect-context.mdx
+++ b/docs/v3/api-ref/python/prefect-context.mdx
@@ -16,7 +16,7 @@ For more user-accessible information about the current run, see [`prefect.runtim
 
 ## Functions
 
-### `serialize_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L63" target="_blank">↗</a></sup>
+### `serialize_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize_context(asset_ctx_kwargs: Union[dict[str, Any], None] = None) -> dict[str, Any]
@@ -30,13 +30,13 @@ in the remote execution environment. This is useful for TaskRunners, who rely on
 task run in the remote environment.
 
 
-### `hydrated_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L92" target="_blank">↗</a></sup>
+### `hydrated_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L92"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 hydrated_context(serialized_context: Optional[dict[str, Any]] = None, client: Union[PrefectClient, SyncPrefectClient, None] = None) -> Generator[None, Any, None]
 ```
 
-### `get_run_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L741" target="_blank">↗</a></sup>
+### `get_run_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L741"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_run_context() -> Union[FlowRunContext, TaskRunContext]
@@ -52,7 +52,7 @@ Get the current run context from within a task or flow function.
 - `RuntimeError`: If called outside of a flow or task run.
 
 
-### `get_settings_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L764" target="_blank">↗</a></sup>
+### `get_settings_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L764"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_settings_context() -> SettingsContext
@@ -66,7 +66,7 @@ Generally, the settings that are being used are a combination of values from the
 profile and environment. See `prefect.context.use_profile` for more details.
 
 
-### `tags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L781" target="_blank">↗</a></sup>
+### `tags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L781"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 tags(*new_tags: str) -> Generator[set[str], None, None]
@@ -112,7 +112,7 @@ Inspect the current tags
 {"a", "b", "c", "d", "e", "f"}
 
 
-### `use_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L838" target="_blank">↗</a></sup>
+### `use_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L838"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 use_profile(profile: Union[Profile, str], override_environment_variables: bool = False, include_current_context: bool = True) -> Generator[SettingsContext, Any, None]
@@ -133,7 +133,7 @@ with the current settings context as a base. If not set, the use_base settings
 will be loaded from the environment and defaults.
 
 
-### `root_settings_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L890" target="_blank">↗</a></sup>
+### `root_settings_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L890"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 root_settings_context() -> SettingsContext
@@ -150,7 +150,7 @@ The profile to use is determined with the following precedence
 
 ## Classes
 
-### `ContextModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L144" target="_blank">↗</a></sup>
+### `ContextModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L144"><Icon icon="github" size="14" /></a></sup>
 
 
 A base model for context data that forbids mutation and extra data while providing
@@ -159,7 +159,7 @@ a context manager
 
 **Methods:**
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L179" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L179"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(cls: type[Self]) -> Optional[Self]
@@ -168,7 +168,7 @@ get(cls: type[Self]) -> Optional[Self]
 Get the current context instance
 
 
-#### `model_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L183" target="_blank">↗</a></sup>
+#### `model_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L183"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_copy(self: Self) -> Self
@@ -180,7 +180,7 @@ Duplicate the context model, optionally choosing which fields to include, exclud
 - A new model instance.
 
 
-#### `serialize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L204" target="_blank">↗</a></sup>
+#### `serialize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L204"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize(self, include_secrets: bool = True) -> dict[str, Any]
@@ -189,7 +189,7 @@ serialize(self, include_secrets: bool = True) -> dict[str, Any]
 Serialize the context model to a dictionary that can be pickled with cloudpickle.
 
 
-### `SyncClientContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L213" target="_blank">↗</a></sup>
+### `SyncClientContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 
 A context for managing the sync Prefect client instances.
@@ -212,13 +212,13 @@ with SyncClientContext.get_or_create() as ctx:
 
 **Methods:**
 
-#### `get_or_create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L262" target="_blank">↗</a></sup>
+#### `get_or_create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L262"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_or_create(cls) -> Generator[Self, None, None]
 ```
 
-### `AsyncClientContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L271" target="_blank">↗</a></sup>
+### `AsyncClientContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L271"><Icon icon="github" size="14" /></a></sup>
 
 
 A context for managing the async Prefect client instances.
@@ -239,7 +239,7 @@ with AsyncClientContext.get_or_create() as ctx:
     assert c1 is ctx.client
 
 
-### `RunContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L329" target="_blank">↗</a></sup>
+### `RunContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L329"><Icon icon="github" size="14" /></a></sup>
 
 
 The base context for a flow or task run. Data in this context will always be
@@ -248,13 +248,13 @@ available when `get_run_context` is called.
 
 **Methods:**
 
-#### `serialize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L350" target="_blank">↗</a></sup>
+#### `serialize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L350"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize(self: Self, include_secrets: bool = True) -> dict[str, Any]
 ```
 
-### `EngineContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L358" target="_blank">↗</a></sup>
+### `EngineContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L358"><Icon icon="github" size="14" /></a></sup>
 
 
 The context for a flow run. Data in this context is only available from within a
@@ -263,13 +263,13 @@ flow run function.
 
 **Methods:**
 
-#### `serialize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L412" target="_blank">↗</a></sup>
+#### `serialize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L412"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize(self: Self, include_secrets: bool = True) -> dict[str, Any]
 ```
 
-### `TaskRunContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L438" target="_blank">↗</a></sup>
+### `TaskRunContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L438"><Icon icon="github" size="14" /></a></sup>
 
 
 The context for a task run. Data in this context is only available from within a
@@ -278,13 +278,13 @@ task run function.
 
 **Methods:**
 
-#### `serialize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L459" target="_blank">↗</a></sup>
+#### `serialize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L459"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize(self: Self, include_secrets: bool = True) -> dict[str, Any]
 ```
 
-### `AssetContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L477" target="_blank">↗</a></sup>
+### `AssetContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L477"><Icon icon="github" size="14" /></a></sup>
 
 
 The asset context for a materializing task run. Contains all asset-related information needed
@@ -293,7 +293,7 @@ for asset event emission and downstream asset dependency propagation.
 
 **Methods:**
 
-#### `from_task_and_inputs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L502" target="_blank">↗</a></sup>
+#### `from_task_and_inputs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L502"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_task_and_inputs(cls, task: 'Task[Any, Any]', task_run_id: UUID, task_inputs: Optional[dict[str, set[Any]]] = None, copy_to_child_ctx: bool = False) -> 'AssetContext'
@@ -311,7 +311,7 @@ Create an AssetContext from a task and its resolved inputs.
 - Configured AssetContext
 
 
-#### `add_asset_metadata` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L558" target="_blank">↗</a></sup>
+#### `add_asset_metadata` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L558"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_asset_metadata(self, asset_key: str, metadata: dict[str, Any]) -> None
@@ -327,7 +327,7 @@ Add metadata for a materialized asset.
 - `ValueError`: If asset_key is not in downstream_assets
 
 
-#### `asset_as_resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L579" target="_blank">↗</a></sup>
+#### `asset_as_resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L579"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 asset_as_resource(asset: Asset) -> dict[str, str]
@@ -336,7 +336,7 @@ asset_as_resource(asset: Asset) -> dict[str, str]
 Convert Asset to event resource format.
 
 
-#### `asset_as_related` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L601" target="_blank">↗</a></sup>
+#### `asset_as_related` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L601"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 asset_as_related(asset: Asset) -> dict[str, str]
@@ -345,7 +345,7 @@ asset_as_related(asset: Asset) -> dict[str, str]
 Convert Asset to event related format.
 
 
-#### `related_materialized_by` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L609" target="_blank">↗</a></sup>
+#### `related_materialized_by` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L609"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 related_materialized_by(by: str) -> dict[str, str]
@@ -354,7 +354,7 @@ related_materialized_by(by: str) -> dict[str, str]
 Create a related resource for the tool that performed the materialization
 
 
-#### `emit_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L616" target="_blank">↗</a></sup>
+#### `emit_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L616"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_events(self, state: State) -> None
@@ -363,7 +363,7 @@ emit_events(self, state: State) -> None
 Emit asset events
 
 
-#### `update_tracked_assets` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L659" target="_blank">↗</a></sup>
+#### `update_tracked_assets` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L659"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_tracked_assets(self) -> None
@@ -372,7 +372,7 @@ update_tracked_assets(self) -> None
 Update the flow run context with assets that should be propagated downstream.
 
 
-#### `serialize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L680" target="_blank">↗</a></sup>
+#### `serialize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L680"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize(self: Self, include_secrets: bool = True) -> dict[str, Any]
@@ -381,7 +381,7 @@ serialize(self: Self, include_secrets: bool = True) -> dict[str, Any]
 Serialize the AssetContext for distributed execution.
 
 
-### `TagsContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L692" target="_blank">↗</a></sup>
+### `TagsContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L692"><Icon icon="github" size="14" /></a></sup>
 
 
 The context for `prefect.tags` management.
@@ -389,13 +389,13 @@ The context for `prefect.tags` management.
 
 **Methods:**
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L703" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L703"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(cls) -> Self
 ```
 
-### `SettingsContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L710" target="_blank">↗</a></sup>
+### `SettingsContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L710"><Icon icon="github" size="14" /></a></sup>
 
 
 The context for a Prefect settings.
@@ -405,7 +405,7 @@ This allows for safe concurrent access and modification of settings.
 
 **Methods:**
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/context.py#L730" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/context.py#L730"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(cls) -> Optional['SettingsContext']

--- a/docs/v3/api-ref/python/prefect-deployments-base.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-base.mdx
@@ -15,7 +15,7 @@ To get started, follow along with [the deloyments tutorial](/tutorials/deploymen
 
 ## Functions
 
-### `create_default_prefect_yaml` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/base.py#L26" target="_blank">↗</a></sup>
+### `create_default_prefect_yaml` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/base.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_default_prefect_yaml(path: str, name: Optional[str] = None, contents: Optional[Dict[str, Any]] = None) -> bool
@@ -32,7 +32,7 @@ will be used
 defaults will be used
 
 
-### `configure_project_by_recipe` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/base.py#L117" target="_blank">↗</a></sup>
+### `configure_project_by_recipe` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/base.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 configure_project_by_recipe(recipe: str, **formatting_kwargs: Any) -> dict[str, Any] | type[NotSet]
@@ -49,7 +49,7 @@ Given a recipe name, returns a dictionary representing base configuration option
 - `ValueError`: if provided recipe name does not exist.
 
 
-### `initialize_project` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/base.py#L146" target="_blank">↗</a></sup>
+### `initialize_project` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/base.py#L146"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 initialize_project(name: Optional[str] = None, recipe: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None) -> List[str]

--- a/docs/v3/api-ref/python/prefect-deployments-runner.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-runner.mdx
@@ -39,13 +39,13 @@ Example:
 
 ## Classes
 
-### `DeploymentApplyError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L115" target="_blank">↗</a></sup>
+### `DeploymentApplyError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when an error occurs while applying a deployment.
 
 
-### `RunnerDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L121" target="_blank">↗</a></sup>
+### `RunnerDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect RunnerDeployment definition, used for specifying and building deployments.
@@ -53,25 +53,25 @@ A Prefect RunnerDeployment definition, used for specifying and building deployme
 
 **Methods:**
 
-#### `entrypoint_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L257" target="_blank">↗</a></sup>
+#### `entrypoint_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L257"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 entrypoint_type(self) -> EntrypointType
 ```
 
-#### `full_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L261" target="_blank">↗</a></sup>
+#### `full_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L261"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 full_name(self) -> str
 ```
 
-#### `validate_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L280" target="_blank">↗</a></sup>
+#### `validate_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L280"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_name(cls, value: str) -> str
 ```
 
-#### `validate_automation_names` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L286" target="_blank">↗</a></sup>
+#### `validate_automation_names` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L286"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_automation_names(self)
@@ -80,7 +80,7 @@ validate_automation_names(self)
 Ensure that each trigger has a name for its automation if none is provided.
 
 
-#### `validate_deployment_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L295" target="_blank">↗</a></sup>
+#### `validate_deployment_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L295"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_deployment_parameters(self) -> Self
@@ -89,19 +89,19 @@ validate_deployment_parameters(self) -> Self
 Update the parameter schema to mark frozen parameters as readonly.
 
 
-#### `reconcile_paused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L312" target="_blank">↗</a></sup>
+#### `reconcile_paused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reconcile_paused(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `reconcile_schedules` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L317" target="_blank">↗</a></sup>
+#### `reconcile_schedules` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L317"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reconcile_schedules(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `from_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L616" target="_blank">↗</a></sup>
+#### `from_flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L616"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_flow(cls, flow: 'Flow[..., Any]', name: str, interval: Optional[Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]] = None, cron: Optional[Union[Iterable[str], str]] = None, rrule: Optional[Union[Iterable[str], str]] = None, paused: Optional[bool] = None, schedule: Optional[Schedule] = None, schedules: Optional['FlexibleScheduleList'] = None, concurrency_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None, parameters: Optional[dict[str, Any]] = None, triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None, description: Optional[str] = None, tags: Optional[List[str]] = None, version: Optional[str] = None, version_type: Optional[VersionType] = None, enforce_parameter_schema: bool = True, work_pool_name: Optional[str] = None, work_queue_name: Optional[str] = None, job_variables: Optional[dict[str, Any]] = None, entrypoint_type: EntrypointType = EntrypointType.FILE_PATH, _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None) -> 'RunnerDeployment'
@@ -141,7 +141,7 @@ available settings.
 - `_sla`: (Experimental) SLA configuration for the deployment. May be removed or modified at any time. Currently only supported on Prefect Cloud.
 
 
-#### `from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L760" target="_blank">↗</a></sup>
+#### `from_entrypoint` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L760"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_entrypoint(cls, entrypoint: str, name: str, flow_name: Optional[str] = None, interval: Optional[Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]] = None, cron: Optional[Union[Iterable[str], str]] = None, rrule: Optional[Union[Iterable[str], str]] = None, paused: Optional[bool] = None, schedule: Optional[Schedule] = None, schedules: Optional['FlexibleScheduleList'] = None, concurrency_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None, parameters: Optional[dict[str, Any]] = None, triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None, description: Optional[str] = None, tags: Optional[List[str]] = None, version: Optional[str] = None, enforce_parameter_schema: bool = True, work_pool_name: Optional[str] = None, work_queue_name: Optional[str] = None, job_variables: Optional[dict[str, Any]] = None, _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None) -> 'RunnerDeployment'
@@ -179,7 +179,7 @@ available settings.
 - `_sla`: (Experimental) SLA configuration for the deployment. May be removed or modified at any time. Currently only supported on Prefect Cloud.
 
 
-#### `from_storage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/runner.py#L990" target="_blank">↗</a></sup>
+#### `from_storage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/runner.py#L990"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_storage(cls, storage: RunnerStorage, entrypoint: str, name: str, flow_name: Optional[str] = None, interval: Optional[Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]] = None, cron: Optional[Union[Iterable[str], str]] = None, rrule: Optional[Union[Iterable[str], str]] = None, paused: Optional[bool] = None, schedule: Optional[Schedule] = None, schedules: Optional['FlexibleScheduleList'] = None, concurrency_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None, parameters: Optional[dict[str, Any]] = None, triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None, description: Optional[str] = None, tags: Optional[List[str]] = None, version: Optional[str] = None, version_type: Optional[VersionType] = None, enforce_parameter_schema: bool = True, work_pool_name: Optional[str] = None, work_queue_name: Optional[str] = None, job_variables: Optional[dict[str, Any]] = None, _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None) -> 'RunnerDeployment'

--- a/docs/v3/api-ref/python/prefect-deployments-schedules.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-schedules.mdx
@@ -7,7 +7,7 @@ sidebarTitle: schedules
 
 ## Functions
 
-### `create_deployment_schedule_create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/schedules.py#L15" target="_blank">↗</a></sup>
+### `create_deployment_schedule_create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/schedules.py#L15"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_deployment_schedule_create(schedule: Union['SCHEDULE_TYPES', 'Schedule'], active: Optional[bool] = True) -> DeploymentScheduleCreate
@@ -17,7 +17,7 @@ create_deployment_schedule_create(schedule: Union['SCHEDULE_TYPES', 'Schedule'],
 Create a DeploymentScheduleCreate object from common schedule parameters.
 
 
-### `normalize_to_deployment_schedule_create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/schedules.py#L29" target="_blank">↗</a></sup>
+### `normalize_to_deployment_schedule_create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/schedules.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 normalize_to_deployment_schedule_create(schedules: Optional['FlexibleScheduleList']) -> List[DeploymentScheduleCreate]

--- a/docs/v3/api-ref/python/prefect-deployments-steps-core.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-steps-core.mdx
@@ -21,7 +21,7 @@ Whenever a step is run, the following actions are taken:
 
 ## Classes
 
-### `StepExecutionError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/steps/core.py#L38" target="_blank">↗</a></sup>
+### `StepExecutionError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/steps/core.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a step fails to execute.

--- a/docs/v3/api-ref/python/prefect-deployments-steps-pull.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-steps-pull.mdx
@@ -12,7 +12,7 @@ Core set of steps for specifying a Prefect project pull step.
 
 ## Functions
 
-### `set_working_directory` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/steps/pull.py#L24" target="_blank">↗</a></sup>
+### `set_working_directory` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/steps/pull.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_working_directory(directory: str) -> dict[str, str]
@@ -29,7 +29,7 @@ Sets the working directory; works with both absolute and relative paths.
 directory that was set
 
 
-### `git_clone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/steps/pull.py#L100" target="_blank">↗</a></sup>
+### `git_clone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/steps/pull.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 git_clone(repository: str, branch: Optional[str] = None, commit_sha: Optional[str] = None, include_submodules: bool = False, access_token: Optional[str] = None, credentials: Optional['Block'] = None, directories: Optional[list[str]] = None) -> dict[str, str]

--- a/docs/v3/api-ref/python/prefect-deployments-steps-utility.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-steps-utility.mdx
@@ -30,7 +30,7 @@ Example:
 
 ## Classes
 
-### `RunShellScriptResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/steps/utility.py#L63" target="_blank">↗</a></sup>
+### `RunShellScriptResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/deployments/steps/utility.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 
 The result of a `run_shell_script` step.

--- a/docs/v3/api-ref/python/prefect-docker-docker_image.mdx
+++ b/docs/v3/api-ref/python/prefect-docker-docker_image.mdx
@@ -7,7 +7,7 @@ sidebarTitle: docker_image
 
 ## Classes
 
-### `DockerImage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/docker/docker_image.py#L19" target="_blank">↗</a></sup>
+### `DockerImage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/docker/docker_image.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 
 Configuration used to build and push a Docker image for a deployment.
@@ -15,19 +15,19 @@ Configuration used to build and push a Docker image for a deployment.
 
 **Methods:**
 
-#### `reference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/docker/docker_image.py#L61" target="_blank">↗</a></sup>
+#### `reference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/docker/docker_image.py#L61"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reference(self) -> str
 ```
 
-#### `build` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/docker/docker_image.py#L64" target="_blank">↗</a></sup>
+#### `build` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/docker/docker_image.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build(self) -> None
 ```
 
-#### `push` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/docker/docker_image.py#L79" target="_blank">↗</a></sup>
+#### `push` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/docker/docker_image.py#L79"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 push(self) -> None

--- a/docs/v3/api-ref/python/prefect-engine.mdx
+++ b/docs/v3/api-ref/python/prefect-engine.mdx
@@ -7,7 +7,7 @@ sidebarTitle: engine
 
 ## Functions
 
-### `handle_engine_signals` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/engine.py#L32" target="_blank">↗</a></sup>
+### `handle_engine_signals` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/engine.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_engine_signals(flow_run_id: UUID | None = None)

--- a/docs/v3/api-ref/python/prefect-events-actions.mdx
+++ b/docs/v3/api-ref/python/prefect-events-actions.mdx
@@ -7,7 +7,7 @@ sidebarTitle: actions
 
 ## Classes
 
-### `Action` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L12" target="_blank">↗</a></sup>
+### `Action` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 
 An Action that may be performed when an Automation is triggered
@@ -15,7 +15,7 @@ An Action that may be performed when an Automation is triggered
 
 **Methods:**
 
-#### `describe_for_cli` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L17" target="_blank">↗</a></sup>
+#### `describe_for_cli` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 describe_for_cli(self) -> str
@@ -24,13 +24,13 @@ describe_for_cli(self) -> str
 A human-readable description of the action
 
 
-### `DoNothing` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L22" target="_blank">↗</a></sup>
+### `DoNothing` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 
 Do nothing when an Automation is triggered
 
 
-### `DeploymentAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L28" target="_blank">↗</a></sup>
+### `DeploymentAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Deployments and need to infer them from
@@ -39,86 +39,86 @@ events
 
 **Methods:**
 
-#### `selected_deployment_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L47" target="_blank">↗</a></sup>
+#### `selected_deployment_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_deployment_requires_id(self)
 ```
 
-### `RunDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L58" target="_blank">↗</a></sup>
+### `RunDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L58"><Icon icon="github" size="14" /></a></sup>
 
 
 Runs the given deployment with the given parameters
 
 
-### `PauseDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L79" target="_blank">↗</a></sup>
+### `PauseDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L79"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses the given Deployment
 
 
-### `ResumeDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L85" target="_blank">↗</a></sup>
+### `ResumeDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes the given Deployment
 
 
-### `ChangeFlowRunState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L91" target="_blank">↗</a></sup>
+### `ChangeFlowRunState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 
 Changes the state of a flow run associated with the trigger
 
 
-### `CancelFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L110" target="_blank">↗</a></sup>
+### `CancelFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 
 Cancels a flow run associated with the trigger
 
 
-### `ResumeFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L116" target="_blank">↗</a></sup>
+### `ResumeFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L116"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a flow run associated with the trigger
 
 
-### `SuspendFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L122" target="_blank">↗</a></sup>
+### `SuspendFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L122"><Icon icon="github" size="14" /></a></sup>
 
 
 Suspends a flow run associated with the trigger
 
 
-### `CallWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L128" target="_blank">↗</a></sup>
+### `CallWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L128"><Icon icon="github" size="14" /></a></sup>
 
 
 Call a webhook when an Automation is triggered.
 
 
-### `SendNotification` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L141" target="_blank">↗</a></sup>
+### `SendNotification` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L141"><Icon icon="github" size="14" /></a></sup>
 
 
 Send a notification when an Automation is triggered
 
 
-### `WorkPoolAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L152" target="_blank">↗</a></sup>
+### `WorkPoolAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Work Pools and need to infer them from
 events
 
 
-### `PauseWorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L172" target="_blank">↗</a></sup>
+### `PauseWorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses a Work Pool
 
 
-### `ResumeWorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L178" target="_blank">↗</a></sup>
+### `ResumeWorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a Work Pool
 
 
-### `WorkQueueAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L184" target="_blank">↗</a></sup>
+### `WorkQueueAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L184"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Work Queues and need to infer them from
@@ -127,25 +127,25 @@ events
 
 **Methods:**
 
-#### `selected_work_queue_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L203" target="_blank">↗</a></sup>
+#### `selected_work_queue_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L203"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_work_queue_requires_id(self) -> Self
 ```
 
-### `PauseWorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L214" target="_blank">↗</a></sup>
+### `PauseWorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L214"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses a Work Queue
 
 
-### `ResumeWorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L220" target="_blank">↗</a></sup>
+### `ResumeWorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L220"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a Work Queue
 
 
-### `AutomationAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L226" target="_blank">↗</a></sup>
+### `AutomationAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L226"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Automations and need to infer them from
@@ -154,25 +154,25 @@ events
 
 **Methods:**
 
-#### `selected_automation_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L245" target="_blank">↗</a></sup>
+#### `selected_automation_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L245"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_automation_requires_id(self) -> Self
 ```
 
-### `PauseAutomation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L256" target="_blank">↗</a></sup>
+### `PauseAutomation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L256"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses a Work Queue
 
 
-### `ResumeAutomation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L262" target="_blank">↗</a></sup>
+### `ResumeAutomation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L262"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a Work Queue
 
 
-### `DeclareIncident` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/actions.py#L268" target="_blank">↗</a></sup>
+### `DeclareIncident` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/actions.py#L268"><Icon icon="github" size="14" /></a></sup>
 
 
 Declares an incident for the triggering event.  Only available on Prefect Cloud

--- a/docs/v3/api-ref/python/prefect-events-cli-automations.mdx
+++ b/docs/v3/api-ref/python/prefect-events-cli-automations.mdx
@@ -12,7 +12,7 @@ Command line interface for working with automations.
 
 ## Functions
 
-### `requires_automations` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/cli/automations.py#L31" target="_blank">↗</a></sup>
+### `requires_automations` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/cli/automations.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 requires_automations(func: Callable[..., Any]) -> Callable[..., Any]

--- a/docs/v3/api-ref/python/prefect-events-clients.mdx
+++ b/docs/v3/api-ref/python/prefect-events-clients.mdx
@@ -7,31 +7,31 @@ sidebarTitle: clients
 
 ## Functions
 
-### `http_to_ws` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L77" target="_blank">↗</a></sup>
+### `http_to_ws` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 http_to_ws(url: str) -> str
 ```
 
-### `events_in_socket_from_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L81" target="_blank">↗</a></sup>
+### `events_in_socket_from_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L81"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 events_in_socket_from_api_url(url: str) -> str
 ```
 
-### `events_out_socket_from_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L85" target="_blank">↗</a></sup>
+### `events_out_socket_from_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 events_out_socket_from_api_url(url: str) -> str
 ```
 
-### `get_events_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L89" target="_blank">↗</a></sup>
+### `get_events_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_events_client(reconnection_attempts: int = 10, checkpoint_every: int = 700) -> 'EventsClient'
 ```
 
-### `get_events_subscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L120" target="_blank">↗</a></sup>
+### `get_events_subscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_events_subscriber(filter: Optional['EventFilter'] = None, reconnection_attempts: int = 10) -> 'PrefectEventSubscriber'
@@ -39,7 +39,7 @@ get_events_subscriber(filter: Optional['EventFilter'] = None, reconnection_attem
 
 ## Classes
 
-### `EventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L150" target="_blank">↗</a></sup>
+### `EventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L150"><Icon icon="github" size="14" /></a></sup>
 
 
 The abstract interface for all Prefect Events clients
@@ -47,19 +47,19 @@ The abstract interface for all Prefect Events clients
 
 **Methods:**
 
-#### `client_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L154" target="_blank">↗</a></sup>
+#### `client_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L154"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_name(self) -> str
 ```
 
-### `NullEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L188" target="_blank">↗</a></sup>
+### `NullEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L188"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Events client implementation that does nothing
 
 
-### `AssertingEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L195" target="_blank">↗</a></sup>
+### `AssertingEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Events client that records all events sent to it for inspection during
@@ -68,7 +68,7 @@ tests.
 
 **Methods:**
 
-#### `reset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L213" target="_blank">↗</a></sup>
+#### `reset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset(cls) -> None
@@ -78,19 +78,19 @@ Reset all captured instances and their events. For use between
 tests
 
 
-#### `pop_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L219" target="_blank">↗</a></sup>
+#### `pop_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L219"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pop_events(self) -> List[Event]
 ```
 
-### `PrefectEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L247" target="_blank">↗</a></sup>
+### `PrefectEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L247"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Events client that streams events to a Prefect server
 
 
-### `AssertingPassthroughEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L410" target="_blank">↗</a></sup>
+### `AssertingPassthroughEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L410"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Events client that BOTH records all events sent to it for inspection
@@ -99,25 +99,25 @@ during tests AND sends them to a Prefect server.
 
 **Methods:**
 
-#### `reset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L429" target="_blank">↗</a></sup>
+#### `reset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L429"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset(cls) -> None
 ```
 
-#### `pop_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L433" target="_blank">↗</a></sup>
+#### `pop_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L433"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pop_events(self) -> list[Event]
 ```
 
-### `PrefectCloudEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L451" target="_blank">↗</a></sup>
+### `PrefectCloudEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L451"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect Events client that streams events to a Prefect Cloud Workspace
 
 
-### `PrefectEventSubscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L486" target="_blank">↗</a></sup>
+### `PrefectEventSubscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L486"><Icon icon="github" size="14" /></a></sup>
 
 
 Subscribes to a Prefect event stream, yielding events as they occur.
@@ -136,12 +136,12 @@ Example:
 
 **Methods:**
 
-#### `client_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L548" target="_blank">↗</a></sup>
+#### `client_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L548"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_name(self) -> str
 ```
 
-### `PrefectCloudEventSubscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L674" target="_blank">↗</a></sup>
+### `PrefectCloudEventSubscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L674"><Icon icon="github" size="14" /></a></sup>
 
-### `PrefectCloudAccountEventSubscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/clients.py#L700" target="_blank">↗</a></sup>
+### `PrefectCloudAccountEventSubscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/clients.py#L700"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-events-filters.mdx
+++ b/docs/v3/api-ref/python/prefect-events-filters.mdx
@@ -7,21 +7,21 @@ sidebarTitle: filters
 
 ## Classes
 
-### `AutomationFilterCreated` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L17" target="_blank">↗</a></sup>
+### `AutomationFilterCreated` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Automation.created`.
 
 
-### `AutomationFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L26" target="_blank">↗</a></sup>
+### `AutomationFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Automation.created`.
 
 
-### `AutomationFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L35" target="_blank">↗</a></sup>
+### `AutomationFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L35"><Icon icon="github" size="14" /></a></sup>
 
-### `EventDataFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L44" target="_blank">↗</a></sup>
+### `EventDataFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for filtering event data.
@@ -29,13 +29,13 @@ A base class for filtering event data.
 
 **Methods:**
 
-#### `get_filters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L47" target="_blank">↗</a></sup>
+#### `get_filters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_filters(self) -> list['EventDataFilter']
 ```
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L65" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L65"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
@@ -44,7 +44,7 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-#### `excludes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L69" target="_blank">↗</a></sup>
+#### `excludes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L69"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 excludes(self, event: Event) -> bool
@@ -53,58 +53,58 @@ excludes(self, event: Event) -> bool
 Would the given filter exclude this event?
 
 
-### `EventOccurredFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L74" target="_blank">↗</a></sup>
+### `EventOccurredFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L87" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L87"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-### `EventNameFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L91" target="_blank">↗</a></sup>
+### `EventNameFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L107" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L107"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-### `EventResourceFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L127" target="_blank">↗</a></sup>
+### `EventResourceFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L145" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-### `EventRelatedFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L163" target="_blank">↗</a></sup>
+### `EventRelatedFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L163"><Icon icon="github" size="14" /></a></sup>
 
-### `EventAnyResourceFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L184" target="_blank">↗</a></sup>
+### `EventAnyResourceFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L184"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L199" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-### `EventIDFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L221" target="_blank">↗</a></sup>
+### `EventIDFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L221"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L226" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L226"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-### `EventOrder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L234" target="_blank">↗</a></sup>
+### `EventOrder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L234"><Icon icon="github" size="14" /></a></sup>
 
-### `EventFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/filters.py#L239" target="_blank">↗</a></sup>
+### `EventFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/filters.py#L239"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-events-related.mdx
+++ b/docs/v3/api-ref/python/prefect-events-related.mdx
@@ -7,13 +7,13 @@ sidebarTitle: related
 
 ## Functions
 
-### `tags_as_related_resources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/related.py#L34" target="_blank">↗</a></sup>
+### `tags_as_related_resources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/related.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 tags_as_related_resources(tags: Iterable[str]) -> List[RelatedResource]
 ```
 
-### `object_as_related_resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/related.py#L46" target="_blank">↗</a></sup>
+### `object_as_related_resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/related.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 object_as_related_resource(kind: str, role: str, object: Any) -> RelatedResource

--- a/docs/v3/api-ref/python/prefect-events-schemas-automations.mdx
+++ b/docs/v3/api-ref/python/prefect-events-schemas-automations.mdx
@@ -7,9 +7,9 @@ sidebarTitle: automations
 
 ## Classes
 
-### `Posture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L34" target="_blank">↗</a></sup>
+### `Posture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L34"><Icon icon="github" size="14" /></a></sup>
 
-### `Trigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L40" target="_blank">↗</a></sup>
+### `Trigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class describing a set of criteria that must be satisfied in order to trigger
@@ -18,7 +18,7 @@ an automation.
 
 **Methods:**
 
-#### `describe_for_cli` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L49" target="_blank">↗</a></sup>
+#### `describe_for_cli` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L49"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 describe_for_cli(self, indent: int = 0) -> str
@@ -27,37 +27,37 @@ describe_for_cli(self, indent: int = 0) -> str
 Return a human-readable description of this trigger for the CLI
 
 
-#### `set_deployment_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L57" target="_blank">↗</a></sup>
+#### `set_deployment_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_deployment_id(self, deployment_id: UUID) -> None
 ```
 
-#### `owner_resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L60" target="_blank">↗</a></sup>
+#### `owner_resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 owner_resource(self) -> Optional[str]
 ```
 
-#### `actions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L63" target="_blank">↗</a></sup>
+#### `actions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 actions(self) -> List[ActionTypes]
 ```
 
-#### `as_automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L74" target="_blank">↗</a></sup>
+#### `as_automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_automation(self) -> 'AutomationCore'
 ```
 
-### `ResourceTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L97" target="_blank">↗</a></sup>
+### `ResourceTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L97"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for triggers that may filter by the labels of resources.
 
 
-### `EventTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L114" target="_blank">↗</a></sup>
+### `EventTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 
 A trigger that fires based on the presence or absence of events within a given
@@ -66,13 +66,13 @@ period of time.
 
 **Methods:**
 
-#### `enforce_minimum_within_for_proactive_triggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L179" target="_blank">↗</a></sup>
+#### `enforce_minimum_within_for_proactive_triggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L179"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enforce_minimum_within_for_proactive_triggers(cls, data: Dict[str, Any]) -> Dict[str, Any]
 ```
 
-#### `describe_for_cli` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L207" target="_blank">↗</a></sup>
+#### `describe_for_cli` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L207"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 describe_for_cli(self, indent: int = 0) -> str
@@ -81,11 +81,11 @@ describe_for_cli(self, indent: int = 0) -> str
 Return a human-readable description of this trigger for the CLI
 
 
-### `MetricTriggerOperator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L230" target="_blank">↗</a></sup>
+### `MetricTriggerOperator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L230"><Icon icon="github" size="14" /></a></sup>
 
-### `PrefectMetric` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L237" target="_blank">↗</a></sup>
+### `PrefectMetric` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L237"><Icon icon="github" size="14" /></a></sup>
 
-### `MetricTriggerQuery` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L243" target="_blank">↗</a></sup>
+### `MetricTriggerQuery` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L243"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines a subset of the Trigger subclass, which is specific
@@ -95,13 +95,13 @@ and breaching conditions for the Automation
 
 **Methods:**
 
-#### `enforce_minimum_range` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L284" target="_blank">↗</a></sup>
+#### `enforce_minimum_range` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L284"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enforce_minimum_range(cls, value: timedelta) -> timedelta
 ```
 
-### `MetricTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L290" target="_blank">↗</a></sup>
+### `MetricTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L290"><Icon icon="github" size="14" /></a></sup>
 
 
 A trigger that fires based on the results of a metric query.
@@ -109,7 +109,7 @@ A trigger that fires based on the results of a metric query.
 
 **Methods:**
 
-#### `describe_for_cli` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L307" target="_blank">↗</a></sup>
+#### `describe_for_cli` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L307"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 describe_for_cli(self, indent: int = 0) -> str
@@ -118,13 +118,13 @@ describe_for_cli(self, indent: int = 0) -> str
 Return a human-readable description of this trigger for the CLI
 
 
-### `CompositeTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L320" target="_blank">↗</a></sup>
+### `CompositeTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L320"><Icon icon="github" size="14" /></a></sup>
 
 
 Requires some number of triggers to have fired within the given time period.
 
 
-### `CompoundTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L337" target="_blank">↗</a></sup>
+### `CompoundTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L337"><Icon icon="github" size="14" /></a></sup>
 
 
 A composite trigger that requires some number of triggers to have
@@ -133,13 +133,13 @@ fired within the given time period
 
 **Methods:**
 
-#### `validate_require` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L345" target="_blank">↗</a></sup>
+#### `validate_require` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L345"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_require(self) -> Self
 ```
 
-#### `describe_for_cli` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L356" target="_blank">↗</a></sup>
+#### `describe_for_cli` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L356"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 describe_for_cli(self, indent: int = 0) -> str
@@ -148,7 +148,7 @@ describe_for_cli(self, indent: int = 0) -> str
 Return a human-readable description of this trigger for the CLI
 
 
-### `SequenceTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L374" target="_blank">↗</a></sup>
+### `SequenceTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L374"><Icon icon="github" size="14" /></a></sup>
 
 
 A composite trigger that requires some number of triggers to have fired
@@ -157,7 +157,7 @@ within the given time period in a specific order
 
 **Methods:**
 
-#### `describe_for_cli` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L380" target="_blank">↗</a></sup>
+#### `describe_for_cli` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L380"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 describe_for_cli(self, indent: int = 0) -> str
@@ -166,11 +166,11 @@ describe_for_cli(self, indent: int = 0) -> str
 Return a human-readable description of this trigger for the CLI
 
 
-### `AutomationCore` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L407" target="_blank">↗</a></sup>
+### `AutomationCore` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L407"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines an action a user wants to take when a certain number of events
 do or don't happen to the matching resources
 
 
-### `Automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/automations.py#L452" target="_blank">↗</a></sup>
+### `Automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/automations.py#L452"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-events-schemas-deployment_triggers.mdx
+++ b/docs/v3/api-ref/python/prefect-events-schemas-deployment_triggers.mdx
@@ -19,34 +19,34 @@ create them from YAML.
 
 ## Classes
 
-### `BaseDeploymentTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L36" target="_blank">↗</a></sup>
+### `BaseDeploymentTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L36"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class describing a set of criteria that must be satisfied in order to trigger
 an automation.
 
 
-### `DeploymentEventTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L73" target="_blank">↗</a></sup>
+### `DeploymentEventTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 
 A trigger that fires based on the presence or absence of events within a given
 period of time.
 
 
-### `DeploymentMetricTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L82" target="_blank">↗</a></sup>
+### `DeploymentMetricTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L82"><Icon icon="github" size="14" /></a></sup>
 
 
 A trigger that fires based on the results of a metric query.
 
 
-### `DeploymentCompoundTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L90" target="_blank">↗</a></sup>
+### `DeploymentCompoundTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L90"><Icon icon="github" size="14" /></a></sup>
 
 
 A composite trigger that requires some number of triggers to have
 fired within the given time period
 
 
-### `DeploymentSequenceTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L97" target="_blank">↗</a></sup>
+### `DeploymentSequenceTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/deployment_triggers.py#L97"><Icon icon="github" size="14" /></a></sup>
 
 
 A composite trigger that requires some number of triggers to have fired

--- a/docs/v3/api-ref/python/prefect-events-schemas-events.mdx
+++ b/docs/v3/api-ref/python/prefect-events-schemas-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Functions
 
-### `matches` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L194" target="_blank">↗</a></sup>
+### `matches` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L194"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches(expected: str, value: Optional[str]) -> bool
@@ -21,7 +21,7 @@ include a a negation prefix ("!this-value") or a wildcard suffix
 
 ## Classes
 
-### `Resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L43" target="_blank">↗</a></sup>
+### `Resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 
 An observable business object of interest to the user
@@ -29,31 +29,31 @@ An observable business object of interest to the user
 
 **Methods:**
 
-#### `enforce_maximum_labels` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L47" target="_blank">↗</a></sup>
+#### `enforce_maximum_labels` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enforce_maximum_labels(self) -> Self
 ```
 
-#### `requires_resource_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L57" target="_blank">↗</a></sup>
+#### `requires_resource_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 requires_resource_id(self) -> Self
 ```
 
-#### `id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L66" target="_blank">↗</a></sup>
+#### `id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L66"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 id(self) -> str
 ```
 
-#### `name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L70" target="_blank">↗</a></sup>
+#### `name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L70"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 name(self) -> Optional[str]
 ```
 
-#### `prefect_object_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L73" target="_blank">↗</a></sup>
+#### `prefect_object_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prefect_object_id(self, kind: str) -> UUID
@@ -63,7 +63,7 @@ Extracts the UUID from an event's resource ID if it's the expected kind
 of prefect resource
 
 
-### `RelatedResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L84" target="_blank">↗</a></sup>
+### `RelatedResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L84"><Icon icon="github" size="14" /></a></sup>
 
 
 A Resource with a specific role in an Event
@@ -71,19 +71,19 @@ A Resource with a specific role in an Event
 
 **Methods:**
 
-#### `requires_resource_role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L88" target="_blank">↗</a></sup>
+#### `requires_resource_role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L88"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 requires_resource_role(self) -> Self
 ```
 
-#### `role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L99" target="_blank">↗</a></sup>
+#### `role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L99"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 role(self) -> str
 ```
 
-### `Event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L114" target="_blank">↗</a></sup>
+### `Event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 
 The client-side view of an event that has happened to a Resource
@@ -91,13 +91,13 @@ The client-side view of an event that has happened to a Resource
 
 **Methods:**
 
-#### `involved_resources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L153" target="_blank">↗</a></sup>
+#### `involved_resources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L153"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 involved_resources(self) -> Sequence[Resource]
 ```
 
-#### `resource_in_role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L157" target="_blank">↗</a></sup>
+#### `resource_in_role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L157"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resource_in_role(self) -> Mapping[str, RelatedResource]
@@ -106,7 +106,7 @@ resource_in_role(self) -> Mapping[str, RelatedResource]
 Returns a mapping of roles to the first related resource in that role
 
 
-#### `resources_in_role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L162" target="_blank">↗</a></sup>
+#### `resources_in_role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resources_in_role(self) -> Mapping[str, Sequence[RelatedResource]]
@@ -115,7 +115,7 @@ resources_in_role(self) -> Mapping[str, Sequence[RelatedResource]]
 Returns a mapping of roles to related resources in that role
 
 
-#### `find_resource_label` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L169" target="_blank">↗</a></sup>
+#### `find_resource_label` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L169"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 find_resource_label(self, label: str) -> Optional[str]
@@ -126,60 +126,60 @@ related resources.  If the label starts with `related:<role>:`, search for the
 first matching label in a related resource with that role.
 
 
-### `ReceivedEvent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L182" target="_blank">↗</a></sup>
+### `ReceivedEvent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L182"><Icon icon="github" size="14" /></a></sup>
 
 
 The server-side view of an event that has happened to a Resource after it has
 been received by the server
 
 
-### `ResourceSpecification` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L214" target="_blank">↗</a></sup>
+### `ResourceSpecification` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L214"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `matches_every_resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L215" target="_blank">↗</a></sup>
+#### `matches_every_resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L215"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches_every_resource(self) -> bool
 ```
 
-#### `matches_every_resource_of_kind` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L218" target="_blank">↗</a></sup>
+#### `matches_every_resource_of_kind` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L218"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches_every_resource_of_kind(self, prefix: str) -> bool
 ```
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L228" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L228"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, candidates: Iterable[Resource]) -> bool
 ```
 
-#### `matches` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L236" target="_blank">↗</a></sup>
+#### `matches` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L236"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches(self, resource: Resource) -> bool
 ```
 
-#### `items` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L243" target="_blank">↗</a></sup>
+#### `items` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L243"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 items(self) -> Iterable[Tuple[str, List[str]]]
 ```
 
-#### `pop` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L260" target="_blank">↗</a></sup>
+#### `pop` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L260"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pop(self, key: str, default: Optional[Union[str, List[str]]] = None) -> Optional[List[str]]
 ```
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L270" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L270"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(self, key: str, default: Optional[Union[str, List[str]]] = None) -> Optional[List[str]]
 ```
 
-#### `deepcopy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/events.py#L283" target="_blank">↗</a></sup>
+#### `deepcopy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/events.py#L283"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 deepcopy(self) -> 'ResourceSpecification'

--- a/docs/v3/api-ref/python/prefect-events-schemas-labelling.mdx
+++ b/docs/v3/api-ref/python/prefect-events-schemas-labelling.mdx
@@ -7,7 +7,7 @@ sidebarTitle: labelling
 
 ## Classes
 
-### `LabelDiver` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L6" target="_blank">↗</a></sup>
+### `LabelDiver` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L6"><Icon icon="github" size="14" /></a></sup>
 
 
 The LabelDiver supports templating use cases for any Labelled object, by
@@ -25,41 +25,41 @@ example:
     ```
 
 
-### `Labelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L76" target="_blank">↗</a></sup>
+### `Labelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `keys` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L77" target="_blank">↗</a></sup>
+#### `keys` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 keys(self) -> Iterable[str]
 ```
 
-#### `items` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L80" target="_blank">↗</a></sup>
+#### `items` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L80"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 items(self) -> Iterable[Tuple[str, str]]
 ```
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L93" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L93"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(self, label: str, default: Optional[str] = None) -> Optional[str]
 ```
 
-#### `as_label_value_array` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L96" target="_blank">↗</a></sup>
+#### `as_label_value_array` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_label_value_array(self) -> List[Dict[str, str]]
 ```
 
-#### `labels` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L100" target="_blank">↗</a></sup>
+#### `labels` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 labels(self) -> LabelDiver
 ```
 
-#### `has_all_labels` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/schemas/labelling.py#L103" target="_blank">↗</a></sup>
+#### `has_all_labels` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/schemas/labelling.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 has_all_labels(self, labels: Dict[str, str]) -> bool

--- a/docs/v3/api-ref/python/prefect-events-utilities.mdx
+++ b/docs/v3/api-ref/python/prefect-events-utilities.mdx
@@ -7,7 +7,7 @@ sidebarTitle: utilities
 
 ## Functions
 
-### `emit_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/utilities.py#L28" target="_blank">↗</a></sup>
+### `emit_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/utilities.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_event(event: str, resource: dict[str, str], occurred: datetime.datetime | None = None, related: list[dict[str, str]] | list[RelatedResource] | None = None, payload: dict[str, Any] | None = None, id: UUID | None = None, follows: Event | None = None, **kwargs: dict[str, Any] | None) -> Event | None

--- a/docs/v3/api-ref/python/prefect-events-worker.mdx
+++ b/docs/v3/api-ref/python/prefect-events-worker.mdx
@@ -7,25 +7,25 @@ sidebarTitle: worker
 
 ## Functions
 
-### `should_emit_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/worker.py#L29" target="_blank">↗</a></sup>
+### `should_emit_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/worker.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_emit_events() -> bool
 ```
 
-### `emit_events_to_cloud` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/worker.py#L37" target="_blank">↗</a></sup>
+### `emit_events_to_cloud` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/worker.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_events_to_cloud() -> bool
 ```
 
-### `should_emit_events_to_running_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/worker.py#L44" target="_blank">↗</a></sup>
+### `should_emit_events_to_running_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/worker.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_emit_events_to_running_server() -> bool
 ```
 
-### `should_emit_events_to_ephemeral_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/worker.py#L49" target="_blank">↗</a></sup>
+### `should_emit_events_to_ephemeral_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/worker.py#L49"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_emit_events_to_ephemeral_server() -> bool
@@ -33,11 +33,11 @@ should_emit_events_to_ephemeral_server() -> bool
 
 ## Classes
 
-### `EventsWorker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/worker.py#L53" target="_blank">↗</a></sup>
+### `EventsWorker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/worker.py#L53"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/worker.py#L100" target="_blank">↗</a></sup>
+#### `instance` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/events/worker.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 instance(cls: Type[Self], client_type: Optional[Type[EventsClient]] = None) -> Self

--- a/docs/v3/api-ref/python/prefect-exceptions.mdx
+++ b/docs/v3/api-ref/python/prefect-exceptions.mdx
@@ -12,7 +12,7 @@ Prefect-specific exceptions.
 
 ## Functions
 
-### `exception_traceback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L48" target="_blank">↗</a></sup>
+### `exception_traceback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L48"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exception_traceback(exc: Exception) -> str
@@ -24,13 +24,13 @@ Convert an exception to a printable string with a traceback
 
 ## Classes
 
-### `PrefectException` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L56" target="_blank">↗</a></sup>
+### `PrefectException` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 
 Base exception type for Prefect errors.
 
 
-### `CrashedRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L62" target="_blank">↗</a></sup>
+### `CrashedRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L62"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the result from a crashed run is retrieved.
@@ -39,7 +39,7 @@ This occurs when a string is attached to the state instead of an exception or if
 the state's data is null.
 
 
-### `FailedRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L71" target="_blank">↗</a></sup>
+### `FailedRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the result from a failed run is retrieved and an exception is not
@@ -49,7 +49,7 @@ This occurs when a string is attached to the state instead of an exception or if
 the state's data is null.
 
 
-### `CancelledRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L81" target="_blank">↗</a></sup>
+### `CancelledRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L81"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the result from a cancelled run is retrieved and an exception
@@ -59,13 +59,13 @@ This occurs when a string is attached to the state instead of an exception
 or if the state's data is null.
 
 
-### `PausedRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L91" target="_blank">↗</a></sup>
+### `PausedRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the result from a paused run is retrieved.
 
 
-### `UnfinishedRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L103" target="_blank">↗</a></sup>
+### `UnfinishedRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the result from a run that is not finished is retrieved.
@@ -73,32 +73,32 @@ Raised when the result from a run that is not finished is retrieved.
 For example, if a run is in a SCHEDULED, PENDING, CANCELLING, or RUNNING state.
 
 
-### `MissingFlowError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L111" target="_blank">↗</a></sup>
+### `MissingFlowError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L111"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a given flow name is not found in the expected script.
 
 
-### `UnspecifiedFlowError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L117" target="_blank">↗</a></sup>
+### `UnspecifiedFlowError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when multiple flows are found in the expected script and no name is given.
 
 
-### `MissingResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L123" target="_blank">↗</a></sup>
+### `MissingResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L123"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a result is missing from a state; often when result persistence is
 disabled and the state is retrieved from the API.
 
 
-### `ScriptError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L130" target="_blank">↗</a></sup>
+### `ScriptError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L130"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a script errors during evaluation while attempting to load data
 
 
-### `ParameterTypeError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L153" target="_blank">↗</a></sup>
+### `ParameterTypeError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L153"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a parameter does not pass Pydantic type validation.
@@ -106,13 +106,13 @@ Raised when a parameter does not pass Pydantic type validation.
 
 **Methods:**
 
-#### `from_validation_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L162" target="_blank">↗</a></sup>
+#### `from_validation_error` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_validation_error(cls, exc: ValidationError) -> Self
 ```
 
-### `ParameterBindError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L171" target="_blank">↗</a></sup>
+### `ParameterBindError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L171"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when args and kwargs cannot be converted to parameters.
@@ -120,13 +120,13 @@ Raised when args and kwargs cannot be converted to parameters.
 
 **Methods:**
 
-#### `from_bind_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L180" target="_blank">↗</a></sup>
+#### `from_bind_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L180"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_bind_failure(cls, fn: Callable[..., Any], exc: TypeError, call_args: tuple[Any, ...], call_kwargs: dict[str, Any]) -> Self
 ```
 
-### `SignatureMismatchError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L196" target="_blank">↗</a></sup>
+### `SignatureMismatchError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L196"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when parameters passed to a function do not match its signature.
@@ -134,64 +134,64 @@ Raised when parameters passed to a function do not match its signature.
 
 **Methods:**
 
-#### `from_bad_params` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L203" target="_blank">↗</a></sup>
+#### `from_bad_params` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L203"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_bad_params(cls, expected_params: list[str], provided_params: list[str]) -> Self
 ```
 
-### `ObjectNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L213" target="_blank">↗</a></sup>
+### `ObjectNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the client receives a 404 (not found) from the API.
 
 
-### `ObjectAlreadyExists` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L233" target="_blank">↗</a></sup>
+### `ObjectAlreadyExists` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L233"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the client receives a 409 (conflict) from the API.
 
 
-### `UpstreamTaskError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L243" target="_blank">↗</a></sup>
+### `UpstreamTaskError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L243"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a task relies on the result of another task but that task is not
 'COMPLETE'
 
 
-### `MissingContextError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L250" target="_blank">↗</a></sup>
+### `MissingContextError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L250"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a method is called that requires a task or flow run context to be
 active but one cannot be found.
 
 
-### `MissingProfileError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L257" target="_blank">↗</a></sup>
+### `MissingProfileError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L257"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a profile name does not exist.
 
 
-### `ReservedArgumentError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L263" target="_blank">↗</a></sup>
+### `ReservedArgumentError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L263"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a function used with Prefect has an argument with a name that is
 reserved for a Prefect feature
 
 
-### `InvalidNameError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L270" target="_blank">↗</a></sup>
+### `InvalidNameError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L270"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a name contains characters that are not permitted.
 
 
-### `PrefectSignal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L276" target="_blank">↗</a></sup>
+### `PrefectSignal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L276"><Icon icon="github" size="14" /></a></sup>
 
 
 Base type for signal-like exceptions that should never be caught by users.
 
 
-### `Abort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L282" target="_blank">↗</a></sup>
+### `Abort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L282"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the API sends an 'ABORT' instruction during state proposal.
@@ -199,25 +199,25 @@ Raised when the API sends an 'ABORT' instruction during state proposal.
 Indicates that the run should exit immediately.
 
 
-### `Pause` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L290" target="_blank">↗</a></sup>
+### `Pause` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L290"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a flow run is PAUSED and needs to exit for resubmission.
 
 
-### `ExternalSignal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L302" target="_blank">↗</a></sup>
+### `ExternalSignal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L302"><Icon icon="github" size="14" /></a></sup>
 
 
 Base type for external signal-like exceptions that should never be caught by users.
 
 
-### `TerminationSignal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L308" target="_blank">↗</a></sup>
+### `TerminationSignal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L308"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a flow run receives a termination signal.
 
 
-### `PrefectHTTPStatusError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L317" target="_blank">↗</a></sup>
+### `PrefectHTTPStatusError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L317"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when client receives a `Response` that contains an HTTPStatusError.
@@ -227,7 +227,7 @@ Used to include API error details in the error messages that the client provides
 
 **Methods:**
 
-#### `from_httpx_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L325" target="_blank">↗</a></sup>
+#### `from_httpx_error` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L325"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_httpx_error(cls: type[Self], httpx_error: HTTPStatusError) -> Self
@@ -236,99 +236,99 @@ from_httpx_error(cls: type[Self], httpx_error: HTTPStatusError) -> Self
 Generate a `PrefectHTTPStatusError` from an `httpx.HTTPStatusError`.
 
 
-### `MappingLengthMismatch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L348" target="_blank">↗</a></sup>
+### `MappingLengthMismatch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L348"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when attempting to call Task.map with arguments of different lengths.
 
 
-### `MappingMissingIterable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L354" target="_blank">↗</a></sup>
+### `MappingMissingIterable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L354"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when attempting to call Task.map with all static arguments
 
 
-### `BlockMissingCapabilities` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L360" target="_blank">↗</a></sup>
+### `BlockMissingCapabilities` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L360"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a block does not have required capabilities for a given operation.
 
 
-### `ProtectedBlockError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L366" target="_blank">↗</a></sup>
+### `ProtectedBlockError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L366"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when an operation is prevented due to block protection.
 
 
-### `InvalidRepositoryURLError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L372" target="_blank">↗</a></sup>
+### `InvalidRepositoryURLError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L372"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when an incorrect URL is provided to a GitHub filesystem block.
 
 
-### `InfrastructureError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L376" target="_blank">↗</a></sup>
+### `InfrastructureError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L376"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for exceptions related to infrastructure blocks
 
 
-### `InfrastructureNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L382" target="_blank">↗</a></sup>
+### `InfrastructureNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L382"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when infrastructure is missing, likely because it has exited or been
 deleted.
 
 
-### `InfrastructureNotAvailable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L389" target="_blank">↗</a></sup>
+### `InfrastructureNotAvailable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L389"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when infrastructure is not accessible from the current machine. For example,
 if a process was spawned on another machine it cannot be managed.
 
 
-### `NotPausedError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L396" target="_blank">↗</a></sup>
+### `NotPausedError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L396"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when attempting to unpause a run that isn't paused.
 
 
-### `FlowPauseTimeout` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L400" target="_blank">↗</a></sup>
+### `FlowPauseTimeout` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L400"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a flow pause times out
 
 
-### `FlowRunWaitTimeout` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L404" target="_blank">↗</a></sup>
+### `FlowRunWaitTimeout` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L404"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a flow run takes longer than a given timeout
 
 
-### `PrefectImportError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L408" target="_blank">↗</a></sup>
+### `PrefectImportError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L408"><Icon icon="github" size="14" /></a></sup>
 
 
 An error raised when a Prefect object cannot be imported due to a move or removal.
 
 
-### `SerializationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L417" target="_blank">↗</a></sup>
+### `SerializationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L417"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when an object cannot be serialized.
 
 
-### `ConfigurationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L423" target="_blank">↗</a></sup>
+### `ConfigurationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L423"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a configuration is invalid.
 
 
-### `ProfileSettingsValidationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L429" target="_blank">↗</a></sup>
+### `ProfileSettingsValidationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L429"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a profile settings are invalid.
 
 
-### `HashError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/exceptions.py#L438" target="_blank">↗</a></sup>
+### `HashError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/exceptions.py#L438"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when hashing objects fails

--- a/docs/v3/api-ref/python/prefect-filesystems.mdx
+++ b/docs/v3/api-ref/python/prefect-filesystems.mdx
@@ -7,15 +7,15 @@ sidebarTitle: filesystems
 
 ## Classes
 
-### `ReadableFileSystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L24" target="_blank">↗</a></sup>
+### `ReadableFileSystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L24"><Icon icon="github" size="14" /></a></sup>
 
-### `WritableFileSystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L32" target="_blank">↗</a></sup>
+### `WritableFileSystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L32"><Icon icon="github" size="14" /></a></sup>
 
-### `ReadableDeploymentStorage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L44" target="_blank">↗</a></sup>
+### `ReadableDeploymentStorage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L44"><Icon icon="github" size="14" /></a></sup>
 
-### `WritableDeploymentStorage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L54" target="_blank">↗</a></sup>
+### `WritableDeploymentStorage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L54"><Icon icon="github" size="14" /></a></sup>
 
-### `LocalFileSystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L73" target="_blank">↗</a></sup>
+### `LocalFileSystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 
 Store data as a file on a local file system.
@@ -23,13 +23,13 @@ Store data as a file on a local file system.
 
 **Methods:**
 
-#### `cast_pathlib` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L97" target="_blank">↗</a></sup>
+#### `cast_pathlib` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L97"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cast_pathlib(cls, value: str | Path | None) -> str | None
 ```
 
-### `RemoteFileSystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L248" target="_blank">↗</a></sup>
+### `RemoteFileSystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L248"><Icon icon="github" size="14" /></a></sup>
 
 
 Store data as a file on a remote file system.
@@ -40,19 +40,19 @@ using a protocol. For example, "s3://my-bucket/my-folder/" will use S3.
 
 **Methods:**
 
-#### `check_basepath` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L284" target="_blank">↗</a></sup>
+#### `check_basepath` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L284"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_basepath(cls, value: str) -> str
 ```
 
-#### `filesystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L407" target="_blank">↗</a></sup>
+#### `filesystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L407"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 filesystem(self) -> fsspec.AbstractFileSystem
 ```
 
-### `SMB` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L425" target="_blank">↗</a></sup>
+### `SMB` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L425"><Icon icon="github" size="14" /></a></sup>
 
 
 Store data as a file on a SMB share.
@@ -60,19 +60,19 @@ Store data as a file on a SMB share.
 
 **Methods:**
 
-#### `basepath` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L467" target="_blank">↗</a></sup>
+#### `basepath` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L467"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 basepath(self) -> str
 ```
 
-#### `filesystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L471" target="_blank">↗</a></sup>
+#### `filesystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L471"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 filesystem(self) -> RemoteFileSystem
 ```
 
-### `NullFileSystem` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/filesystems.py#L526" target="_blank">↗</a></sup>
+### `NullFileSystem` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/filesystems.py#L526"><Icon icon="github" size="14" /></a></sup>
 
 
 A file system that does not store any data.

--- a/docs/v3/api-ref/python/prefect-flow_engine.mdx
+++ b/docs/v3/api-ref/python/prefect-flow_engine.mdx
@@ -7,43 +7,43 @@ sidebarTitle: flow_engine
 
 ## Functions
 
-### `load_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L124" target="_blank">↗</a></sup>
+### `load_flow_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L124"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_flow_run(flow_run_id: UUID) -> FlowRun
 ```
 
-### `load_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L130" target="_blank">↗</a></sup>
+### `load_flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L130"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_flow(flow_run: FlowRun) -> Flow[..., Any]
 ```
 
-### `load_flow_and_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L146" target="_blank">↗</a></sup>
+### `load_flow_and_flow_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L146"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_flow_and_flow_run(flow_run_id: UUID) -> tuple[FlowRun, Flow[..., Any]]
 ```
 
-### `run_flow_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L1354" target="_blank">↗</a></sup>
+### `run_flow_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L1354"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_flow_sync(flow: Flow[P, R], flow_run: Optional[FlowRun] = None, parameters: Optional[Dict[str, Any]] = None, wait_for: Optional[Iterable[PrefectFuture[Any]]] = None, return_type: Literal['state', 'result'] = 'result', context: Optional[dict[str, Any]] = None) -> Union[R, State, None]
 ```
 
-### `run_generator_flow_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L1402" target="_blank">↗</a></sup>
+### `run_generator_flow_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L1402"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_generator_flow_sync(flow: Flow[P, R], flow_run: Optional[FlowRun] = None, parameters: Optional[Dict[str, Any]] = None, wait_for: Optional[Iterable[PrefectFuture[Any]]] = None, return_type: Literal['state', 'result'] = 'result', context: Optional[dict[str, Any]] = None) -> Generator[R, None, None]
 ```
 
-### `run_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L1486" target="_blank">↗</a></sup>
+### `run_flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L1486"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_flow(flow: Flow[P, R], flow_run: Optional[FlowRun] = None, parameters: Optional[Dict[str, Any]] = None, wait_for: Optional[Iterable[PrefectFuture[R]]] = None, return_type: Literal['state', 'result'] = 'result', error_logger: Optional[logging.Logger] = None, context: Optional[dict[str, Any]] = None) -> R | State | None | Coroutine[Any, Any, R | State | None] | Generator[R, None, None] | AsyncGenerator[R, None]
 ```
 
-### `run_flow_in_subprocess` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L1559" target="_blank">↗</a></sup>
+### `run_flow_in_subprocess` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L1559"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_flow_in_subprocess(flow: 'Flow[..., Any]', flow_run: 'FlowRun | None' = None, parameters: dict[str, Any] | None = None, wait_for: Iterable[PrefectFuture[Any]] | None = None, context: dict[str, Any] | None = None) -> multiprocessing.context.SpawnProcess
@@ -71,57 +71,57 @@ in a subprocess or on another machine).
 
 ## Classes
 
-### `FlowRunTimeoutError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L120" target="_blank">↗</a></sup>
+### `FlowRunTimeoutError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a flow run exceeds its defined timeout.
 
 
-### `BaseFlowRunEngine` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L153" target="_blank">↗</a></sup>
+### `BaseFlowRunEngine` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L153"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L178" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> State
 ```
 
-#### `is_running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L181" target="_blank">↗</a></sup>
+#### `is_running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L181"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_running(self) -> bool
 ```
 
-#### `is_pending` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L186" target="_blank">↗</a></sup>
+#### `is_pending` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L186"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_pending(self) -> bool
 ```
 
-#### `cancel_all_tasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L191" target="_blank">↗</a></sup>
+#### `cancel_all_tasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L191"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cancel_all_tasks(self) -> None
 ```
 
-### `FlowRunEngine` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L230" target="_blank">↗</a></sup>
+### `FlowRunEngine` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L236" target="_blank">↗</a></sup>
+#### `client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L236"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client(self) -> SyncPrefectClient
 ```
 
-#### `begin_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L280" target="_blank">↗</a></sup>
+#### `begin_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L280"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 begin_run(self) -> State
 ```
 
-#### `set_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L319" target="_blank">↗</a></sup>
+#### `set_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L319"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state(self, state: State, force: bool = False) -> State
@@ -130,37 +130,37 @@ set_state(self, state: State, force: bool = False) -> State
 
 
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L336" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L336"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: bool = True) -> 'Union[R, State, None]'
 ```
 
-#### `handle_success` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L362" target="_blank">↗</a></sup>
+#### `handle_success` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L362"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_success(self, result: R) -> R
 ```
 
-#### `handle_exception` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L382" target="_blank">↗</a></sup>
+#### `handle_exception` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L382"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_exception(self, exc: Exception, msg: Optional[str] = None, result_store: Optional[ResultStore] = None) -> State
 ```
 
-#### `handle_timeout` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L415" target="_blank">↗</a></sup>
+#### `handle_timeout` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L415"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_timeout(self, exc: TimeoutError) -> None
 ```
 
-#### `handle_crash` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L433" target="_blank">↗</a></sup>
+#### `handle_crash` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L433"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_crash(self, exc: BaseException) -> None
 ```
 
-#### `load_subflow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L442" target="_blank">↗</a></sup>
+#### `load_subflow_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L442"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_subflow_run(self, parent_task_run: TaskRun, client: SyncPrefectClient, context: FlowRunContext) -> Union[FlowRun, None]
@@ -178,25 +178,25 @@ If no existing flow run is found, or if the subflow should be rerun,
 then no flow run is returned.
 
 
-#### `create_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L491" target="_blank">↗</a></sup>
+#### `create_flow_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L491"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_flow_run(self, client: SyncPrefectClient) -> FlowRun
 ```
 
-#### `call_hooks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L526" target="_blank">↗</a></sup>
+#### `call_hooks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L526"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_hooks(self, state: Optional[State] = None) -> None
 ```
 
-#### `setup_run_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L583" target="_blank">↗</a></sup>
+#### `setup_run_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L583"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_run_context(self, client: Optional[SyncPrefectClient] = None)
 ```
 
-#### `initialize_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L665" target="_blank">↗</a></sup>
+#### `initialize_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L665"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 initialize_run(self)
@@ -205,19 +205,19 @@ initialize_run(self)
 Enters a client context and creates a flow run if needed.
 
 
-#### `start` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L741" target="_blank">↗</a></sup>
+#### `start` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L741"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start(self) -> Generator[None, None, None]
 ```
 
-#### `run_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L753" target="_blank">↗</a></sup>
+#### `run_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L753"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_context(self)
 ```
 
-#### `call_flow_fn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L772" target="_blank">↗</a></sup>
+#### `call_flow_fn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L772"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_flow_fn(self) -> Union[R, Coroutine[Any, Any, R]]
@@ -227,7 +227,7 @@ Convenience method to call the flow function. Returns a coroutine if the
 flow is async.
 
 
-### `AsyncFlowRunEngine` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L790" target="_blank">↗</a></sup>
+### `AsyncFlowRunEngine` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L790"><Icon icon="github" size="14" /></a></sup>
 
 
 Async version of the flow run engine.
@@ -238,7 +238,7 @@ not being fully asyncified.
 
 **Methods:**
 
-#### `client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flow_engine.py#L803" target="_blank">↗</a></sup>
+#### `client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flow_engine.py#L803"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client(self) -> PrefectClient

--- a/docs/v3/api-ref/python/prefect-flows.mdx
+++ b/docs/v3/api-ref/python/prefect-flows.mdx
@@ -12,13 +12,13 @@ Module containing the base workflow class and decorator - for most use cases, us
 
 ## Functions
 
-### `bind_flow_to_infrastructure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2243" target="_blank">↗</a></sup>
+### `bind_flow_to_infrastructure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2243"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 bind_flow_to_infrastructure(flow: Flow[P, R], work_pool: str, worker_cls: type['BaseWorker[Any, Any, Any]'], job_variables: dict[str, Any] | None = None) -> InfrastructureBoundFlow[P, R]
 ```
 
-### `select_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2278" target="_blank">↗</a></sup>
+### `select_flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2278"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 select_flow(flows: Iterable[Flow[P, R]], flow_name: Optional[str] = None, from_message: Optional[str] = None) -> Flow[P, R]
@@ -36,7 +36,7 @@ Returns
 - `UnspecifiedFlowError`: If multiple flows exist but no flow name was provided
 
 
-### `load_flow_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2324" target="_blank">↗</a></sup>
+### `load_flow_from_entrypoint` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2324"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_flow_from_entrypoint(entrypoint: str, use_placeholder_flow: bool = True) -> Flow[P, Any]
@@ -60,7 +60,7 @@ cannot be loaded from the entrypoint (e.g. dependencies are missing)
 - `MissingFlowError`: If the flow function specified in the entrypoint does not exist
 
 
-### `load_function_and_convert_to_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2376" target="_blank">↗</a></sup>
+### `load_function_and_convert_to_flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2376"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_function_and_convert_to_flow(entrypoint: str) -> Flow[P, Any]
@@ -70,7 +70,7 @@ load_function_and_convert_to_flow(entrypoint: str) -> Flow[P, Any]
 Loads a function from an entrypoint and converts it to a flow if it is not already a flow.
 
 
-### `serve` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2399" target="_blank">↗</a></sup>
+### `serve` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2399"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serve(*args: 'RunnerDeployment', **kwargs: Any) -> None
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 ```
 
 
-### `load_placeholder_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2687" target="_blank">↗</a></sup>
+### `load_placeholder_flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2687"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_placeholder_flow(entrypoint: str, raises: Exception) -> Flow[P, Any]
@@ -139,7 +139,7 @@ or a module path to a flow function
 - `raises`: an exception to raise when the flow is called
 
 
-### `safe_load_flow_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2722" target="_blank">↗</a></sup>
+### `safe_load_flow_from_entrypoint` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2722"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 safe_load_flow_from_entrypoint(entrypoint: str) -> Optional[Flow[P, Any]]
@@ -159,7 +159,7 @@ Safely load a Prefect flow from an entrypoint string. Returns None if loading fa
 - (e.g. unresolved dependencies, syntax errors, or missing objects).
 
 
-### `load_flow_arguments_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2892" target="_blank">↗</a></sup>
+### `load_flow_arguments_from_entrypoint` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2892"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_flow_arguments_from_entrypoint(entrypoint: str, arguments: Optional[Union[list[str], set[str]]] = None) -> dict[str, Any]
@@ -176,7 +176,7 @@ from the `flow` decorator.
 or a module path to a flow function
 
 
-### `is_entrypoint_async` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2972" target="_blank">↗</a></sup>
+### `is_entrypoint_async` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2972"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_entrypoint_async(entrypoint: str) -> bool
@@ -195,13 +195,13 @@ a module path to a function.
 
 ## Classes
 
-### `FlowStateHook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L120" target="_blank">↗</a></sup>
+### `FlowStateHook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 
 A callable that is invoked when a flow enters a given state.
 
 
-### `Flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L144" target="_blank">↗</a></sup>
+### `Flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L144"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect workflow definition.
@@ -258,25 +258,25 @@ loaded from the parent flow.
 
 **Methods:**
 
-#### `ismethod` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L407" target="_blank">↗</a></sup>
+#### `ismethod` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L407"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ismethod(self) -> bool
 ```
 
-#### `isclassmethod` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L411" target="_blank">↗</a></sup>
+#### `isclassmethod` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L411"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 isclassmethod(self) -> bool
 ```
 
-#### `isstaticmethod` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L415" target="_blank">↗</a></sup>
+#### `isstaticmethod` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L415"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 isstaticmethod(self) -> bool
 ```
 
-#### `with_options` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L439" target="_blank">↗</a></sup>
+#### `with_options` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L439"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 with_options(self) -> 'Flow[P, R]'
@@ -342,7 +342,7 @@ Examples:
     ```
 
 
-#### `validate_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L577" target="_blank">↗</a></sup>
+#### `validate_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L577"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]
@@ -358,7 +358,7 @@ associated types specified by the function's type annotations.
 - `ParameterTypeError`: if the provided parameters are not valid
 
 
-#### `serialize_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L653" target="_blank">↗</a></sup>
+#### `serialize_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L653"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serialize_parameters(self, parameters: dict[str, Any | PrefectFuture[Any] | State]) -> dict[str, Any]
@@ -371,7 +371,7 @@ converting everything directly to a string. This maintains basic types like
 integers during API roundtrips.
 
 
-#### `to_deployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L831" target="_blank">↗</a></sup>
+#### `to_deployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L831"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_deployment(self, name: str, interval: Optional[Union[Iterable[Union[int, float, datetime.timedelta]], int, float, datetime.timedelta]] = None, cron: Optional[Union[Iterable[str], str]] = None, rrule: Optional[Union[Iterable[str], str]] = None, paused: Optional[bool] = None, schedule: Optional[Schedule] = None, schedules: Optional['FlexibleScheduleList'] = None, concurrency_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None, parameters: Optional[dict[str, Any]] = None, triggers: Optional[list[Union[DeploymentTriggerTypes, TriggerTypes]]] = None, description: Optional[str] = None, tags: Optional[list[str]] = None, version: Optional[str] = None, version_type: Optional[VersionType] = None, enforce_parameter_schema: bool = True, work_pool_name: Optional[str] = None, work_queue_name: Optional[str] = None, job_variables: Optional[dict[str, Any]] = None, entrypoint_type: EntrypointType = EntrypointType.FILE_PATH, _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None) -> 'RunnerDeployment'
@@ -433,37 +433,37 @@ if __name__ == "__main__":
 ```
 
 
-#### `on_completion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L975" target="_blank">↗</a></sup>
+#### `on_completion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L975"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_completion(self, fn: FlowStateHook[P, R]) -> FlowStateHook[P, R]
 ```
 
-#### `on_cancellation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L979" target="_blank">↗</a></sup>
+#### `on_cancellation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L979"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_cancellation(self, fn: FlowStateHook[P, R]) -> FlowStateHook[P, R]
 ```
 
-#### `on_crashed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L983" target="_blank">↗</a></sup>
+#### `on_crashed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L983"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_crashed(self, fn: FlowStateHook[P, R]) -> FlowStateHook[P, R]
 ```
 
-#### `on_running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L987" target="_blank">↗</a></sup>
+#### `on_running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L987"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_running(self, fn: FlowStateHook[P, R]) -> FlowStateHook[P, R]
 ```
 
-#### `on_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L991" target="_blank">↗</a></sup>
+#### `on_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L991"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_failure(self, fn: FlowStateHook[P, R]) -> FlowStateHook[P, R]
 ```
 
-#### `serve` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L995" target="_blank">↗</a></sup>
+#### `serve` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L995"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 serve(self, name: Optional[str] = None, interval: Optional[Union[Iterable[Union[int, float, datetime.timedelta]], int, float, datetime.timedelta]] = None, cron: Optional[Union[Iterable[str], str]] = None, rrule: Optional[Union[Iterable[str], str]] = None, paused: Optional[bool] = None, schedule: Optional[Schedule] = None, schedules: Optional['FlexibleScheduleList'] = None, global_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None, triggers: Optional[list[Union[DeploymentTriggerTypes, TriggerTypes]]] = None, parameters: Optional[dict[str, Any]] = None, description: Optional[str] = None, tags: Optional[list[str]] = None, version: Optional[str] = None, enforce_parameter_schema: bool = True, pause_on_shutdown: bool = True, print_starting_message: bool = True, limit: Optional[int] = None, webserver: bool = False, entrypoint_type: EntrypointType = EntrypointType.FILE_PATH) -> None
@@ -533,7 +533,7 @@ if __name__ == "__main__":
 ```
 
 
-#### `from_source` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L1264" target="_blank">↗</a></sup>
+#### `from_source` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L1264"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_source(cls, source: Union[str, Path, 'RunnerStorage', ReadableDeploymentStorage], entrypoint: str) -> 'Flow[..., Any]'
@@ -609,9 +609,9 @@ if __name__ == "__main__":
 ```
 
 
-### `FlowDecorator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L1766" target="_blank">↗</a></sup>
+### `FlowDecorator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L1766"><Icon icon="github" size="14" /></a></sup>
 
-### `InfrastructureBoundFlow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2026" target="_blank">↗</a></sup>
+### `InfrastructureBoundFlow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2026"><Icon icon="github" size="14" /></a></sup>
 
 
 A flow that is bound to running on a specific infrastructure.
@@ -619,7 +619,7 @@ A flow that is bound to running on a specific infrastructure.
 
 **Methods:**
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2142" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2142"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, *args: P.args, **kwargs: P.kwargs) -> PrefectFlowRunFuture[R]
@@ -653,7 +653,7 @@ print(result)
 ```
 
 
-#### `with_options` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2185" target="_blank">↗</a></sup>
+#### `with_options` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/flows.py#L2185"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 with_options(self) -> 'InfrastructureBoundFlow[P, R]'

--- a/docs/v3/api-ref/python/prefect-futures.mdx
+++ b/docs/v3/api-ref/python/prefect-futures.mdx
@@ -7,13 +7,13 @@ sidebarTitle: futures
 
 ## Functions
 
-### `as_completed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L512" target="_blank">↗</a></sup>
+### `as_completed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L512"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_completed(futures: list[PrefectFuture[R]], timeout: float | None = None) -> Generator[PrefectFuture[R], None]
 ```
 
-### `wait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L563" target="_blank">↗</a></sup>
+### `wait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L563"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait(futures: list[PrefectFuture[R]], timeout: float | None = None) -> DoneAndNotDoneFutures[R]
@@ -51,7 +51,7 @@ def flow():
 ```
 
 
-### `resolve_futures_to_states` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L613" target="_blank">↗</a></sup>
+### `resolve_futures_to_states` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L613"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resolve_futures_to_states(expr: PrefectFuture[R] | Any) -> PrefectFuture[R] | Any
@@ -65,7 +65,7 @@ Resolving futures to their final states may wait for execution to complete.
 Unsupported object types will be returned without modification.
 
 
-### `resolve_futures_to_results` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L634" target="_blank">↗</a></sup>
+### `resolve_futures_to_results` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L634"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resolve_futures_to_results(expr: PrefectFuture[R] | Any) -> Any
@@ -81,7 +81,7 @@ Unsupported object types will be returned without modification.
 
 ## Classes
 
-### `PrefectFuture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L34" target="_blank">↗</a></sup>
+### `PrefectFuture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 Abstract base class for Prefect futures. A Prefect future is a handle to the
@@ -91,7 +91,7 @@ to complete and to retrieve the result of the run.
 
 **Methods:**
 
-#### `task_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L52" target="_blank">↗</a></sup>
+#### `task_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L52"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task_run_id(self) -> uuid.UUID
@@ -100,7 +100,7 @@ task_run_id(self) -> uuid.UUID
 The ID of the task run associated with this future
 
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L64" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> State
@@ -109,19 +109,19 @@ state(self) -> State
 The current state of the task run associated with this future
 
 
-#### `wait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L85" target="_blank">↗</a></sup>
+#### `wait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait(self, timeout: float | None = None) -> None
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L98" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, timeout: float | None = None, raise_on_failure: bool = True) -> R
 ```
 
-#### `add_done_callback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L119" target="_blank">↗</a></sup>
+#### `add_done_callback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_done_callback(self, fn: Callable[['PrefectFuture[R]'], None]) -> None
@@ -133,7 +133,7 @@ Add a callback to be run when the future completes or is cancelled.
 - `fn`: A callable that will be called with this future as its only argument when the future completes or is cancelled.
 
 
-### `PrefectTaskRunFuture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L129" target="_blank">↗</a></sup>
+### `PrefectTaskRunFuture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L129"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect future that represents the eventual execution of a task run.
@@ -141,7 +141,7 @@ A Prefect future that represents the eventual execution of a task run.
 
 **Methods:**
 
-#### `task_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L139" target="_blank">↗</a></sup>
+#### `task_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L139"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task_run_id(self) -> uuid.UUID
@@ -150,7 +150,7 @@ task_run_id(self) -> uuid.UUID
 The ID of the task run associated with this future
 
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L144" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L144"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> State
@@ -159,7 +159,7 @@ state(self) -> State
 The current state of the task run associated with this future
 
 
-### `PrefectWrappedFuture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L158" target="_blank">↗</a></sup>
+### `PrefectWrappedFuture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L158"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect future that wraps another future object.
@@ -167,7 +167,7 @@ A Prefect future that wraps another future object.
 
 **Methods:**
 
-#### `wrapped_future` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L172" target="_blank">↗</a></sup>
+#### `wrapped_future` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wrapped_future(self) -> F
@@ -176,7 +176,7 @@ wrapped_future(self) -> F
 The underlying future object wrapped by this Prefect future
 
 
-#### `add_done_callback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L176" target="_blank">↗</a></sup>
+#### `add_done_callback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L176"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_done_callback(self, fn: Callable[[PrefectFuture[R]], None]) -> None
@@ -185,7 +185,7 @@ add_done_callback(self, fn: Callable[[PrefectFuture[R]], None]) -> None
 Add a callback to be executed when the future completes.
 
 
-### `PrefectConcurrentFuture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L189" target="_blank">↗</a></sup>
+### `PrefectConcurrentFuture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect future that wraps a concurrent.futures.Future. This future is used
@@ -194,19 +194,19 @@ when the task run is submitted to a ThreadPoolExecutor.
 
 **Methods:**
 
-#### `wait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L195" target="_blank">↗</a></sup>
+#### `wait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait(self, timeout: float | None = None) -> None
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L203" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L203"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, timeout: float | None = None, raise_on_failure: bool = True) -> R
 ```
 
-### `PrefectDistributedFuture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L228" target="_blank">↗</a></sup>
+### `PrefectDistributedFuture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L228"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents the result of a computation happening anywhere.
@@ -218,25 +218,25 @@ any task run scheduled in Prefect's API.
 
 **Methods:**
 
-#### `wait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L240" target="_blank">↗</a></sup>
+#### `wait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L240"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait(self, timeout: float | None = None) -> None
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L294" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L294"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, timeout: float | None = None, raise_on_failure: bool = True) -> R
 ```
 
-#### `add_done_callback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L324" target="_blank">↗</a></sup>
+#### `add_done_callback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L324"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_done_callback(self, fn: Callable[[PrefectFuture[R]], None]) -> None
 ```
 
-### `PrefectFlowRunFuture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L346" target="_blank">↗</a></sup>
+### `PrefectFlowRunFuture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L346"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect future that represents the eventual execution of a flow run.
@@ -244,7 +244,7 @@ A Prefect future that represents the eventual execution of a flow run.
 
 **Methods:**
 
-#### `flow_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L356" target="_blank">↗</a></sup>
+#### `flow_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L356"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 flow_run_id(self) -> uuid.UUID
@@ -253,7 +253,7 @@ flow_run_id(self) -> uuid.UUID
 The ID of the flow run associated with this future
 
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L361" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L361"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> State
@@ -262,25 +262,25 @@ state(self) -> State
 The current state of the flow run associated with this future
 
 
-#### `wait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L376" target="_blank">↗</a></sup>
+#### `wait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L376"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait(self, timeout: float | None = None) -> None
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L416" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L416"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, timeout: float | None = None, raise_on_failure: bool = True) -> R
 ```
 
-#### `add_done_callback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L439" target="_blank">↗</a></sup>
+#### `add_done_callback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L439"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_done_callback(self, fn: Callable[[PrefectFuture[R]], None]) -> None
 ```
 
-### `PrefectFutureList` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L461" target="_blank">↗</a></sup>
+### `PrefectFutureList` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L461"><Icon icon="github" size="14" /></a></sup>
 
 
 A list of Prefect futures.
@@ -291,7 +291,7 @@ in the list to complete and to retrieve the results of all task runs.
 
 **Methods:**
 
-#### `wait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L469" target="_blank">↗</a></sup>
+#### `wait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L469"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait(self, timeout: float | None = None) -> None
@@ -304,7 +304,7 @@ Wait for all futures in the list to complete.
 complete. This method will not raise if the timeout is reached.
 
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L479" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L479"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self: Self, timeout: float | None = None, raise_on_failure: bool = True) -> list[R]
@@ -324,7 +324,7 @@ complete.
 - `TimeoutError`: If the timeout is reached before all futures complete.
 
 
-### `DoneAndNotDoneFutures` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py#L553" target="_blank">↗</a></sup>
+### `DoneAndNotDoneFutures` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/futures.py#L553"><Icon icon="github" size="14" /></a></sup>
 
 
 A named 2-tuple of sets.

--- a/docs/v3/api-ref/python/prefect-infrastructure-provisioners-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-infrastructure-provisioners-__init__.mdx
@@ -7,7 +7,7 @@ sidebarTitle: __init__
 
 ## Functions
 
-### `get_infrastructure_provisioner_for_work_pool_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L38" target="_blank">↗</a></sup>
+### `get_infrastructure_provisioner_for_work_pool_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_infrastructure_provisioner_for_work_pool_type(work_pool_type: str) -> Type[Provisioner]
@@ -28,17 +28,17 @@ Retrieve an instance of the infrastructure provisioner for the given work pool t
 
 ## Classes
 
-### `Provisioner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L23" target="_blank">↗</a></sup>
+### `Provisioner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L25" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L25"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self) -> rich.console.Console
 ```
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L28" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/__init__.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self, value: rich.console.Console) -> None

--- a/docs/v3/api-ref/python/prefect-infrastructure-provisioners-cloud_run.mdx
+++ b/docs/v3/api-ref/python/prefect-infrastructure-provisioners-cloud_run.mdx
@@ -7,17 +7,17 @@ sidebarTitle: cloud_run
 
 ## Classes
 
-### `CloudRunPushProvisioner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/cloud_run.py#L34" target="_blank">↗</a></sup>
+### `CloudRunPushProvisioner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/cloud_run.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/cloud_run.py#L44" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/cloud_run.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self) -> Console
 ```
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/cloud_run.py#L48" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/cloud_run.py#L48"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self, value: Console) -> None

--- a/docs/v3/api-ref/python/prefect-infrastructure-provisioners-coiled.mdx
+++ b/docs/v3/api-ref/python/prefect-infrastructure-provisioners-coiled.mdx
@@ -7,7 +7,7 @@ sidebarTitle: coiled
 
 ## Classes
 
-### `CoiledPushProvisioner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/coiled.py#L26" target="_blank">↗</a></sup>
+### `CoiledPushProvisioner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/coiled.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 A infrastructure provisioner for Coiled push work pools.
@@ -15,13 +15,13 @@ A infrastructure provisioner for Coiled push work pools.
 
 **Methods:**
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/coiled.py#L35" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/coiled.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self) -> Console
 ```
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/coiled.py#L39" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/coiled.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self, value: Console) -> None

--- a/docs/v3/api-ref/python/prefect-infrastructure-provisioners-container_instance.mdx
+++ b/docs/v3/api-ref/python/prefect-infrastructure-provisioners-container_instance.mdx
@@ -21,7 +21,7 @@ Classes:
 
 ## Classes
 
-### `AzureCLI` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L47" target="_blank">↗</a></sup>
+### `AzureCLI` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 
 A class for executing Azure CLI commands and handling their output.
@@ -30,7 +30,7 @@ A class for executing Azure CLI commands and handling their output.
 - `console`: A Rich console object for displaying messages.
 
 
-### `ContainerInstancePushProvisioner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L130" target="_blank">↗</a></sup>
+### `ContainerInstancePushProvisioner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L130"><Icon icon="github" size="14" /></a></sup>
 
 
 A class responsible for provisioning Azure resources and setting up a push work pool.
@@ -38,13 +38,13 @@ A class responsible for provisioning Azure resources and setting up a push work 
 
 **Methods:**
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L168" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L168"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self) -> Console
 ```
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L172" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/container_instance.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self, value: Console) -> None

--- a/docs/v3/api-ref/python/prefect-infrastructure-provisioners-ecs.mdx
+++ b/docs/v3/api-ref/python/prefect-infrastructure-provisioners-ecs.mdx
@@ -7,7 +7,7 @@ sidebarTitle: ecs
 
 ## Functions
 
-### `console_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L48" target="_blank">↗</a></sup>
+### `console_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L48"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console_context(value: Console) -> Generator[None, None, None]
@@ -15,7 +15,7 @@ console_context(value: Console) -> Generator[None, None, None]
 
 ## Classes
 
-### `IamPolicyResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L56" target="_blank">↗</a></sup>
+### `IamPolicyResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents an IAM policy resource for managing ECS tasks.
@@ -26,13 +26,13 @@ Represents an IAM policy resource for managing ECS tasks.
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L162" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `IamUserResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L166" target="_blank">↗</a></sup>
+### `IamUserResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L166"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents an IAM user resource for managing ECS tasks.
@@ -43,79 +43,79 @@ Represents an IAM user resource for managing ECS tasks.
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L240" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L240"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `CredentialsBlockResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L244" target="_blank">↗</a></sup>
+### `CredentialsBlockResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L244"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L366" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L366"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `AuthenticationResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L370" target="_blank">↗</a></sup>
+### `AuthenticationResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L370"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `resources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L426" target="_blank">↗</a></sup>
+#### `resources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L426"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resources(self) -> list['ExecutionRoleResource | IamUserResource | IamPolicyResource | CredentialsBlockResource']
 ```
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L520" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L520"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `ClusterResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L528" target="_blank">↗</a></sup>
+### `ClusterResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L528"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L605" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L605"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `VpcResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L609" target="_blank">↗</a></sup>
+### `VpcResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L609"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L843" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L843"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `ContainerRepositoryResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L847" target="_blank">↗</a></sup>
+### `ContainerRepositoryResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L847"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L993" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L993"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str | Panel]
 ```
 
-### `ExecutionRoleResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L997" target="_blank">↗</a></sup>
+### `ExecutionRoleResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L997"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `next_steps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1102" target="_blank">↗</a></sup>
+#### `next_steps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1102"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 next_steps(self) -> list[str]
 ```
 
-### `ElasticContainerServicePushProvisioner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1106" target="_blank">↗</a></sup>
+### `ElasticContainerServicePushProvisioner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1106"><Icon icon="github" size="14" /></a></sup>
 
 
 An infrastructure provisioner for ECS push work pools.
@@ -123,19 +123,19 @@ An infrastructure provisioner for ECS push work pools.
 
 **Methods:**
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1115" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1115"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self) -> Console
 ```
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1119" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1119"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self, value: Console) -> None
 ```
 
-#### `is_boto3_installed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1130" target="_blank">↗</a></sup>
+#### `is_boto3_installed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/ecs.py#L1130"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_boto3_installed() -> bool

--- a/docs/v3/api-ref/python/prefect-infrastructure-provisioners-modal.mdx
+++ b/docs/v3/api-ref/python/prefect-infrastructure-provisioners-modal.mdx
@@ -7,7 +7,7 @@ sidebarTitle: modal
 
 ## Classes
 
-### `ModalPushProvisioner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/modal.py#L26" target="_blank">↗</a></sup>
+### `ModalPushProvisioner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/modal.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 A infrastructure provisioner for Modal push work pools.
@@ -15,13 +15,13 @@ A infrastructure provisioner for Modal push work pools.
 
 **Methods:**
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/modal.py#L35" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/modal.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self) -> Console
 ```
 
-#### `console` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/infrastructure/provisioners/modal.py#L39" target="_blank">↗</a></sup>
+#### `console` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/infrastructure/provisioners/modal.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 console(self, value: Console) -> None

--- a/docs/v3/api-ref/python/prefect-input-actions.mdx
+++ b/docs/v3/api-ref/python/prefect-input-actions.mdx
@@ -7,7 +7,7 @@ sidebarTitle: actions
 
 ## Functions
 
-### `ensure_flow_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/actions.py#L20" target="_blank">↗</a></sup>
+### `ensure_flow_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/actions.py#L20"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ensure_flow_run_id(flow_run_id: Optional[UUID] = None) -> UUID

--- a/docs/v3/api-ref/python/prefect-input-run_input.mdx
+++ b/docs/v3/api-ref/python/prefect-input-run_input.mdx
@@ -70,7 +70,7 @@ async def receiver_flow():
 
 ## Functions
 
-### `keyset_from_paused_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L113" target="_blank">↗</a></sup>
+### `keyset_from_paused_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L113"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 keyset_from_paused_state(state: 'State') -> Keyset
@@ -83,7 +83,7 @@ Get the keyset for the given Paused state.
 - `-`: the state to get the keyset for
 
 
-### `keyset_from_base_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L129" target="_blank">↗</a></sup>
+### `keyset_from_base_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L129"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 keyset_from_base_key(base_key: str) -> Keyset
@@ -99,7 +99,7 @@ Get the keyset for the given base key.
 - - Dict[str, str]: the keyset
 
 
-### `run_input_subclass_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L419" target="_blank">↗</a></sup>
+### `run_input_subclass_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L419"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_input_subclass_from_type(_type: Union[Type[R], Type[T], pydantic.BaseModel]) -> Union[Type[AutomaticRunInput[T]], Type[R]]
@@ -109,7 +109,7 @@ run_input_subclass_from_type(_type: Union[Type[R], Type[T], pydantic.BaseModel])
 Create a new `RunInput` subclass from the given type.
 
 
-### `receive_input` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L683" target="_blank">↗</a></sup>
+### `receive_input` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L683"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 receive_input(input_type: Union[Type[R], Type[T], pydantic.BaseModel], timeout: Optional[float] = 3600, poll_interval: float = 10, raise_timeout_error: bool = False, exclude_keys: Optional[Set[str]] = None, key_prefix: Optional[str] = None, flow_run_id: Optional[UUID] = None, with_metadata: bool = False) -> Union[GetAutomaticInputHandler[T], GetInputHandler[R]]
@@ -117,25 +117,25 @@ receive_input(input_type: Union[Type[R], Type[T], pydantic.BaseModel], timeout: 
 
 ## Classes
 
-### `RunInputMetadata` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L146" target="_blank">↗</a></sup>
+### `RunInputMetadata` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L146"><Icon icon="github" size="14" /></a></sup>
 
-### `BaseRunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L152" target="_blank">↗</a></sup>
+### `BaseRunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `metadata` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L159" target="_blank">↗</a></sup>
+#### `metadata` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L159"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 metadata(self) -> RunInputMetadata
 ```
 
-#### `keyset_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L163" target="_blank">↗</a></sup>
+#### `keyset_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L163"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 keyset_from_type(cls) -> Keyset
 ```
 
-#### `load_from_flow_run_input` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L222" target="_blank">↗</a></sup>
+#### `load_from_flow_run_input` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L222"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_from_flow_run_input(cls, flow_run_input: 'FlowRunInput') -> Self
@@ -147,7 +147,7 @@ Load the run input from a FlowRunInput object.
 - `-`: the flow run input to load the input for
 
 
-#### `with_initial_data` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L238" target="_blank">↗</a></sup>
+#### `with_initial_data` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L238"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 with_initial_data(cls: Type[R], description: Optional[str] = None, **kwargs: Any) -> Type[R]
@@ -162,17 +162,17 @@ a flow run that requires input
 - `-`: the initial data to populate the subclass
 
 
-### `RunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L299" target="_blank">↗</a></sup>
+### `RunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L299"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `receive` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L301" target="_blank">↗</a></sup>
+#### `receive` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L301"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 receive(cls, timeout: Optional[float] = 3600, poll_interval: float = 10, raise_timeout_error: bool = False, exclude_keys: Optional[Set[str]] = None, key_prefix: Optional[str] = None, flow_run_id: Optional[UUID] = None) -> GetInputHandler[Self]
 ```
 
-#### `subclass_from_base_model_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L324" target="_blank">↗</a></sup>
+#### `subclass_from_base_model_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L324"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 subclass_from_base_model_type(cls, model_cls: Type[pydantic.BaseModel]) -> Type['RunInput']
@@ -186,11 +186,11 @@ subclass.
 to create the new `RunInput` subclass
 
 
-### `AutomaticRunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L338" target="_blank">↗</a></sup>
+### `AutomaticRunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L338"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `subclass_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L358" target="_blank">↗</a></sup>
+#### `subclass_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L358"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 subclass_from_type(cls, _type: Type[T]) -> Type['AutomaticRunInput[T]']
@@ -203,27 +203,27 @@ flow run inputs. This helps in ensuring that values saved under a type
 (like List[int]) are retrievable under the generic type name (like "list").
 
 
-#### `receive` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L395" target="_blank">↗</a></sup>
+#### `receive` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L395"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 receive(cls, timeout: Optional[float] = 3600, poll_interval: float = 10, raise_timeout_error: bool = False, exclude_keys: Optional[Set[str]] = None, key_prefix: Optional[str] = None, flow_run_id: Optional[UUID] = None, with_metadata: bool = False) -> GetAutomaticInputHandler[T]
 ```
 
-### `GetInputHandler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L440" target="_blank">↗</a></sup>
+### `GetInputHandler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L440"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `to_instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L504" target="_blank">↗</a></sup>
+#### `to_instance` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L504"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_instance(self, flow_run_input: 'FlowRunInput') -> R
 ```
 
-### `GetAutomaticInputHandler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L521" target="_blank">↗</a></sup>
+### `GetAutomaticInputHandler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L521"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `to_instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/input/run_input.py#L603" target="_blank">↗</a></sup>
+#### `to_instance` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/input/run_input.py#L603"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_instance(self, flow_run_input: 'FlowRunInput') -> Union[T, AutomaticRunInput[T]]

--- a/docs/v3/api-ref/python/prefect-locking-filesystem.mdx
+++ b/docs/v3/api-ref/python/prefect-locking-filesystem.mdx
@@ -7,7 +7,7 @@ sidebarTitle: filesystem
 
 ## Classes
 
-### `FileSystemLockManager` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/filesystem.py#L35" target="_blank">↗</a></sup>
+### `FileSystemLockManager` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/filesystem.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 
 A lock manager that implements locking using local files.
@@ -15,31 +15,31 @@ A lock manager that implements locking using local files.
 
 **Methods:**
 
-#### `acquire_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/filesystem.py#L97" target="_blank">↗</a></sup>
+#### `acquire_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/filesystem.py#L97"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 acquire_lock(self, key: str, holder: str, acquire_timeout: Optional[float] = None, hold_timeout: Optional[float] = None) -> bool
 ```
 
-#### `release_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/filesystem.py#L195" target="_blank">↗</a></sup>
+#### `release_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/filesystem.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 release_lock(self, key: str, holder: str) -> None
 ```
 
-#### `is_locked` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/filesystem.py#L205" target="_blank">↗</a></sup>
+#### `is_locked` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/filesystem.py#L205"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_locked(self, key: str, use_cache: bool = False) -> bool
 ```
 
-#### `is_lock_holder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/filesystem.py#L220" target="_blank">↗</a></sup>
+#### `is_lock_holder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/filesystem.py#L220"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_lock_holder(self, key: str, holder: str) -> bool
 ```
 
-#### `wait_for_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/filesystem.py#L230" target="_blank">↗</a></sup>
+#### `wait_for_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/filesystem.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait_for_lock(self, key: str, timeout: Optional[float] = None) -> bool

--- a/docs/v3/api-ref/python/prefect-locking-memory.mdx
+++ b/docs/v3/api-ref/python/prefect-locking-memory.mdx
@@ -7,7 +7,7 @@ sidebarTitle: memory
 
 ## Classes
 
-### `MemoryLockManager` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/memory.py#L27" target="_blank">↗</a></sup>
+### `MemoryLockManager` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/memory.py#L27"><Icon icon="github" size="14" /></a></sup>
 
 
 A lock manager that stores lock information in memory.
@@ -18,31 +18,31 @@ use in a distributed environment or across different processes.
 
 **Methods:**
 
-#### `acquire_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/memory.py#L64" target="_blank">↗</a></sup>
+#### `acquire_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/memory.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 acquire_lock(self, key: str, holder: str, acquire_timeout: float | None = None, hold_timeout: float | None = None) -> bool
 ```
 
-#### `release_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/memory.py#L172" target="_blank">↗</a></sup>
+#### `release_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/memory.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 release_lock(self, key: str, holder: str) -> None
 ```
 
-#### `is_locked` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/memory.py#L186" target="_blank">↗</a></sup>
+#### `is_locked` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/memory.py#L186"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_locked(self, key: str) -> bool
 ```
 
-#### `is_lock_holder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/memory.py#L189" target="_blank">↗</a></sup>
+#### `is_lock_holder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/memory.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_lock_holder(self, key: str, holder: str) -> bool
 ```
 
-#### `wait_for_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/memory.py#L197" target="_blank">↗</a></sup>
+#### `wait_for_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/memory.py#L197"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait_for_lock(self, key: str, timeout: float | None = None) -> bool

--- a/docs/v3/api-ref/python/prefect-locking-protocol.mdx
+++ b/docs/v3/api-ref/python/prefect-locking-protocol.mdx
@@ -7,11 +7,11 @@ sidebarTitle: protocol
 
 ## Classes
 
-### `LockManager` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/protocol.py#L5" target="_blank">↗</a></sup>
+### `LockManager` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/protocol.py#L5"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `acquire_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/protocol.py#L6" target="_blank">↗</a></sup>
+#### `acquire_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/protocol.py#L6"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 acquire_lock(self, key: str, holder: str, acquire_timeout: Optional[float] = None, hold_timeout: Optional[float] = None) -> bool
@@ -35,7 +35,7 @@ indefinitely by default.
 - True if the lock was successfully acquired; False otherwise.
 
 
-#### `release_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/protocol.py#L60" target="_blank">↗</a></sup>
+#### `release_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/protocol.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 release_lock(self, key: str, holder: str) -> None
@@ -49,7 +49,7 @@ Releases the lock on the corresponding transaction record.
 holder provided when acquiring the lock.
 
 
-#### `is_locked` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/protocol.py#L71" target="_blank">↗</a></sup>
+#### `is_locked` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/protocol.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_locked(self, key: str) -> bool
@@ -64,7 +64,7 @@ Simple check to see if the corresponding record is currently locked.
 - True is the record is locked; False otherwise.
 
 
-#### `is_lock_holder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/protocol.py#L83" target="_blank">↗</a></sup>
+#### `is_lock_holder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/protocol.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_lock_holder(self, key: str, holder: str) -> bool
@@ -80,7 +80,7 @@ Check if the current holder is the lock holder for the transaction record.
 - True if the current holder is the lock holder; False otherwise.
 
 
-#### `wait_for_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/locking/protocol.py#L96" target="_blank">↗</a></sup>
+#### `wait_for_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/locking/protocol.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait_for_lock(self, key: str, timeout: Optional[float] = None) -> bool

--- a/docs/v3/api-ref/python/prefect-logging-clients.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-clients.mdx
@@ -7,19 +7,19 @@ sidebarTitle: clients
 
 ## Functions
 
-### `http_to_ws` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/clients.py#L67" target="_blank">↗</a></sup>
+### `http_to_ws` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/clients.py#L67"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 http_to_ws(url: str) -> str
 ```
 
-### `logs_out_socket_from_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/clients.py#L71" target="_blank">↗</a></sup>
+### `logs_out_socket_from_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/clients.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logs_out_socket_from_api_url(url: str) -> str
 ```
 
-### `get_logs_subscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/clients.py#L89" target="_blank">↗</a></sup>
+### `get_logs_subscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/clients.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_logs_subscriber(filter: Optional['LogFilter'] = None, reconnection_attempts: int = 10) -> 'PrefectLogsSubscriber'
@@ -34,7 +34,7 @@ you're using Prefect Cloud or OSS and returns the appropriate subscriber.
 
 ## Classes
 
-### `PrefectLogsSubscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/clients.py#L127" target="_blank">↗</a></sup>
+### `PrefectLogsSubscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/clients.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 
 Subscribes to a Prefect logs stream, yielding logs as they occur.
@@ -54,13 +54,13 @@ Example:
 
 **Methods:**
 
-#### `client_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/clients.py#L193" target="_blank">↗</a></sup>
+#### `client_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/clients.py#L193"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_name(self) -> str
 ```
 
-### `PrefectCloudLogsSubscriber` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/clients.py#L321" target="_blank">↗</a></sup>
+### `PrefectCloudLogsSubscriber` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/clients.py#L321"><Icon icon="github" size="14" /></a></sup>
 
 
 Logs subscriber for Prefect Cloud

--- a/docs/v3/api-ref/python/prefect-logging-configuration.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-configuration.mdx
@@ -7,7 +7,7 @@ sidebarTitle: configuration
 
 ## Functions
 
-### `load_logging_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/configuration.py#L32" target="_blank">↗</a></sup>
+### `load_logging_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/configuration.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_logging_config(path: Path) -> dict[str, Any]
@@ -17,7 +17,7 @@ load_logging_config(path: Path) -> dict[str, Any]
 Loads logging configuration from a path allowing override from the environment
 
 
-### `setup_logging` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/configuration.py#L68" target="_blank">↗</a></sup>
+### `setup_logging` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/configuration.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_logging(incremental: bool | None = None) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-logging-filters.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-filters.mdx
@@ -7,7 +7,7 @@ sidebarTitle: filters
 
 ## Functions
 
-### `redact_substr` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/filters.py#L8" target="_blank">↗</a></sup>
+### `redact_substr` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/filters.py#L8"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 redact_substr(obj: Any, substr: str) -> Any
@@ -26,7 +26,7 @@ Redact a string from a potentially nested object.
 
 ## Classes
 
-### `ObfuscateApiKeyFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/filters.py#L29" target="_blank">↗</a></sup>
+### `ObfuscateApiKeyFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/filters.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 
 A logging filter that obfuscates any string that matches the obfuscate_string function.
@@ -34,7 +34,7 @@ A logging filter that obfuscates any string that matches the obfuscate_string fu
 
 **Methods:**
 
-#### `filter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/filters.py#L34" target="_blank">↗</a></sup>
+#### `filter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/filters.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 filter(self, record: logging.LogRecord) -> bool

--- a/docs/v3/api-ref/python/prefect-logging-formatters.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-formatters.mdx
@@ -7,7 +7,7 @@ sidebarTitle: formatters
 
 ## Functions
 
-### `format_exception_info` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/formatters.py#L19" target="_blank">↗</a></sup>
+### `format_exception_info` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/formatters.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format_exception_info(exc_info: ExceptionInfoType) -> dict[str, Any]
@@ -15,7 +15,7 @@ format_exception_info(exc_info: ExceptionInfoType) -> dict[str, Any]
 
 ## Classes
 
-### `JsonFormatter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/formatters.py#L37" target="_blank">↗</a></sup>
+### `JsonFormatter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/formatters.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 
 Formats log records as a JSON string.
@@ -26,17 +26,17 @@ newlines.
 
 **Methods:**
 
-#### `format` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/formatters.py#L58" target="_blank">↗</a></sup>
+#### `format` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/formatters.py#L58"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format(self, record: logging.LogRecord) -> str
 ```
 
-### `PrefectFormatter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/formatters.py#L76" target="_blank">↗</a></sup>
+### `PrefectFormatter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/formatters.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `formatMessage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/formatters.py#L125" target="_blank">↗</a></sup>
+#### `formatMessage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/formatters.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 formatMessage(self, record: logging.LogRecord) -> str

--- a/docs/v3/api-ref/python/prefect-logging-handlers.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-handlers.mdx
@@ -7,29 +7,29 @@ sidebarTitle: handlers
 
 ## Classes
 
-### `APILogWorker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L52" target="_blank">↗</a></sup>
+### `APILogWorker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L52"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `max_batch_size` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L54" target="_blank">↗</a></sup>
+#### `max_batch_size` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 max_batch_size(self) -> int
 ```
 
-#### `min_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L62" target="_blank">↗</a></sup>
+#### `min_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L62"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 min_interval(self) -> float | None
 ```
 
-#### `instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L84" target="_blank">↗</a></sup>
+#### `instance` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L84"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 instance(cls: Type[Self], *args: Any) -> Self
 ```
 
-### `APILogHandler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L98" target="_blank">↗</a></sup>
+### `APILogHandler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 
 A logging handler that sends logs to the Prefect API.
@@ -40,7 +40,7 @@ the background.
 
 **Methods:**
 
-#### `flush` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L106" target="_blank">↗</a></sup>
+#### `flush` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L106"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 flush(self) -> None
@@ -52,7 +52,7 @@ completion.
 Use `aflush` from async contexts instead.
 
 
-#### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L143" target="_blank">↗</a></sup>
+#### `emit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit(self, record: logging.LogRecord) -> None
@@ -61,13 +61,13 @@ emit(self, record: logging.LogRecord) -> None
 Send a log to the `APILogWorker`
 
 
-#### `handleError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L161" target="_blank">↗</a></sup>
+#### `handleError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L161"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handleError(self, record: logging.LogRecord) -> None
 ```
 
-#### `prepare` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L184" target="_blank">↗</a></sup>
+#### `prepare` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L184"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prepare(self, record: logging.LogRecord) -> Dict[str, Any]
@@ -83,17 +83,17 @@ If a flow run id cannot be found, the log will be dropped.
 Logs exceeding the maximum size will be dropped.
 
 
-### `WorkerAPILogHandler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L256" target="_blank">↗</a></sup>
+### `WorkerAPILogHandler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L256"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L257" target="_blank">↗</a></sup>
+#### `emit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L257"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit(self, record: logging.LogRecord) -> None
 ```
 
-#### `prepare` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L265" target="_blank">↗</a></sup>
+#### `prepare` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L265"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prepare(self, record: logging.LogRecord) -> Dict[str, Any]
@@ -106,11 +106,11 @@ This will add in the worker id to the log.
 Logs exceeding the maximum size will be dropped.
 
 
-### `PrefectConsoleHandler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L294" target="_blank">↗</a></sup>
+### `PrefectConsoleHandler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L294"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/handlers.py#L334" target="_blank">↗</a></sup>
+#### `emit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/handlers.py#L334"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit(self, record: logging.LogRecord) -> None

--- a/docs/v3/api-ref/python/prefect-logging-highlighters.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-highlighters.mdx
@@ -7,31 +7,31 @@ sidebarTitle: highlighters
 
 ## Classes
 
-### `LevelHighlighter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/highlighters.py#L6" target="_blank">↗</a></sup>
+### `LevelHighlighter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/highlighters.py#L6"><Icon icon="github" size="14" /></a></sup>
 
 
 Apply style to log levels.
 
 
-### `UrlHighlighter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/highlighters.py#L19" target="_blank">↗</a></sup>
+### `UrlHighlighter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/highlighters.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 
 Apply style to urls.
 
 
-### `NameHighlighter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/highlighters.py#L29" target="_blank">↗</a></sup>
+### `NameHighlighter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/highlighters.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 
 Apply style to names.
 
 
-### `StateHighlighter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/highlighters.py#L43" target="_blank">↗</a></sup>
+### `StateHighlighter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/highlighters.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 
 Apply style to states.
 
 
-### `PrefectConsoleHighlighter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/highlighters.py#L54" target="_blank">↗</a></sup>
+### `PrefectConsoleHighlighter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/highlighters.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 
 Applies style from multiple highlighters.

--- a/docs/v3/api-ref/python/prefect-logging-loggers.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-loggers.mdx
@@ -7,7 +7,7 @@ sidebarTitle: loggers
 
 ## Functions
 
-### `get_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L65" target="_blank">↗</a></sup>
+### `get_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L65"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_logger(name: str | None = None) -> logging.Logger
@@ -21,7 +21,7 @@ See `get_run_logger` for retrieving loggers for use within task or flow runs.
 By default, only run-related loggers are connected to the `APILogHandler`.
 
 
-### `get_run_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L94" target="_blank">↗</a></sup>
+### `get_run_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L94"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_run_logger(context: Optional['RunContext'] = None, **kwargs: Any) -> Union[logging.Logger, LoggingAdapter]
@@ -46,7 +46,7 @@ addition to the run metadata
 - `MissingContextError`: If no context can be found
 
 
-### `flow_run_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L166" target="_blank">↗</a></sup>
+### `flow_run_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L166"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 flow_run_logger(flow_run: 'FlowRun', flow: Optional['Flow[Any, Any]'] = None, **kwargs: str) -> PrefectLogAdapter
@@ -61,7 +61,7 @@ records.
 If the flow run context is available, see `get_run_logger` instead.
 
 
-### `task_run_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L192" target="_blank">↗</a></sup>
+### `task_run_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L192"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task_run_logger(task_run: 'TaskRun', task: Optional['Task[Any, Any]'] = None, flow_run: Optional['FlowRun'] = None, flow: Optional['Flow[Any, Any]'] = None, **kwargs: Any) -> LoggingAdapter
@@ -79,7 +79,7 @@ If only the flow run context is available, it will be used for default values
 of `flow_run` and `flow`.
 
 
-### `get_worker_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L234" target="_blank">↗</a></sup>
+### `get_worker_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L234"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_worker_logger(worker: 'BaseWorker[Any, Any, Any]', name: Optional[str] = None) -> logging.Logger | LoggingAdapter
@@ -93,7 +93,7 @@ If the worker does not have a backend_id a basic logger will be returned.
 If the worker does not have a backend_id attribute, a basic logger will be returned.
 
 
-### `disable_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L260" target="_blank">↗</a></sup>
+### `disable_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L260"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 disable_logger(name: str)
@@ -105,7 +105,7 @@ Upon exiting the context manager, the logger is returned to its
 original state.
 
 
-### `disable_run_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L280" target="_blank">↗</a></sup>
+### `disable_run_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L280"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 disable_run_logger()
@@ -117,7 +117,7 @@ within the context manager. Upon exiting the context manager, both loggers
 are returned to their original state.
 
 
-### `print_as_log` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L290" target="_blank">↗</a></sup>
+### `print_as_log` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L290"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 print_as_log(*args: Any, **kwargs: Any) -> None
@@ -132,7 +132,7 @@ If `print` sends data to a file other than `sys.stdout` or `sys.stderr`, it will
 not be forwarded to the Prefect logger either.
 
 
-### `patch_print` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L321" target="_blank">↗</a></sup>
+### `patch_print` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L321"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 patch_print()
@@ -144,7 +144,7 @@ Patches the Python builtin `print` method to use `print_as_log`
 
 ## Classes
 
-### `PrefectLogAdapter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L34" target="_blank">↗</a></sup>
+### `PrefectLogAdapter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 Adapter that ensures extra kwargs are passed through correctly; without this
@@ -157,19 +157,19 @@ not a bug in the LoggingAdapter and subclassing is the intended workaround.
 
 **Methods:**
 
-#### `process` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L44" target="_blank">↗</a></sup>
+#### `process` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process(self, msg: str, kwargs: MutableMapping[str, Any]) -> tuple[str, MutableMapping[str, Any]]
 ```
 
-#### `getChild` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L50" target="_blank">↗</a></sup>
+#### `getChild` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L50"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 getChild(self, suffix: str, extra: dict[str, Any] | None = None) -> 'PrefectLogAdapter'
 ```
 
-### `LogEavesdropper` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L336" target="_blank">↗</a></sup>
+### `LogEavesdropper` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L336"><Icon icon="github" size="14" /></a></sup>
 
 
 A context manager that collects logs for the duration of the context
@@ -192,7 +192,7 @@ Another one!"
 
 **Methods:**
 
-#### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L389" target="_blank">↗</a></sup>
+#### `emit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L389"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit(self, record: LogRecord) -> None
@@ -201,7 +201,7 @@ emit(self, record: LogRecord) -> None
 The logging.Handler implementation, not intended to be called directly.
 
 
-#### `text` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L393" target="_blank">↗</a></sup>
+#### `text` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/logging/loggers.py#L393"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 text(self) -> str

--- a/docs/v3/api-ref/python/prefect-plugins.mdx
+++ b/docs/v3/api-ref/python/prefect-plugins.mdx
@@ -18,7 +18,7 @@ Currently supported entrypoints:
 
 ## Functions
 
-### `safe_load_entrypoints` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/plugins.py#L20" target="_blank">↗</a></sup>
+### `safe_load_entrypoints` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/plugins.py#L20"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 safe_load_entrypoints(entrypoints: EntryPoints) -> dict[str, Union[Exception, Any]]
@@ -28,7 +28,7 @@ safe_load_entrypoints(entrypoints: EntryPoints) -> dict[str, Union[Exception, An
 Load entry points for a group capturing any exceptions that occur.
 
 
-### `load_prefect_collections` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/plugins.py#L43" target="_blank">↗</a></sup>
+### `load_prefect_collections` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/plugins.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_prefect_collections() -> dict[str, Union[ModuleType, Exception]]

--- a/docs/v3/api-ref/python/prefect-results.mdx
+++ b/docs/v3/api-ref/python/prefect-results.mdx
@@ -7,13 +7,13 @@ sidebarTitle: results
 
 ## Functions
 
-### `DEFAULT_STORAGE_KEY_FN` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L71" target="_blank">↗</a></sup>
+### `DEFAULT_STORAGE_KEY_FN` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 DEFAULT_STORAGE_KEY_FN() -> str
 ```
 
-### `get_default_result_storage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L105" target="_blank">↗</a></sup>
+### `get_default_result_storage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L105"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_default_result_storage() -> WritableFileSystem
@@ -23,7 +23,7 @@ get_default_result_storage() -> WritableFileSystem
 Generate a default file system for result storage.
 
 
-### `resolve_result_storage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L167" target="_blank">↗</a></sup>
+### `resolve_result_storage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L167"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resolve_result_storage(result_storage: ResultStorage | UUID | Path) -> WritableFileSystem
@@ -34,7 +34,7 @@ Resolve one of the valid `ResultStorage` input types into a saved block
 document id and an instance of the block.
 
 
-### `resolve_serializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L202" target="_blank">↗</a></sup>
+### `resolve_serializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L202"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resolve_serializer(serializer: ResultSerializer) -> Serializer
@@ -45,7 +45,7 @@ Resolve one of the valid `ResultSerializer` input types into a serializer
 instance.
 
 
-### `get_default_result_serializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L236" target="_blank">↗</a></sup>
+### `get_default_result_serializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L236"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_default_result_serializer() -> Serializer
@@ -55,7 +55,7 @@ get_default_result_serializer() -> Serializer
 Generate a default file system for result storage.
 
 
-### `get_default_persist_setting` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L244" target="_blank">↗</a></sup>
+### `get_default_persist_setting` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L244"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_default_persist_setting() -> bool
@@ -65,7 +65,7 @@ get_default_persist_setting() -> bool
 Return the default option for result persistence.
 
 
-### `get_default_persist_setting_for_tasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L252" target="_blank">↗</a></sup>
+### `get_default_persist_setting_for_tasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L252"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_default_persist_setting_for_tasks() -> bool
@@ -75,7 +75,7 @@ get_default_persist_setting_for_tasks() -> bool
 Return the default option for result persistence for tasks.
 
 
-### `should_persist_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L264" target="_blank">↗</a></sup>
+### `should_persist_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L264"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_persist_result() -> bool
@@ -88,19 +88,19 @@ If there is no current run context, the value of `results.persist_by_default` on
 current settings will be returned.
 
 
-### `default_cache` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L293" target="_blank">↗</a></sup>
+### `default_cache` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L293"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_cache() -> LRUCache[str, 'ResultRecord[Any]']
 ```
 
-### `result_storage_discriminator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L297" target="_blank">↗</a></sup>
+### `result_storage_discriminator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L297"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result_storage_discriminator(x: Any) -> str
 ```
 
-### `get_result_store` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L1023" target="_blank">↗</a></sup>
+### `get_result_store` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L1023"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_result_store() -> ResultStore
@@ -112,7 +112,7 @@ Get the current result store.
 
 ## Classes
 
-### `ResultStore` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L310" target="_blank">↗</a></sup>
+### `ResultStore` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L310"><Icon icon="github" size="14" /></a></sup>
 
 
 Manages the storage and retrieval of results.
@@ -120,13 +120,13 @@ Manages the storage and retrieval of results.
 
 **Methods:**
 
-#### `result_storage_block_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L344" target="_blank">↗</a></sup>
+#### `result_storage_block_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L344"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result_storage_block_id(self) -> UUID | None
 ```
 
-#### `generate_default_holder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L452" target="_blank">↗</a></sup>
+#### `generate_default_holder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L452"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_default_holder() -> str
@@ -138,7 +138,7 @@ Generate a default holder string using hostname, PID, and thread ID.
 - A unique identifier string.
 
 
-#### `exists` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L516" target="_blank">↗</a></sup>
+#### `exists` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L516"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exists(self, key: str) -> bool
@@ -153,7 +153,7 @@ Check if a result record exists in storage.
 - True if the result record exists, False otherwise.
 
 
-#### `read` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L621" target="_blank">↗</a></sup>
+#### `read` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L621"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 read(self, key: str, holder: str | None = None) -> 'ResultRecord[Any]'
@@ -169,7 +169,7 @@ Read a result record from storage.
 - A result record.
 
 
-#### `create_result_record` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L657" target="_blank">↗</a></sup>
+#### `create_result_record` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L657"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_result_record(self, obj: Any, key: str | None = None, expiration: DateTime | None = None) -> 'ResultRecord[Any]'
@@ -183,7 +183,7 @@ Create a result record.
 - `expiration`: The expiration time for the result record.
 
 
-#### `write` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L694" target="_blank">↗</a></sup>
+#### `write` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L694"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 write(self, obj: Any, key: str | None = None, expiration: DateTime | None = None, holder: str | None = None) -> None
@@ -200,7 +200,7 @@ Handles the creation of a `ResultRecord` and its serialization to storage.
 - `holder`: The holder of the lock if a lock was set on the record.
 
 
-#### `persist_result_record` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L813" target="_blank">↗</a></sup>
+#### `persist_result_record` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L813"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 persist_result_record(self, result_record: 'ResultRecord[Any]', holder: str | None = None) -> None
@@ -212,7 +212,7 @@ Persist a result record to storage.
 - `result_record`: The result record to persist.
 
 
-#### `supports_isolation_level` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L841" target="_blank">↗</a></sup>
+#### `supports_isolation_level` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L841"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 supports_isolation_level(self, level: 'IsolationLevel') -> bool
@@ -227,7 +227,7 @@ Check if the result store supports a given isolation level.
 - True if the isolation level is supported, False otherwise.
 
 
-#### `acquire_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L860" target="_blank">↗</a></sup>
+#### `acquire_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L860"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 acquire_lock(self, key: str, holder: str | None = None, timeout: float | None = None) -> bool
@@ -245,7 +245,7 @@ current host, process, and thread will be used.
 - True if the lock was successfully acquired; False otherwise.
 
 
-#### `release_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L907" target="_blank">↗</a></sup>
+#### `release_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L907"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 release_lock(self, key: str, holder: str | None = None) -> None
@@ -260,7 +260,7 @@ If not provided, a default holder based on the current host, process, and
 thread will be used.
 
 
-#### `is_locked` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L925" target="_blank">↗</a></sup>
+#### `is_locked` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L925"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_locked(self, key: str) -> bool
@@ -269,7 +269,7 @@ is_locked(self, key: str) -> bool
 Check if a result record is locked.
 
 
-#### `is_lock_holder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L936" target="_blank">↗</a></sup>
+#### `is_lock_holder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L936"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_lock_holder(self, key: str, holder: str | None = None) -> bool
@@ -286,7 +286,7 @@ current host, process, and thread will be used.
 - True if the current holder is the lock holder; False otherwise.
 
 
-#### `wait_for_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/results.py#L956" target="_blank">↗</a></sup>
+#### `wait_for_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/results.py#L956"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 wait_for_lock(self, key: str, timeout: float | None = None) -> bool

--- a/docs/v3/api-ref/python/prefect-runner-runner.mdx
+++ b/docs/v3/api-ref/python/prefect-runner-runner.mdx
@@ -42,13 +42,13 @@ Example:
 
 ## Classes
 
-### `ProcessMapEntry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/runner.py#L142" target="_blank">↗</a></sup>
+### `ProcessMapEntry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/runner.py#L142"><Icon icon="github" size="14" /></a></sup>
 
-### `Runner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/runner.py#L147" target="_blank">↗</a></sup>
+### `Runner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/runner.py#L147"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `handle_sigterm` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/runner.py#L405" target="_blank">↗</a></sup>
+#### `handle_sigterm` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/runner.py#L405"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_sigterm(self, *args: Any, **kwargs: Any) -> None
@@ -57,7 +57,7 @@ handle_sigterm(self, *args: Any, **kwargs: Any) -> None
 Gracefully shuts down the runner when a SIGTERM is received.
 
 
-#### `execute_in_background` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/runner.py#L503" target="_blank">↗</a></sup>
+#### `execute_in_background` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/runner.py#L503"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 execute_in_background(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> 'concurrent.futures.Future[Any]'
@@ -66,7 +66,7 @@ execute_in_background(self, func: Callable[..., Any], *args: Any, **kwargs: Any)
 Executes a function in the background.
 
 
-#### `reschedule_current_flow_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/runner.py#L903" target="_blank">↗</a></sup>
+#### `reschedule_current_flow_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/runner.py#L903"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reschedule_current_flow_runs(self) -> None
@@ -78,7 +78,7 @@ This should only be called when the runner is shutting down because it kill all
 child processes and short-circuit the crash detection logic.
 
 
-#### `has_slots_available` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/runner.py#L1150" target="_blank">↗</a></sup>
+#### `has_slots_available` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/runner.py#L1150"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 has_slots_available(self) -> bool

--- a/docs/v3/api-ref/python/prefect-runner-server.mdx
+++ b/docs/v3/api-ref/python/prefect-runner-server.mdx
@@ -7,25 +7,25 @@ sidebarTitle: server
 
 ## Functions
 
-### `perform_health_check` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/server.py#L51" target="_blank">↗</a></sup>
+### `perform_health_check` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/server.py#L51"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 perform_health_check(runner: 'Runner', delay_threshold: int | None = None) -> Callable[..., JSONResponse]
 ```
 
-### `run_count` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/server.py#L77" target="_blank">↗</a></sup>
+### `run_count` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/server.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_count(runner: 'Runner') -> Callable[..., int]
 ```
 
-### `shutdown` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/server.py#L85" target="_blank">↗</a></sup>
+### `shutdown` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/server.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 shutdown(runner: 'Runner') -> Callable[..., JSONResponse]
 ```
 
-### `start_webserver` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/server.py#L311" target="_blank">↗</a></sup>
+### `start_webserver` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/server.py#L311"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start_webserver(runner: 'Runner', log_level: str | None = None) -> None
@@ -41,4 +41,4 @@ Run a FastAPI server for a runner.
 
 ## Classes
 
-### `RunnerGenericFlowRunRequest` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/server.py#L45" target="_blank">↗</a></sup>
+### `RunnerGenericFlowRunRequest` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/server.py#L45"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-runner-storage.mdx
+++ b/docs/v3/api-ref/python/prefect-runner-storage.mdx
@@ -7,7 +7,7 @@ sidebarTitle: storage
 
 ## Functions
 
-### `create_storage_from_source` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L782" target="_blank">↗</a></sup>
+### `create_storage_from_source` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L782"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_storage_from_source(source: str, pull_interval: Optional[int] = 60) -> RunnerStorage
@@ -28,7 +28,7 @@ local storage
 
 ## Classes
 
-### `RunnerStorage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L31" target="_blank">↗</a></sup>
+### `RunnerStorage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 
 A storage interface for a runner to use to retrieve
@@ -37,7 +37,7 @@ remotely stored flow code.
 
 **Methods:**
 
-#### `set_base_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L37" target="_blank">↗</a></sup>
+#### `set_base_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_base_path(self, path: Path) -> None
@@ -47,7 +47,7 @@ Sets the base path to use when pulling contents from remote storage to
 local storage.
 
 
-#### `pull_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L45" target="_blank">↗</a></sup>
+#### `pull_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L45"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pull_interval(self) -> Optional[int]
@@ -57,7 +57,7 @@ The interval at which contents from remote storage should be pulled to
 local storage. If None, remote storage will perform a one-time sync.
 
 
-#### `destination` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L53" target="_blank">↗</a></sup>
+#### `destination` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L53"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 destination(self) -> Path
@@ -66,7 +66,7 @@ destination(self) -> Path
 The local file path to pull contents from remote storage to.
 
 
-#### `to_pull_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L65" target="_blank">↗</a></sup>
+#### `to_pull_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L65"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_pull_step(self) -> dict[str, Any] | list[dict[str, Any]]
@@ -76,9 +76,9 @@ Returns a dictionary representation of the storage object that can be
 used as a deployment pull step.
 
 
-### `GitCredentials` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L79" target="_blank">↗</a></sup>
+### `GitCredentials` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L79"><Icon icon="github" size="14" /></a></sup>
 
-### `GitRepository` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L84" target="_blank">↗</a></sup>
+### `GitRepository` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L84"><Icon icon="github" size="14" /></a></sup>
 
 
 Pulls the contents of a git repository to the local filesystem.
@@ -114,31 +114,31 @@ await storage.pull_code()
 
 **Methods:**
 
-#### `destination` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L160" target="_blank">↗</a></sup>
+#### `destination` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L160"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 destination(self) -> Path
 ```
 
-#### `set_base_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L163" target="_blank">↗</a></sup>
+#### `set_base_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L163"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_base_path(self, path: Path) -> None
 ```
 
-#### `pull_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L167" target="_blank">↗</a></sup>
+#### `pull_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L167"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pull_interval(self) -> Optional[int]
 ```
 
-#### `to_pull_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L429" target="_blank">↗</a></sup>
+#### `to_pull_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L429"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_pull_step(self) -> dict[str, Any]
 ```
 
-### `RemoteStorage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L467" target="_blank">↗</a></sup>
+### `RemoteStorage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L467"><Icon icon="github" size="14" /></a></sup>
 
 
 Pulls the contents of a remote storage location to the local filesystem.
@@ -186,13 +186,13 @@ await storage.pull_code()
 
 **Methods:**
 
-#### `set_base_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L561" target="_blank">↗</a></sup>
+#### `set_base_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L561"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_base_path(self, path: Path) -> None
 ```
 
-#### `pull_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L565" target="_blank">↗</a></sup>
+#### `pull_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L565"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pull_interval(self) -> Optional[int]
@@ -202,7 +202,7 @@ The interval at which contents from remote storage should be pulled to
 local storage. If None, remote storage will perform a one-time sync.
 
 
-#### `destination` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L573" target="_blank">↗</a></sup>
+#### `destination` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L573"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 destination(self) -> Path
@@ -211,7 +211,7 @@ destination(self) -> Path
 The local file path to pull contents from remote storage to.
 
 
-#### `to_pull_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L617" target="_blank">↗</a></sup>
+#### `to_pull_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L617"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_pull_step(self) -> dict[str, Any]
@@ -221,7 +221,7 @@ Returns a dictionary representation of the storage object that can be
 used as a deployment pull step.
 
 
-### `BlockStorageAdapter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L658" target="_blank">↗</a></sup>
+### `BlockStorageAdapter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L658"><Icon icon="github" size="14" /></a></sup>
 
 
 A storage adapter for a storage block object to allow it to be used as a
@@ -230,31 +230,31 @@ runner storage object.
 
 **Methods:**
 
-#### `set_base_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L681" target="_blank">↗</a></sup>
+#### `set_base_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L681"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_base_path(self, path: Path) -> None
 ```
 
-#### `pull_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L685" target="_blank">↗</a></sup>
+#### `pull_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L685"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pull_interval(self) -> Optional[int]
 ```
 
-#### `destination` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L689" target="_blank">↗</a></sup>
+#### `destination` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L689"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 destination(self) -> Path
 ```
 
-#### `to_pull_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L697" target="_blank">↗</a></sup>
+#### `to_pull_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L697"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_pull_step(self) -> dict[str, Any]
 ```
 
-### `LocalStorage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L720" target="_blank">↗</a></sup>
+### `LocalStorage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L720"><Icon icon="github" size="14" /></a></sup>
 
 
 Sets the working directory in the local filesystem.
@@ -272,25 +272,25 @@ Examples:
 
 **Methods:**
 
-#### `destination` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L746" target="_blank">↗</a></sup>
+#### `destination` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L746"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 destination(self) -> Path
 ```
 
-#### `set_base_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L749" target="_blank">↗</a></sup>
+#### `set_base_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L749"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_base_path(self, path: Path) -> None
 ```
 
-#### `pull_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L753" target="_blank">↗</a></sup>
+#### `pull_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L753"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pull_interval(self) -> Optional[int]
 ```
 
-#### `to_pull_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/storage.py#L761" target="_blank">↗</a></sup>
+#### `to_pull_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/storage.py#L761"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_pull_step(self) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-runner-utils.mdx
+++ b/docs/v3/api-ref/python/prefect-runner-utils.mdx
@@ -7,7 +7,7 @@ sidebarTitle: utils
 
 ## Functions
 
-### `inject_schemas_into_openapi` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/utils.py#L12" target="_blank">↗</a></sup>
+### `inject_schemas_into_openapi` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/utils.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 inject_schemas_into_openapi(webserver: FastAPI, schemas_to_inject: dict[Hashable, Any]) -> dict[str, Any]
@@ -24,7 +24,7 @@ Augments the webserver's OpenAPI schema with additional schemas from deployments
 - The augmented OpenAPI schema dictionary.
 
 
-### `merge_definitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/utils.py#L33" target="_blank">↗</a></sup>
+### `merge_definitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/utils.py#L33"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 merge_definitions(injected_schemas: dict[Hashable, Any], openapi_schema: dict[str, Any]) -> dict[str, Any]
@@ -38,7 +38,7 @@ Integrates definitions from injected schemas into the OpenAPI components.
 - `openapi_schema`: The base OpenAPI schema to update.
 
 
-### `update_refs_in_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/utils.py#L56" target="_blank">↗</a></sup>
+### `update_refs_in_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/utils.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_refs_in_schema(schema_item: dict[str, Any] | list[Any], new_ref: str) -> None
@@ -52,7 +52,7 @@ Recursively replaces `$ref` with a new reference base in a schema item.
 - `new_ref`: The new base string to replace in `$ref` values.
 
 
-### `update_refs_to_components` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runner/utils.py#L76" target="_blank">↗</a></sup>
+### `update_refs_to_components` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runner/utils.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_refs_to_components(openapi_schema: dict[str, Any]) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-runtime-deployment.mdx
+++ b/docs/v3/api-ref/python/prefect-runtime-deployment.mdx
@@ -35,31 +35,31 @@ Available attributes:
 
 ## Functions
 
-### `get_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/deployment.py#L107" target="_blank">↗</a></sup>
+### `get_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/deployment.py#L107"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_id() -> Optional[str]
 ```
 
-### `get_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/deployment.py#L125" target="_blank">↗</a></sup>
+### `get_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/deployment.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parameters() -> dict[str, Any]
 ```
 
-### `get_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/deployment.py#L136" target="_blank">↗</a></sup>
+### `get_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/deployment.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_name() -> Optional[str]
 ```
 
-### `get_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/deployment.py#L148" target="_blank">↗</a></sup>
+### `get_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/deployment.py#L148"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_version() -> Optional[str]
 ```
 
-### `get_flow_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/deployment.py#L160" target="_blank">↗</a></sup>
+### `get_flow_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/deployment.py#L160"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_run_id() -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-runtime-flow_run.mdx
+++ b/docs/v3/api-ref/python/prefect-runtime-flow_run.mdx
@@ -30,85 +30,85 @@ Available attributes:
 
 ## Functions
 
-### `get_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L136" target="_blank">↗</a></sup>
+### `get_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_id() -> Optional[str]
 ```
 
-### `get_tags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L147" target="_blank">↗</a></sup>
+### `get_tags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L147"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_tags() -> List[str]
 ```
 
-### `get_run_count` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L162" target="_blank">↗</a></sup>
+### `get_run_count` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_run_count() -> int
 ```
 
-### `get_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L177" target="_blank">↗</a></sup>
+### `get_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_name() -> Optional[str]
 ```
 
-### `get_flow_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L192" target="_blank">↗</a></sup>
+### `get_flow_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L192"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_name() -> Optional[str]
 ```
 
-### `get_flow_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L207" target="_blank">↗</a></sup>
+### `get_flow_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L207"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_version() -> Optional[str]
 ```
 
-### `get_scheduled_start_time` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L222" target="_blank">↗</a></sup>
+### `get_scheduled_start_time` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L222"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_scheduled_start_time() -> DateTime
 ```
 
-### `get_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L237" target="_blank">↗</a></sup>
+### `get_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L237"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parameters() -> Dict[str, Any]
 ```
 
-### `get_parent_flow_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L253" target="_blank">↗</a></sup>
+### `get_parent_flow_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L253"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parent_flow_run_id() -> Optional[str]
 ```
 
-### `get_parent_deployment_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L275" target="_blank">↗</a></sup>
+### `get_parent_deployment_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L275"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parent_deployment_id() -> Optional[str]
 ```
 
-### `get_root_flow_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L294" target="_blank">↗</a></sup>
+### `get_root_flow_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L294"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_root_flow_run_id() -> str
 ```
 
-### `get_flow_run_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L318" target="_blank">↗</a></sup>
+### `get_flow_run_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L318"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_run_api_url() -> Optional[str]
 ```
 
-### `get_flow_run_ui_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L325" target="_blank">↗</a></sup>
+### `get_flow_run_ui_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L325"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_run_ui_url() -> Optional[str]
 ```
 
-### `get_job_variables` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/flow_run.py#L332" target="_blank">↗</a></sup>
+### `get_job_variables` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/flow_run.py#L332"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_job_variables() -> Optional[Dict[str, Any]]

--- a/docs/v3/api-ref/python/prefect-runtime-task_run.mdx
+++ b/docs/v3/api-ref/python/prefect-runtime-task_run.mdx
@@ -25,49 +25,49 @@ Available attributes:
 
 ## Functions
 
-### `get_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L89" target="_blank">↗</a></sup>
+### `get_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_id() -> str | None
 ```
 
-### `get_tags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L95" target="_blank">↗</a></sup>
+### `get_tags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L95"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_tags() -> list[str]
 ```
 
-### `get_run_count` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L103" target="_blank">↗</a></sup>
+### `get_run_count` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_run_count() -> int
 ```
 
-### `get_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L111" target="_blank">↗</a></sup>
+### `get_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L111"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_name() -> str | None
 ```
 
-### `get_task_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L119" target="_blank">↗</a></sup>
+### `get_task_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_task_name() -> str | None
 ```
 
-### `get_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L127" target="_blank">↗</a></sup>
+### `get_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parameters() -> dict[str, Any]
 ```
 
-### `get_task_run_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L135" target="_blank">↗</a></sup>
+### `get_task_run_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L135"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_task_run_api_url() -> str | None
 ```
 
-### `get_task_run_ui_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/runtime/task_run.py#L143" target="_blank">↗</a></sup>
+### `get_task_run_ui_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/runtime/task_run.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_task_run_ui_url() -> str | None

--- a/docs/v3/api-ref/python/prefect-schedules.mdx
+++ b/docs/v3/api-ref/python/prefect-schedules.mdx
@@ -12,7 +12,7 @@ This module contains functionality for creating schedules for deployments.
 
 ## Functions
 
-### `Cron` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/schedules.py#L72" target="_blank">↗</a></sup>
+### `Cron` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/schedules.py#L72"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Cron(timezone: str | None = None, day_or: bool = True, active: bool = True, parameters: dict[str, Any] | None = None, slug: str | None = None) -> Schedule
@@ -54,7 +54,7 @@ Cron("0 8 * * 1", timezone="America/New_York")
 ```
 
 
-### `Interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/schedules.py#L128" target="_blank">↗</a></sup>
+### `Interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/schedules.py#L128"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Interval(anchor_date: datetime.datetime | None = None, timezone: str | None = None, active: bool = True, parameters: dict[str, Any] | None = None, slug: str | None = None) -> Schedule
@@ -96,7 +96,7 @@ Interval(60, anchor_date=datetime(2024, 1, 1))
 ```
 
 
-### `RRule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/schedules.py#L187" target="_blank">↗</a></sup>
+### `RRule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/schedules.py#L187"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 RRule(timezone: str | None = None, active: bool = True, parameters: dict[str, Any] | None = None, slug: str | None = None) -> Schedule
@@ -134,7 +134,7 @@ RRule("RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=2FR", timezone="America/Chicago")
 
 ## Classes
 
-### `Schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/schedules.py#L19" target="_blank">↗</a></sup>
+### `Schedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/schedules.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 
 A dataclass representing a schedule.

--- a/docs/v3/api-ref/python/prefect-serializers.mdx
+++ b/docs/v3/api-ref/python/prefect-serializers.mdx
@@ -21,7 +21,7 @@ bytes to an object respectively.
 
 ## Functions
 
-### `prefect_json_object_encoder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L44" target="_blank">↗</a></sup>
+### `prefect_json_object_encoder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prefect_json_object_encoder(obj: Any) -> Any
@@ -33,7 +33,7 @@ prefect_json_object_encoder(obj: Any) -> Any
 Raises a `TypeError` to fallback on other encoders on failure.
 
 
-### `prefect_json_object_decoder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L67" target="_blank">↗</a></sup>
+### `prefect_json_object_decoder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L67"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prefect_json_object_decoder(result: dict[str, Any]) -> Any
@@ -46,7 +46,7 @@ with `prefect_json_object_encoder`
 
 ## Classes
 
-### `Serializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L86" target="_blank">↗</a></sup>
+### `Serializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L86"><Icon icon="github" size="14" /></a></sup>
 
 
 A serializer that can encode objects of type 'D' into bytes.
@@ -54,7 +54,7 @@ A serializer that can encode objects of type 'D' into bytes.
 
 **Methods:**
 
-#### `dumps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L121" target="_blank">↗</a></sup>
+#### `dumps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dumps(self, obj: D) -> bytes
@@ -63,7 +63,7 @@ dumps(self, obj: D) -> bytes
 Encode the object into a blob of bytes.
 
 
-#### `loads` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L125" target="_blank">↗</a></sup>
+#### `loads` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 loads(self, blob: bytes) -> D
@@ -72,7 +72,7 @@ loads(self, blob: bytes) -> D
 Decode the blob of bytes into an object.
 
 
-### `PickleSerializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L137" target="_blank">↗</a></sup>
+### `PickleSerializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L137"><Icon icon="github" size="14" /></a></sup>
 
 
 Serializes objects using the pickle protocol.
@@ -85,25 +85,25 @@ Serializes objects using the pickle protocol.
 
 **Methods:**
 
-#### `check_picklelib` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L153" target="_blank">↗</a></sup>
+#### `check_picklelib` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L153"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_picklelib(cls, value: str) -> str
 ```
 
-#### `dumps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L156" target="_blank">↗</a></sup>
+#### `dumps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L156"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dumps(self, obj: D) -> bytes
 ```
 
-#### `loads` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L161" target="_blank">↗</a></sup>
+#### `loads` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L161"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 loads(self, blob: bytes) -> D
 ```
 
-### `JSONSerializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L166" target="_blank">↗</a></sup>
+### `JSONSerializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L166"><Icon icon="github" size="14" /></a></sup>
 
 
 Serializes data to JSON.
@@ -115,31 +115,31 @@ Wraps the `json` library to serialize to UTF-8 bytes instead of string types.
 
 **Methods:**
 
-#### `dumps_kwargs_cannot_contain_default` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L199" target="_blank">↗</a></sup>
+#### `dumps_kwargs_cannot_contain_default` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dumps_kwargs_cannot_contain_default(cls, value: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `loads_kwargs_cannot_contain_object_hook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L205" target="_blank">↗</a></sup>
+#### `loads_kwargs_cannot_contain_object_hook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L205"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 loads_kwargs_cannot_contain_object_hook(cls, value: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `dumps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L210" target="_blank">↗</a></sup>
+#### `dumps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L210"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dumps(self, obj: D) -> bytes
 ```
 
-#### `loads` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L221" target="_blank">↗</a></sup>
+#### `loads` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L221"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 loads(self, blob: bytes) -> D
 ```
 
-### `CompressedSerializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L229" target="_blank">↗</a></sup>
+### `CompressedSerializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L229"><Icon icon="github" size="14" /></a></sup>
 
 
 Wraps another serializer, compressing its output.
@@ -148,37 +148,37 @@ Uses `lzma` by default. See `compressionlib` for using alternative libraries.
 
 **Methods:**
 
-#### `validate_serializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L247" target="_blank">↗</a></sup>
+#### `validate_serializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L247"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_serializer(cls, value: Union[str, Serializer[D]]) -> Serializer[D]
 ```
 
-#### `check_compressionlib` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L251" target="_blank">↗</a></sup>
+#### `check_compressionlib` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L251"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_compressionlib(cls, value: str) -> str
 ```
 
-#### `dumps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L254" target="_blank">↗</a></sup>
+#### `dumps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L254"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dumps(self, obj: D) -> bytes
 ```
 
-#### `loads` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L259" target="_blank">↗</a></sup>
+#### `loads` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L259"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 loads(self, blob: bytes) -> D
 ```
 
-### `CompressedPickleSerializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L265" target="_blank">↗</a></sup>
+### `CompressedPickleSerializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L265"><Icon icon="github" size="14" /></a></sup>
 
 
 A compressed serializer preconfigured to use the pickle serializer.
 
 
-### `CompressedJSONSerializer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/serializers.py#L275" target="_blank">↗</a></sup>
+### `CompressedJSONSerializer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/serializers.py#L275"><Icon icon="github" size="14" /></a></sup>
 
 
 A compressed serializer preconfigured to use the json serializer.

--- a/docs/v3/api-ref/python/prefect-server-api-clients.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-clients.mdx
@@ -7,8 +7,8 @@ sidebarTitle: clients
 
 ## Classes
 
-### `BaseClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/clients.py#L30" target="_blank">↗</a></sup>
+### `BaseClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/clients.py#L30"><Icon icon="github" size="14" /></a></sup>
 
-### `OrchestrationClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/clients.py#L66" target="_blank">↗</a></sup>
+### `OrchestrationClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/clients.py#L66"><Icon icon="github" size="14" /></a></sup>
 
-### `WorkPoolsOrchestrationClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/clients.py#L226" target="_blank">↗</a></sup>
+### `WorkPoolsOrchestrationClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/clients.py#L226"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-api-concurrency_limits.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-concurrency_limits.mdx
@@ -12,6 +12,6 @@ Routes for interacting with concurrency limit objects.
 
 ## Classes
 
-### `Abort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/concurrency_limits.py#L172" target="_blank">↗</a></sup>
+### `Abort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/concurrency_limits.py#L172"><Icon icon="github" size="14" /></a></sup>
 
-### `Delay` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/concurrency_limits.py#L177" target="_blank">↗</a></sup>
+### `Delay` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/concurrency_limits.py#L177"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-api-concurrency_limits_v2.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-concurrency_limits_v2.mdx
@@ -7,4 +7,4 @@ sidebarTitle: concurrency_limits_v2
 
 ## Classes
 
-### `MinimalConcurrencyLimitResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/concurrency_limits_v2.py#L148" target="_blank">↗</a></sup>
+### `MinimalConcurrencyLimitResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/concurrency_limits_v2.py#L148"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-api-dependencies.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-dependencies.mdx
@@ -12,13 +12,13 @@ Utilities for injecting FastAPI dependencies.
 
 ## Functions
 
-### `provide_request_api_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L21" target="_blank">↗</a></sup>
+### `provide_request_api_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L21"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 provide_request_api_version(x_prefect_api_version: str = Header(None)) -> Version | None
 ```
 
-### `LimitBody` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L103" target="_blank">↗</a></sup>
+### `LimitBody` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 LimitBody() -> Any
@@ -29,7 +29,7 @@ A `fastapi.Depends` factory for pulling a `limit: int` parameter from the
 request body while determining the default from the current settings.
 
 
-### `get_created_by` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L132" target="_blank">↗</a></sup>
+### `get_created_by` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L132"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_created_by(prefect_automation_id: Optional[UUID] = Header(None, include_in_schema=False), prefect_automation_name: Optional[str] = Header(None, include_in_schema=False)) -> Optional[schemas.core.CreatedBy]
@@ -40,7 +40,7 @@ A dependency that returns the provenance information to use when creating object
 during this API call.
 
 
-### `get_updated_by` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L154" target="_blank">↗</a></sup>
+### `get_updated_by` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L154"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_updated_by(prefect_automation_id: Optional[UUID] = Header(None, include_in_schema=False), prefect_automation_name: Optional[str] = Header(None, include_in_schema=False)) -> Optional[schemas.core.UpdatedBy]
@@ -51,7 +51,7 @@ A dependency that returns the provenance information to use when updating object
 during this API call.
 
 
-### `is_ephemeral_request` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L170" target="_blank">↗</a></sup>
+### `is_ephemeral_request` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L170"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_ephemeral_request(request: Request) -> bool
@@ -61,7 +61,7 @@ is_ephemeral_request(request: Request) -> bool
 A dependency that returns whether the request is to an ephemeral server.
 
 
-### `get_prefect_client_version` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L182" target="_blank">↗</a></sup>
+### `get_prefect_client_version` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L182"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_prefect_client_version(user_agent: Annotated[Optional[str], Header(include_in_schema=False)] = None) -> Optional[str]
@@ -73,7 +73,7 @@ Attempts to parse out the Prefect client version from the User-Agent header.
 
 ## Classes
 
-### `EnforceMinimumAPIVersion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/dependencies.py#L41" target="_blank">↗</a></sup>
+### `EnforceMinimumAPIVersion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/dependencies.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 
 FastAPI Dependency used to check compatibility between the version of the api

--- a/docs/v3/api-ref/python/prefect-server-api-events.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-events.mdx
@@ -7,13 +7,13 @@ sidebarTitle: events
 
 ## Functions
 
-### `verified_page_token` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/events.py#L165" target="_blank">↗</a></sup>
+### `verified_page_token` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/events.py#L165"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 verified_page_token(page_token: str = Query(..., alias='page-token')) -> str
 ```
 
-### `generate_next_page_link` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/events.py#L246" target="_blank">↗</a></sup>
+### `generate_next_page_link` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/events.py#L246"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_next_page_link(request: Request, page_token: Optional[str]) -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-server-api-middleware.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-middleware.mdx
@@ -7,7 +7,7 @@ sidebarTitle: middleware
 
 ## Classes
 
-### `CsrfMiddleware` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/middleware.py#L15" target="_blank">↗</a></sup>
+### `CsrfMiddleware` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/middleware.py#L15"><Icon icon="github" size="14" /></a></sup>
 
 
 Middleware for CSRF protection. This middleware will check for a CSRF token

--- a/docs/v3/api-ref/python/prefect-server-api-server.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-server.mdx
@@ -12,13 +12,13 @@ Defines the Prefect REST API FastAPI app.
 
 ## Functions
 
-### `is_client_retryable_exception` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L199" target="_blank">↗</a></sup>
+### `is_client_retryable_exception` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_client_retryable_exception(exc: Exception) -> bool
 ```
 
-### `replace_placeholder_string_in_files` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L228" target="_blank">↗</a></sup>
+### `replace_placeholder_string_in_files` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L228"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 replace_placeholder_string_in_files(directory: str, placeholder: str, replacement: str, allowed_extensions: list[str] | None = None) -> None
@@ -29,13 +29,13 @@ Recursively loops through all files in the given directory and replaces
 a placeholder string.
 
 
-### `copy_directory` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L255" target="_blank">↗</a></sup>
+### `copy_directory` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L255"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 copy_directory(directory: str, path: str) -> None
 ```
 
-### `create_api_app` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L312" target="_blank">↗</a></sup>
+### `create_api_app` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_api_app(dependencies: list[Any] | None = None, health_check_path: str = '/health', version_check_path: str = '/version', fast_api_app_kwargs: dict[str, Any] | None = None, final: bool = False, ignore_cache: bool = False) -> FastAPI
@@ -57,13 +57,13 @@ an existing app in the cache
 - a FastAPI app that serves the Prefect REST API
 
 
-### `create_ui_app` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L427" target="_blank">↗</a></sup>
+### `create_ui_app` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L427"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_ui_app(ephemeral: bool) -> FastAPI
 ```
 
-### `create_app` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L585" target="_blank">↗</a></sup>
+### `create_app` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L585"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_app(settings: Optional[prefect.settings.Settings] = None, ephemeral: bool = False, webserver_only: bool = False, final: bool = False, ignore_cache: bool = False) -> FastAPI
@@ -87,7 +87,7 @@ match. Otherwise, an application is returned from the cache.
 
 ## Classes
 
-### `SPAStaticFiles` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L135" target="_blank">↗</a></sup>
+### `SPAStaticFiles` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L135"><Icon icon="github" size="14" /></a></sup>
 
 
 Implementation of `StaticFiles` for serving single page applications.
@@ -96,7 +96,7 @@ Adds `get_response` handling to ensure that when a resource isn't found the
 application still returns the index.
 
 
-### `RequestLimitMiddleware` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L150" target="_blank">↗</a></sup>
+### `RequestLimitMiddleware` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L150"><Icon icon="github" size="14" /></a></sup>
 
 
 A middleware that limits the number of concurrent requests handled by the API.
@@ -106,35 +106,35 @@ at high volume. Ideally, we would only apply the limit to routes that perform
 writes.
 
 
-### `SubprocessASGIServer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L771" target="_blank">↗</a></sup>
+### `SubprocessASGIServer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L771"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `find_available_port` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L793" target="_blank">↗</a></sup>
+#### `find_available_port` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L793"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 find_available_port(self) -> int
 ```
 
-#### `is_port_available` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L803" target="_blank">↗</a></sup>
+#### `is_port_available` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L803"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_port_available(port: int) -> bool
 ```
 
-#### `address` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L814" target="_blank">↗</a></sup>
+#### `address` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L814"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 address(self) -> str
 ```
 
-#### `api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L818" target="_blank">↗</a></sup>
+#### `api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L818"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 api_url(self) -> str
 ```
 
-#### `start` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L821" target="_blank">↗</a></sup>
+#### `start` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L821"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start(self, timeout: Optional[int] = None) -> None
@@ -147,7 +147,7 @@ the server once.
 - `timeout`: The maximum time to wait for the server to start
 
 
-#### `stop` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/server.py#L915" target="_blank">↗</a></sup>
+#### `stop` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/server.py#L915"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stop(self) -> None

--- a/docs/v3/api-ref/python/prefect-server-api-task_workers.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-task_workers.mdx
@@ -7,4 +7,4 @@ sidebarTitle: task_workers
 
 ## Classes
 
-### `TaskWorkerFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/task_workers.py#L13" target="_blank">↗</a></sup>
+### `TaskWorkerFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/task_workers.py#L13"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-api-templates.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-templates.mdx
@@ -7,7 +7,7 @@ sidebarTitle: templates
 
 ## Functions
 
-### `validate_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/templates.py#L24" target="_blank">↗</a></sup>
+### `validate_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/templates.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_template(template: str = Body(default='')) -> Response

--- a/docs/v3/api-ref/python/prefect-server-api-ui-flow_runs.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-ui-flow_runs.mdx
@@ -7,4 +7,4 @@ sidebarTitle: flow_runs
 
 ## Classes
 
-### `SimpleFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/ui/flow_runs.py#L27" target="_blank">↗</a></sup>
+### `SimpleFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/ui/flow_runs.py#L27"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-api-ui-flows.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-ui-flows.mdx
@@ -7,11 +7,11 @@ sidebarTitle: flows
 
 ## Classes
 
-### `SimpleNextFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/ui/flows.py#L29" target="_blank">↗</a></sup>
+### `SimpleNextFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/ui/flows.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_next_scheduled_start_time` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/ui/flows.py#L41" target="_blank">↗</a></sup>
+#### `validate_next_scheduled_start_time` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/ui/flows.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_next_scheduled_start_time(cls, v: DateTime | datetime) -> DateTime

--- a/docs/v3/api-ref/python/prefect-server-api-ui-task_runs.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-ui-task_runs.mdx
@@ -7,11 +7,11 @@ sidebarTitle: task_runs
 
 ## Classes
 
-### `TaskRunCount` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/ui/task_runs.py#L27" target="_blank">↗</a></sup>
+### `TaskRunCount` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/ui/task_runs.py#L27"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `ser_model` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/ui/task_runs.py#L34" target="_blank">↗</a></sup>
+#### `ser_model` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/ui/task_runs.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ser_model(self) -> dict[str, int]

--- a/docs/v3/api-ref/python/prefect-server-api-workers.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-workers.mdx
@@ -12,4 +12,4 @@ Routes for interacting with work queue objects.
 
 ## Classes
 
-### `WorkerLookups` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/api/workers.py#L55" target="_blank">↗</a></sup>
+### `WorkerLookups` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/api/workers.py#L55"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-database-alembic_commands.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-alembic_commands.mdx
@@ -7,7 +7,7 @@ sidebarTitle: alembic_commands
 
 ## Functions
 
-### `with_alembic_lock` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L22" target="_blank">↗</a></sup>
+### `with_alembic_lock` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 with_alembic_lock(fn: Callable[P, R]) -> Callable[P, R]
@@ -23,13 +23,13 @@ dask threads were simultaneously performing alembic upgrades, and causing
 cryptic `KeyError: 'config'` when `del globals_[attr_name]`.
 
 
-### `alembic_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L41" target="_blank">↗</a></sup>
+### `alembic_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 alembic_config() -> 'Config'
 ```
 
-### `alembic_upgrade` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L54" target="_blank">↗</a></sup>
+### `alembic_upgrade` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 alembic_upgrade(revision: str = 'head', dry_run: bool = False) -> None
@@ -43,7 +43,7 @@ Run alembic upgrades on Prefect REST API database
 - `dry_run`: Show what migrations would be made without applying them. Will emit sql statements to stdout.
 
 
-### `alembic_downgrade` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L76" target="_blank">↗</a></sup>
+### `alembic_downgrade` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 alembic_downgrade(revision: str = '-1', dry_run: bool = False) -> None
@@ -57,7 +57,7 @@ Run alembic downgrades on Prefect REST API database
 - `dry_run`: Show what migrations would be made without applying them. Will emit sql statements to stdout.
 
 
-### `alembic_revision` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L91" target="_blank">↗</a></sup>
+### `alembic_revision` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 alembic_revision(message: Optional[str] = None, autogenerate: bool = False, **kwargs: Any) -> None
@@ -71,7 +71,7 @@ Create a new revision file for the database.
 - `autogenerate`: whether or not to autogenerate the script from the database.
 
 
-### `alembic_stamp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L110" target="_blank">↗</a></sup>
+### `alembic_stamp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/alembic_commands.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 alembic_stamp(revision: Union[str, list[str], tuple[str, ...]]) -> None

--- a/docs/v3/api-ref/python/prefect-server-database-configurations.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-configurations.mdx
@@ -7,7 +7,7 @@ sidebarTitle: configurations
 
 ## Classes
 
-### `ConnectionTracker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L59" target="_blank">↗</a></sup>
+### `ConnectionTracker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 
 A test utility which tracks the connections given out by a connection pool, to
@@ -16,37 +16,37 @@ make it easy to see which connections are currently checked out and open.
 
 **Methods:**
 
-#### `track_pool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L78" target="_blank">↗</a></sup>
+#### `track_pool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 track_pool(self, pool: sa.pool.Pool) -> None
 ```
 
-#### `on_connect` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L83" target="_blank">↗</a></sup>
+#### `on_connect` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_connect(self, adapted_connection: AdaptedConnection, connection_record: ConnectionPoolEntry) -> None
 ```
 
-#### `on_close` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L92" target="_blank">↗</a></sup>
+#### `on_close` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L92"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_close(self, adapted_connection: AdaptedConnection, connection_record: ConnectionPoolEntry) -> None
 ```
 
-#### `on_close_detached` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L103" target="_blank">↗</a></sup>
+#### `on_close_detached` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_close_detached(self, adapted_connection: AdaptedConnection) -> None
 ```
 
-#### `clear` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L113" target="_blank">↗</a></sup>
+#### `clear` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L113"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 clear(self) -> None
 ```
 
-### `BaseDatabaseConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L124" target="_blank">↗</a></sup>
+### `BaseDatabaseConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L124"><Icon icon="github" size="14" /></a></sup>
 
 
 Abstract base class used to inject database connection configuration into Prefect.
@@ -57,7 +57,7 @@ database connections and sessions.
 
 **Methods:**
 
-#### `unique_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L171" target="_blank">↗</a></sup>
+#### `unique_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L171"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unique_key(self) -> tuple[Hashable, ...]
@@ -66,7 +66,7 @@ unique_key(self) -> tuple[Hashable, ...]
 Returns a key used to determine whether to instantiate a new DB interface.
 
 
-#### `is_inmemory` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L200" target="_blank">↗</a></sup>
+#### `is_inmemory` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L200"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_inmemory(self) -> bool
@@ -75,7 +75,7 @@ is_inmemory(self) -> bool
 Returns true if database is run in memory
 
 
-#### `begin_transaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L204" target="_blank">↗</a></sup>
+#### `begin_transaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L204"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 begin_transaction(self, session: AsyncSession, with_for_update: bool = False) -> AbstractAsyncContextManager[AsyncSessionTransaction]
@@ -84,11 +84,11 @@ begin_transaction(self, session: AsyncSession, with_for_update: bool = False) ->
 Enter a transaction for a session
 
 
-### `AsyncPostgresConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L211" target="_blank">↗</a></sup>
+### `AsyncPostgresConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L211"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `is_inmemory` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L374" target="_blank">↗</a></sup>
+#### `is_inmemory` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L374"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_inmemory(self) -> bool
@@ -97,11 +97,11 @@ is_inmemory(self) -> bool
 Returns true if database is run in memory
 
 
-### `AioSqliteConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L380" target="_blank">↗</a></sup>
+### `AioSqliteConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L380"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `setup_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L469" target="_blank">↗</a></sup>
+#### `setup_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L469"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_sqlite(self, conn: DBAPIConnection, record: ConnectionPoolEntry) -> None
@@ -111,19 +111,19 @@ Issue PRAGMA statements to SQLITE on connect. PRAGMAs only last for the
 duration of the connection. See https://www.sqlite.org/pragma.html for more info.
 
 
-#### `begin_sqlite_conn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L520" target="_blank">↗</a></sup>
+#### `begin_sqlite_conn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L520"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 begin_sqlite_conn(self, conn: aiosqlite.AsyncAdapt_aiosqlite_connection) -> None
 ```
 
-#### `begin_sqlite_stmt` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L529" target="_blank">↗</a></sup>
+#### `begin_sqlite_stmt` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L529"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 begin_sqlite_stmt(self, conn: sa.Connection) -> None
 ```
 
-#### `is_inmemory` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/configurations.py#L576" target="_blank">↗</a></sup>
+#### `is_inmemory` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/configurations.py#L576"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_inmemory(self) -> bool

--- a/docs/v3/api-ref/python/prefect-server-database-dependencies.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-dependencies.mdx
@@ -12,7 +12,7 @@ Injected database interface dependencies
 
 ## Functions
 
-### `provide_database_interface` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L69" target="_blank">↗</a></sup>
+### `provide_database_interface` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L69"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 provide_database_interface() -> 'PrefectDBInterface'
@@ -25,7 +25,7 @@ If components of the interface are not set, defaults will be inferred
 based on the dialect of the connection URL.
 
 
-### `inject_db` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L143" target="_blank">↗</a></sup>
+### `inject_db` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 inject_db(fn: Callable[P, R]) -> Callable[P, R]
@@ -38,7 +38,7 @@ The decorated function _must_ take a `db` kwarg and if a db is passed
 when called it will be used instead of creating a new one.
 
 
-### `db_injector` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L178" target="_blank">↗</a></sup>
+### `db_injector` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 db_injector(func: Union[_DBMethod[T, P, R], _DBFunction[P, R]]) -> Union[_Method[T, P, R], _Function[P, R]]
@@ -65,7 +65,7 @@ iscoroutinefunction() test.
 - binding transparently.
 
 
-### `temporary_database_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L361" target="_blank">↗</a></sup>
+### `temporary_database_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L361"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_database_config(tmp_database_config: Optional[BaseDatabaseConfiguration]) -> Generator[None, object, None]
@@ -80,7 +80,7 @@ be restored.
 - `tmp_database_config`: Prefect REST API database configuration to inject.
 
 
-### `temporary_query_components` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L382" target="_blank">↗</a></sup>
+### `temporary_query_components` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L382"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_query_components(tmp_queries: Optional['BaseQueryComponents']) -> Generator[None, object, None]
@@ -95,7 +95,7 @@ be restored.
 - `tmp_queries`: Prefect REST API query components to inject.
 
 
-### `temporary_orm_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L403" target="_blank">↗</a></sup>
+### `temporary_orm_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L403"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_orm_config(tmp_orm_config: Optional['BaseORMConfiguration']) -> Generator[None, object, None]
@@ -110,7 +110,7 @@ be restored.
 - `tmp_orm_config`: Prefect REST API ORM configuration to inject.
 
 
-### `temporary_interface_class` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L424" target="_blank">↗</a></sup>
+### `temporary_interface_class` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L424"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_interface_class(tmp_interface_class: Optional[type['PrefectDBInterface']]) -> Generator[None, object, None]
@@ -124,7 +124,7 @@ the existing interface will be restored.
 - `tmp_interface_class`: Prefect REST API interface class to inject.
 
 
-### `temporary_database_interface` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L444" target="_blank">↗</a></sup>
+### `temporary_database_interface` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L444"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_database_interface(tmp_database_config: Optional[BaseDatabaseConfiguration] = None, tmp_queries: Optional['BaseQueryComponents'] = None, tmp_orm_config: Optional['BaseORMConfiguration'] = None, tmp_interface_class: Optional[type['PrefectDBInterface']] = None) -> Generator[None, object, None]
@@ -147,7 +147,7 @@ be restored.
 - `tmp_interface_class`: Optional database interface class to inject
 
 
-### `set_database_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L479" target="_blank">↗</a></sup>
+### `set_database_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L479"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_database_config(database_config: Optional[BaseDatabaseConfiguration]) -> None
@@ -157,7 +157,7 @@ set_database_config(database_config: Optional[BaseDatabaseConfiguration]) -> Non
 Set Prefect REST API database configuration.
 
 
-### `set_query_components` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L484" target="_blank">↗</a></sup>
+### `set_query_components` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L484"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_query_components(query_components: Optional['BaseQueryComponents']) -> None
@@ -167,7 +167,7 @@ set_query_components(query_components: Optional['BaseQueryComponents']) -> None
 Set Prefect REST API query components.
 
 
-### `set_orm_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L489" target="_blank">↗</a></sup>
+### `set_orm_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L489"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_orm_config(orm_config: Optional['BaseORMConfiguration']) -> None
@@ -177,7 +177,7 @@ set_orm_config(orm_config: Optional['BaseORMConfiguration']) -> None
 Set Prefect REST API orm configuration.
 
 
-### `set_interface_class` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L494" target="_blank">↗</a></sup>
+### `set_interface_class` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L494"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_interface_class(interface_class: Optional[type['PrefectDBInterface']]) -> None
@@ -189,4 +189,4 @@ Set Prefect REST API interface class.
 
 ## Classes
 
-### `DBInjector` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/dependencies.py#L254" target="_blank">↗</a></sup>
+### `DBInjector` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/dependencies.py#L254"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-database-interface.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-interface.mdx
@@ -7,13 +7,13 @@ sidebarTitle: interface
 
 ## Classes
 
-### `DBSingleton` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L21" target="_blank">↗</a></sup>
+### `DBSingleton` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L21"><Icon icon="github" size="14" /></a></sup>
 
 
 Ensures that only one database interface is created per unique key
 
 
-### `PrefectDBInterface` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L55" target="_blank">↗</a></sup>
+### `PrefectDBInterface` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 
 An interface for backend-specific SqlAlchemy actions and ORM models.
@@ -26,13 +26,13 @@ against.
 
 **Methods:**
 
-#### `dialect` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L141" target="_blank">↗</a></sup>
+#### `dialect` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L141"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dialect(self) -> type[sa.engine.Dialect]
 ```
 
-#### `Base` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L145" target="_blank">↗</a></sup>
+#### `Base` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Base(self) -> type[orm_models.Base]
@@ -41,7 +41,7 @@ Base(self) -> type[orm_models.Base]
 Base class for orm models
 
 
-#### `Flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L150" target="_blank">↗</a></sup>
+#### `Flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L150"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Flow(self) -> type[orm_models.Flow]
@@ -50,7 +50,7 @@ Flow(self) -> type[orm_models.Flow]
 A flow orm model
 
 
-#### `FlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L155" target="_blank">↗</a></sup>
+#### `FlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L155"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 FlowRun(self) -> type[orm_models.FlowRun]
@@ -59,7 +59,7 @@ FlowRun(self) -> type[orm_models.FlowRun]
 A flow run orm model
 
 
-#### `FlowRunState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L160" target="_blank">↗</a></sup>
+#### `FlowRunState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L160"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 FlowRunState(self) -> type[orm_models.FlowRunState]
@@ -68,7 +68,7 @@ FlowRunState(self) -> type[orm_models.FlowRunState]
 A flow run state orm model
 
 
-#### `TaskRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L165" target="_blank">↗</a></sup>
+#### `TaskRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L165"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 TaskRun(self) -> type[orm_models.TaskRun]
@@ -77,7 +77,7 @@ TaskRun(self) -> type[orm_models.TaskRun]
 A task run orm model
 
 
-#### `TaskRunState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L170" target="_blank">↗</a></sup>
+#### `TaskRunState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L170"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 TaskRunState(self) -> type[orm_models.TaskRunState]
@@ -86,7 +86,7 @@ TaskRunState(self) -> type[orm_models.TaskRunState]
 A task run state orm model
 
 
-#### `Artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L175" target="_blank">↗</a></sup>
+#### `Artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L175"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Artifact(self) -> type[orm_models.Artifact]
@@ -95,7 +95,7 @@ Artifact(self) -> type[orm_models.Artifact]
 An artifact orm model
 
 
-#### `ArtifactCollection` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L180" target="_blank">↗</a></sup>
+#### `ArtifactCollection` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L180"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ArtifactCollection(self) -> type[orm_models.ArtifactCollection]
@@ -104,7 +104,7 @@ ArtifactCollection(self) -> type[orm_models.ArtifactCollection]
 An artifact collection orm model
 
 
-#### `TaskRunStateCache` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L185" target="_blank">↗</a></sup>
+#### `TaskRunStateCache` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L185"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 TaskRunStateCache(self) -> type[orm_models.TaskRunStateCache]
@@ -113,7 +113,7 @@ TaskRunStateCache(self) -> type[orm_models.TaskRunStateCache]
 A task run state cache orm model
 
 
-#### `Deployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L190" target="_blank">↗</a></sup>
+#### `Deployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L190"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Deployment(self) -> type[orm_models.Deployment]
@@ -122,7 +122,7 @@ Deployment(self) -> type[orm_models.Deployment]
 A deployment orm model
 
 
-#### `DeploymentSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L195" target="_blank">↗</a></sup>
+#### `DeploymentSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 DeploymentSchedule(self) -> type[orm_models.DeploymentSchedule]
@@ -131,7 +131,7 @@ DeploymentSchedule(self) -> type[orm_models.DeploymentSchedule]
 A deployment schedule orm model
 
 
-#### `SavedSearch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L200" target="_blank">↗</a></sup>
+#### `SavedSearch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L200"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 SavedSearch(self) -> type[orm_models.SavedSearch]
@@ -140,7 +140,7 @@ SavedSearch(self) -> type[orm_models.SavedSearch]
 A saved search orm model
 
 
-#### `WorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L205" target="_blank">↗</a></sup>
+#### `WorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L205"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 WorkPool(self) -> type[orm_models.WorkPool]
@@ -149,7 +149,7 @@ WorkPool(self) -> type[orm_models.WorkPool]
 A work pool orm model
 
 
-#### `Worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L210" target="_blank">↗</a></sup>
+#### `Worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L210"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Worker(self) -> type[orm_models.Worker]
@@ -158,7 +158,7 @@ Worker(self) -> type[orm_models.Worker]
 A worker process orm model
 
 
-#### `Log` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L215" target="_blank">↗</a></sup>
+#### `Log` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L215"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Log(self) -> type[orm_models.Log]
@@ -167,7 +167,7 @@ Log(self) -> type[orm_models.Log]
 A log orm model
 
 
-#### `ConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L220" target="_blank">↗</a></sup>
+#### `ConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L220"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ConcurrencyLimit(self) -> type[orm_models.ConcurrencyLimit]
@@ -176,7 +176,7 @@ ConcurrencyLimit(self) -> type[orm_models.ConcurrencyLimit]
 A concurrency model
 
 
-#### `ConcurrencyLimitV2` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L225" target="_blank">↗</a></sup>
+#### `ConcurrencyLimitV2` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L225"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ConcurrencyLimitV2(self) -> type[orm_models.ConcurrencyLimitV2]
@@ -185,7 +185,7 @@ ConcurrencyLimitV2(self) -> type[orm_models.ConcurrencyLimitV2]
 A v2 concurrency model
 
 
-#### `CsrfToken` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L230" target="_blank">↗</a></sup>
+#### `CsrfToken` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 CsrfToken(self) -> type[orm_models.CsrfToken]
@@ -194,7 +194,7 @@ CsrfToken(self) -> type[orm_models.CsrfToken]
 A csrf token model
 
 
-#### `WorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L235" target="_blank">↗</a></sup>
+#### `WorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L235"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 WorkQueue(self) -> type[orm_models.WorkQueue]
@@ -203,7 +203,7 @@ WorkQueue(self) -> type[orm_models.WorkQueue]
 A work queue model
 
 
-#### `Agent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L240" target="_blank">↗</a></sup>
+#### `Agent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L240"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Agent(self) -> type[orm_models.Agent]
@@ -212,7 +212,7 @@ Agent(self) -> type[orm_models.Agent]
 An agent model
 
 
-#### `BlockType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L245" target="_blank">↗</a></sup>
+#### `BlockType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L245"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 BlockType(self) -> type[orm_models.BlockType]
@@ -221,7 +221,7 @@ BlockType(self) -> type[orm_models.BlockType]
 A block type model
 
 
-#### `BlockSchema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L250" target="_blank">↗</a></sup>
+#### `BlockSchema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L250"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 BlockSchema(self) -> type[orm_models.BlockSchema]
@@ -230,7 +230,7 @@ BlockSchema(self) -> type[orm_models.BlockSchema]
 A block schema model
 
 
-#### `BlockSchemaReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L255" target="_blank">↗</a></sup>
+#### `BlockSchemaReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L255"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 BlockSchemaReference(self) -> type[orm_models.BlockSchemaReference]
@@ -239,7 +239,7 @@ BlockSchemaReference(self) -> type[orm_models.BlockSchemaReference]
 A block schema reference model
 
 
-#### `BlockDocument` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L260" target="_blank">↗</a></sup>
+#### `BlockDocument` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L260"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 BlockDocument(self) -> type[orm_models.BlockDocument]
@@ -248,7 +248,7 @@ BlockDocument(self) -> type[orm_models.BlockDocument]
 A block document model
 
 
-#### `BlockDocumentReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L265" target="_blank">↗</a></sup>
+#### `BlockDocumentReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L265"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 BlockDocumentReference(self) -> type[orm_models.BlockDocumentReference]
@@ -257,7 +257,7 @@ BlockDocumentReference(self) -> type[orm_models.BlockDocumentReference]
 A block document reference model
 
 
-#### `Configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L270" target="_blank">↗</a></sup>
+#### `Configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L270"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Configuration(self) -> type[orm_models.Configuration]
@@ -266,7 +266,7 @@ Configuration(self) -> type[orm_models.Configuration]
 An configuration model
 
 
-#### `Variable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L275" target="_blank">↗</a></sup>
+#### `Variable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L275"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Variable(self) -> type[orm_models.Variable]
@@ -275,7 +275,7 @@ Variable(self) -> type[orm_models.Variable]
 A variable model
 
 
-#### `FlowRunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L280" target="_blank">↗</a></sup>
+#### `FlowRunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L280"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 FlowRunInput(self) -> type[orm_models.FlowRunInput]
@@ -284,7 +284,7 @@ FlowRunInput(self) -> type[orm_models.FlowRunInput]
 A flow run input model
 
 
-#### `Automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L285" target="_blank">↗</a></sup>
+#### `Automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L285"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Automation(self) -> type[orm_models.Automation]
@@ -293,7 +293,7 @@ Automation(self) -> type[orm_models.Automation]
 An automation model
 
 
-#### `AutomationBucket` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L290" target="_blank">↗</a></sup>
+#### `AutomationBucket` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L290"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AutomationBucket(self) -> type[orm_models.AutomationBucket]
@@ -302,7 +302,7 @@ AutomationBucket(self) -> type[orm_models.AutomationBucket]
 An automation bucket model
 
 
-#### `AutomationRelatedResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L295" target="_blank">↗</a></sup>
+#### `AutomationRelatedResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L295"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AutomationRelatedResource(self) -> type[orm_models.AutomationRelatedResource]
@@ -311,7 +311,7 @@ AutomationRelatedResource(self) -> type[orm_models.AutomationRelatedResource]
 An automation related resource model
 
 
-#### `CompositeTriggerChildFiring` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L300" target="_blank">↗</a></sup>
+#### `CompositeTriggerChildFiring` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L300"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 CompositeTriggerChildFiring(self) -> type[orm_models.CompositeTriggerChildFiring]
@@ -320,7 +320,7 @@ CompositeTriggerChildFiring(self) -> type[orm_models.CompositeTriggerChildFiring
 A model capturing a composite trigger's child firing
 
 
-#### `AutomationEventFollower` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L307" target="_blank">↗</a></sup>
+#### `AutomationEventFollower` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L307"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AutomationEventFollower(self) -> type[orm_models.AutomationEventFollower]
@@ -329,7 +329,7 @@ AutomationEventFollower(self) -> type[orm_models.AutomationEventFollower]
 A model capturing one event following another event
 
 
-#### `Event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L312" target="_blank">↗</a></sup>
+#### `Event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Event(self) -> type[orm_models.Event]
@@ -338,7 +338,7 @@ Event(self) -> type[orm_models.Event]
 An event model
 
 
-#### `EventResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/interface.py#L317" target="_blank">↗</a></sup>
+#### `EventResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/interface.py#L317"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 EventResource(self) -> type[orm_models.EventResource]

--- a/docs/v3/api-ref/python/prefect-server-database-orm_models.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-orm_models.mdx
@@ -7,20 +7,20 @@ sidebarTitle: orm_models
 
 ## Classes
 
-### `Base` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L57" target="_blank">↗</a></sup>
+### `Base` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 
 Base SQLAlchemy model that automatically infers the table name
 and provides ID, created, and updated columns
 
 
-### `Flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L138" target="_blank">↗</a></sup>
+### `Flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L138"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy mixin of a flow.
 
 
-### `FlowRunState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L161" target="_blank">↗</a></sup>
+### `FlowRunState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L161"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy mixin of a flow run state.
@@ -28,19 +28,19 @@ SQLAlchemy mixin of a flow run state.
 
 **Methods:**
 
-#### `data` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L195" target="_blank">↗</a></sup>
+#### `data` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 data(self) -> Optional[Any]
 ```
 
-#### `as_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L208" target="_blank">↗</a></sup>
+#### `as_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L208"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_state(self) -> schemas.states.State
 ```
 
-### `TaskRunState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L224" target="_blank">↗</a></sup>
+### `TaskRunState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L224"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a task run state.
@@ -48,33 +48,33 @@ SQLAlchemy model of a task run state.
 
 **Methods:**
 
-#### `data` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L259" target="_blank">↗</a></sup>
+#### `data` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L259"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 data(self) -> Optional[Any]
 ```
 
-#### `as_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L272" target="_blank">↗</a></sup>
+#### `as_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L272"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_state(self) -> schemas.states.State
 ```
 
-### `Artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L288" target="_blank">↗</a></sup>
+### `Artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L288"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of artifacts.
 
 
-### `ArtifactCollection` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L329" target="_blank">↗</a></sup>
+### `ArtifactCollection` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L329"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskRunStateCache` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L353" target="_blank">↗</a></sup>
+### `TaskRunStateCache` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L353"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a task run state cache.
 
 
-### `Run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L374" target="_blank">↗</a></sup>
+### `Run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L374"><Icon icon="github" size="14" /></a></sup>
 
 
 Common columns and logic for FlowRun and TaskRun models
@@ -82,7 +82,7 @@ Common columns and logic for FlowRun and TaskRun models
 
 **Methods:**
 
-#### `estimated_run_time` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L397" target="_blank">↗</a></sup>
+#### `estimated_run_time` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L397"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 estimated_run_time(self) -> datetime.timedelta
@@ -93,7 +93,7 @@ state is exited. To give up-to-date estimates, we estimate incremental
 run time for any runs currently in a RUNNING state.
 
 
-#### `estimated_start_time_delta` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L431" target="_blank">↗</a></sup>
+#### `estimated_start_time_delta` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L431"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 estimated_start_time_delta(self) -> datetime.timedelta
@@ -106,7 +106,7 @@ have a start time and are not in a final state and were expected to
 start already.
 
 
-### `FlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L475" target="_blank">↗</a></sup>
+### `FlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L475"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a flow run.
@@ -114,13 +114,13 @@ SQLAlchemy model of a flow run.
 
 **Methods:**
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L540" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L540"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> Optional[FlowRunState]
 ```
 
-#### `set_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L553" target="_blank">↗</a></sup>
+#### `set_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L553"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state(self, state: Optional[FlowRunState]) -> None
@@ -133,7 +133,7 @@ relationship, but because this is a one-to-one pointer to a
 one-to-many relationship, SQLAlchemy can't figure it out.
 
 
-### `TaskRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L654" target="_blank">↗</a></sup>
+### `TaskRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L654"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a task run.
@@ -141,13 +141,13 @@ SQLAlchemy model of a task run.
 
 **Methods:**
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L693" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L693"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> Optional[TaskRunState]
 ```
 
-#### `set_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L706" target="_blank">↗</a></sup>
+#### `set_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L706"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state(self, state: Optional[TaskRunState]) -> None
@@ -160,9 +160,9 @@ relationship, but because this is a one-to-one pointer to a
 one-to-many relationship, SQLAlchemy can't figure it out.
 
 
-### `DeploymentSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L777" target="_blank">↗</a></sup>
+### `DeploymentSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L777"><Icon icon="github" size="14" /></a></sup>
 
-### `Deployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L810" target="_blank">↗</a></sup>
+### `Deployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L810"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a deployment.
@@ -170,75 +170,75 @@ SQLAlchemy model of a deployment.
 
 **Methods:**
 
-#### `job_variables` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L831" target="_blank">↗</a></sup>
+#### `job_variables` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L831"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 job_variables(self) -> Mapped[dict[str, Any]]
 ```
 
-### `Log` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L919" target="_blank">↗</a></sup>
+### `Log` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L919"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a logging statement.
 
 
-### `ConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L942" target="_blank">↗</a></sup>
+### `ConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L942"><Icon icon="github" size="14" /></a></sup>
 
-### `ConcurrencyLimitV2` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L952" target="_blank">↗</a></sup>
+### `ConcurrencyLimitV2` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L952"><Icon icon="github" size="14" /></a></sup>
 
-### `BlockType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L965" target="_blank">↗</a></sup>
+### `BlockType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L965"><Icon icon="github" size="14" /></a></sup>
 
-### `BlockSchema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L986" target="_blank">↗</a></sup>
+### `BlockSchema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L986"><Icon icon="github" size="14" /></a></sup>
 
-### `BlockSchemaReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1018" target="_blank">↗</a></sup>
+### `BlockSchemaReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1018"><Icon icon="github" size="14" /></a></sup>
 
-### `BlockDocument` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1030" target="_blank">↗</a></sup>
+### `BlockDocument` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1030"><Icon icon="github" size="14" /></a></sup>
 
-### `BlockDocumentReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1079" target="_blank">↗</a></sup>
+### `BlockDocumentReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1079"><Icon icon="github" size="14" /></a></sup>
 
-### `Configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1091" target="_blank">↗</a></sup>
+### `Configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1091"><Icon icon="github" size="14" /></a></sup>
 
-### `SavedSearch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1098" target="_blank">↗</a></sup>
+### `SavedSearch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1098"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a saved search.
 
 
-### `WorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1109" target="_blank">↗</a></sup>
+### `WorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1109"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of a work queue
 
 
-### `WorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1146" target="_blank">↗</a></sup>
+### `WorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1146"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of an worker
 
 
-### `Worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1183" target="_blank">↗</a></sup>
+### `Worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1183"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of an worker
 
 
-### `Agent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1212" target="_blank">↗</a></sup>
+### `Agent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1212"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLAlchemy model of an agent
 
 
-### `Variable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1228" target="_blank">↗</a></sup>
+### `Variable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1228"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1236" target="_blank">↗</a></sup>
+### `FlowRunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1236"><Icon icon="github" size="14" /></a></sup>
 
-### `CsrfToken` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1248" target="_blank">↗</a></sup>
+### `CsrfToken` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1248"><Icon icon="github" size="14" /></a></sup>
 
-### `Automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1254" target="_blank">↗</a></sup>
+### `Automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1254"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `sort_expression` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1278" target="_blank">↗</a></sup>
+#### `sort_expression` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1278"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 sort_expression(cls, value: AutomationSort) -> sa.ColumnExpressionArgument[Any]
@@ -247,19 +247,19 @@ sort_expression(cls, value: AutomationSort) -> sa.ColumnExpressionArgument[Any]
 Return an expression used to sort Automations
 
 
-### `AutomationBucket` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1289" target="_blank">↗</a></sup>
+### `AutomationBucket` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1289"><Icon icon="github" size="14" /></a></sup>
 
-### `AutomationRelatedResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1327" target="_blank">↗</a></sup>
+### `AutomationRelatedResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1327"><Icon icon="github" size="14" /></a></sup>
 
-### `CompositeTriggerChildFiring` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1351" target="_blank">↗</a></sup>
+### `CompositeTriggerChildFiring` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1351"><Icon icon="github" size="14" /></a></sup>
 
-### `AutomationEventFollower` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1374" target="_blank">↗</a></sup>
+### `AutomationEventFollower` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1374"><Icon icon="github" size="14" /></a></sup>
 
-### `Event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1396" target="_blank">↗</a></sup>
+### `Event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1396"><Icon icon="github" size="14" /></a></sup>
 
-### `EventResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1445" target="_blank">↗</a></sup>
+### `EventResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1445"><Icon icon="github" size="14" /></a></sup>
 
-### `BaseORMConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1508" target="_blank">↗</a></sup>
+### `BaseORMConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1508"><Icon icon="github" size="14" /></a></sup>
 
 
 Abstract base class used to inject database-specific ORM configuration into Prefect.
@@ -270,7 +270,7 @@ Use with caution.
 
 **Methods:**
 
-#### `unique_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1516" target="_blank">↗</a></sup>
+#### `unique_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1516"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unique_key(self) -> tuple[Hashable, ...]
@@ -279,7 +279,7 @@ unique_key(self) -> tuple[Hashable, ...]
 Returns a key used to determine whether to instantiate a new DB interface.
 
 
-#### `versions_dir` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1524" target="_blank">↗</a></sup>
+#### `versions_dir` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1524"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 versions_dir(self) -> Path
@@ -288,7 +288,7 @@ versions_dir(self) -> Path
 Directory containing migrations
 
 
-#### `deployment_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1529" target="_blank">↗</a></sup>
+#### `deployment_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1529"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 deployment_unique_upsert_columns(self) -> _UpsertColumns
@@ -297,7 +297,7 @@ deployment_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a Deployment
 
 
-#### `concurrency_limit_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1534" target="_blank">↗</a></sup>
+#### `concurrency_limit_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1534"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 concurrency_limit_unique_upsert_columns(self) -> _UpsertColumns
@@ -306,7 +306,7 @@ concurrency_limit_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a ConcurrencyLimit
 
 
-#### `flow_run_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1539" target="_blank">↗</a></sup>
+#### `flow_run_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1539"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 flow_run_unique_upsert_columns(self) -> _UpsertColumns
@@ -315,7 +315,7 @@ flow_run_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a FlowRun
 
 
-#### `block_type_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1544" target="_blank">↗</a></sup>
+#### `block_type_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1544"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_type_unique_upsert_columns(self) -> _UpsertColumns
@@ -324,7 +324,7 @@ block_type_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a BlockType
 
 
-#### `artifact_collection_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1549" target="_blank">↗</a></sup>
+#### `artifact_collection_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1549"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 artifact_collection_unique_upsert_columns(self) -> _UpsertColumns
@@ -333,7 +333,7 @@ artifact_collection_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting an ArtifactCollection
 
 
-#### `block_schema_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1554" target="_blank">↗</a></sup>
+#### `block_schema_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1554"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_schema_unique_upsert_columns(self) -> _UpsertColumns
@@ -342,7 +342,7 @@ block_schema_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a BlockSchema
 
 
-#### `flow_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1559" target="_blank">↗</a></sup>
+#### `flow_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1559"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 flow_unique_upsert_columns(self) -> _UpsertColumns
@@ -351,7 +351,7 @@ flow_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a Flow
 
 
-#### `saved_search_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1564" target="_blank">↗</a></sup>
+#### `saved_search_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1564"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 saved_search_unique_upsert_columns(self) -> _UpsertColumns
@@ -360,7 +360,7 @@ saved_search_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a SavedSearch
 
 
-#### `task_run_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1569" target="_blank">↗</a></sup>
+#### `task_run_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1569"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task_run_unique_upsert_columns(self) -> _UpsertColumns
@@ -369,7 +369,7 @@ task_run_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a TaskRun
 
 
-#### `block_document_unique_upsert_columns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1578" target="_blank">↗</a></sup>
+#### `block_document_unique_upsert_columns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1578"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 block_document_unique_upsert_columns(self) -> _UpsertColumns
@@ -378,7 +378,7 @@ block_document_unique_upsert_columns(self) -> _UpsertColumns
 Unique columns for upserting a BlockDocument
 
 
-### `AsyncPostgresORMConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1583" target="_blank">↗</a></sup>
+### `AsyncPostgresORMConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1583"><Icon icon="github" size="14" /></a></sup>
 
 
 Postgres specific orm configuration
@@ -386,7 +386,7 @@ Postgres specific orm configuration
 
 **Methods:**
 
-#### `versions_dir` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1587" target="_blank">↗</a></sup>
+#### `versions_dir` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1587"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 versions_dir(self) -> Path
@@ -395,7 +395,7 @@ versions_dir(self) -> Path
 Directory containing migrations
 
 
-### `AioSqliteORMConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1599" target="_blank">↗</a></sup>
+### `AioSqliteORMConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1599"><Icon icon="github" size="14" /></a></sup>
 
 
 SQLite specific orm configuration
@@ -403,7 +403,7 @@ SQLite specific orm configuration
 
 **Methods:**
 
-#### `versions_dir` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/orm_models.py#L1603" target="_blank">↗</a></sup>
+#### `versions_dir` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/orm_models.py#L1603"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 versions_dir(self) -> Path

--- a/docs/v3/api-ref/python/prefect-server-database-query_components.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-query_components.mdx
@@ -7,9 +7,9 @@ sidebarTitle: query_components
 
 ## Classes
 
-### `FlowRunGraphV2Node` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L41" target="_blank">↗</a></sup>
+### `FlowRunGraphV2Node` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L41"><Icon icon="github" size="14" /></a></sup>
 
-### `BaseQueryComponents` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L63" target="_blank">↗</a></sup>
+### `BaseQueryComponents` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 
 Abstract base class used to inject dialect-specific SQL operations into Prefect.
@@ -17,7 +17,7 @@ Abstract base class used to inject dialect-specific SQL operations into Prefect.
 
 **Methods:**
 
-#### `unique_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L72" target="_blank">↗</a></sup>
+#### `unique_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L72"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unique_key(self) -> tuple[Hashable, ...]
@@ -26,7 +26,7 @@ unique_key(self) -> tuple[Hashable, ...]
 Returns a key used to determine whether to instantiate a new DB interface.
 
 
-#### `insert` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L81" target="_blank">↗</a></sup>
+#### `insert` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L81"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 insert(self, obj: type[orm_models.Base]) -> Union[postgresql.Insert, sqlite.Insert]
@@ -35,7 +35,7 @@ insert(self, obj: type[orm_models.Base]) -> Union[postgresql.Insert, sqlite.Inse
 dialect-specific insert statement
 
 
-#### `uses_json_strings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L90" target="_blank">↗</a></sup>
+#### `uses_json_strings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L90"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 uses_json_strings(self) -> bool
@@ -44,7 +44,7 @@ uses_json_strings(self) -> bool
 specifies whether the configured dialect returns JSON as strings
 
 
-#### `cast_to_json` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L94" target="_blank">↗</a></sup>
+#### `cast_to_json` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L94"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cast_to_json(self, json_obj: sa.ColumnElement[T]) -> sa.ColumnElement[T]
@@ -53,7 +53,7 @@ cast_to_json(self, json_obj: sa.ColumnElement[T]) -> sa.ColumnElement[T]
 casts to JSON object if necessary
 
 
-#### `build_json_object` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L98" target="_blank">↗</a></sup>
+#### `build_json_object` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_json_object(self, *args: Union[str, sa.ColumnElement[Any]]) -> sa.ColumnElement[Any]
@@ -62,7 +62,7 @@ build_json_object(self, *args: Union[str, sa.ColumnElement[Any]]) -> sa.ColumnEl
 builds a JSON object from sequential key-value pairs
 
 
-#### `json_arr_agg` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L104" target="_blank">↗</a></sup>
+#### `json_arr_agg` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L104"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 json_arr_agg(self, json_array: sa.ColumnElement[Any]) -> sa.ColumnElement[Any]
@@ -71,19 +71,19 @@ json_arr_agg(self, json_array: sa.ColumnElement[Any]) -> sa.ColumnElement[Any]
 aggregates a JSON array
 
 
-#### `make_timestamp_intervals` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L110" target="_blank">↗</a></sup>
+#### `make_timestamp_intervals` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 make_timestamp_intervals(self, start_time: datetime.datetime, end_time: datetime.datetime, interval: datetime.timedelta) -> sa.Select[tuple[datetime.datetime, datetime.datetime]]
 ```
 
-#### `set_state_id_on_inserted_flow_runs_statement` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L118" target="_blank">↗</a></sup>
+#### `set_state_id_on_inserted_flow_runs_statement` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L118"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state_id_on_inserted_flow_runs_statement(self, inserted_flow_run_ids: Sequence[UUID], insert_flow_run_states: Iterable[dict[str, Any]]) -> sa.Update
 ```
 
-#### `get_scheduled_flow_runs_from_work_queues` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L125" target="_blank">↗</a></sup>
+#### `get_scheduled_flow_runs_from_work_queues` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_scheduled_flow_runs_from_work_queues(self, db: PrefectDBInterface, limit_per_queue: Optional[int] = None, work_queue_ids: Optional[list[UUID]] = None, scheduled_before: Optional[DateTime] = None) -> sa.Select[tuple[orm_models.FlowRun, UUID]]
@@ -96,7 +96,7 @@ This query returns a `(orm_models.FlowRun, orm_models.WorkQueue.id)` pair; calli
 will return only the flow run because it grabs the first result.
 
 
-#### `clear_configuration_value_cache_for_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L377" target="_blank">↗</a></sup>
+#### `clear_configuration_value_cache_for_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L377"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 clear_configuration_value_cache_for_key(self, key: str) -> None
@@ -105,47 +105,47 @@ clear_configuration_value_cache_for_key(self, key: str) -> None
 Removes a configuration key from the cache.
 
 
-### `AsyncPostgresQueryComponents` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L542" target="_blank">↗</a></sup>
+### `AsyncPostgresQueryComponents` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L542"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `insert` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L545" target="_blank">↗</a></sup>
+#### `insert` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L545"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 insert(self, obj: type[orm_models.Base]) -> postgresql.Insert
 ```
 
-#### `uses_json_strings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L551" target="_blank">↗</a></sup>
+#### `uses_json_strings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L551"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 uses_json_strings(self) -> bool
 ```
 
-#### `cast_to_json` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L554" target="_blank">↗</a></sup>
+#### `cast_to_json` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L554"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cast_to_json(self, json_obj: sa.ColumnElement[T]) -> sa.ColumnElement[T]
 ```
 
-#### `build_json_object` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L557" target="_blank">↗</a></sup>
+#### `build_json_object` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L557"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_json_object(self, *args: Union[str, sa.ColumnElement[Any]]) -> sa.ColumnElement[Any]
 ```
 
-#### `json_arr_agg` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L562" target="_blank">↗</a></sup>
+#### `json_arr_agg` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L562"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 json_arr_agg(self, json_array: sa.ColumnElement[Any]) -> sa.ColumnElement[Any]
 ```
 
-#### `make_timestamp_intervals` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L567" target="_blank">↗</a></sup>
+#### `make_timestamp_intervals` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L567"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 make_timestamp_intervals(self, start_time: datetime.datetime, end_time: datetime.datetime, interval: datetime.timedelta) -> sa.Select[tuple[datetime.datetime, datetime.datetime]]
 ```
 
-#### `set_state_id_on_inserted_flow_runs_statement` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L589" target="_blank">↗</a></sup>
+#### `set_state_id_on_inserted_flow_runs_statement` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L589"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state_id_on_inserted_flow_runs_statement(self, db: PrefectDBInterface, inserted_flow_run_ids: Sequence[UUID], insert_flow_run_states: Iterable[dict[str, Any]]) -> sa.Update
@@ -155,7 +155,7 @@ Given a list of flow run ids and associated states, set the state_id
 to the appropriate state for all flow runs
 
 
-### `UUIDList` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L778" target="_blank">↗</a></sup>
+### `UUIDList` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L778"><Icon icon="github" size="14" /></a></sup>
 
 
 Map a JSON list of strings back to a list of UUIDs at the result loading stage
@@ -163,53 +163,53 @@ Map a JSON list of strings back to a list of UUIDs at the result loading stage
 
 **Methods:**
 
-#### `process_result_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L784" target="_blank">↗</a></sup>
+#### `process_result_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L784"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_result_value(self, value: Optional[list[Union[str, UUID]]], dialect: sa.Dialect) -> Optional[list[UUID]]
 ```
 
-### `AioSqliteQueryComponents` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L792" target="_blank">↗</a></sup>
+### `AioSqliteQueryComponents` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L792"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `insert` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L795" target="_blank">↗</a></sup>
+#### `insert` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L795"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 insert(self, obj: type[orm_models.Base]) -> sqlite.Insert
 ```
 
-#### `uses_json_strings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L801" target="_blank">↗</a></sup>
+#### `uses_json_strings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L801"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 uses_json_strings(self) -> bool
 ```
 
-#### `cast_to_json` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L804" target="_blank">↗</a></sup>
+#### `cast_to_json` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L804"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cast_to_json(self, json_obj: sa.ColumnElement[T]) -> sa.ColumnElement[T]
 ```
 
-#### `build_json_object` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L807" target="_blank">↗</a></sup>
+#### `build_json_object` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L807"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_json_object(self, *args: Union[str, sa.ColumnElement[Any]]) -> sa.ColumnElement[Any]
 ```
 
-#### `json_arr_agg` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L812" target="_blank">↗</a></sup>
+#### `json_arr_agg` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L812"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 json_arr_agg(self, json_array: sa.ColumnElement[Any]) -> sa.ColumnElement[Any]
 ```
 
-#### `make_timestamp_intervals` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L817" target="_blank">↗</a></sup>
+#### `make_timestamp_intervals` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L817"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 make_timestamp_intervals(self, start_time: datetime.datetime, end_time: datetime.datetime, interval: datetime.timedelta) -> sa.Select[tuple[datetime.datetime, datetime.datetime]]
 ```
 
-#### `set_state_id_on_inserted_flow_runs_statement` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/database/query_components.py#L851" target="_blank">↗</a></sup>
+#### `set_state_id_on_inserted_flow_runs_statement` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/database/query_components.py#L851"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state_id_on_inserted_flow_runs_statement(self, db: PrefectDBInterface, inserted_flow_run_ids: Sequence[UUID], insert_flow_run_states: Iterable[dict[str, Any]]) -> sa.Update

--- a/docs/v3/api-ref/python/prefect-server-events-actions.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-actions.mdx
@@ -13,9 +13,9 @@ and carries them out.  Also includes the various concrete subtypes of Actions
 
 ## Classes
 
-### `ActionFailed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L107" target="_blank">↗</a></sup>
+### `ActionFailed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L107"><Icon icon="github" size="14" /></a></sup>
 
-### `Action` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L112" target="_blank">↗</a></sup>
+### `Action` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L112"><Icon icon="github" size="14" /></a></sup>
 
 
 An Action that may be performed when an Automation is triggered
@@ -23,7 +23,7 @@ An Action that may be performed when an Automation is triggered
 
 **Methods:**
 
-#### `logging_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L249" target="_blank">↗</a></sup>
+#### `logging_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L249"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logging_context(self, triggered_action: 'TriggeredAction') -> Dict[str, Any]
@@ -32,15 +32,15 @@ logging_context(self, triggered_action: 'TriggeredAction') -> Dict[str, Any]
 Common logging context for all actions
 
 
-### `DoNothing` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L266" target="_blank">↗</a></sup>
+### `DoNothing` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L266"><Icon icon="github" size="14" /></a></sup>
 
 
 Do nothing when an Automation is triggered
 
 
-### `EmitEventAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L278" target="_blank">↗</a></sup>
+### `EmitEventAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L278"><Icon icon="github" size="14" /></a></sup>
 
-### `ExternalDataAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L292" target="_blank">↗</a></sup>
+### `ExternalDataAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L292"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that require data from an external source such as
@@ -49,13 +49,13 @@ the Orchestration API
 
 **Methods:**
 
-#### `reason_from_response` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L322" target="_blank">↗</a></sup>
+#### `reason_from_response` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L322"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reason_from_response(self, response: Response) -> str
 ```
 
-### `JinjaTemplateAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L386" target="_blank">↗</a></sup>
+### `JinjaTemplateAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L386"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that use Jinja templates supplied by the user and
@@ -65,25 +65,25 @@ and the orchestration API.
 
 **Methods:**
 
-#### `validate_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L405" target="_blank">↗</a></sup>
+#### `validate_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L405"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_template(cls, template: str, field_name: str) -> str
 ```
 
-#### `templates_in_dictionary` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L416" target="_blank">↗</a></sup>
+#### `templates_in_dictionary` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L416"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 templates_in_dictionary(cls, dict_: dict[Any, Any | dict[Any, Any]]) -> list[tuple[dict[Any, Any], dict[Any, str]]]
 ```
 
-#### `instantiate_object` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L437" target="_blank">↗</a></sup>
+#### `instantiate_object` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L437"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 instantiate_object(self, model: Type[PrefectBaseModel], data: Dict[str, Any], triggered_action: 'TriggeredAction', resource: Optional['Resource'] = None) -> PrefectBaseModel
 ```
 
-### `DeploymentAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L631" target="_blank">↗</a></sup>
+### `DeploymentAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L631"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Deployments and need to infer them from
@@ -92,19 +92,19 @@ events
 
 **Methods:**
 
-#### `selected_deployment_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L650" target="_blank">↗</a></sup>
+#### `selected_deployment_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L650"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_deployment_requires_id(self) -> Self
 ```
 
-### `DeploymentCommandAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L676" target="_blank">↗</a></sup>
+### `DeploymentCommandAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L676"><Icon icon="github" size="14" /></a></sup>
 
 
 Executes a command against a matching deployment
 
 
-### `RunDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L720" target="_blank">↗</a></sup>
+### `RunDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L720"><Icon icon="github" size="14" /></a></sup>
 
 
 Runs the given deployment with the given parameters
@@ -112,61 +112,61 @@ Runs the given deployment with the given parameters
 
 **Methods:**
 
-#### `validate_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L797" target="_blank">↗</a></sup>
+#### `validate_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L797"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_parameters(cls, value: dict[str, Any] | None) -> dict[str, Any] | None
 ```
 
-### `PauseDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L952" target="_blank">↗</a></sup>
+### `PauseDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L952"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses the given Deployment
 
 
-### `ResumeDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L968" target="_blank">↗</a></sup>
+### `ResumeDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L968"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes the given Deployment
 
 
-### `FlowRunAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L984" target="_blank">↗</a></sup>
+### `FlowRunAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L984"><Icon icon="github" size="14" /></a></sup>
 
 
 An action that operates on a flow run
 
 
-### `FlowRunStateChangeAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1003" target="_blank">↗</a></sup>
+### `FlowRunStateChangeAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1003"><Icon icon="github" size="14" /></a></sup>
 
 
 Changes the state of a flow run associated with the trigger
 
 
-### `ChangeFlowRunState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1044" target="_blank">↗</a></sup>
+### `ChangeFlowRunState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1044"><Icon icon="github" size="14" /></a></sup>
 
 
 Changes the state of a flow run associated with the trigger
 
 
-### `CancelFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1075" target="_blank">↗</a></sup>
+### `CancelFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1075"><Icon icon="github" size="14" /></a></sup>
 
 
 Cancels a flow run associated with the trigger
 
 
-### `SuspendFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1087" target="_blank">↗</a></sup>
+### `SuspendFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1087"><Icon icon="github" size="14" /></a></sup>
 
 
 Suspends a flow run associated with the trigger
 
 
-### `ResumeFlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1106" target="_blank">↗</a></sup>
+### `ResumeFlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1106"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a paused or suspended flow run associated with the trigger
 
 
-### `CallWebhook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1140" target="_blank">↗</a></sup>
+### `CallWebhook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1140"><Icon icon="github" size="14" /></a></sup>
 
 
 Call a webhook when an Automation is triggered.
@@ -174,7 +174,7 @@ Call a webhook when an Automation is triggered.
 
 **Methods:**
 
-#### `ensure_payload_is_a_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1154" target="_blank">↗</a></sup>
+#### `ensure_payload_is_a_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1154"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ensure_payload_is_a_string(cls, value: Union[str, Dict[str, Any], None]) -> Optional[str]
@@ -186,7 +186,7 @@ may currently be a dictionary, as well as the API, where older versions of the
 frontend may be sending a JSON object with the single `"message"` key.
 
 
-#### `validate_payload_templates` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1171" target="_blank">↗</a></sup>
+#### `validate_payload_templates` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1171"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_payload_templates(cls, value: Optional[str]) -> Optional[str]
@@ -195,7 +195,7 @@ validate_payload_templates(cls, value: Optional[str]) -> Optional[str]
 Validate user-provided payload template.
 
 
-### `SendNotification` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1240" target="_blank">↗</a></sup>
+### `SendNotification` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1240"><Icon icon="github" size="14" /></a></sup>
 
 
 Send a notification when an Automation is triggered
@@ -203,13 +203,13 @@ Send a notification when an Automation is triggered
 
 **Methods:**
 
-#### `is_valid_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1251" target="_blank">↗</a></sup>
+#### `is_valid_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1251"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_valid_template(cls, value: str, info: ValidationInfo) -> str
 ```
 
-### `WorkPoolAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1307" target="_blank">↗</a></sup>
+### `WorkPoolAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1307"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Work Pools and need to infer them from
@@ -218,27 +218,27 @@ events
 
 **Methods:**
 
-#### `selected_work_pool_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1327" target="_blank">↗</a></sup>
+#### `selected_work_pool_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1327"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_work_pool_requires_id(self) -> Self
 ```
 
-### `WorkPoolCommandAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1352" target="_blank">↗</a></sup>
+### `WorkPoolCommandAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1352"><Icon icon="github" size="14" /></a></sup>
 
-### `PauseWorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1409" target="_blank">↗</a></sup>
+### `PauseWorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1409"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses a Work Pool
 
 
-### `ResumeWorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1425" target="_blank">↗</a></sup>
+### `ResumeWorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1425"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a Work Pool
 
 
-### `WorkQueueAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1441" target="_blank">↗</a></sup>
+### `WorkQueueAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1441"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Work Queues and need to infer them from
@@ -247,27 +247,27 @@ events
 
 **Methods:**
 
-#### `selected_work_queue_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1460" target="_blank">↗</a></sup>
+#### `selected_work_queue_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1460"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_work_queue_requires_id(self) -> Self
 ```
 
-### `WorkQueueCommandAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1486" target="_blank">↗</a></sup>
+### `WorkQueueCommandAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1486"><Icon icon="github" size="14" /></a></sup>
 
-### `PauseWorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1528" target="_blank">↗</a></sup>
+### `PauseWorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1528"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses a Work Queue
 
 
-### `ResumeWorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1544" target="_blank">↗</a></sup>
+### `ResumeWorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1544"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a Work Queue
 
 
-### `AutomationAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1560" target="_blank">↗</a></sup>
+### `AutomationAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1560"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Actions that operate on Automations and need to infer them from
@@ -276,21 +276,21 @@ events
 
 **Methods:**
 
-#### `selected_automation_requires_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1579" target="_blank">↗</a></sup>
+#### `selected_automation_requires_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1579"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 selected_automation_requires_id(self) -> Self
 ```
 
-### `AutomationCommandAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1605" target="_blank">↗</a></sup>
+### `AutomationCommandAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1605"><Icon icon="github" size="14" /></a></sup>
 
-### `PauseAutomation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1645" target="_blank">↗</a></sup>
+### `PauseAutomation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1645"><Icon icon="github" size="14" /></a></sup>
 
 
 Pauses a Work Queue
 
 
-### `ResumeAutomation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/actions.py#L1661" target="_blank">↗</a></sup>
+### `ResumeAutomation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/actions.py#L1661"><Icon icon="github" size="14" /></a></sup>
 
 
 Resumes a Work Queue

--- a/docs/v3/api-ref/python/prefect-server-events-clients.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-clients.mdx
@@ -7,19 +7,19 @@ sidebarTitle: clients
 
 ## Classes
 
-### `EventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L37" target="_blank">↗</a></sup>
+### `EventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 
 The abstract interface for a Prefect Events client
 
 
-### `NullEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L55" target="_blank">↗</a></sup>
+### `NullEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 
 A no-op implementation of the Prefect Events client for testing
 
 
-### `AssertingEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L62" target="_blank">↗</a></sup>
+### `AssertingEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L62"><Icon icon="github" size="14" /></a></sup>
 
 
 An implementation of the Prefect Events client that records all events sent
@@ -28,7 +28,7 @@ to it for inspection during tests.
 
 **Methods:**
 
-#### `reset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L80" target="_blank">↗</a></sup>
+#### `reset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L80"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset(cls) -> None
@@ -37,13 +37,13 @@ reset(cls) -> None
 Reset all captured instances and their events.  For use this between tests
 
 
-#### `emitted_events_count` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L108" target="_blank">↗</a></sup>
+#### `emitted_events_count` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L108"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emitted_events_count(cls) -> int
 ```
 
-#### `assert_emitted_event_count` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L112" target="_blank">↗</a></sup>
+#### `assert_emitted_event_count` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L112"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_emitted_event_count(cls, count: int) -> None
@@ -52,7 +52,7 @@ assert_emitted_event_count(cls, count: int) -> None
 Assert that the given number of events were emitted.
 
 
-#### `assert_emitted_event_with` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L120" target="_blank">↗</a></sup>
+#### `assert_emitted_event_with` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_emitted_event_with(cls, event: Optional[str] = None, resource: Optional[Dict[str, LabelValue]] = None, related: Optional[List[Dict[str, LabelValue]]] = None, payload: Optional[Dict[str, Any]] = None) -> None
@@ -61,12 +61,12 @@ assert_emitted_event_with(cls, event: Optional[str] = None, resource: Optional[D
 Assert that an event was emitted containing the given properties.
 
 
-#### `assert_no_emitted_event_with` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L199" target="_blank">↗</a></sup>
+#### `assert_no_emitted_event_with` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_no_emitted_event_with(cls, event: Optional[str] = None, resource: Optional[Dict[str, LabelValue]] = None, related: Optional[List[Dict[str, LabelValue]]] = None, payload: Optional[Dict[str, Any]] = None) -> None
 ```
 
-### `PrefectServerEventsClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L214" target="_blank">↗</a></sup>
+### `PrefectServerEventsClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L214"><Icon icon="github" size="14" /></a></sup>
 
-### `PrefectServerEventsAPIClient` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/clients.py#L244" target="_blank">↗</a></sup>
+### `PrefectServerEventsAPIClient` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/clients.py#L244"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-events-counting.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-counting.mdx
@@ -7,29 +7,29 @@ sidebarTitle: counting
 
 ## Classes
 
-### `InvalidEventCountParameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L26" target="_blank">↗</a></sup>
+### `InvalidEventCountParameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the given parameters are invalid for counting events.
 
 
-### `TimeUnit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L34" target="_blank">↗</a></sup>
+### `TimeUnit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `as_timedelta` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L41" target="_blank">↗</a></sup>
+#### `as_timedelta` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_timedelta(self, interval: float) -> Duration
 ```
 
-#### `validate_buckets` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L55" target="_blank">↗</a></sup>
+#### `validate_buckets` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_buckets(self, start_datetime: datetime.datetime, end_datetime: datetime.datetime, interval: float) -> None
 ```
 
-#### `get_interval_spans` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L78" target="_blank">↗</a></sup>
+#### `get_interval_spans` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_interval_spans(self, start_datetime: datetime.datetime, end_datetime: datetime.datetime, interval: float) -> Generator[int | tuple[datetime.datetime, datetime.datetime], None, None]
@@ -38,7 +38,7 @@ get_interval_spans(self, start_datetime: datetime.datetime, end_datetime: dateti
 Divide the given range of dates into evenly-sized spans of interval units
 
 
-#### `database_value_expression` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L110" target="_blank">↗</a></sup>
+#### `database_value_expression` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 database_value_expression(self, time_interval: float) -> sa.Cast[str]
@@ -47,7 +47,7 @@ database_value_expression(self, time_interval: float) -> sa.Cast[str]
 Returns the SQL expression to place an event in a time bucket
 
 
-#### `database_label_expression` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L145" target="_blank">↗</a></sup>
+#### `database_label_expression` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 database_label_expression(self, db: PrefectDBInterface, time_interval: float) -> sa.Function[str]
@@ -56,11 +56,11 @@ database_label_expression(self, db: PrefectDBInterface, time_interval: float) ->
 Returns the SQL expression to label a time bucket
 
 
-### `Countable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L175" target="_blank">↗</a></sup>
+### `Countable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L175"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `get_database_query` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/counting.py#L183" target="_blank">↗</a></sup>
+#### `get_database_query` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/counting.py#L183"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_database_query(self, filter: 'EventFilter', time_unit: TimeUnit, time_interval: float) -> Select[tuple[str, str, DateTime, DateTime, int]]

--- a/docs/v3/api-ref/python/prefect-server-events-filters.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-filters.mdx
@@ -7,27 +7,27 @@ sidebarTitle: filters
 
 ## Classes
 
-### `AutomationFilterCreated` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L31" target="_blank">↗</a></sup>
+### `AutomationFilterCreated` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Automation.created`.
 
 
-### `AutomationFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L47" target="_blank">↗</a></sup>
+### `AutomationFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Automation.created`.
 
 
-### `AutomationFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L61" target="_blank">↗</a></sup>
+### `AutomationFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L61"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Automation.tags`.
 
 
-### `AutomationFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L95" target="_blank">↗</a></sup>
+### `AutomationFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L95"><Icon icon="github" size="14" /></a></sup>
 
-### `EventDataFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L121" target="_blank">↗</a></sup>
+### `EventDataFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for filtering event data.
@@ -35,13 +35,13 @@ A base class for filtering event data.
 
 **Methods:**
 
-#### `get_filters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L126" target="_blank">↗</a></sup>
+#### `get_filters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L126"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_filters(self) -> list['EventDataFilter']
 ```
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L145" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
@@ -50,7 +50,7 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-#### `excludes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L149" target="_blank">↗</a></sup>
+#### `excludes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L149"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 excludes(self, event: Event) -> bool
@@ -59,7 +59,7 @@ excludes(self, event: Event) -> bool
 Would the given filter exclude this event?
 
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L153" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L153"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self) -> Sequence['ColumnExpressionArgument[bool]']
@@ -68,11 +68,11 @@ build_where_clauses(self) -> Sequence['ColumnExpressionArgument[bool]']
 Convert the criteria to a WHERE clause.
 
 
-### `EventOccurredFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L161" target="_blank">↗</a></sup>
+### `EventOccurredFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L161"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `clamp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L174" target="_blank">↗</a></sup>
+#### `clamp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L174"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 clamp(self, max_duration: timedelta) -> None
@@ -81,109 +81,109 @@ clamp(self, max_duration: timedelta) -> None
 Limit how far the query can look back based on the given duration
 
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L181" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L181"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L185" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L185"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-### `EventNameFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L194" target="_blank">↗</a></sup>
+### `EventNameFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L194"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L210" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L210"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L230" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-### `LabelSet` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L256" target="_blank">↗</a></sup>
+### `LabelSet` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L256"><Icon icon="github" size="14" /></a></sup>
 
-### `LabelOperations` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L262" target="_blank">↗</a></sup>
+### `LabelOperations` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L262"><Icon icon="github" size="14" /></a></sup>
 
-### `EventResourceFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L280" target="_blank">↗</a></sup>
+### `EventResourceFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L280"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L298" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L298"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L316" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L316"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-### `EventRelatedFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L387" target="_blank">↗</a></sup>
+### `EventRelatedFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L387"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L405" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L405"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-### `EventAnyResourceFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L486" target="_blank">↗</a></sup>
+### `EventAnyResourceFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L486"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L501" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L501"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L523" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L523"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-### `EventIDFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L591" target="_blank">↗</a></sup>
+### `EventIDFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L591"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L596" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L596"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
 ```
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L604" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L604"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-### `EventOrder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L615" target="_blank">↗</a></sup>
+### `EventOrder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L615"><Icon icon="github" size="14" /></a></sup>
 
-### `EventFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L620" target="_blank">↗</a></sup>
+### `EventFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L620"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L653" target="_blank">↗</a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L653"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
 ```
 
-#### `logical_limit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L670" target="_blank">↗</a></sup>
+#### `logical_limit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/filters.py#L670"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 logical_limit(self) -> int

--- a/docs/v3/api-ref/python/prefect-server-events-jinja_filters.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-jinja_filters.mdx
@@ -7,7 +7,7 @@ sidebarTitle: jinja_filters
 
 ## Functions
 
-### `ui_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/jinja_filters.py#L33" target="_blank">↗</a></sup>
+### `ui_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/jinja_filters.py#L33"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ui_url(ctx: Mapping[str, Any], obj: Any) -> Optional[str]
@@ -17,7 +17,7 @@ ui_url(ctx: Mapping[str, Any], obj: Any) -> Optional[str]
 Return the UI URL for the given object.
 
 
-### `ui_resource_events_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/jinja_filters.py#L39" target="_blank">↗</a></sup>
+### `ui_resource_events_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/jinja_filters.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ui_resource_events_url(ctx: Mapping[str, Any], obj: Any) -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-server-events-messaging.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-messaging.mdx
@@ -7,13 +7,13 @@ sidebarTitle: messaging
 
 ## Functions
 
-### `create_event_publisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/messaging.py#L78" target="_blank">↗</a></sup>
+### `create_event_publisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/messaging.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_event_publisher() -> EventPublisher
 ```
 
-### `create_actions_publisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/messaging.py#L83" target="_blank">↗</a></sup>
+### `create_actions_publisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/messaging.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_actions_publisher() -> Publisher
@@ -21,4 +21,4 @@ create_actions_publisher() -> Publisher
 
 ## Classes
 
-### `EventPublisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/messaging.py#L26" target="_blank">↗</a></sup>
+### `EventPublisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/messaging.py#L26"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-events-ordering.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-ordering.mdx
@@ -14,10 +14,10 @@ occurred causally.
 
 ## Classes
 
-### `EventArrivedEarly` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/ordering.py#L46" target="_blank">↗</a></sup>
+### `EventArrivedEarly` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/ordering.py#L46"><Icon icon="github" size="14" /></a></sup>
 
-### `MaxDepthExceeded` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/ordering.py#L51" target="_blank">↗</a></sup>
+### `MaxDepthExceeded` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/ordering.py#L51"><Icon icon="github" size="14" /></a></sup>
 
-### `event_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/ordering.py#L56" target="_blank">↗</a></sup>
+### `event_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/ordering.py#L56"><Icon icon="github" size="14" /></a></sup>
 
-### `CausalOrdering` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/ordering.py#L62" target="_blank">↗</a></sup>
+### `CausalOrdering` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/ordering.py#L62"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-events-pipeline.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-pipeline.mdx
@@ -7,11 +7,11 @@ sidebarTitle: pipeline
 
 ## Classes
 
-### `EventsPipeline` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/pipeline.py#L7" target="_blank">↗</a></sup>
+### `EventsPipeline` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/pipeline.py#L7"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `events_to_messages` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/pipeline.py#L9" target="_blank">↗</a></sup>
+#### `events_to_messages` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/pipeline.py#L9"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 events_to_messages(events: list[Event]) -> list[MemoryMessage]

--- a/docs/v3/api-ref/python/prefect-server-events-schemas-automations.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-schemas-automations.mdx
@@ -7,11 +7,11 @@ sidebarTitle: automations
 
 ## Classes
 
-### `Posture` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L52" target="_blank">↗</a></sup>
+### `Posture` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L52"><Icon icon="github" size="14" /></a></sup>
 
-### `TriggerState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L58" target="_blank">↗</a></sup>
+### `TriggerState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L58"><Icon icon="github" size="14" /></a></sup>
 
-### `Trigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L63" target="_blank">↗</a></sup>
+### `Trigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class describing a set of criteria that must be satisfied in order to trigger
@@ -20,19 +20,19 @@ an automation.
 
 **Methods:**
 
-#### `automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L77" target="_blank">↗</a></sup>
+#### `automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 automation(self) -> 'Automation'
 ```
 
-#### `parent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L84" target="_blank">↗</a></sup>
+#### `parent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L84"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parent(self) -> 'Union[Trigger, Automation]'
 ```
 
-#### `reset_ids` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L100" target="_blank">↗</a></sup>
+#### `reset_ids` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset_ids(self) -> None
@@ -41,7 +41,7 @@ reset_ids(self) -> None
 Resets the ID of this trigger and all of its children
 
 
-#### `all_triggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L106" target="_blank">↗</a></sup>
+#### `all_triggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L106"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_triggers(self) -> Sequence[Trigger]
@@ -50,13 +50,13 @@ all_triggers(self) -> Sequence[Trigger]
 Returns all triggers within this trigger
 
 
-#### `create_automation_state_change_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L111" target="_blank">↗</a></sup>
+#### `create_automation_state_change_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L111"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_automation_state_change_event(self, firing: 'Firing', trigger_state: TriggerState) -> ReceivedEvent
 ```
 
-### `CompositeTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L116" target="_blank">↗</a></sup>
+### `CompositeTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L116"><Icon icon="github" size="14" /></a></sup>
 
 
 Requires some number of triggers to have fired within the given time period.
@@ -64,7 +64,7 @@ Requires some number of triggers to have fired within the given time period.
 
 **Methods:**
 
-#### `create_automation_state_change_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L125" target="_blank">↗</a></sup>
+#### `create_automation_state_change_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_automation_state_change_event(self, firing: Firing, trigger_state: TriggerState) -> ReceivedEvent
@@ -74,31 +74,31 @@ Returns a ReceivedEvent for an automation state change
 into a triggered or resolved state.
 
 
-#### `all_triggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L165" target="_blank">↗</a></sup>
+#### `all_triggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L165"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_triggers(self) -> Sequence[Trigger]
 ```
 
-#### `child_trigger_ids` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L169" target="_blank">↗</a></sup>
+#### `child_trigger_ids` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L169"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 child_trigger_ids(self) -> List[UUID]
 ```
 
-#### `num_expected_firings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L173" target="_blank">↗</a></sup>
+#### `num_expected_firings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L173"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 num_expected_firings(self) -> int
 ```
 
-#### `ready_to_fire` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L177" target="_blank">↗</a></sup>
+#### `ready_to_fire` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ready_to_fire(self, firings: Sequence['Firing']) -> bool
 ```
 
-### `CompoundTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L180" target="_blank">↗</a></sup>
+### `CompoundTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L180"><Icon icon="github" size="14" /></a></sup>
 
 
 A composite trigger that requires some number of triggers to have
@@ -107,25 +107,25 @@ fired within the given time period
 
 **Methods:**
 
-#### `num_expected_firings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L188" target="_blank">↗</a></sup>
+#### `num_expected_firings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L188"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 num_expected_firings(self) -> int
 ```
 
-#### `ready_to_fire` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L196" target="_blank">↗</a></sup>
+#### `ready_to_fire` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L196"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ready_to_fire(self, firings: Sequence['Firing']) -> bool
 ```
 
-#### `validate_require` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L200" target="_blank">↗</a></sup>
+#### `validate_require` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L200"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_require(self) -> Self
 ```
 
-### `SequenceTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L212" target="_blank">↗</a></sup>
+### `SequenceTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L212"><Icon icon="github" size="14" /></a></sup>
 
 
 A composite trigger that requires some number of triggers to have fired
@@ -134,19 +134,19 @@ within the given time period in a specific order
 
 **Methods:**
 
-#### `expected_firing_order` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L219" target="_blank">↗</a></sup>
+#### `expected_firing_order` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L219"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 expected_firing_order(self) -> List[UUID]
 ```
 
-#### `ready_to_fire` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L222" target="_blank">↗</a></sup>
+#### `ready_to_fire` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L222"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ready_to_fire(self, firings: Sequence['Firing']) -> bool
 ```
 
-### `ResourceTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L229" target="_blank">↗</a></sup>
+### `ResourceTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L229"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for triggers that may filter by the labels of resources.
@@ -154,13 +154,13 @@ Base class for triggers that may filter by the labels of resources.
 
 **Methods:**
 
-#### `covers_resources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L245" target="_blank">↗</a></sup>
+#### `covers_resources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L245"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 covers_resources(self, resource: Resource, related: Sequence[RelatedResource]) -> bool
 ```
 
-### `EventTrigger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L261" target="_blank">↗</a></sup>
+### `EventTrigger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L261"><Icon icon="github" size="14" /></a></sup>
 
 
 A trigger that fires based on the presence or absence of events within a given
@@ -169,19 +169,19 @@ period of time.
 
 **Methods:**
 
-#### `enforce_minimum_within_for_proactive_triggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L326" target="_blank">↗</a></sup>
+#### `enforce_minimum_within_for_proactive_triggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L326"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enforce_minimum_within_for_proactive_triggers(cls, data: Dict[str, Any] | Any) -> Dict[str, Any]
 ```
 
-#### `covers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L352" target="_blank">↗</a></sup>
+#### `covers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L352"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 covers(self, event: ReceivedEvent) -> bool
 ```
 
-#### `immediate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L362" target="_blank">↗</a></sup>
+#### `immediate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L362"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 immediate(self) -> bool
@@ -190,7 +190,7 @@ immediate(self) -> bool
 Does this reactive trigger fire immediately for all events?
 
 
-#### `event_pattern` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L369" target="_blank">↗</a></sup>
+#### `event_pattern` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L369"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 event_pattern(self) -> re.Pattern[str]
@@ -200,31 +200,31 @@ A regular expression which may be evaluated against any event string to
 determine if this trigger would be interested in the event
 
 
-#### `starts_after` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L389" target="_blank">↗</a></sup>
+#### `starts_after` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L389"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 starts_after(self, event: str) -> bool
 ```
 
-#### `expects` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L401" target="_blank">↗</a></sup>
+#### `expects` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L401"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 expects(self, event: str) -> bool
 ```
 
-#### `bucketing_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L410" target="_blank">↗</a></sup>
+#### `bucketing_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L410"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 bucketing_key(self, event: ReceivedEvent) -> Tuple[str, ...]
 ```
 
-#### `meets_threshold` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L415" target="_blank">↗</a></sup>
+#### `meets_threshold` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L415"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 meets_threshold(self, event_count: int) -> bool
 ```
 
-#### `create_automation_state_change_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L424" target="_blank">↗</a></sup>
+#### `create_automation_state_change_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L424"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_automation_state_change_event(self, firing: Firing, trigger_state: TriggerState) -> ReceivedEvent
@@ -234,7 +234,7 @@ Returns a ReceivedEvent for an automation state change
 into a triggered or resolved state.
 
 
-### `AutomationCore` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L476" target="_blank">↗</a></sup>
+### `AutomationCore` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L476"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines an action a user wants to take when a certain number of events
@@ -243,7 +243,7 @@ do or don't happen to the matching resources
 
 **Methods:**
 
-#### `triggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L516" target="_blank">↗</a></sup>
+#### `triggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L516"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 triggers(self) -> Sequence[Trigger]
@@ -252,7 +252,7 @@ triggers(self) -> Sequence[Trigger]
 Returns all triggers within this automation
 
 
-#### `triggers_of_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L520" target="_blank">↗</a></sup>
+#### `triggers_of_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L520"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 triggers_of_type(self, trigger_type: Type[T]) -> Sequence[T]
@@ -261,7 +261,7 @@ triggers_of_type(self, trigger_type: Type[T]) -> Sequence[T]
 Returns all triggers of the specified type within this automation
 
 
-#### `trigger_by_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L524" target="_blank">↗</a></sup>
+#### `trigger_by_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L524"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 trigger_by_id(self, trigger_id: UUID) -> Optional[Trigger]
@@ -270,7 +270,7 @@ trigger_by_id(self, trigger_id: UUID) -> Optional[Trigger]
 Returns the trigger with the given ID, or None if no such trigger exists
 
 
-#### `prevent_run_deployment_loops` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L532" target="_blank">↗</a></sup>
+#### `prevent_run_deployment_loops` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L532"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prevent_run_deployment_loops(self) -> Self
@@ -279,29 +279,29 @@ prevent_run_deployment_loops(self) -> Self
 Detects potential infinite loops in automations with RunDeployment actions
 
 
-### `Automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L605" target="_blank">↗</a></sup>
+### `Automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L605"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L611" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L611"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: type[Self], obj: Any) -> Self
 ```
 
-### `AutomationCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L626" target="_blank">↗</a></sup>
+### `AutomationCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L626"><Icon icon="github" size="14" /></a></sup>
 
-### `AutomationUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L632" target="_blank">↗</a></sup>
+### `AutomationUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L632"><Icon icon="github" size="14" /></a></sup>
 
-### `AutomationPartialUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L636" target="_blank">↗</a></sup>
+### `AutomationPartialUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L636"><Icon icon="github" size="14" /></a></sup>
 
-### `AutomationSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L640" target="_blank">↗</a></sup>
+### `AutomationSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L640"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines automations sorting options.
 
 
-### `Firing` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L649" target="_blank">↗</a></sup>
+### `Firing` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L649"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents one instance of a trigger firing
@@ -309,25 +309,25 @@ Represents one instance of a trigger firing
 
 **Methods:**
 
-#### `validate_trigger_states` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L704" target="_blank">↗</a></sup>
+#### `validate_trigger_states` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L704"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_trigger_states(cls, value: set[TriggerState]) -> set[TriggerState]
 ```
 
-#### `all_firings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L709" target="_blank">↗</a></sup>
+#### `all_firings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L709"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_firings(self) -> Sequence[Firing]
 ```
 
-#### `all_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L714" target="_blank">↗</a></sup>
+#### `all_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L714"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_events(self) -> Sequence[ReceivedEvent]
 ```
 
-### `TriggeredAction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L721" target="_blank">↗</a></sup>
+### `TriggeredAction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L721"><Icon icon="github" size="14" /></a></sup>
 
 
 An action caused as the result of an automation
@@ -335,7 +335,7 @@ An action caused as the result of an automation
 
 **Methods:**
 
-#### `idempotency_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L764" target="_blank">↗</a></sup>
+#### `idempotency_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L764"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 idempotency_key(self) -> str
@@ -344,13 +344,13 @@ idempotency_key(self) -> str
 Produce a human-friendly idempotency key for this action
 
 
-#### `all_firings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L774" target="_blank">↗</a></sup>
+#### `all_firings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L774"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_firings(self) -> Sequence[Firing]
 ```
 
-#### `all_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L777" target="_blank">↗</a></sup>
+#### `all_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/automations.py#L777"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_events(self) -> Sequence[ReceivedEvent]

--- a/docs/v3/api-ref/python/prefect-server-events-schemas-events.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-schemas-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Functions
 
-### `matches` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L239" target="_blank">↗</a></sup>
+### `matches` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L239"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches(expected: str, value: Optional[str]) -> bool
@@ -21,7 +21,7 @@ include a a negation prefix ("!this-value") or a wildcard suffix
 
 ## Classes
 
-### `Resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L44" target="_blank">↗</a></sup>
+### `Resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 
 An observable business object of interest to the user
@@ -29,31 +29,31 @@ An observable business object of interest to the user
 
 **Methods:**
 
-#### `enforce_maximum_labels` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L48" target="_blank">↗</a></sup>
+#### `enforce_maximum_labels` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L48"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enforce_maximum_labels(self) -> Self
 ```
 
-#### `requires_resource_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L58" target="_blank">↗</a></sup>
+#### `requires_resource_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L58"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 requires_resource_id(self) -> Self
 ```
 
-#### `id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L67" target="_blank">↗</a></sup>
+#### `id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L67"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 id(self) -> str
 ```
 
-#### `name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L71" target="_blank">↗</a></sup>
+#### `name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 name(self) -> Optional[str]
 ```
 
-#### `prefect_object_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L74" target="_blank">↗</a></sup>
+#### `prefect_object_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prefect_object_id(self, kind: str) -> UUID
@@ -63,7 +63,7 @@ Extracts the UUID from an event's resource ID if it's the expected kind
 of prefect resource
 
 
-### `RelatedResource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L85" target="_blank">↗</a></sup>
+### `RelatedResource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 
 A Resource with a specific role in an Event
@@ -71,19 +71,19 @@ A Resource with a specific role in an Event
 
 **Methods:**
 
-#### `requires_resource_role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L89" target="_blank">↗</a></sup>
+#### `requires_resource_role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 requires_resource_role(self) -> Self
 ```
 
-#### `role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L100" target="_blank">↗</a></sup>
+#### `role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 role(self) -> str
 ```
 
-### `Event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L114" target="_blank">↗</a></sup>
+### `Event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 
 The client-side view of an event that has happened to a Resource
@@ -91,13 +91,13 @@ The client-side view of an event that has happened to a Resource
 
 **Methods:**
 
-#### `involved_resources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L148" target="_blank">↗</a></sup>
+#### `involved_resources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L148"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 involved_resources(self) -> Sequence[Resource]
 ```
 
-#### `resource_in_role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L152" target="_blank">↗</a></sup>
+#### `resource_in_role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resource_in_role(self) -> Mapping[str, RelatedResource]
@@ -106,7 +106,7 @@ resource_in_role(self) -> Mapping[str, RelatedResource]
 Returns a mapping of roles to the first related resource in that role
 
 
-#### `resources_in_role` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L157" target="_blank">↗</a></sup>
+#### `resources_in_role` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L157"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resources_in_role(self) -> Mapping[str, Sequence[RelatedResource]]
@@ -115,19 +115,19 @@ resources_in_role(self) -> Mapping[str, Sequence[RelatedResource]]
 Returns a mapping of roles to related resources in that role
 
 
-#### `enforce_maximum_related_resources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L166" target="_blank">↗</a></sup>
+#### `enforce_maximum_related_resources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L166"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enforce_maximum_related_resources(cls, value: List[RelatedResource]) -> List[RelatedResource]
 ```
 
-#### `receive` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L177" target="_blank">↗</a></sup>
+#### `receive` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 receive(self, received: Optional[prefect.types._datetime.DateTime] = None) -> 'ReceivedEvent'
 ```
 
-#### `find_resource_label` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L185" target="_blank">↗</a></sup>
+#### `find_resource_label` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L185"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 find_resource_label(self, label: str) -> Optional[str]
@@ -138,7 +138,7 @@ related resources.  If the label starts with `related:<role>:`, search for the
 first matching label in a related resource with that role.
 
 
-### `ReceivedEvent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L198" target="_blank">↗</a></sup>
+### `ReceivedEvent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L198"><Icon icon="github" size="14" /></a></sup>
 
 
 The server-side view of an event that has happened to a Resource after it has
@@ -147,78 +147,78 @@ been received by the server
 
 **Methods:**
 
-#### `as_database_row` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L211" target="_blank">↗</a></sup>
+#### `as_database_row` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L211"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_database_row(self) -> dict[str, Any]
 ```
 
-#### `as_database_resource_rows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L218" target="_blank">↗</a></sup>
+#### `as_database_resource_rows` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L218"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_database_resource_rows(self) -> List[Dict[str, Any]]
 ```
 
-### `ResourceSpecification` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L259" target="_blank">↗</a></sup>
+### `ResourceSpecification` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L259"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `matches_every_resource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L260" target="_blank">↗</a></sup>
+#### `matches_every_resource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L260"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches_every_resource(self) -> bool
 ```
 
-#### `matches_every_resource_of_kind` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L263" target="_blank">↗</a></sup>
+#### `matches_every_resource_of_kind` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L263"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches_every_resource_of_kind(self, prefix: str) -> bool
 ```
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L273" target="_blank">↗</a></sup>
+#### `includes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L273"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 includes(self, candidates: Iterable[Resource]) -> bool
 ```
 
-#### `matches` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L281" target="_blank">↗</a></sup>
+#### `matches` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L281"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matches(self, resource: Resource) -> bool
 ```
 
-#### `items` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L288" target="_blank">↗</a></sup>
+#### `items` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L288"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 items(self) -> Iterable[Tuple[str, List[str]]]
 ```
 
-#### `pop` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L305" target="_blank">↗</a></sup>
+#### `pop` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L305"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pop(self, key: str, default: Optional[Union[str, List[str]]] = None) -> Optional[List[str]]
 ```
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L315" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L315"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(self, key: str, default: Optional[Union[str, List[str]]] = None) -> Optional[List[str]]
 ```
 
-#### `deepcopy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L328" target="_blank">↗</a></sup>
+#### `deepcopy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L328"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 deepcopy(self) -> 'ResourceSpecification'
 ```
 
-### `EventPage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L332" target="_blank">↗</a></sup>
+### `EventPage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L332"><Icon icon="github" size="14" /></a></sup>
 
 
 A single page of events returned from the API, with an optional link to the
 next page of results
 
 
-### `EventCount` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/events.py#L345" target="_blank">↗</a></sup>
+### `EventCount` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/events.py#L345"><Icon icon="github" size="14" /></a></sup>
 
 
 The count of events with the given filter value

--- a/docs/v3/api-ref/python/prefect-server-events-schemas-labelling.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-schemas-labelling.mdx
@@ -7,7 +7,7 @@ sidebarTitle: labelling
 
 ## Classes
 
-### `LabelDiver` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L6" target="_blank">↗</a></sup>
+### `LabelDiver` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L6"><Icon icon="github" size="14" /></a></sup>
 
 
 The LabelDiver supports templating use cases for any Labelled object, by
@@ -25,41 +25,41 @@ example:
     ```
 
 
-### `Labelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L76" target="_blank">↗</a></sup>
+### `Labelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `keys` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L77" target="_blank">↗</a></sup>
+#### `keys` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 keys(self) -> Iterable[str]
 ```
 
-#### `items` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L80" target="_blank">↗</a></sup>
+#### `items` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L80"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 items(self) -> Iterable[Tuple[str, str]]
 ```
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L93" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L93"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(self, label: str, default: Optional[str] = None) -> Optional[str]
 ```
 
-#### `as_label_value_array` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L96" target="_blank">↗</a></sup>
+#### `as_label_value_array` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_label_value_array(self) -> List[Dict[str, str]]
 ```
 
-#### `labels` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L100" target="_blank">↗</a></sup>
+#### `labels` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 labels(self) -> LabelDiver
 ```
 
-#### `has_all_labels` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L103" target="_blank">↗</a></sup>
+#### `has_all_labels` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/schemas/labelling.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 has_all_labels(self, labels: Dict[str, str]) -> bool

--- a/docs/v3/api-ref/python/prefect-server-events-services-actions.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-services-actions.mdx
@@ -7,7 +7,7 @@ sidebarTitle: actions
 
 ## Classes
 
-### `Actions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/actions.py#L22" target="_blank">↗</a></sup>
+### `Actions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/actions.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 
 Runs the actions triggered by automations
@@ -15,7 +15,7 @@ Runs the actions triggered by automations
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/actions.py#L28" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/actions.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-events-services-event_logger.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-services-event_logger.mdx
@@ -7,7 +7,7 @@ sidebarTitle: event_logger
 
 ## Classes
 
-### `EventLogger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/event_logger.py#L25" target="_blank">↗</a></sup>
+### `EventLogger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/event_logger.py#L25"><Icon icon="github" size="14" /></a></sup>
 
 
 A debugging service that logs events to the console as they arrive.
@@ -15,7 +15,7 @@ A debugging service that logs events to the console as they arrive.
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/event_logger.py#L31" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/event_logger.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-events-services-event_persister.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-services-event_persister.mdx
@@ -13,7 +13,7 @@ storage as fast as it can.  Never gets tired.
 
 ## Classes
 
-### `EventPersister` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L83" target="_blank">↗</a></sup>
+### `EventPersister` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 
 A service that persists events to the database as they arrive.
@@ -21,19 +21,19 @@ A service that persists events to the database as they arrive.
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L89" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-#### `started_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L97" target="_blank">↗</a></sup>
+#### `started_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L97"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 started_event(self) -> asyncio.Event
 ```
 
-#### `started_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L103" target="_blank">↗</a></sup>
+#### `started_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/event_persister.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 started_event(self, value: asyncio.Event) -> None

--- a/docs/v3/api-ref/python/prefect-server-events-services-triggers.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-services-triggers.mdx
@@ -7,7 +7,7 @@ sidebarTitle: triggers
 
 ## Classes
 
-### `ReactiveTriggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/triggers.py#L24" target="_blank">↗</a></sup>
+### `ReactiveTriggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/triggers.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 
 Evaluates reactive automation triggers
@@ -15,13 +15,13 @@ Evaluates reactive automation triggers
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/triggers.py#L30" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/triggers.py#L30"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-### `ProactiveTriggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/triggers.py#L64" target="_blank">↗</a></sup>
+### `ProactiveTriggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/triggers.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 
 Evaluates proactive automation triggers
@@ -29,7 +29,7 @@ Evaluates proactive automation triggers
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/services/triggers.py#L68" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/services/triggers.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-events-storage-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-storage-__init__.mdx
@@ -7,19 +7,19 @@ sidebarTitle: __init__
 
 ## Functions
 
-### `to_page_token` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L19" target="_blank">↗</a></sup>
+### `to_page_token` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_page_token(filter: 'EventFilter', count: int, page_size: int, current_offset: int) -> Optional[str]
 ```
 
-### `from_page_token` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L37" target="_blank">↗</a></sup>
+### `from_page_token` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_page_token(page_token: str) -> Tuple['EventFilter', int, int, int]
 ```
 
-### `process_time_based_counts` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L56" target="_blank">↗</a></sup>
+### `process_time_based_counts` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_time_based_counts(filter: 'EventFilter', time_unit: TimeUnit, time_interval: float, counts: List[EventCount]) -> List[EventCount]
@@ -38,6 +38,6 @@ occurred time of the events themselves.
 
 ## Classes
 
-### `InvalidTokenError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L15" target="_blank">↗</a></sup>
+### `InvalidTokenError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L15"><Icon icon="github" size="14" /></a></sup>
 
-### `QueryRangeTooLarge` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L98" target="_blank">↗</a></sup>
+### `QueryRangeTooLarge` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/__init__.py#L98"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-events-storage-database.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-storage-database.mdx
@@ -7,25 +7,25 @@ sidebarTitle: database
 
 ## Functions
 
-### `build_distinct_queries` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/database.py#L35" target="_blank">↗</a></sup>
+### `build_distinct_queries` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/database.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_distinct_queries(db: PrefectDBInterface, events_filter: EventFilter) -> list[sa.Column['ORMEvent']]
 ```
 
-### `get_max_query_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/database.py#L288" target="_blank">↗</a></sup>
+### `get_max_query_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/database.py#L288"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_max_query_parameters() -> int
 ```
 
-### `get_number_of_event_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/database.py#L297" target="_blank">↗</a></sup>
+### `get_number_of_event_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/database.py#L297"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_number_of_event_fields() -> int
 ```
 
-### `get_number_of_resource_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/storage/database.py#L302" target="_blank">↗</a></sup>
+### `get_number_of_resource_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/storage/database.py#L302"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_number_of_resource_fields() -> int

--- a/docs/v3/api-ref/python/prefect-server-events-stream.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-stream.mdx
@@ -7,23 +7,23 @@ sidebarTitle: stream
 
 ## Classes
 
-### `Distributor` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/stream.py#L139" target="_blank">↗</a></sup>
+### `Distributor` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/stream.py#L139"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/stream.py#L143" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/stream.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-#### `environment_variable_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/stream.py#L147" target="_blank">↗</a></sup>
+#### `environment_variable_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/stream.py#L147"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 environment_variable_name(cls) -> dict[str, str]
 ```
 
-#### `enabled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/stream.py#L151" target="_blank">↗</a></sup>
+#### `enabled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/stream.py#L151"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enabled(cls) -> bool

--- a/docs/v3/api-ref/python/prefect-server-events-triggers.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-triggers.mdx
@@ -13,13 +13,13 @@ to act on them based on the automations that users have set up.
 
 ## Functions
 
-### `find_interested_triggers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/triggers.py#L658" target="_blank">↗</a></sup>
+### `find_interested_triggers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/triggers.py#L658"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 find_interested_triggers(event: ReceivedEvent) -> Collection[EventTrigger]
 ```
 
-### `load_automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/triggers.py#L663" target="_blank">↗</a></sup>
+### `load_automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/triggers.py#L663"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_automation(automation: Optional[Automation]) -> None
@@ -29,7 +29,7 @@ load_automation(automation: Optional[Automation]) -> None
 Loads the given automation into memory so that it is available for evaluations
 
 
-### `forget_automation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/triggers.py#L681" target="_blank">↗</a></sup>
+### `forget_automation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/triggers.py#L681"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 forget_automation(automation_id: UUID) -> None
@@ -39,7 +39,7 @@ forget_automation(automation_id: UUID) -> None
 Unloads the given automation from memory
 
 
-### `causal_ordering` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/triggers.py#L1002" target="_blank">↗</a></sup>
+### `causal_ordering` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/events/triggers.py#L1002"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 causal_ordering() -> CausalOrdering

--- a/docs/v3/api-ref/python/prefect-server-exceptions.mdx
+++ b/docs/v3/api-ref/python/prefect-server-exceptions.mdx
@@ -7,7 +7,7 @@ sidebarTitle: exceptions
 
 ## Classes
 
-### `ObjectNotFoundError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/exceptions.py#L4" target="_blank">↗</a></sup>
+### `ObjectNotFoundError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/exceptions.py#L4"><Icon icon="github" size="14" /></a></sup>
 
 
 Error raised by the Prefect REST API when a requested object is not found.
@@ -16,20 +16,20 @@ If thrown during a request, this exception will be caught and
 a 404 response will be returned.
 
 
-### `OrchestrationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/exceptions.py#L13" target="_blank">↗</a></sup>
+### `OrchestrationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/exceptions.py#L13"><Icon icon="github" size="14" /></a></sup>
 
 
 An error raised while orchestrating a state transition
 
 
-### `MissingVariableError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/exceptions.py#L17" target="_blank">↗</a></sup>
+### `MissingVariableError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/exceptions.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 
 An error raised by the Prefect REST API when attempting to create or update a
 deployment with missing required variables.
 
 
-### `FlowRunGraphTooLarge` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/exceptions.py#L23" target="_blank">↗</a></sup>
+### `FlowRunGraphTooLarge` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/exceptions.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised to indicate that a flow run's graph has more nodes that the configured

--- a/docs/v3/api-ref/python/prefect-server-logs-stream.mdx
+++ b/docs/v3/api-ref/python/prefect-server-logs-stream.mdx
@@ -12,7 +12,7 @@ Log streaming for live log distribution via websockets.
 
 ## Functions
 
-### `log_matches_filter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/logs/stream.py#L99" target="_blank">↗</a></sup>
+### `log_matches_filter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/logs/stream.py#L99"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 log_matches_filter(log: Log, filter: LogFilter) -> bool
@@ -31,7 +31,7 @@ Check if a log matches the given filter criteria.
 
 ## Classes
 
-### `LogDistributor` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/logs/stream.py#L220" target="_blank">↗</a></sup>
+### `LogDistributor` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/logs/stream.py#L220"><Icon icon="github" size="14" /></a></sup>
 
 
 Service for distributing logs to websocket subscribers
@@ -39,19 +39,19 @@ Service for distributing logs to websocket subscribers
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/logs/stream.py#L226" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/logs/stream.py#L226"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-#### `environment_variable_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/logs/stream.py#L230" target="_blank">↗</a></sup>
+#### `environment_variable_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/logs/stream.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 environment_variable_name(cls) -> str
 ```
 
-#### `enabled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/logs/stream.py#L234" target="_blank">↗</a></sup>
+#### `enabled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/logs/stream.py#L234"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enabled(cls) -> bool

--- a/docs/v3/api-ref/python/prefect-server-models-block_schemas.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-block_schemas.mdx
@@ -13,7 +13,7 @@ Intended for internal use by the Prefect REST API.
 
 ## Classes
 
-### `MissingBlockTypeException` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/block_schemas.py#L28" target="_blank">↗</a></sup>
+### `MissingBlockTypeException` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/block_schemas.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the block type corresponding to a block schema cannot be found

--- a/docs/v3/api-ref/python/prefect-server-models-concurrency_limits_v2.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-concurrency_limits_v2.mdx
@@ -7,13 +7,13 @@ sidebarTitle: concurrency_limits_v2
 
 ## Functions
 
-### `active_slots_after_decay` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/concurrency_limits_v2.py#L12" target="_blank">↗</a></sup>
+### `active_slots_after_decay` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/concurrency_limits_v2.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 active_slots_after_decay(db: PrefectDBInterface) -> ColumnElement[float]
 ```
 
-### `denied_slots_after_decay` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/concurrency_limits_v2.py#L24" target="_blank">↗</a></sup>
+### `denied_slots_after_decay` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/concurrency_limits_v2.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 denied_slots_after_decay(db: PrefectDBInterface) -> ColumnElement[float]

--- a/docs/v3/api-ref/python/prefect-server-models-events.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Functions
 
-### `state_payload` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/events.py#L261" target="_blank">↗</a></sup>
+### `state_payload` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/events.py#L261"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state_payload(state: Optional[schemas.states.State]) -> Optional[Dict[str, str]]

--- a/docs/v3/api-ref/python/prefect-server-models-flow_runs.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-flow_runs.mdx
@@ -13,4 +13,4 @@ Intended for internal use by the Prefect REST API.
 
 ## Classes
 
-### `DependencyResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/flow_runs.py#L374" target="_blank">↗</a></sup>
+### `DependencyResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/flow_runs.py#L374"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-models-logs.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-logs.mdx
@@ -13,7 +13,7 @@ Intended for internal use by the Prefect REST API.
 
 ## Functions
 
-### `split_logs_into_batches` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/logs.py#L33" target="_blank">↗</a></sup>
+### `split_logs_into_batches` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/logs.py#L33"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 split_logs_into_batches(logs: Sequence[schemas.actions.LogCreate]) -> Generator[Tuple[LogCreate, ...], None, None]

--- a/docs/v3/api-ref/python/prefect-server-models-task_workers.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-task_workers.mdx
@@ -7,13 +7,13 @@ sidebarTitle: task_workers
 
 ## Classes
 
-### `TaskWorkerResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/task_workers.py#L16" target="_blank">↗</a></sup>
+### `TaskWorkerResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/task_workers.py#L16"><Icon icon="github" size="14" /></a></sup>
 
-### `InMemoryTaskWorkerTracker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/task_workers.py#L22" target="_blank">↗</a></sup>
+### `InMemoryTaskWorkerTracker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/task_workers.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `reset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/task_workers.py#L74" target="_blank">↗</a></sup>
+#### `reset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/task_workers.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset(self) -> None

--- a/docs/v3/api-ref/python/prefect-server-models-work_queues.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-work_queues.mdx
@@ -13,7 +13,7 @@ Intended for internal use by the Prefect REST API.
 
 ## Functions
 
-### `is_last_polled_recent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/models/work_queues.py#L209" target="_blank">↗</a></sup>
+### `is_last_polled_recent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/models/work_queues.py#L209"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_last_polled_recent(last_polled: Optional[DateTime]) -> bool

--- a/docs/v3/api-ref/python/prefect-server-orchestration-core_policy.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-core_policy.mdx
@@ -15,7 +15,7 @@ Prefect enforces on a state transition.
 
 ## Classes
 
-### `CoreFlowPolicyWithoutDeploymentConcurrency` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L56" target="_blank">↗</a></sup>
+### `CoreFlowPolicyWithoutDeploymentConcurrency` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 
 Orchestration rules that run against flow-run-state transitions in priority order.
@@ -23,13 +23,13 @@ Orchestration rules that run against flow-run-state transitions in priority orde
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L62" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L62"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.FlowRun, core.FlowRunPolicy],], type[BaseOrchestrationRule[orm_models.FlowRun, core.FlowRunPolicy]]]]
 ```
 
-### `CoreFlowPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L94" target="_blank">↗</a></sup>
+### `CoreFlowPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L94"><Icon icon="github" size="14" /></a></sup>
 
 
 Orchestration rules that run against flow-run-state transitions in priority order.
@@ -37,13 +37,13 @@ Orchestration rules that run against flow-run-state transitions in priority orde
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L100" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.FlowRun, core.FlowRunPolicy]], type[BaseOrchestrationRule[orm_models.FlowRun, core.FlowRunPolicy]]]]
 ```
 
-### `CoreTaskPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L134" target="_blank">↗</a></sup>
+### `CoreTaskPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L134"><Icon icon="github" size="14" /></a></sup>
 
 
 Orchestration rules that run against task-run-state transitions in priority order.
@@ -51,13 +51,13 @@ Orchestration rules that run against task-run-state transitions in priority orde
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L140" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L140"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.TaskRun, core.TaskRunPolicy]], type[BaseOrchestrationRule[orm_models.TaskRun, core.TaskRunPolicy]]]]
 ```
 
-### `ClientSideTaskOrchestrationPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L171" target="_blank">↗</a></sup>
+### `ClientSideTaskOrchestrationPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L171"><Icon icon="github" size="14" /></a></sup>
 
 
 Orchestration rules that run against task-run-state transitions in priority order,
@@ -66,13 +66,13 @@ specifically for clients doing client-side orchestration.
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L178" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.TaskRun, core.TaskRunPolicy]], type[BaseOrchestrationRule[orm_models.TaskRun, core.TaskRunPolicy]]]]
 ```
 
-### `BackgroundTaskPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L208" target="_blank">↗</a></sup>
+### `BackgroundTaskPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L208"><Icon icon="github" size="14" /></a></sup>
 
 
 Orchestration rules that run against task-run-state transitions in priority order.
@@ -80,43 +80,43 @@ Orchestration rules that run against task-run-state transitions in priority orde
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L214" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L214"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[type[BaseUniversalTransform[orm_models.TaskRun, core.TaskRunPolicy]] | type[BaseOrchestrationRule[orm_models.TaskRun, core.TaskRunPolicy]]]
 ```
 
-### `MinimalFlowPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L245" target="_blank">↗</a></sup>
+### `MinimalFlowPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L245"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L247" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L247"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.FlowRun, core.FlowRunPolicy]], type[BaseOrchestrationRule[orm_models.FlowRun, core.FlowRunPolicy]]]]
 ```
 
-### `MarkLateRunsPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L260" target="_blank">↗</a></sup>
+### `MarkLateRunsPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L260"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L262" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L262"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.FlowRun, core.FlowRunPolicy]], type[BaseOrchestrationRule[orm_models.FlowRun, core.FlowRunPolicy]]]]
 ```
 
-### `MinimalTaskPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L274" target="_blank">↗</a></sup>
+### `MinimalTaskPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L274"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L276" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L276"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.TaskRun, core.TaskRunPolicy]], type[BaseOrchestrationRule[orm_models.TaskRun, core.TaskRunPolicy]]]]
 ```
 
-### `SecureTaskConcurrencySlots` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L287" target="_blank">↗</a></sup>
+### `SecureTaskConcurrencySlots` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L287"><Icon icon="github" size="14" /></a></sup>
 
 
 Checks relevant concurrency slots are available before entering a Running state.
@@ -130,14 +130,14 @@ before trying again. If the concurrency limit set on a tag is 0, the transition 
 be aborted to prevent deadlocks.
 
 
-### `ReleaseTaskConcurrencySlots` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L369" target="_blank">↗</a></sup>
+### `ReleaseTaskConcurrencySlots` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L369"><Icon icon="github" size="14" /></a></sup>
 
 
 Releases any concurrency slots held by a run upon exiting a Running or
 Cancelling state.
 
 
-### `SecureFlowConcurrencySlots` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L398" target="_blank">↗</a></sup>
+### `SecureFlowConcurrencySlots` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L398"><Icon icon="github" size="14" /></a></sup>
 
 
 Enforce deployment concurrency limits.
@@ -151,7 +151,7 @@ before provisioning dynamic infrastructure to run a flow. If a slot isn't availa
 won't provision infrastructure.
 
 
-### `ReleaseFlowConcurrencySlots` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L514" target="_blank">↗</a></sup>
+### `ReleaseFlowConcurrencySlots` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L514"><Icon icon="github" size="14" /></a></sup>
 
 
 Releases deployment concurrency slots held by a flow run.
@@ -160,13 +160,13 @@ This rule releases a concurrency slot for a deployment when a flow run
 transitions out of the Running or Cancelling state.
 
 
-### `CacheInsertion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L572" target="_blank">↗</a></sup>
+### `CacheInsertion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L572"><Icon icon="github" size="14" /></a></sup>
 
 
 Caches completed states with cache keys after they are validated.
 
 
-### `CacheRetrieval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L618" target="_blank">↗</a></sup>
+### `CacheRetrieval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L618"><Icon icon="github" size="14" /></a></sup>
 
 
 Rejects running states if a completed state has been cached.
@@ -176,7 +176,7 @@ has already been associated with a completed state in the cache table. The clien
 will be instructed to transition into the cached completed state instead.
 
 
-### `RetryFailedFlows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L668" target="_blank">↗</a></sup>
+### `RetryFailedFlows` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L668"><Icon icon="github" size="14" /></a></sup>
 
 
 Rejects failed states and schedules a retry if the retry limit has not been reached.
@@ -186,7 +186,7 @@ set and the run count has not reached the specified limit. The client will be
 instructed to transition into a scheduled state to retry flow execution.
 
 
-### `RetryFailedTasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L744" target="_blank">↗</a></sup>
+### `RetryFailedTasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L744"><Icon icon="github" size="14" /></a></sup>
 
 
 Rejects failed states and schedules a retry if the retry limit has not been reached.
@@ -197,13 +197,13 @@ asserts it is a retriable task run. The client will be instructed to
 transition into a scheduled state to retry task execution.
 
 
-### `EnqueueScheduledTasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L796" target="_blank">↗</a></sup>
+### `EnqueueScheduledTasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L796"><Icon icon="github" size="14" /></a></sup>
 
 
 Enqueues background task runs when they are scheduled
 
 
-### `RenameReruns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L827" target="_blank">↗</a></sup>
+### `RenameReruns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L827"><Icon icon="github" size="14" /></a></sup>
 
 
 Name the states if they have run more than once.
@@ -212,7 +212,7 @@ In the special case where the initial state is an "AwaitingRetry" scheduled stat
 the proposed state will be renamed to "Retrying" instead.
 
 
-### `CopyScheduledTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L857" target="_blank">↗</a></sup>
+### `CopyScheduledTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L857"><Icon icon="github" size="14" /></a></sup>
 
 
 Ensures scheduled time is copied from scheduled states to pending states.
@@ -221,7 +221,7 @@ If a new scheduled time has been proposed on the pending state, the scheduled ti
 on the scheduled state will be ignored.
 
 
-### `WaitForScheduledTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L887" target="_blank">↗</a></sup>
+### `WaitForScheduledTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L887"><Icon icon="github" size="14" /></a></sup>
 
 
 Prevents transitions to running states from happening too early.
@@ -233,7 +233,7 @@ database and the client will be sent an instruction to wait for `delay_seconds`
 before attempting the transition again.
 
 
-### `CopyTaskParametersID` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L929" target="_blank">↗</a></sup>
+### `CopyTaskParametersID` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L929"><Icon icon="github" size="14" /></a></sup>
 
 
 Ensures a task's parameters ID is copied from Scheduled to Pending and from
@@ -243,25 +243,25 @@ If a parameters ID has been included on the proposed state, the parameters ID
 on the initial state will be ignored.
 
 
-### `HandlePausingFlows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L956" target="_blank">↗</a></sup>
+### `HandlePausingFlows` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L956"><Icon icon="github" size="14" /></a></sup>
 
 
 Governs runs attempting to enter a Paused/Suspended state
 
 
-### `HandleResumingPausedFlows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1022" target="_blank">↗</a></sup>
+### `HandleResumingPausedFlows` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1022"><Icon icon="github" size="14" /></a></sup>
 
 
 Governs runs attempting to leave a Paused state
 
 
-### `UpdateFlowRunTrackerOnTasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1096" target="_blank">↗</a></sup>
+### `UpdateFlowRunTrackerOnTasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1096"><Icon icon="github" size="14" /></a></sup>
 
 
 Tracks the flow run attempt a task run state is associated with.
 
 
-### `HandleTaskTerminalStateTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1123" target="_blank">↗</a></sup>
+### `HandleTaskTerminalStateTransitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1123"><Icon icon="github" size="14" /></a></sup>
 
 
 We do not allow tasks to leave terminal states if:
@@ -272,7 +272,7 @@ We reset the run count when a task leaves a terminal state for a non-terminal st
 which resets task run retries; this is particularly relevant for flow run retries.
 
 
-### `HandleFlowTerminalStateTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1187" target="_blank">↗</a></sup>
+### `HandleFlowTerminalStateTransitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1187"><Icon icon="github" size="14" /></a></sup>
 
 
 We do not allow flows to leave terminal states if:
@@ -284,7 +284,7 @@ We reset the pause metadata when a flow leaves a terminal state for a non-termin
 state. This resets pause behavior during manual flow run retries.
 
 
-### `PreventPendingTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1265" target="_blank">↗</a></sup>
+### `PreventPendingTransitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1265"><Icon icon="github" size="14" /></a></sup>
 
 
 Prevents transitions to PENDING.
@@ -307,9 +307,9 @@ For re-runs of deployed runs, they should transition to SCHEDULED first.
 For re-runs of ad-hoc runs, they should transition directly to RUNNING.
 
 
-### `EnsureOnlyScheduledFlowsMarkedLate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1314" target="_blank">↗</a></sup>
+### `EnsureOnlyScheduledFlowsMarkedLate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1314"><Icon icon="github" size="14" /></a></sup>
 
-### `PreventRunningTasksFromStoppedFlows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1336" target="_blank">↗</a></sup>
+### `PreventRunningTasksFromStoppedFlows` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1336"><Icon icon="github" size="14" /></a></sup>
 
 
 Prevents running tasks from stopped flows.
@@ -318,13 +318,13 @@ A running state implies execution, but also the converse. This rule ensures that
 flow's tasks cannot be run unless the flow is also running.
 
 
-### `EnforceCancellingToCancelledTransition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1383" target="_blank">↗</a></sup>
+### `EnforceCancellingToCancelledTransition` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1383"><Icon icon="github" size="14" /></a></sup>
 
 
 Rejects transitions from Cancelling to any terminal state except for Cancelled.
 
 
-### `BypassCancellingFlowRunsWithNoInfra` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1407" target="_blank">↗</a></sup>
+### `BypassCancellingFlowRunsWithNoInfra` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1407"><Icon icon="github" size="14" /></a></sup>
 
 
 Rejects transitions from Scheduled to Cancelling, and instead sets the state to Cancelled,
@@ -339,7 +339,7 @@ to clean up, we can transition directly to `Cancelled`. Runs that are `Resuming`
 Runs that are `AwaitingRetry` are a `Scheduled` state that may have associated infrastructure.
 
 
-### `PreventDuplicateTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1451" target="_blank">↗</a></sup>
+### `PreventDuplicateTransitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1451"><Icon icon="github" size="14" /></a></sup>
 
 
 Prevent duplicate transitions from being made right after one another.

--- a/docs/v3/api-ref/python/prefect-server-orchestration-dependencies.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-dependencies.mdx
@@ -12,25 +12,25 @@ Injected orchestration dependencies
 
 ## Functions
 
-### `temporary_task_policy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L101" target="_blank">↗</a></sup>
+### `temporary_task_policy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L101"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_task_policy(tmp_task_policy: type[TaskRunOrchestrationPolicy])
 ```
 
-### `temporary_flow_policy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L115" target="_blank">↗</a></sup>
+### `temporary_flow_policy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_flow_policy(tmp_flow_policy: type[FlowRunOrchestrationPolicy])
 ```
 
-### `temporary_task_orchestration_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L129" target="_blank">↗</a></sup>
+### `temporary_task_orchestration_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L129"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_task_orchestration_parameters(tmp_orchestration_parameters: dict[str, Any])
 ```
 
-### `temporary_flow_orchestration_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L151" target="_blank">↗</a></sup>
+### `temporary_flow_orchestration_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L151"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_flow_orchestration_parameters(tmp_orchestration_parameters: dict[str, Any])
@@ -38,4 +38,4 @@ temporary_flow_orchestration_parameters(tmp_orchestration_parameters: dict[str, 
 
 ## Classes
 
-### `OrchestrationDependencies` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L23" target="_blank">↗</a></sup>
+### `OrchestrationDependencies` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/dependencies.py#L23"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-orchestration-global_policy.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-global_policy.mdx
@@ -18,7 +18,7 @@ state database, they should be the most deeply nested contexts in orchestration 
 
 ## Functions
 
-### `COMMON_GLOBAL_TRANSFORMS` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L34" target="_blank">↗</a></sup>
+### `COMMON_GLOBAL_TRANSFORMS` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 COMMON_GLOBAL_TRANSFORMS() -> list[type[BaseUniversalTransform[orm_models.Run, Union[core.FlowRunPolicy, core.TaskRunPolicy]]]]
@@ -26,7 +26,7 @@ COMMON_GLOBAL_TRANSFORMS() -> list[type[BaseUniversalTransform[orm_models.Run, U
 
 ## Classes
 
-### `GlobalFlowPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L54" target="_blank">↗</a></sup>
+### `GlobalFlowPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 
 Global transforms that run against flow-run-state transitions in priority order.
@@ -37,13 +37,13 @@ is validated.
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L63" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.FlowRun, core.FlowRunPolicy]], type[BaseOrchestrationRule[orm_models.FlowRun, core.FlowRunPolicy]]]]
 ```
 
-### `GlobalTaskPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L87" target="_blank">↗</a></sup>
+### `GlobalTaskPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L87"><Icon icon="github" size="14" /></a></sup>
 
 
 Global transforms that run against task-run-state transitions in priority order.
@@ -54,37 +54,37 @@ is validated.
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L96" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[Union[type[BaseUniversalTransform[orm_models.TaskRun, core.TaskRunPolicy]], type[BaseOrchestrationRule[orm_models.TaskRun, core.TaskRunPolicy]]]]
 ```
 
-### `SetRunStateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L115" target="_blank">↗</a></sup>
+### `SetRunStateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 
 Updates the state type of a run on a state transition.
 
 
-### `SetRunStateName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L135" target="_blank">↗</a></sup>
+### `SetRunStateName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L135"><Icon icon="github" size="14" /></a></sup>
 
 
 Updates the state name of a run on a state transition.
 
 
-### `SetStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L155" target="_blank">↗</a></sup>
+### `SetStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L155"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the time a run enters a running state for the first time.
 
 
-### `SetRunStateTimestamp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L177" target="_blank">↗</a></sup>
+### `SetRunStateTimestamp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the time a run changes states.
 
 
-### `SetEndTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L197" target="_blank">↗</a></sup>
+### `SetEndTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L197"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the time a run enters a terminal state.
@@ -94,31 +94,31 @@ However, it's possible to force these transitions manually via the API. While
 leaving a terminal state, the end time will be unset.
 
 
-### `IncrementRunTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L233" target="_blank">↗</a></sup>
+### `IncrementRunTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L233"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the amount of time a run spends in the running state.
 
 
-### `IncrementFlowRunCount` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L257" target="_blank">↗</a></sup>
+### `IncrementFlowRunCount` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L257"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the number of times a run enters a running state. For use with retries.
 
 
-### `RemoveResumingIndicator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L283" target="_blank">↗</a></sup>
+### `RemoveResumingIndicator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L283"><Icon icon="github" size="14" /></a></sup>
 
 
 Removes the indicator on a flow run that marks it as resuming.
 
 
-### `IncrementTaskRunCount` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L309" target="_blank">↗</a></sup>
+### `IncrementTaskRunCount` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L309"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the number of times a run enters a running state. For use with retries.
 
 
-### `SetExpectedStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L328" target="_blank">↗</a></sup>
+### `SetExpectedStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L328"><Icon icon="github" size="14" /></a></sup>
 
 
 Estimates the time a state is expected to start running if not set.
@@ -127,7 +127,7 @@ For scheduled states, this estimate is simply the scheduled time. For other stat
 this is set to the time the proposed state was created by Prefect.
 
 
-### `SetNextScheduledStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L356" target="_blank">↗</a></sup>
+### `SetNextScheduledStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L356"><Icon icon="github" size="14" /></a></sup>
 
 
 Records the scheduled time on a run.
@@ -137,20 +137,20 @@ the state's scheduled time. When leaving a scheduled state,
 `run.next_scheduled_start_time` is unset.
 
 
-### `UpdateSubflowParentTask` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L386" target="_blank">↗</a></sup>
+### `UpdateSubflowParentTask` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L386"><Icon icon="github" size="14" /></a></sup>
 
 
 Whenever a subflow changes state, it must update its parent task run's state.
 
 
-### `UpdateSubflowStateDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L418" target="_blank">↗</a></sup>
+### `UpdateSubflowStateDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L418"><Icon icon="github" size="14" /></a></sup>
 
 
 Update a child subflow state's references to a corresponding tracking task run id
 in the parent flow run
 
 
-### `UpdateStateDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L442" target="_blank">↗</a></sup>
+### `UpdateStateDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/global_policy.py#L442"><Icon icon="github" size="14" /></a></sup>
 
 
 Update a state's references to a corresponding flow- or task- run.

--- a/docs/v3/api-ref/python/prefect-server-orchestration-instrumentation_policies.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-instrumentation_policies.mdx
@@ -13,7 +13,7 @@ Observability
 
 ## Classes
 
-### `InstrumentFlowRunStateTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/instrumentation_policies.py#L25" target="_blank">↗</a></sup>
+### `InstrumentFlowRunStateTransitions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/instrumentation_policies.py#L25"><Icon icon="github" size="14" /></a></sup>
 
 
 When a Flow Run changes states, fire a Prefect Event for the state change

--- a/docs/v3/api-ref/python/prefect-server-orchestration-policies.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-policies.mdx
@@ -21,7 +21,7 @@ mechanism to configure and observe exactly what logic will fire against a transi
 
 ## Classes
 
-### `BaseOrchestrationPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/policies.py#L30" target="_blank">↗</a></sup>
+### `BaseOrchestrationPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/policies.py#L30"><Icon icon="github" size="14" /></a></sup>
 
 
 An abstract base class used to organize orchestration rules in priority order.
@@ -33,7 +33,7 @@ different orchestration logic.
 
 **Methods:**
 
-#### `priority` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/policies.py#L41" target="_blank">↗</a></sup>
+#### `priority` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/policies.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 priority() -> list[type[BaseUniversalTransform[T, RP] | BaseOrchestrationRule[T, RP]]]
@@ -42,7 +42,7 @@ priority() -> list[type[BaseUniversalTransform[T, RP] | BaseOrchestrationRule[T,
 A list of orchestration rules in priority order.
 
 
-#### `compile_transition_rules` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/policies.py#L51" target="_blank">↗</a></sup>
+#### `compile_transition_rules` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/policies.py#L51"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compile_transition_rules(cls, from_state: states.StateType | None = None, to_state: states.StateType | None = None) -> list[type[BaseUniversalTransform[T, RP] | BaseOrchestrationRule[T, RP]]]
@@ -51,8 +51,8 @@ compile_transition_rules(cls, from_state: states.StateType | None = None, to_sta
 Returns rules in policy that are valid for the specified state transition.
 
 
-### `TaskRunOrchestrationPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/policies.py#L69" target="_blank">↗</a></sup>
+### `TaskRunOrchestrationPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/policies.py#L69"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunOrchestrationPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/policies.py#L75" target="_blank">↗</a></sup>
+### `FlowRunOrchestrationPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/policies.py#L75"><Icon icon="github" size="14" /></a></sup>
 
-### `GenericOrchestrationPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/policies.py#L81" target="_blank">↗</a></sup>
+### `GenericOrchestrationPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/policies.py#L81"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-orchestration-rules.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-rules.mdx
@@ -27,7 +27,7 @@ single line of user code.
 
 ## Classes
 
-### `OrchestrationContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L72" target="_blank">↗</a></sup>
+### `OrchestrationContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L72"><Icon icon="github" size="14" /></a></sup>
 
 
 A container for a state transition, governed by orchestration rules.
@@ -52,7 +52,7 @@ should occur at all and nothing is written to the database.
 
 **Methods:**
 
-#### `initial_state_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L126" target="_blank">↗</a></sup>
+#### `initial_state_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L126"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 initial_state_type(self) -> Optional[states.StateType]
@@ -61,7 +61,7 @@ initial_state_type(self) -> Optional[states.StateType]
 The state type of `self.initial_state` if it exists.
 
 
-#### `proposed_state_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L132" target="_blank">↗</a></sup>
+#### `proposed_state_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L132"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 proposed_state_type(self) -> Optional[states.StateType]
@@ -70,7 +70,7 @@ proposed_state_type(self) -> Optional[states.StateType]
 The state type of `self.proposed_state` if it exists.
 
 
-#### `validated_state_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L138" target="_blank">↗</a></sup>
+#### `validated_state_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L138"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validated_state_type(self) -> Optional[states.StateType]
@@ -79,7 +79,7 @@ validated_state_type(self) -> Optional[states.StateType]
 The state type of `self.validated_state` if it exists.
 
 
-#### `run_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L143" target="_blank">↗</a></sup>
+#### `run_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_settings(self) -> RP
@@ -88,7 +88,7 @@ run_settings(self) -> RP
 Run-level settings used to orchestrate the state transition.
 
 
-#### `safe_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L149" target="_blank">↗</a></sup>
+#### `safe_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L149"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 safe_copy(self) -> Self
@@ -106,7 +106,7 @@ without risking mutation.
 - A mutation-safe copy of the `OrchestrationContext`
 
 
-#### `entry_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L177" target="_blank">↗</a></sup>
+#### `entry_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 entry_context(self) -> tuple[Optional[states.State], Optional[states.State], Self]
@@ -120,7 +120,7 @@ to the database. These hooks have a consistent interface which can be generated
 with this method.
 
 
-#### `exit_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L192" target="_blank">↗</a></sup>
+#### `exit_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L192"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exit_context(self) -> tuple[Optional[states.State], Optional[states.State], Self]
@@ -134,7 +134,7 @@ to the database. These hooks have a consistent interface which can be generated
 with this method.
 
 
-### `FlowOrchestrationContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L211" target="_blank">↗</a></sup>
+### `FlowOrchestrationContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L211"><Icon icon="github" size="14" /></a></sup>
 
 
 A container for a flow run state transition, governed by orchestration rules.
@@ -160,7 +160,7 @@ should occur at all and nothing is written to the database.
 
 **Methods:**
 
-#### `safe_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L336" target="_blank">↗</a></sup>
+#### `safe_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L336"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 safe_copy(self) -> Self
@@ -178,7 +178,7 @@ without risking mutation.
 - A mutation-safe copy of `FlowOrchestrationContext`
 
 
-#### `run_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L356" target="_blank">↗</a></sup>
+#### `run_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L356"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_settings(self) -> core.FlowRunPolicy
@@ -187,7 +187,7 @@ run_settings(self) -> core.FlowRunPolicy
 Run-level settings used to orchestrate the state transition.
 
 
-### `TaskOrchestrationContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L368" target="_blank">↗</a></sup>
+### `TaskOrchestrationContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L368"><Icon icon="github" size="14" /></a></sup>
 
 
 A container for a task run state transition, governed by orchestration rules.
@@ -213,7 +213,7 @@ should occur at all and nothing is written to the database.
 
 **Methods:**
 
-#### `safe_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L497" target="_blank">↗</a></sup>
+#### `safe_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L497"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 safe_copy(self) -> Self
@@ -231,7 +231,7 @@ without risking mutation.
 - A mutation-safe copy of `TaskOrchestrationContext`
 
 
-#### `run_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L517" target="_blank">↗</a></sup>
+#### `run_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L517"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_settings(self) -> core.TaskRunPolicy
@@ -240,7 +240,7 @@ run_settings(self) -> core.TaskRunPolicy
 Run-level settings used to orchestrate the state transition.
 
 
-### `BaseOrchestrationRule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L534" target="_blank">↗</a></sup>
+### `BaseOrchestrationRule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L534"><Icon icon="github" size="14" /></a></sup>
 
 
 An abstract base class used to implement a discrete piece of orchestration logic.
@@ -315,13 +315,13 @@ state type is not contained in `FROM_STATES`, no hooks will fire
 this state type is not contained in `TO_STATES`, no hooks will fire
 
 
-### `FlowRunOrchestrationRule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L945" target="_blank">↗</a></sup>
+### `FlowRunOrchestrationRule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L945"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskRunOrchestrationRule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L951" target="_blank">↗</a></sup>
+### `TaskRunOrchestrationRule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L951"><Icon icon="github" size="14" /></a></sup>
 
-### `GenericOrchestrationRule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L957" target="_blank">↗</a></sup>
+### `GenericOrchestrationRule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L957"><Icon icon="github" size="14" /></a></sup>
 
-### `BaseUniversalTransform` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L963" target="_blank">↗</a></sup>
+### `BaseUniversalTransform` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L963"><Icon icon="github" size="14" /></a></sup>
 
 
 An abstract base class used to implement privileged bookkeeping logic.
@@ -340,7 +340,7 @@ passed between transforms
 
 **Methods:**
 
-#### `nullified_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1060" target="_blank">↗</a></sup>
+#### `nullified_transition` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1060"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 nullified_transition(self) -> bool
@@ -355,7 +355,7 @@ nothing should be written to the database.
 - True if the transition is nullified, False otherwise.
 
 
-#### `exception_in_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1073" target="_blank">↗</a></sup>
+#### `exception_in_transition` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1073"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exception_in_transition(self) -> bool
@@ -367,8 +367,8 @@ Determines if the transition has encountered an exception.
 - True if the transition is encountered an exception, False otherwise.
 
 
-### `TaskRunUniversalTransform` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1084" target="_blank">↗</a></sup>
+### `TaskRunUniversalTransform` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1084"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunUniversalTransform` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1090" target="_blank">↗</a></sup>
+### `FlowRunUniversalTransform` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1090"><Icon icon="github" size="14" /></a></sup>
 
-### `GenericUniversalTransform` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1096" target="_blank">↗</a></sup>
+### `GenericUniversalTransform` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/orchestration/rules.py#L1096"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-schemas-actions.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-actions.mdx
@@ -12,7 +12,7 @@ Reduced schemas for accepting API actions.
 
 ## Functions
 
-### `validate_base_job_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L852" target="_blank">↗</a></sup>
+### `validate_base_job_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L852"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_base_job_template(v: dict[str, Any]) -> dict[str, Any]
@@ -20,41 +20,41 @@ validate_base_job_template(v: dict[str, Any]) -> dict[str, Any]
 
 ## Classes
 
-### `ActionBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L56" target="_blank">↗</a></sup>
+### `ActionBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L56"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L60" target="_blank">↗</a></sup>
+### `FlowCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a flow.
 
 
-### `FlowUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L78" target="_blank">↗</a></sup>
+### `FlowUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a flow.
 
 
-### `DeploymentScheduleCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L88" target="_blank">↗</a></sup>
+### `DeploymentScheduleCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L88"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_max_scheduled_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L109" target="_blank">↗</a></sup>
+#### `validate_max_scheduled_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L109"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_max_scheduled_runs(cls, v: PositiveInteger | None) -> PositiveInteger | None
 ```
 
-### `DeploymentScheduleUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L117" target="_blank">↗</a></sup>
+### `DeploymentScheduleUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_max_scheduled_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L139" target="_blank">↗</a></sup>
+#### `validate_max_scheduled_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L139"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_max_scheduled_runs(cls, v: PositiveInteger | None) -> PositiveInteger | None
 ```
 
-### `DeploymentCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L147" target="_blank">↗</a></sup>
+### `DeploymentCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L147"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a deployment.
@@ -62,7 +62,7 @@ Data used by the Prefect REST API to create a deployment.
 
 **Methods:**
 
-#### `check_valid_configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L225" target="_blank">↗</a></sup>
+#### `check_valid_configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L225"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_valid_configuration(self, base_job_template: dict[str, Any]) -> None
@@ -77,13 +77,13 @@ errors. Instead of this method, use `validate_job_variables_for_deployment`
 function from `prefect_cloud.orion.api.validation`.
 
 
-#### `remove_old_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L251" target="_blank">↗</a></sup>
+#### `remove_old_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L251"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 remove_old_fields(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `DeploymentUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L278" target="_blank">↗</a></sup>
+### `DeploymentUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L278"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a deployment.
@@ -91,13 +91,13 @@ Data used by the Prefect REST API to update a deployment.
 
 **Methods:**
 
-#### `remove_old_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L283" target="_blank">↗</a></sup>
+#### `remove_old_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L283"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 remove_old_fields(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `check_valid_configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L345" target="_blank">↗</a></sup>
+#### `check_valid_configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L345"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_valid_configuration(self, base_job_template: dict[str, Any]) -> None
@@ -112,7 +112,7 @@ errors. Instead of this method, use `validate_job_variables_for_deployment`
 function from `prefect_cloud.orion.api.validation`.
 
 
-### `FlowRunUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L384" target="_blank">↗</a></sup>
+### `FlowRunUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L384"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a flow run.
@@ -120,13 +120,13 @@ Data used by the Prefect REST API to update a flow run.
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L399" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L399"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-### `StateCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L403" target="_blank">↗</a></sup>
+### `StateCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L403"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a new state.
@@ -134,7 +134,7 @@ Data used by the Prefect REST API to create a new state.
 
 **Methods:**
 
-#### `default_name_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L424" target="_blank">↗</a></sup>
+#### `default_name_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L424"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_name_from_type(self)
@@ -143,13 +143,13 @@ default_name_from_type(self)
 If a name is not provided, use the type
 
 
-#### `default_scheduled_start_time` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L434" target="_blank">↗</a></sup>
+#### `default_scheduled_start_time` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L434"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_scheduled_start_time(self)
 ```
 
-### `TaskRunCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L444" target="_blank">↗</a></sup>
+### `TaskRunCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L444"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a task run
@@ -157,19 +157,19 @@ Data used by the Prefect REST API to create a task run
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L516" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L516"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-#### `validate_cache_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L521" target="_blank">↗</a></sup>
+#### `validate_cache_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L521"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_cache_key(cls, cache_key: str | None) -> str | None
 ```
 
-### `TaskRunUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L525" target="_blank">↗</a></sup>
+### `TaskRunUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L525"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a task run
@@ -177,13 +177,13 @@ Data used by the Prefect REST API to update a task run
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L534" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L534"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-### `FlowRunCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L538" target="_blank">↗</a></sup>
+### `FlowRunCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L538"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a flow run.
@@ -191,13 +191,13 @@ Data used by the Prefect REST API to create a flow run.
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L613" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L613"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-### `DeploymentFlowRunCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L617" target="_blank">↗</a></sup>
+### `DeploymentFlowRunCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L617"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a flow run from a deployment.
@@ -205,43 +205,43 @@ Data used by the Prefect REST API to create a flow run from a deployment.
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L672" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L672"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-### `SavedSearchCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L676" target="_blank">↗</a></sup>
+### `SavedSearchCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L676"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a saved search.
 
 
-### `ConcurrencyLimitCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L685" target="_blank">↗</a></sup>
+### `ConcurrencyLimitCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L685"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a concurrency limit.
 
 
-### `ConcurrencyLimitV2Create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L694" target="_blank">↗</a></sup>
+### `ConcurrencyLimitV2Create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L694"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a v2 concurrency limit.
 
 
-### `ConcurrencyLimitV2Update` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L714" target="_blank">↗</a></sup>
+### `ConcurrencyLimitV2Update` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L714"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a v2 concurrency limit.
 
 
-### `BlockTypeCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L725" target="_blank">↗</a></sup>
+### `BlockTypeCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L725"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a block type.
 
 
-### `BlockTypeUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L746" target="_blank">↗</a></sup>
+### `BlockTypeUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L746"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a block type.
@@ -249,19 +249,19 @@ Data used by the Prefect REST API to update a block type.
 
 **Methods:**
 
-#### `updatable_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L755" target="_blank">↗</a></sup>
+#### `updatable_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L755"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 updatable_fields(cls) -> set[str]
 ```
 
-### `BlockSchemaCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L759" target="_blank">↗</a></sup>
+### `BlockSchemaCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L759"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a block schema.
 
 
-### `BlockDocumentCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L777" target="_blank">↗</a></sup>
+### `BlockDocumentCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L777"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a block document.
@@ -269,19 +269,19 @@ Data used by the Prefect REST API to create a block document.
 
 **Methods:**
 
-#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L802" target="_blank">↗</a></sup>
+#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L802"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_name_is_present_if_not_anonymous(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `BlockDocumentUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L808" target="_blank">↗</a></sup>
+### `BlockDocumentUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L808"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a block document.
 
 
-### `BlockDocumentReferenceCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L820" target="_blank">↗</a></sup>
+### `BlockDocumentReferenceCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L820"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used to create block document reference.
@@ -289,43 +289,43 @@ Data used to create block document reference.
 
 **Methods:**
 
-#### `validate_parent_and_ref_are_different` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L837" target="_blank">↗</a></sup>
+#### `validate_parent_and_ref_are_different` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L837"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_parent_and_ref_are_different(cls, values)
 ```
 
-### `LogCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L841" target="_blank">↗</a></sup>
+### `LogCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L841"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a log.
 
 
-### `WorkPoolCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L883" target="_blank">↗</a></sup>
+### `WorkPoolCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L883"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a work pool.
 
 
-### `WorkPoolUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L912" target="_blank">↗</a></sup>
+### `WorkPoolUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L912"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a work pool.
 
 
-### `WorkQueueCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L928" target="_blank">↗</a></sup>
+### `WorkQueueCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L928"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a work queue.
 
 
-### `WorkQueueUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L957" target="_blank">↗</a></sup>
+### `WorkQueueUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L957"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a work queue.
 
 
-### `ArtifactCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L978" target="_blank">↗</a></sup>
+### `ArtifactCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L978"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create an artifact.
@@ -333,25 +333,25 @@ Data used by the Prefect REST API to create an artifact.
 
 **Methods:**
 
-#### `from_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L1018" target="_blank">↗</a></sup>
+#### `from_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L1018"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_result(cls, data: Any | dict[str, Any]) -> 'ArtifactCreate'
 ```
 
-### `ArtifactUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L1036" target="_blank">↗</a></sup>
+### `ArtifactUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L1036"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update an artifact.
 
 
-### `VariableCreate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L1046" target="_blank">↗</a></sup>
+### `VariableCreate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L1046"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to create a Variable.
 
 
-### `VariableUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/actions.py#L1062" target="_blank">↗</a></sup>
+### `VariableUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/actions.py#L1062"><Icon icon="github" size="14" /></a></sup>
 
 
 Data used by the Prefect REST API to update a Variable.

--- a/docs/v3/api-ref/python/prefect-server-schemas-core.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-core.mdx
@@ -12,13 +12,13 @@ Full schemas of Prefect REST API objects.
 
 ## Classes
 
-### `Flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L83" target="_blank">↗</a></sup>
+### `Flow` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of flow data.
 
 
-### `FlowRunPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L101" target="_blank">↗</a></sup>
+### `FlowRunPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L101"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines of how a flow run should retry.
@@ -26,29 +26,29 @@ Defines of how a flow run should retry.
 
 **Methods:**
 
-#### `populate_deprecated_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L135" target="_blank">↗</a></sup>
+#### `populate_deprecated_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L135"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 populate_deprecated_fields(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `CreatedBy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L139" target="_blank">↗</a></sup>
+### `CreatedBy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L139"><Icon icon="github" size="14" /></a></sup>
 
-### `UpdatedBy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L151" target="_blank">↗</a></sup>
+### `UpdatedBy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L151"><Icon icon="github" size="14" /></a></sup>
 
-### `ConcurrencyLimitStrategy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L163" target="_blank">↗</a></sup>
+### `ConcurrencyLimitStrategy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L163"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of concurrency collision strategies.
 
 
-### `ConcurrencyOptions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L172" target="_blank">↗</a></sup>
+### `ConcurrencyOptions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 
 Class for storing the concurrency config in database.
 
 
-### `FlowRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L180" target="_blank">↗</a></sup>
+### `FlowRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L180"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of flow run data.
@@ -56,13 +56,13 @@ An ORM representation of flow run data.
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L322" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L322"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-### `TaskRunPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L340" target="_blank">↗</a></sup>
+### `TaskRunPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L340"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines of how a task run should retry.
@@ -70,52 +70,52 @@ Defines of how a task run should retry.
 
 **Methods:**
 
-#### `populate_deprecated_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L369" target="_blank">↗</a></sup>
+#### `populate_deprecated_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L369"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 populate_deprecated_fields(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-#### `validate_configured_retry_delays` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L374" target="_blank">↗</a></sup>
+#### `validate_configured_retry_delays` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L374"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_configured_retry_delays(cls, v: int | float | list[int] | list[float] | None) -> int | float | list[int] | list[float] | None
 ```
 
-#### `validate_jitter_factor` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L381" target="_blank">↗</a></sup>
+#### `validate_jitter_factor` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L381"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_jitter_factor(cls, v: float | None) -> float | None
 ```
 
-### `RunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L385" target="_blank">↗</a></sup>
+### `RunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L385"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for classes that represent inputs to runs, which
 could include, constants, parameters, task runs or flow runs.
 
 
-### `TaskRunResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L396" target="_blank">↗</a></sup>
+### `TaskRunResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L396"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a task run result input to another task run.
 
 
-### `FlowRunResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L403" target="_blank">↗</a></sup>
+### `FlowRunResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L403"><Icon icon="github" size="14" /></a></sup>
 
-### `Parameter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L408" target="_blank">↗</a></sup>
+### `Parameter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L408"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a parameter input to a task run.
 
 
-### `Constant` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L415" target="_blank">↗</a></sup>
+### `Constant` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L415"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents constant input value to a task run.
 
 
-### `TaskRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L422" target="_blank">↗</a></sup>
+### `TaskRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L422"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of task run data.
@@ -123,67 +123,67 @@ An ORM representation of task run data.
 
 **Methods:**
 
-#### `set_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L537" target="_blank">↗</a></sup>
+#### `set_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L537"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_name(cls, name: str) -> str
 ```
 
-#### `validate_cache_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L542" target="_blank">↗</a></sup>
+#### `validate_cache_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L542"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_cache_key(cls, cache_key: str) -> str
 ```
 
-### `DeploymentSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L546" target="_blank">↗</a></sup>
+### `DeploymentSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L546"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_max_scheduled_runs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L571" target="_blank">↗</a></sup>
+#### `validate_max_scheduled_runs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L571"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_max_scheduled_runs(cls, v: int) -> int
 ```
 
-### `VersionInfo` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L577" target="_blank">↗</a></sup>
+### `VersionInfo` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L577"><Icon icon="github" size="14" /></a></sup>
 
-### `Deployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L582" target="_blank">↗</a></sup>
+### `Deployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L582"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of deployment data.
 
 
-### `ConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L694" target="_blank">↗</a></sup>
+### `ConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L694"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a concurrency limit.
 
 
-### `ConcurrencyLimitV2` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L707" target="_blank">↗</a></sup>
+### `ConcurrencyLimitV2` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L707"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a v2 concurrency limit.
 
 
-### `BlockType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L726" target="_blank">↗</a></sup>
+### `BlockType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L726"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block type
 
 
-### `BlockSchema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L750" target="_blank">↗</a></sup>
+### `BlockSchema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L750"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block schema.
 
 
-### `BlockSchemaReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L773" target="_blank">↗</a></sup>
+### `BlockSchemaReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L773"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block schema reference.
 
 
-### `BlockDocument` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L793" target="_blank">↗</a></sup>
+### `BlockDocument` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L793"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block document.
@@ -191,13 +191,13 @@ An ORM representation of a block document.
 
 **Methods:**
 
-#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L828" target="_blank">↗</a></sup>
+#### `validate_name_is_present_if_not_anonymous` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L828"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_name_is_present_if_not_anonymous(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `BlockDocumentReference` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L881" target="_blank">↗</a></sup>
+### `BlockDocumentReference` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L881"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a block document reference.
@@ -205,53 +205,53 @@ An ORM representation of a block document reference.
 
 **Methods:**
 
-#### `validate_parent_and_ref_are_different` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L901" target="_blank">↗</a></sup>
+#### `validate_parent_and_ref_are_different` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L901"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_parent_and_ref_are_different(cls, values: dict[str, Any]) -> dict[str, Any]
 ```
 
-### `Configuration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L907" target="_blank">↗</a></sup>
+### `Configuration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L907"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of account info.
 
 
-### `SavedSearchFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L914" target="_blank">↗</a></sup>
+### `SavedSearchFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L914"><Icon icon="github" size="14" /></a></sup>
 
 
 A filter for a saved search model. Intended for use by the Prefect UI.
 
 
-### `SavedSearch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L931" target="_blank">↗</a></sup>
+### `SavedSearch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L931"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of saved search data. Represents a set of filter criteria.
 
 
-### `Log` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L941" target="_blank">↗</a></sup>
+### `Log` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L941"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of log data.
 
 
-### `QueueFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L956" target="_blank">↗</a></sup>
+### `QueueFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L956"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter criteria definition for a work queue.
 
 
-### `WorkQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L969" target="_blank">↗</a></sup>
+### `WorkQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L969"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a work queue
 
 
-### `WorkQueueHealthPolicy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1002" target="_blank">↗</a></sup>
+### `WorkQueueHealthPolicy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1002"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `evaluate_health_status` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1018" target="_blank">↗</a></sup>
+#### `evaluate_health_status` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1018"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 evaluate_health_status(self, late_runs_count: int, last_polled: Optional[DateTime] = None) -> bool
@@ -267,21 +267,21 @@ Given empirical information about the state of the work queue, evaluate its heal
 - whether or not the work queue is healthy.
 
 
-### `WorkQueueStatusDetail` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1049" target="_blank">↗</a></sup>
+### `WorkQueueStatusDetail` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1049"><Icon icon="github" size="14" /></a></sup>
 
-### `Agent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1065" target="_blank">↗</a></sup>
+### `Agent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1065"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of an agent
 
 
-### `WorkPoolStorageConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1083" target="_blank">↗</a></sup>
+### `WorkPoolStorageConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1083"><Icon icon="github" size="14" /></a></sup>
 
 
 A representation of a work pool's storage configuration
 
 
-### `WorkPool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1102" target="_blank">↗</a></sup>
+### `WorkPool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1102"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a work pool
@@ -289,44 +289,44 @@ An ORM representation of a work pool
 
 **Methods:**
 
-#### `helpful_error_for_missing_default_queue_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1138" target="_blank">↗</a></sup>
+#### `helpful_error_for_missing_default_queue_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1138"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 helpful_error_for_missing_default_queue_id(cls, v: UUID | None) -> UUID
 ```
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1142" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1142"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: Type[Self], obj: Any) -> Self
 ```
 
-### `Worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1159" target="_blank">↗</a></sup>
+### `Worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1159"><Icon icon="github" size="14" /></a></sup>
 
 
 An ORM representation of a worker
 
 
-### `Artifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1181" target="_blank">↗</a></sup>
+### `Artifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1181"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `from_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1218" target="_blank">↗</a></sup>
+#### `from_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1218"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_result(cls, data: Any | dict[str, Any]) -> 'Artifact'
 ```
 
-#### `validate_metadata_length` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1237" target="_blank">↗</a></sup>
+#### `validate_metadata_length` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1237"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_metadata_length(cls, v: dict[str, str]) -> dict[str, str]
 ```
 
-### `ArtifactCollection` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1241" target="_blank">↗</a></sup>
+### `ArtifactCollection` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1241"><Icon icon="github" size="14" /></a></sup>
 
-### `Variable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1278" target="_blank">↗</a></sup>
+### `Variable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1278"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunInput` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1297" target="_blank">↗</a></sup>
+### `FlowRunInput` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1297"><Icon icon="github" size="14" /></a></sup>
 
-### `CsrfToken` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/core.py#L1306" target="_blank">↗</a></sup>
+### `CsrfToken` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/core.py#L1306"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-schemas-filters.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-filters.mdx
@@ -14,13 +14,13 @@ Each filter schema includes logic for transforming itself into a SQL `where` cla
 
 ## Classes
 
-### `Operator` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L39" target="_blank">↗</a></sup>
+### `Operator` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 
 Operators for combining filter criteria.
 
 
-### `PrefectFilterBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L46" target="_blank">↗</a></sup>
+### `PrefectFilterBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 
 Base model for Prefect filters
@@ -28,7 +28,7 @@ Base model for Prefect filters
 
 **Methods:**
 
-#### `as_sql_filter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L52" target="_blank">↗</a></sup>
+#### `as_sql_filter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L52"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_filter(self, db: 'PrefectDBInterface') -> sa.ColumnElement[bool]
@@ -37,7 +37,7 @@ as_sql_filter(self, db: 'PrefectDBInterface') -> sa.ColumnElement[bool]
 Generate SQL filter from provided filter parameters. If no filters parameters are available, return a TRUE filter.
 
 
-### `PrefectOperatorFilterBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L66" target="_blank">↗</a></sup>
+### `PrefectOperatorFilterBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L66"><Icon icon="github" size="14" /></a></sup>
 
 
 Base model for Prefect filters that combines criteria with a user-provided operator
@@ -45,139 +45,139 @@ Base model for Prefect filters that combines criteria with a user-provided opera
 
 **Methods:**
 
-#### `as_sql_filter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L75" target="_blank">↗</a></sup>
+#### `as_sql_filter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L75"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_filter(self, db: 'PrefectDBInterface') -> sa.ColumnElement[bool]
 ```
 
-### `FlowFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L82" target="_blank">↗</a></sup>
+### `FlowFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L82"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Flow.id`.
 
 
-### `FlowFilterDeployment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L98" target="_blank">↗</a></sup>
+### `FlowFilterDeployment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by flows by deployment
 
 
-### `FlowFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L128" target="_blank">↗</a></sup>
+### `FlowFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L128"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Flow.name`.
 
 
-### `FlowFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L158" target="_blank">↗</a></sup>
+### `FlowFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L158"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Flow.tags`.
 
 
-### `FlowFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L184" target="_blank">↗</a></sup>
+### `FlowFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L184"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for flows. Only flows matching all criteria will be returned.
 
 
-### `FlowRunFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L217" target="_blank">↗</a></sup>
+### `FlowRunFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L217"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.id`.
 
 
-### `FlowRunFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L238" target="_blank">↗</a></sup>
+### `FlowRunFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L238"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.name`.
 
 
-### `FlowRunFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L268" target="_blank">↗</a></sup>
+### `FlowRunFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L268"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.tags`.
 
 
-### `FlowRunFilterDeploymentId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L308" target="_blank">↗</a></sup>
+### `FlowRunFilterDeploymentId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L308"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.deployment_id`.
 
 
-### `FlowRunFilterWorkQueueName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L334" target="_blank">↗</a></sup>
+### `FlowRunFilterWorkQueueName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L334"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.work_queue_name`.
 
 
-### `FlowRunFilterStateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L362" target="_blank">↗</a></sup>
+### `FlowRunFilterStateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L362"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.state_type`.
 
 
-### `FlowRunFilterStateName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L383" target="_blank">↗</a></sup>
+### `FlowRunFilterStateName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L383"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.state_name`.
 
 
-### `FlowRunFilterState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L404" target="_blank">↗</a></sup>
+### `FlowRunFilterState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L404"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.state_type` and `FlowRun.state_name`.
 
 
-### `FlowRunFilterFlowVersion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L429" target="_blank">↗</a></sup>
+### `FlowRunFilterFlowVersion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L429"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.flow_version`.
 
 
-### `FlowRunFilterStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L445" target="_blank">↗</a></sup>
+### `FlowRunFilterStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L445"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.start_time`.
 
 
-### `FlowRunFilterEndTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L483" target="_blank">↗</a></sup>
+### `FlowRunFilterEndTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L483"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.end_time`.
 
 
-### `FlowRunFilterExpectedStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L515" target="_blank">↗</a></sup>
+### `FlowRunFilterExpectedStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L515"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.expected_start_time`.
 
 
-### `FlowRunFilterNextScheduledStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L538" target="_blank">↗</a></sup>
+### `FlowRunFilterNextScheduledStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L538"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.next_scheduled_start_time`.
 
 
-### `FlowRunFilterParentFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L567" target="_blank">↗</a></sup>
+### `FlowRunFilterParentFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L567"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for subflows of a given flow run
 
 
-### `FlowRunFilterParentTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L594" target="_blank">↗</a></sup>
+### `FlowRunFilterParentTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L594"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `FlowRun.parent_task_run_id`.
 
 
-### `FlowRunFilterIdempotencyKey` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L620" target="_blank">↗</a></sup>
+### `FlowRunFilterIdempotencyKey` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L620"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by FlowRun.idempotency_key.
 
 
-### `FlowRunFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L641" target="_blank">↗</a></sup>
+### `FlowRunFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L641"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter flow runs. Only flow runs matching all criteria will be returned
@@ -185,416 +185,416 @@ Filter flow runs. Only flow runs matching all criteria will be returned
 
 **Methods:**
 
-#### `only_filters_on_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L688" target="_blank">↗</a></sup>
+#### `only_filters_on_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L688"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 only_filters_on_id(self) -> bool
 ```
 
-### `TaskRunFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L744" target="_blank">↗</a></sup>
+### `TaskRunFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L744"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.flow_run_id`.
 
 
-### `TaskRunFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L769" target="_blank">↗</a></sup>
+### `TaskRunFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L769"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.id`.
 
 
-### `TaskRunFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L785" target="_blank">↗</a></sup>
+### `TaskRunFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L785"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.name`.
 
 
-### `TaskRunFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L815" target="_blank">↗</a></sup>
+### `TaskRunFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L815"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.tags`.
 
 
-### `TaskRunFilterStateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L843" target="_blank">↗</a></sup>
+### `TaskRunFilterStateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L843"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.state_type`.
 
 
-### `TaskRunFilterStateName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L859" target="_blank">↗</a></sup>
+### `TaskRunFilterStateName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L859"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.state_name`.
 
 
-### `TaskRunFilterState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L875" target="_blank">↗</a></sup>
+### `TaskRunFilterState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L875"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.type` and `TaskRun.name`.
 
 
-### `TaskRunFilterSubFlowRuns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L900" target="_blank">↗</a></sup>
+### `TaskRunFilterSubFlowRuns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L900"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.subflow_run`.
 
 
-### `TaskRunFilterStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L922" target="_blank">↗</a></sup>
+### `TaskRunFilterStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L922"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.start_time`.
 
 
-### `TaskRunFilterExpectedStartTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L954" target="_blank">↗</a></sup>
+### `TaskRunFilterExpectedStartTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L954"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `TaskRun.expected_start_time`.
 
 
-### `TaskRunFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L977" target="_blank">↗</a></sup>
+### `TaskRunFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L977"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter task runs. Only task runs matching all criteria will be returned
 
 
-### `DeploymentFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1030" target="_blank">↗</a></sup>
+### `DeploymentFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1030"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.id`.
 
 
-### `DeploymentFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1051" target="_blank">↗</a></sup>
+### `DeploymentFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1051"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.name`.
 
 
-### `DeploymentOrFlowNameFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1081" target="_blank">↗</a></sup>
+### `DeploymentOrFlowNameFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1081"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.name` or `Flow.name` with a single input string for ilike filtering.
 
 
-### `DeploymentFilterPaused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1106" target="_blank">↗</a></sup>
+### `DeploymentFilterPaused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1106"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.paused`.
 
 
-### `DeploymentFilterWorkQueueName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1123" target="_blank">↗</a></sup>
+### `DeploymentFilterWorkQueueName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1123"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.work_queue_name`.
 
 
-### `DeploymentFilterConcurrencyLimit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1141" target="_blank">↗</a></sup>
+### `DeploymentFilterConcurrencyLimit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1141"><Icon icon="github" size="14" /></a></sup>
 
 
 DEPRECATED: Prefer `Deployment.concurrency_limit_id` over `Deployment.concurrency_limit`.
 
 
-### `DeploymentFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1166" target="_blank">↗</a></sup>
+### `DeploymentFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1166"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Deployment.tags`.
 
 
-### `DeploymentFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1204" target="_blank">↗</a></sup>
+### `DeploymentFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1204"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for deployments. Only deployments matching all criteria will be returned.
 
 
-### `DeploymentScheduleFilterActive` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1251" target="_blank">↗</a></sup>
+### `DeploymentScheduleFilterActive` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1251"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `DeploymentSchedule.active`.
 
 
-### `DeploymentScheduleFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1268" target="_blank">↗</a></sup>
+### `DeploymentScheduleFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1268"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter for deployments. Only deployments matching all criteria will be returned.
 
 
-### `LogFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1286" target="_blank">↗</a></sup>
+### `LogFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1286"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.name`.
 
 
-### `LogFilterLevel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1304" target="_blank">↗</a></sup>
+### `LogFilterLevel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1304"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.level`.
 
 
-### `LogFilterTimestamp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1330" target="_blank">↗</a></sup>
+### `LogFilterTimestamp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1330"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.timestamp`.
 
 
-### `LogFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1353" target="_blank">↗</a></sup>
+### `LogFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1353"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.flow_run_id`.
 
 
-### `LogFilterTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1369" target="_blank">↗</a></sup>
+### `LogFilterTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1369"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Log.task_run_id`.
 
 
-### `LogFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1396" target="_blank">↗</a></sup>
+### `LogFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1396"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter logs. Only logs matching all criteria will be returned
 
 
-### `FilterSet` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1429" target="_blank">↗</a></sup>
+### `FilterSet` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1429"><Icon icon="github" size="14" /></a></sup>
 
 
 A collection of filters for common objects
 
 
-### `BlockTypeFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1447" target="_blank">↗</a></sup>
+### `BlockTypeFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1447"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockType.name`
 
 
-### `BlockTypeFilterSlug` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1469" target="_blank">↗</a></sup>
+### `BlockTypeFilterSlug` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1469"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockType.slug`
 
 
-### `BlockTypeFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1486" target="_blank">↗</a></sup>
+### `BlockTypeFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1486"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter BlockTypes
 
 
-### `BlockSchemaFilterBlockTypeId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1510" target="_blank">↗</a></sup>
+### `BlockSchemaFilterBlockTypeId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1510"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockSchema.block_type_id`.
 
 
-### `BlockSchemaFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1526" target="_blank">↗</a></sup>
+### `BlockSchemaFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1526"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by BlockSchema.id
 
 
-### `BlockSchemaFilterCapabilities` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1542" target="_blank">↗</a></sup>
+### `BlockSchemaFilterCapabilities` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1542"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockSchema.capabilities`
 
 
-### `BlockSchemaFilterVersion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1563" target="_blank">↗</a></sup>
+### `BlockSchemaFilterVersion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1563"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockSchema.capabilities`
 
 
-### `BlockSchemaFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1581" target="_blank">↗</a></sup>
+### `BlockSchemaFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1581"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter BlockSchemas
 
 
-### `BlockDocumentFilterIsAnonymous` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1614" target="_blank">↗</a></sup>
+### `BlockDocumentFilterIsAnonymous` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1614"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.is_anonymous`.
 
 
-### `BlockDocumentFilterBlockTypeId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1633" target="_blank">↗</a></sup>
+### `BlockDocumentFilterBlockTypeId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1633"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.block_type_id`.
 
 
-### `BlockDocumentFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1649" target="_blank">↗</a></sup>
+### `BlockDocumentFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1649"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.id`.
 
 
-### `BlockDocumentFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1665" target="_blank">↗</a></sup>
+### `BlockDocumentFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1665"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `BlockDocument.name`.
 
 
-### `BlockDocumentFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1691" target="_blank">↗</a></sup>
+### `BlockDocumentFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1691"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter BlockDocuments. Only BlockDocuments matching all criteria will be returned
 
 
-### `WorkQueueFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1727" target="_blank">↗</a></sup>
+### `WorkQueueFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1727"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkQueue.id`.
 
 
-### `WorkQueueFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1744" target="_blank">↗</a></sup>
+### `WorkQueueFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1744"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkQueue.name`.
 
 
-### `WorkQueueFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1778" target="_blank">↗</a></sup>
+### `WorkQueueFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1778"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter work queues. Only work queues matching all criteria will be
 returned
 
 
-### `WorkPoolFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1803" target="_blank">↗</a></sup>
+### `WorkPoolFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1803"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkPool.id`.
 
 
-### `WorkPoolFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1819" target="_blank">↗</a></sup>
+### `WorkPoolFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1819"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkPool.name`.
 
 
-### `WorkPoolFilterType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1835" target="_blank">↗</a></sup>
+### `WorkPoolFilterType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1835"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `WorkPool.type`.
 
 
-### `WorkPoolFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1851" target="_blank">↗</a></sup>
+### `WorkPoolFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1851"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter work pools. Only work pools matching all criteria will be returned
 
 
-### `WorkerFilterWorkPoolId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1879" target="_blank">↗</a></sup>
+### `WorkerFilterWorkPoolId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1879"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.worker_config_id`.
 
 
-### `WorkerFilterStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1895" target="_blank">↗</a></sup>
+### `WorkerFilterStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1895"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.status`.
 
 
-### `WorkerFilterLastHeartbeatTime` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1916" target="_blank">↗</a></sup>
+### `WorkerFilterLastHeartbeatTime` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1916"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.last_heartbeat_time`.
 
 
-### `WorkerFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1943" target="_blank">↗</a></sup>
+### `WorkerFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1943"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Worker.last_heartbeat_time`.
 
 
-### `ArtifactFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1973" target="_blank">↗</a></sup>
+### `ArtifactFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1973"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.id`.
 
 
-### `ArtifactFilterKey` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L1989" target="_blank">↗</a></sup>
+### `ArtifactFilterKey` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L1989"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.key`.
 
 
-### `ArtifactFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2030" target="_blank">↗</a></sup>
+### `ArtifactFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2030"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.flow_run_id`.
 
 
-### `ArtifactFilterTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2046" target="_blank">↗</a></sup>
+### `ArtifactFilterTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2046"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.task_run_id`.
 
 
-### `ArtifactFilterType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2062" target="_blank">↗</a></sup>
+### `ArtifactFilterType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2062"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Artifact.type`.
 
 
-### `ArtifactFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2083" target="_blank">↗</a></sup>
+### `ArtifactFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2083"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter artifacts. Only artifacts matching all criteria will be returned
 
 
-### `ArtifactCollectionFilterLatestId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2121" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterLatestId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2121"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.latest_id`.
 
 
-### `ArtifactCollectionFilterKey` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2137" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterKey` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2137"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.key`.
 
 
-### `ArtifactCollectionFilterFlowRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2179" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterFlowRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2179"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.flow_run_id`.
 
 
-### `ArtifactCollectionFilterTaskRunId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2195" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterTaskRunId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2195"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.task_run_id`.
 
 
-### `ArtifactCollectionFilterType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2211" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilterType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2211"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `ArtifactCollection.type`.
 
 
-### `ArtifactCollectionFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2232" target="_blank">↗</a></sup>
+### `ArtifactCollectionFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2232"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter artifact collections. Only artifact collections matching all criteria will be returned
 
 
-### `VariableFilterId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2270" target="_blank">↗</a></sup>
+### `VariableFilterId` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2270"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Variable.id`.
 
 
-### `VariableFilterName` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2286" target="_blank">↗</a></sup>
+### `VariableFilterName` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2286"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Variable.name`.
 
 
-### `VariableFilterTags` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2312" target="_blank">↗</a></sup>
+### `VariableFilterTags` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2312"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter by `Variable.tags`.
 
 
-### `VariableFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/filters.py#L2340" target="_blank">↗</a></sup>
+### `VariableFilter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/filters.py#L2340"><Icon icon="github" size="14" /></a></sup>
 
 
 Filter variables. Only variables matching all criteria will be returned

--- a/docs/v3/api-ref/python/prefect-server-schemas-graph.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-graph.mdx
@@ -7,12 +7,12 @@ sidebarTitle: graph
 
 ## Classes
 
-### `GraphState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/graph.py#L9" target="_blank">↗</a></sup>
+### `GraphState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/graph.py#L9"><Icon icon="github" size="14" /></a></sup>
 
-### `GraphArtifact` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/graph.py#L16" target="_blank">↗</a></sup>
+### `GraphArtifact` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/graph.py#L16"><Icon icon="github" size="14" /></a></sup>
 
-### `Edge` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/graph.py#L25" target="_blank">↗</a></sup>
+### `Edge` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/graph.py#L25"><Icon icon="github" size="14" /></a></sup>
 
-### `Node` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/graph.py#L29" target="_blank">↗</a></sup>
+### `Node` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/graph.py#L29"><Icon icon="github" size="14" /></a></sup>
 
-### `Graph` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/graph.py#L42" target="_blank">↗</a></sup>
+### `Graph` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/graph.py#L42"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-schemas-internal.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-internal.mdx
@@ -11,4 +11,4 @@ appropriate for use on the API itself.
 
 ## Classes
 
-### `InternalWorkPoolUpdate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/internal.py#L11" target="_blank">↗</a></sup>
+### `InternalWorkPoolUpdate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/internal.py#L11"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-schemas-responses.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-responses.mdx
@@ -12,43 +12,43 @@ Schemas for special responses from the Prefect REST API.
 
 ## Classes
 
-### `SetStateStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L26" target="_blank">↗</a></sup>
+### `SetStateStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumerates return statuses for setting run states.
 
 
-### `StateAcceptDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L35" target="_blank">↗</a></sup>
+### `StateAcceptDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with an ACCEPT state transition.
 
 
-### `StateRejectDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L47" target="_blank">↗</a></sup>
+### `StateRejectDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with a REJECT state transition.
 
 
-### `StateAbortDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L62" target="_blank">↗</a></sup>
+### `StateAbortDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L62"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with an ABORT state transition.
 
 
-### `StateWaitDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L77" target="_blank">↗</a></sup>
+### `StateWaitDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 
 Details associated with a WAIT state transition.
 
 
-### `HistoryResponseState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L99" target="_blank">↗</a></sup>
+### `HistoryResponseState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L99"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a single state's history over an interval.
 
 
-### `HistoryResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L123" target="_blank">↗</a></sup>
+### `HistoryResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L123"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents a history of aggregation states over an interval
@@ -56,84 +56,84 @@ Represents a history of aggregation states over an interval
 
 **Methods:**
 
-#### `validate_timestamps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L138" target="_blank">↗</a></sup>
+#### `validate_timestamps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L138"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_timestamps(cls, values: dict) -> dict
 ```
 
-### `OrchestrationResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L157" target="_blank">↗</a></sup>
+### `OrchestrationResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L157"><Icon icon="github" size="14" /></a></sup>
 
 
 A container for the output of state orchestration.
 
 
-### `WorkerFlowRunResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L167" target="_blank">↗</a></sup>
+### `WorkerFlowRunResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L167"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L175" target="_blank">↗</a></sup>
+### `FlowRunResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L175"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L312" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: Type[Self], obj: Any) -> Self
 ```
 
-### `TaskRunResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L347" target="_blank">↗</a></sup>
+### `TaskRunResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L347"><Icon icon="github" size="14" /></a></sup>
 
-### `DeploymentResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L402" target="_blank">↗</a></sup>
+### `DeploymentResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L402"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L509" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L509"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: Type[Self], obj: Any) -> Self
 ```
 
-### `WorkQueueResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L530" target="_blank">↗</a></sup>
+### `WorkQueueResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L530"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L540" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L540"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: Type[Self], obj: Any) -> Self
 ```
 
-### `WorkQueueWithStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L559" target="_blank">↗</a></sup>
+### `WorkQueueWithStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L559"><Icon icon="github" size="14" /></a></sup>
 
 
 Combines a work queue and its status details into a single object
 
 
-### `WorkerResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L567" target="_blank">↗</a></sup>
+### `WorkerResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L567"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `model_validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L574" target="_blank">↗</a></sup>
+#### `model_validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L574"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_validate(cls: Type[Self], obj: Any) -> Self
 ```
 
-### `GlobalConcurrencyLimitResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L604" target="_blank">↗</a></sup>
+### `GlobalConcurrencyLimitResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L604"><Icon icon="github" size="14" /></a></sup>
 
 
 A response object for global concurrency limits.
 
 
-### `FlowPaginationResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L623" target="_blank">↗</a></sup>
+### `FlowPaginationResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L623"><Icon icon="github" size="14" /></a></sup>
 
-### `FlowRunPaginationResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L631" target="_blank">↗</a></sup>
+### `FlowRunPaginationResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L631"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskRunPaginationResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L639" target="_blank">↗</a></sup>
+### `TaskRunPaginationResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L639"><Icon icon="github" size="14" /></a></sup>
 
-### `DeploymentPaginationResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L647" target="_blank">↗</a></sup>
+### `DeploymentPaginationResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L647"><Icon icon="github" size="14" /></a></sup>
 
-### `SchemaValuePropertyError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L655" target="_blank">↗</a></sup>
+### `SchemaValuePropertyError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L655"><Icon icon="github" size="14" /></a></sup>
 
-### `SchemaValueIndexError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L660" target="_blank">↗</a></sup>
+### `SchemaValueIndexError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L660"><Icon icon="github" size="14" /></a></sup>
 
-### `SchemaValuesValidationResponse` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/responses.py#L668" target="_blank">↗</a></sup>
+### `SchemaValuesValidationResponse` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/responses.py#L668"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-schemas-schedules.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-schedules.mdx
@@ -12,7 +12,7 @@ Schedule schemas
 
 ## Classes
 
-### `IntervalSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L71" target="_blank">↗</a></sup>
+### `IntervalSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L71"><Icon icon="github" size="14" /></a></sup>
 
 
 A schedule formed by adding `interval` increments to an `anchor_date`. If no
@@ -44,13 +44,13 @@ if not provided, the current timestamp will be used.
 
 **Methods:**
 
-#### `validate_timezone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L110" target="_blank">↗</a></sup>
+#### `validate_timezone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_timezone(self)
 ```
 
-### `CronSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L302" target="_blank">↗</a></sup>
+### `CronSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L302"><Icon icon="github" size="14" /></a></sup>
 
 
 Cron schedule
@@ -77,19 +77,19 @@ behaves like fcron and enables you to e.g. define a job that executes each
 
 **Methods:**
 
-#### `validate_timezone` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L338" target="_blank">↗</a></sup>
+#### `validate_timezone` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L338"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_timezone(self)
 ```
 
-#### `valid_cron_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L344" target="_blank">↗</a></sup>
+#### `valid_cron_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L344"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 valid_cron_string(cls, v: str) -> str
 ```
 
-### `RRuleSchedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L477" target="_blank">↗</a></sup>
+### `RRuleSchedule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L477"><Icon icon="github" size="14" /></a></sup>
 
 
 RRule schedule, based on the iCalendar standard
@@ -112,19 +112,19 @@ a 9am daily schedule with a UTC start date will maintain a 9am UTC time.
 
 **Methods:**
 
-#### `validate_rrule_str` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L504" target="_blank">↗</a></sup>
+#### `validate_rrule_str` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L504"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_rrule_str(cls, v: str) -> str
 ```
 
-#### `from_rrule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L508" target="_blank">↗</a></sup>
+#### `from_rrule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L508"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_rrule(cls, rrule: dateutil.rrule.rrule | dateutil.rrule.rruleset) -> 'RRuleSchedule'
 ```
 
-#### `to_rrule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/schedules.py#L565" target="_blank">↗</a></sup>
+#### `to_rrule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/schedules.py#L565"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_rrule(self) -> dateutil.rrule.rrule

--- a/docs/v3/api-ref/python/prefect-server-schemas-sorting.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-sorting.mdx
@@ -12,7 +12,7 @@ Schemas for sorting Prefect REST API objects.
 
 ## Classes
 
-### `FlowRunSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L21" target="_blank">↗</a></sup>
+### `FlowRunSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L21"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines flow run sorting options.
@@ -20,7 +20,7 @@ Defines flow run sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L35" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -29,7 +29,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort flow runs
 
 
-### `TaskRunSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L61" target="_blank">↗</a></sup>
+### `TaskRunSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L61"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines task run sorting options.
@@ -37,7 +37,7 @@ Defines task run sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L73" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -46,7 +46,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `LogSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L89" target="_blank">↗</a></sup>
+### `LogSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines log sorting options.
@@ -54,7 +54,7 @@ Defines log sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L96" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -63,7 +63,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `FlowSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L105" target="_blank">↗</a></sup>
+### `FlowSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L105"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines flow sorting options.
@@ -71,7 +71,7 @@ Defines flow sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L114" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -80,7 +80,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `DeploymentSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L125" target="_blank">↗</a></sup>
+### `DeploymentSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines deployment sorting options.
@@ -88,7 +88,7 @@ Defines deployment sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L134" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L134"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -97,7 +97,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `ArtifactSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L145" target="_blank">↗</a></sup>
+### `ArtifactSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines artifact sorting options.
@@ -105,7 +105,7 @@ Defines artifact sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L155" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L155"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -114,7 +114,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `ArtifactCollectionSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L167" target="_blank">↗</a></sup>
+### `ArtifactCollectionSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L167"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines artifact collection sorting options.
@@ -122,7 +122,7 @@ Defines artifact collection sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L177" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -131,7 +131,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `VariableSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L189" target="_blank">↗</a></sup>
+### `VariableSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines variables sorting options.
@@ -139,7 +139,7 @@ Defines variables sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L198" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L198"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
@@ -148,7 +148,7 @@ as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]
 Return an expression used to sort task runs
 
 
-### `BlockDocumentSort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L209" target="_blank">↗</a></sup>
+### `BlockDocumentSort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L209"><Icon icon="github" size="14" /></a></sup>
 
 
 Defines block document sorting options.
@@ -156,7 +156,7 @@ Defines block document sorting options.
 
 **Methods:**
 
-#### `as_sql_sort` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/sorting.py#L217" target="_blank">↗</a></sup>
+#### `as_sql_sort` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/sorting.py#L217"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 as_sql_sort(self, db: 'PrefectDBInterface') -> Iterable[sa.ColumnElement[Any]]

--- a/docs/v3/api-ref/python/prefect-server-schemas-states.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-states.mdx
@@ -12,7 +12,7 @@ State schemas.
 
 ## Functions
 
-### `Scheduled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L312" target="_blank">↗</a></sup>
+### `Scheduled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Scheduled(scheduled_time: Optional[DateTime] = None, cls: type[_State] = State, **kwargs: Any) -> _State
@@ -25,7 +25,7 @@ Convenience function for creating `Scheduled` states.
 - a Scheduled state
 
 
-### `Completed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L334" target="_blank">↗</a></sup>
+### `Completed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L334"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Completed(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -38,7 +38,7 @@ Convenience function for creating `Completed` states.
 - a Completed state
 
 
-### `Running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L343" target="_blank">↗</a></sup>
+### `Running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L343"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Running(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -51,7 +51,7 @@ Convenience function for creating `Running` states.
 - a Running state
 
 
-### `Failed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L352" target="_blank">↗</a></sup>
+### `Failed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L352"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Failed(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -64,7 +64,7 @@ Convenience function for creating `Failed` states.
 - a Failed state
 
 
-### `Crashed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L361" target="_blank">↗</a></sup>
+### `Crashed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L361"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Crashed(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -77,7 +77,7 @@ Convenience function for creating `Crashed` states.
 - a Crashed state
 
 
-### `Cancelling` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L370" target="_blank">↗</a></sup>
+### `Cancelling` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L370"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Cancelling(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -90,7 +90,7 @@ Convenience function for creating `Cancelling` states.
 - a Cancelling state
 
 
-### `Cancelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L379" target="_blank">↗</a></sup>
+### `Cancelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L379"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Cancelled(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -103,7 +103,7 @@ Convenience function for creating `Cancelled` states.
 - a Cancelled state
 
 
-### `Pending` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L388" target="_blank">↗</a></sup>
+### `Pending` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L388"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Pending(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -116,7 +116,7 @@ Convenience function for creating `Pending` states.
 - a Pending state
 
 
-### `Paused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L397" target="_blank">↗</a></sup>
+### `Paused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L397"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Paused(cls: type[_State] = State, timeout_seconds: Optional[int] = None, pause_expiration_time: Optional[DateTime] = None, reschedule: bool = False, pause_key: Optional[str] = None, **kwargs: Any) -> _State
@@ -129,7 +129,7 @@ Convenience function for creating `Paused` states.
 - a Paused state
 
 
-### `Suspended` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L431" target="_blank">↗</a></sup>
+### `Suspended` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L431"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Suspended(cls: type[_State] = State, timeout_seconds: Optional[int] = None, pause_expiration_time: Optional[DateTime] = None, pause_key: Optional[str] = None, **kwargs: Any) -> _State
@@ -142,7 +142,7 @@ Convenience function for creating `Suspended` states.
 - a Suspended state
 
 
-### `AwaitingRetry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L454" target="_blank">↗</a></sup>
+### `AwaitingRetry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L454"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AwaitingRetry(cls: type[_State] = State, scheduled_time: Optional[DateTime] = None, **kwargs: Any) -> _State
@@ -155,7 +155,7 @@ Convenience function for creating `AwaitingRetry` states.
 - an AwaitingRetry state
 
 
-### `AwaitingConcurrencySlot` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L469" target="_blank">↗</a></sup>
+### `AwaitingConcurrencySlot` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L469"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AwaitingConcurrencySlot(cls: type[_State] = State, scheduled_time: Optional[DateTime] = None, **kwargs: Any) -> _State
@@ -168,7 +168,7 @@ Convenience function for creating `AwaitingConcurrencySlot` states.
 - an AwaitingConcurrencySlot state
 
 
-### `Retrying` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L487" target="_blank">↗</a></sup>
+### `Retrying` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L487"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Retrying(cls: type[_State] = State, **kwargs: Any) -> _State
@@ -181,7 +181,7 @@ Convenience function for creating `Retrying` states.
 - a Retrying state
 
 
-### `Late` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L496" target="_blank">↗</a></sup>
+### `Late` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L496"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Late(cls: type[_State] = State, scheduled_time: Optional[DateTime] = None, **kwargs: Any) -> _State
@@ -196,29 +196,29 @@ Convenience function for creating `Late` states.
 
 ## Classes
 
-### `StateType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L40" target="_blank">↗</a></sup>
+### `StateType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of state types.
 
 
-### `CountByState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L54" target="_blank">↗</a></sup>
+### `CountByState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `check_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L67" target="_blank">↗</a></sup>
+#### `check_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L67"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_key(cls, value: Optional[Any], info: ValidationInfo) -> Optional[Any]
 ```
 
-### `StateDetails` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L81" target="_blank">↗</a></sup>
+### `StateDetails` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L81"><Icon icon="github" size="14" /></a></sup>
 
-### `StateBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L103" target="_blank">↗</a></sup>
+### `StateBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `orm_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L104" target="_blank">↗</a></sup>
+#### `orm_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L104"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 orm_dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]
@@ -231,7 +231,7 @@ omits the `data` field entirely for the purposes of constructing an ORM model.
 If state data is required, an artifact must be created separately.
 
 
-### `State` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L119" target="_blank">↗</a></sup>
+### `State` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 
 Represents the state of a run.
@@ -239,7 +239,7 @@ Represents the state of a run.
 
 **Methods:**
 
-#### `from_orm_without_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L138" target="_blank">↗</a></sup>
+#### `from_orm_without_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L138"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_orm_without_result(cls, orm_state: Union['ORMFlowRunState', 'ORMTaskRunState'], with_data: Optional[Any] = None) -> Self
@@ -255,7 +255,7 @@ artifact and attach data passed using the `with_data` argument to the `data`
 field.
 
 
-#### `default_name_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L164" target="_blank">↗</a></sup>
+#### `default_name_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L164"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_name_from_type(self) -> Self
@@ -264,73 +264,73 @@ default_name_from_type(self) -> Self
 If a name is not provided, use the type
 
 
-#### `default_scheduled_start_time` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L174" target="_blank">↗</a></sup>
+#### `default_scheduled_start_time` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L174"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_scheduled_start_time(self) -> Self
 ```
 
-#### `is_scheduled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L183" target="_blank">↗</a></sup>
+#### `is_scheduled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L183"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_scheduled(self) -> bool
 ```
 
-#### `is_pending` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L186" target="_blank">↗</a></sup>
+#### `is_pending` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L186"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_pending(self) -> bool
 ```
 
-#### `is_running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L189" target="_blank">↗</a></sup>
+#### `is_running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_running(self) -> bool
 ```
 
-#### `is_completed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L192" target="_blank">↗</a></sup>
+#### `is_completed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L192"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_completed(self) -> bool
 ```
 
-#### `is_failed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L195" target="_blank">↗</a></sup>
+#### `is_failed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_failed(self) -> bool
 ```
 
-#### `is_crashed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L198" target="_blank">↗</a></sup>
+#### `is_crashed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L198"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_crashed(self) -> bool
 ```
 
-#### `is_cancelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L201" target="_blank">↗</a></sup>
+#### `is_cancelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L201"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_cancelled(self) -> bool
 ```
 
-#### `is_cancelling` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L204" target="_blank">↗</a></sup>
+#### `is_cancelling` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L204"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_cancelling(self) -> bool
 ```
 
-#### `is_final` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L207" target="_blank">↗</a></sup>
+#### `is_final` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L207"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_final(self) -> bool
 ```
 
-#### `is_paused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L210" target="_blank">↗</a></sup>
+#### `is_paused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L210"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_paused(self) -> bool
 ```
 
-#### `fresh_copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L213" target="_blank">↗</a></sup>
+#### `fresh_copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 fresh_copy(self, **kwargs: Any) -> Self
@@ -339,31 +339,31 @@ fresh_copy(self, **kwargs: Any) -> Self
 Return a fresh copy of the state with a new ID.
 
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L229" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L229"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: Literal[True] = ...) -> Any
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L232" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L232"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: Literal[False] = False) -> Union[Any, Exception]
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L237" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L237"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: bool = ...) -> Union[Any, Exception]
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L239" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L239"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: bool = True) -> Union[Any, Exception]
 ```
 
-#### `to_state_create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/states.py#L256" target="_blank">↗</a></sup>
+#### `to_state_create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/states.py#L256"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_state_create(self) -> 'StateCreate'

--- a/docs/v3/api-ref/python/prefect-server-schemas-statuses.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-statuses.mdx
@@ -7,7 +7,7 @@ sidebarTitle: statuses
 
 ## Classes
 
-### `WorkPoolStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L4" target="_blank">↗</a></sup>
+### `WorkPoolStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L4"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of work pool statuses.
@@ -15,19 +15,19 @@ Enumeration of work pool statuses.
 
 **Methods:**
 
-#### `in_kebab_case` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L11" target="_blank">↗</a></sup>
+#### `in_kebab_case` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L11"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 in_kebab_case(self) -> str
 ```
 
-### `WorkerStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L15" target="_blank">↗</a></sup>
+### `WorkerStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L15"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of worker statuses.
 
 
-### `DeploymentStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L22" target="_blank">↗</a></sup>
+### `DeploymentStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of deployment statuses.
@@ -35,13 +35,13 @@ Enumeration of deployment statuses.
 
 **Methods:**
 
-#### `in_kebab_case` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L28" target="_blank">↗</a></sup>
+#### `in_kebab_case` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L28"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 in_kebab_case(self) -> str
 ```
 
-### `WorkQueueStatus` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L32" target="_blank">↗</a></sup>
+### `WorkQueueStatus` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 
 Enumeration of work queue statuses.
@@ -49,7 +49,7 @@ Enumeration of work queue statuses.
 
 **Methods:**
 
-#### `in_kebab_case` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/statuses.py#L39" target="_blank">↗</a></sup>
+#### `in_kebab_case` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/statuses.py#L39"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 in_kebab_case(self) -> str

--- a/docs/v3/api-ref/python/prefect-server-schemas-ui.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-ui.mdx
@@ -10,7 +10,7 @@ Schemas for UI endpoints.
 
 ## Classes
 
-### `UITaskRun` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/schemas/ui.py#L8" target="_blank">↗</a></sup>
+### `UITaskRun` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/schemas/ui.py#L8"><Icon icon="github" size="14" /></a></sup>
 
 
 A task run with additional details for display in the UI.

--- a/docs/v3/api-ref/python/prefect-server-services-base.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-base.mdx
@@ -7,11 +7,11 @@ sidebarTitle: base
 
 ## Classes
 
-### `Service` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L70" target="_blank">↗</a></sup>
+### `Service` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L70"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L76" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
@@ -20,13 +20,13 @@ service_settings(cls) -> ServicesBaseSetting
 The Prefect setting that controls whether the service is enabled
 
 
-#### `environment_variable_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L81" target="_blank">↗</a></sup>
+#### `environment_variable_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L81"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 environment_variable_name(cls) -> str
 ```
 
-#### `enabled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L85" target="_blank">↗</a></sup>
+#### `enabled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enabled(cls) -> bool
@@ -35,7 +35,7 @@ enabled(cls) -> bool
 Whether the service is enabled
 
 
-#### `all_services` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L90" target="_blank">↗</a></sup>
+#### `all_services` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L90"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_services(cls) -> Sequence[type[Self]]
@@ -44,7 +44,7 @@ all_services(cls) -> Sequence[type[Self]]
 Get list of all service classes
 
 
-#### `enabled_services` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L104" target="_blank">↗</a></sup>
+#### `enabled_services` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L104"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enabled_services(cls) -> list[type[Self]]
@@ -53,14 +53,14 @@ enabled_services(cls) -> list[type[Self]]
 Get list of enabled service classes
 
 
-### `RunInAllServers` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L149" target="_blank">↗</a></sup>
+### `RunInAllServers` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L149"><Icon icon="github" size="14" /></a></sup>
 
 
 A marker class for services that should run in all server processes, both the
 web server and the standalone services process.
 
 
-### `LoopService` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/base.py#L158" target="_blank">↗</a></sup>
+### `LoopService` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/base.py#L158"><Icon icon="github" size="14" /></a></sup>
 
 
 Loop services are relatively lightweight maintenance routines that need to run

--- a/docs/v3/api-ref/python/prefect-server-services-cancellation_cleanup.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-cancellation_cleanup.mdx
@@ -12,7 +12,7 @@ The CancellationCleanup service. Responsible for cancelling tasks and subflows t
 
 ## Classes
 
-### `CancellationCleanup` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/cancellation_cleanup.py#L26" target="_blank">↗</a></sup>
+### `CancellationCleanup` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/cancellation_cleanup.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 Cancels tasks and subflows of flow runs that have been cancelled
@@ -20,7 +20,7 @@ Cancels tasks and subflows of flow runs that have been cancelled
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/cancellation_cleanup.py#L32" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/cancellation_cleanup.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-services-foreman.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-foreman.mdx
@@ -12,7 +12,7 @@ Foreman is a loop service designed to monitor workers.
 
 ## Classes
 
-### `Foreman` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/foreman.py#L34" target="_blank">↗</a></sup>
+### `Foreman` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/foreman.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 Monitors the status of workers and their associated work pools
@@ -20,7 +20,7 @@ Monitors the status of workers and their associated work pools
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/foreman.py#L40" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/foreman.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-services-late_runs.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-late_runs.mdx
@@ -13,7 +13,7 @@ The threshold for a late run can be configured by changing `PREFECT_API_SERVICES
 
 ## Classes
 
-### `MarkLateRuns` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/late_runs.py#L34" target="_blank">↗</a></sup>
+### `MarkLateRuns` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/late_runs.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 Finds flow runs that are later than their scheduled start time
@@ -25,7 +25,7 @@ Prefect REST API Settings.
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/late_runs.py#L44" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/late_runs.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-services-pause_expirations.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-pause_expirations.mdx
@@ -12,7 +12,7 @@ The FailExpiredPauses service. Responsible for putting Paused flow runs in a Fai
 
 ## Classes
 
-### `FailExpiredPauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/pause_expirations.py#L23" target="_blank">↗</a></sup>
+### `FailExpiredPauses` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/pause_expirations.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 
 Fails flow runs that have been paused and never resumed
@@ -20,7 +20,7 @@ Fails flow runs that have been paused and never resumed
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/pause_expirations.py#L29" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/pause_expirations.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-services-scheduler.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-scheduler.mdx
@@ -12,13 +12,13 @@ The Scheduler service.
 
 ## Classes
 
-### `TryAgain` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/scheduler.py#L34" target="_blank">↗</a></sup>
+### `TryAgain` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/scheduler.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 
 Internal control-flow exception used to retry the Scheduler's main loop
 
 
-### `Scheduler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/scheduler.py#L38" target="_blank">↗</a></sup>
+### `Scheduler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/scheduler.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 
 Schedules flow runs from deployments.
@@ -26,13 +26,13 @@ Schedules flow runs from deployments.
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/scheduler.py#L48" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/scheduler.py#L48"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-### `RecentDeploymentsScheduler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/scheduler.py#L305" target="_blank">↗</a></sup>
+### `RecentDeploymentsScheduler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/scheduler.py#L305"><Icon icon="github" size="14" /></a></sup>
 
 
 Schedules deployments that were updated very recently
@@ -48,7 +48,7 @@ accelerate scheduling for any deployments that users are interacting with.
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/scheduler.py#L322" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/scheduler.py#L322"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting

--- a/docs/v3/api-ref/python/prefect-server-services-task_run_recorder.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-task_run_recorder.mdx
@@ -7,13 +7,13 @@ sidebarTitle: task_run_recorder
 
 ## Functions
 
-### `causal_ordering` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L41" target="_blank">↗</a></sup>
+### `causal_ordering` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 causal_ordering() -> CausalOrdering
 ```
 
-### `task_run_from_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L68" target="_blank">↗</a></sup>
+### `task_run_from_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task_run_from_event(event: ReceivedEvent) -> TaskRun
@@ -21,7 +21,7 @@ task_run_from_event(event: ReceivedEvent) -> TaskRun
 
 ## Classes
 
-### `TaskRunRecorder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L192" target="_blank">↗</a></sup>
+### `TaskRunRecorder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L192"><Icon icon="github" size="14" /></a></sup>
 
 
 Constructs task runs and states from client-emitted events
@@ -29,19 +29,19 @@ Constructs task runs and states from client-emitted events
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L199" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-#### `started_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L207" target="_blank">↗</a></sup>
+#### `started_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L207"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 started_event(self) -> asyncio.Event
 ```
 
-#### `started_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L213" target="_blank">↗</a></sup>
+#### `started_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/task_run_recorder.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 started_event(self, value: asyncio.Event) -> None

--- a/docs/v3/api-ref/python/prefect-server-services-telemetry.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-telemetry.mdx
@@ -12,7 +12,7 @@ The Telemetry service.
 
 ## Classes
 
-### `Telemetry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/telemetry.py#L26" target="_blank">↗</a></sup>
+### `Telemetry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/telemetry.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 
 Sends anonymous data to Prefect to help us improve
@@ -22,19 +22,19 @@ It can be toggled off with the PREFECT_SERVER_ANALYTICS_ENABLED setting.
 
 **Methods:**
 
-#### `service_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/telemetry.py#L36" target="_blank">↗</a></sup>
+#### `service_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/telemetry.py#L36"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 service_settings(cls) -> ServicesBaseSetting
 ```
 
-#### `environment_variable_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/telemetry.py#L40" target="_blank">↗</a></sup>
+#### `environment_variable_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/telemetry.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 environment_variable_name(cls) -> str
 ```
 
-#### `enabled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/services/telemetry.py#L44" target="_blank">↗</a></sup>
+#### `enabled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/services/telemetry.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enabled(cls) -> bool

--- a/docs/v3/api-ref/python/prefect-server-task_queue.mdx
+++ b/docs/v3/api-ref/python/prefect-server-task_queue.mdx
@@ -12,23 +12,23 @@ Implements an in-memory task queue for delivering background task runs to TaskWo
 
 ## Classes
 
-### `TaskQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/task_queue.py#L17" target="_blank">↗</a></sup>
+### `TaskQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/task_queue.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `configure_task_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/task_queue.py#L36" target="_blank">↗</a></sup>
+#### `configure_task_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/task_queue.py#L36"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 configure_task_key(cls, task_key: str, scheduled_size: Optional[int] = None, retry_size: Optional[int] = None) -> None
 ```
 
-#### `for_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/task_queue.py#L47" target="_blank">↗</a></sup>
+#### `for_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/task_queue.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 for_key(cls, task_key: str) -> Self
 ```
 
-#### `reset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/task_queue.py#L56" target="_blank">↗</a></sup>
+#### `reset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/task_queue.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset(cls) -> None
@@ -37,13 +37,13 @@ reset(cls) -> None
 A unit testing utility to reset the state of the task queues subsystem
 
 
-#### `get_nowait` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/task_queue.py#L73" target="_blank">↗</a></sup>
+#### `get_nowait` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/task_queue.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_nowait(self) -> schemas.core.TaskRun
 ```
 
-### `MultiQueue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/task_queue.py#L87" target="_blank">↗</a></sup>
+### `MultiQueue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/task_queue.py#L87"><Icon icon="github" size="14" /></a></sup>
 
 
 A queue that can pull tasks from from any of a number of task queues

--- a/docs/v3/api-ref/python/prefect-server-utilities-database.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-database.mdx
@@ -15,13 +15,13 @@ allow the Prefect REST API to seamlessly switch between the two.
 
 ## Functions
 
-### `db_injector` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L77" target="_blank">↗</a></sup>
+### `db_injector` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L77"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 db_injector(func: Union[_DBMethod[T, P, R], _DBFunction[P, R]]) -> Union[_Method[T, P, R], _Function[P, R]]
 ```
 
-### `generate_uuid_postgresql` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L96" target="_blank">↗</a></sup>
+### `generate_uuid_postgresql` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_uuid_postgresql(element: GenerateUUID, compiler: SQLCompiler, **kwargs: Any) -> str
@@ -31,7 +31,7 @@ generate_uuid_postgresql(element: GenerateUUID, compiler: SQLCompiler, **kwargs:
 Generates a random UUID in Postgres; requires the pgcrypto extension.
 
 
-### `generate_uuid_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L107" target="_blank">↗</a></sup>
+### `generate_uuid_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L107"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_uuid_sqlite(element: GenerateUUID, compiler: SQLCompiler, **kwargs: Any) -> str
@@ -44,7 +44,7 @@ sufficient for our purposes of having a random client-generated ID
 that is compatible with a UUID spec.
 
 
-### `bindparams_from_clause` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L327" target="_blank">↗</a></sup>
+### `bindparams_from_clause` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L327"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 bindparams_from_clause(query: sa.ClauseElement) -> dict[str, sa.BindParameter[Any]]
@@ -54,19 +54,19 @@ bindparams_from_clause(query: sa.ClauseElement) -> dict[str, sa.BindParameter[An
 Retrieve all non-anonymous bind parameters defined in a SQL clause
 
 
-### `datetime_or_interval_add_postgresql` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L425" target="_blank">↗</a></sup>
+### `datetime_or_interval_add_postgresql` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L425"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 datetime_or_interval_add_postgresql(element: Union[date_add, interval_add, date_diff], compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `date_diff_seconds_postgresql` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L435" target="_blank">↗</a></sup>
+### `date_diff_seconds_postgresql` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L435"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 date_diff_seconds_postgresql(element: date_diff_seconds, compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `current_timestamp_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L507" target="_blank">↗</a></sup>
+### `current_timestamp_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L507"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 current_timestamp_sqlite(element: functions.now, compiler: SQLCompiler, **kwargs: Any) -> str
@@ -76,31 +76,31 @@ current_timestamp_sqlite(element: functions.now, compiler: SQLCompiler, **kwargs
 Generates the current timestamp for SQLite
 
 
-### `date_add_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L515" target="_blank">↗</a></sup>
+### `date_add_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L515"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 date_add_sqlite(element: date_add, compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `interval_add_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L523" target="_blank">↗</a></sup>
+### `interval_add_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L523"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 interval_add_sqlite(element: interval_add, compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `date_diff_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L532" target="_blank">↗</a></sup>
+### `date_diff_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L532"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 date_diff_sqlite(element: date_diff, compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `date_diff_seconds_sqlite` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L539" target="_blank">↗</a></sup>
+### `date_diff_seconds_sqlite` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L539"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 date_diff_seconds_sqlite(element: date_diff_seconds, compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `sqlite_json_operators` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L690" target="_blank">↗</a></sup>
+### `sqlite_json_operators` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L690"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 sqlite_json_operators(element: sa.BinaryExpression[Any], compiler: SQLCompiler, override_operator: Optional[OperatorType] = None, **kwargs: Any) -> str
@@ -110,13 +110,13 @@ sqlite_json_operators(element: sa.BinaryExpression[Any], compiler: SQLCompiler, 
 Intercept the PostgreSQL-only JSON / JSONB operators and translate them to SQLite
 
 
-### `sqlite_greatest_as_max` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L709" target="_blank">↗</a></sup>
+### `sqlite_greatest_as_max` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L709"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 sqlite_greatest_as_max(element: greatest[Any], compiler: SQLCompiler, **kwargs: Any) -> str
 ```
 
-### `get_dialect` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L727" target="_blank">↗</a></sup>
+### `get_dialect` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L727"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_dialect(obj: Union[str, Session, sa.Engine]) -> type[sa.Dialect]
@@ -131,7 +131,7 @@ SQLite or Postgres.
 
 ## Classes
 
-### `GenerateUUID` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L85" target="_blank">↗</a></sup>
+### `GenerateUUID` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L85"><Icon icon="github" size="14" /></a></sup>
 
 
 Platform-independent UUID default generator.
@@ -139,7 +139,7 @@ Note the actual functionality for this class is specified in the
 `compiles`-decorated functions below
 
 
-### `Timestamp` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L133" target="_blank">↗</a></sup>
+### `Timestamp` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L133"><Icon icon="github" size="14" /></a></sup>
 
 
 TypeDecorator that ensures that timestamps have a timezone.
@@ -150,25 +150,25 @@ as naive timestamps without timezones) and recovered as UTC.
 
 **Methods:**
 
-#### `load_dialect_impl` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L143" target="_blank">↗</a></sup>
+#### `load_dialect_impl` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_dialect_impl(self, dialect: sa.Dialect) -> TypeEngine[Any]
 ```
 
-#### `process_bind_param` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L155" target="_blank">↗</a></sup>
+#### `process_bind_param` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L155"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_bind_param(self, value: Optional[datetime.datetime], dialect: sa.Dialect) -> Optional[datetime.datetime]
 ```
 
-#### `process_result_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L170" target="_blank">↗</a></sup>
+#### `process_result_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L170"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_result_value(self, value: Optional[datetime.datetime], dialect: sa.Dialect) -> Optional[datetime.datetime]
 ```
 
-### `UUID` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L183" target="_blank">↗</a></sup>
+### `UUID` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L183"><Icon icon="github" size="14" /></a></sup>
 
 
 Platform-independent UUID type.
@@ -180,25 +180,25 @@ hyphens.
 
 **Methods:**
 
-#### `load_dialect_impl` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L195" target="_blank">↗</a></sup>
+#### `load_dialect_impl` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L195"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_dialect_impl(self, dialect: sa.Dialect) -> TypeEngine[Any]
 ```
 
-#### `process_bind_param` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L201" target="_blank">↗</a></sup>
+#### `process_bind_param` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L201"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_bind_param(self, value: Optional[Union[str, uuid.UUID]], dialect: sa.Dialect) -> Optional[str]
 ```
 
-#### `process_result_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L213" target="_blank">↗</a></sup>
+#### `process_result_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_result_value(self, value: Optional[Union[str, uuid.UUID]], dialect: sa.Dialect) -> Optional[uuid.UUID]
 ```
 
-### `JSON` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L224" target="_blank">↗</a></sup>
+### `JSON` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L224"><Icon icon="github" size="14" /></a></sup>
 
 
 JSON type that returns SQLAlchemy's dialect-specific JSON types, where
@@ -210,13 +210,13 @@ to SQL compilation
 
 **Methods:**
 
-#### `load_dialect_impl` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L238" target="_blank">↗</a></sup>
+#### `load_dialect_impl` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L238"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_dialect_impl(self, dialect: sa.Dialect) -> TypeEngine[Any]
 ```
 
-#### `process_bind_param` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L246" target="_blank">↗</a></sup>
+#### `process_bind_param` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L246"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_bind_param(self, value: Optional[Any], dialect: sa.Dialect) -> Optional[Any]
@@ -225,7 +225,7 @@ process_bind_param(self, value: Optional[Any], dialect: sa.Dialect) -> Optional[
 Prepares the given value to be used as a JSON field in a parameter binding
 
 
-### `Pydantic` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L267" target="_blank">↗</a></sup>
+### `Pydantic` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L267"><Icon icon="github" size="14" /></a></sup>
 
 
 A pydantic type that converts inserted parameters to
@@ -234,40 +234,40 @@ json and converts read values to the pydantic type.
 
 **Methods:**
 
-#### `process_bind_param` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L306" target="_blank">↗</a></sup>
+#### `process_bind_param` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L306"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_bind_param(self, value: Optional[T], dialect: sa.Dialect) -> Optional[str]
 ```
 
-#### `process_result_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L320" target="_blank">↗</a></sup>
+#### `process_result_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L320"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_result_value(self, value: Optional[Any], dialect: sa.Dialect) -> Optional[T]
 ```
 
-### `date_add` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L346" target="_blank">↗</a></sup>
+### `date_add` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L346"><Icon icon="github" size="14" /></a></sup>
 
 
 Platform-independent way to add a timestamp and an interval
 
 
-### `interval_add` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L365" target="_blank">↗</a></sup>
+### `interval_add` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L365"><Icon icon="github" size="14" /></a></sup>
 
 
 Platform-independent way to add two intervals.
 
 
-### `date_diff` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L384" target="_blank">↗</a></sup>
+### `date_diff` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L384"><Icon icon="github" size="14" /></a></sup>
 
 
 Platform-independent difference of two timestamps. Computes d1 - d2.
 
 
-### `date_diff_seconds` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L401" target="_blank">↗</a></sup>
+### `date_diff_seconds` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L401"><Icon icon="github" size="14" /></a></sup>
 
 
 Platform-independent calculation of the number of seconds between two timestamps or from 'now'
 
 
-### `greatest` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/database.py#L704" target="_blank">↗</a></sup>
+### `greatest` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/database.py#L704"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-utilities-http.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-http.mdx
@@ -7,7 +7,7 @@ sidebarTitle: http
 
 ## Functions
 
-### `should_redact_header` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/http.py#L1" target="_blank">↗</a></sup>
+### `should_redact_header` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/http.py#L1"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_redact_header(key: str) -> bool

--- a/docs/v3/api-ref/python/prefect-server-utilities-messaging-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-messaging-__init__.mdx
@@ -7,7 +7,7 @@ sidebarTitle: __init__
 
 ## Functions
 
-### `create_cache` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L158" target="_blank">↗</a></sup>
+### `create_cache` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L158"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_cache() -> Cache
@@ -20,7 +20,7 @@ Creates a new cache with the applications default settings.
 - a new Cache instance
 
 
-### `create_publisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L184" target="_blank">↗</a></sup>
+### `create_publisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L184"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_publisher(topic: str, cache: Optional[Cache] = None, deduplicate_by: Optional[str] = None) -> Publisher
@@ -34,7 +34,7 @@ Returns:
     a new Consumer instance
 
 
-### `create_consumer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L213" target="_blank">↗</a></sup>
+### `create_consumer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_consumer(topic: str, **kwargs: Any) -> Consumer
@@ -50,7 +50,7 @@ Returns:
 
 ## Classes
 
-### `Message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L32" target="_blank">↗</a></sup>
+### `Message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 
 A protocol representing a message sent to a message broker.
@@ -58,39 +58,39 @@ A protocol representing a message sent to a message broker.
 
 **Methods:**
 
-#### `data` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L38" target="_blank">↗</a></sup>
+#### `data` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 data(self) -> Union[str, bytes]
 ```
 
-#### `attributes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L41" target="_blank">↗</a></sup>
+#### `attributes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 attributes(self) -> Mapping[str, Any]
 ```
 
-### `Cache` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L44" target="_blank">↗</a></sup>
+### `Cache` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L44"><Icon icon="github" size="14" /></a></sup>
 
-### `Publisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L59" target="_blank">↗</a></sup>
+### `Publisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L59"><Icon icon="github" size="14" /></a></sup>
 
-### `CapturedMessage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L85" target="_blank">↗</a></sup>
+### `CapturedMessage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L85"><Icon icon="github" size="14" /></a></sup>
 
-### `CapturingPublisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L90" target="_blank">↗</a></sup>
+### `CapturingPublisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L90"><Icon icon="github" size="14" /></a></sup>
 
-### `StopConsumer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L129" target="_blank">↗</a></sup>
+### `StopConsumer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L129"><Icon icon="github" size="14" /></a></sup>
 
 
 Exception to raise to stop a consumer.
 
 
-### `Consumer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L138" target="_blank">↗</a></sup>
+### `Consumer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L138"><Icon icon="github" size="14" /></a></sup>
 
 
 Abstract base class for consumers that receive messages from a message broker and
 call a handler function for each message received.
 
 
-### `CacheModule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L154" target="_blank">↗</a></sup>
+### `CacheModule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L154"><Icon icon="github" size="14" /></a></sup>
 
-### `BrokerModule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L172" target="_blank">↗</a></sup>
+### `BrokerModule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/__init__.py#L172"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-utilities-messaging-memory.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-messaging-memory.mdx
@@ -7,9 +7,9 @@ sidebarTitle: memory
 
 ## Classes
 
-### `MemoryMessage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L74" target="_blank">↗</a></sup>
+### `MemoryMessage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L74"><Icon icon="github" size="14" /></a></sup>
 
-### `Subscription` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L80" target="_blank">↗</a></sup>
+### `Subscription` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L80"><Icon icon="github" size="14" /></a></sup>
 
 
 A subscription to a topic.
@@ -24,42 +24,42 @@ message.
 Messages remain in the dead letter queue until they are removed manually.
 
 
-### `Topic` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L188" target="_blank">↗</a></sup>
+### `Topic` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L188"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `by_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L199" target="_blank">↗</a></sup>
+#### `by_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 by_name(cls, name: str) -> 'Topic'
 ```
 
-#### `clear_all` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L208" target="_blank">↗</a></sup>
+#### `clear_all` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L208"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 clear_all(cls) -> None
 ```
 
-#### `subscribe` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L213" target="_blank">↗</a></sup>
+#### `subscribe` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 subscribe(self, **subscription_kwargs: Any) -> Subscription
 ```
 
-#### `unsubscribe` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L218" target="_blank">↗</a></sup>
+#### `unsubscribe` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L218"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unsubscribe(self, subscription: Subscription) -> None
 ```
 
-#### `clear` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L221" target="_blank">↗</a></sup>
+#### `clear` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L221"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 clear(self) -> None
 ```
 
-### `Cache` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L248" target="_blank">↗</a></sup>
+### `Cache` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L248"><Icon icon="github" size="14" /></a></sup>
 
-### `Publisher` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L293" target="_blank">↗</a></sup>
+### `Publisher` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L293"><Icon icon="github" size="14" /></a></sup>
 
-### `Consumer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L326" target="_blank">↗</a></sup>
+### `Consumer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/messaging/memory.py#L326"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-utilities-schemas-bases.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-schemas-bases.mdx
@@ -7,7 +7,7 @@ sidebarTitle: bases
 
 ## Functions
 
-### `get_class_fields_only` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L22" target="_blank">↗</a></sup>
+### `get_class_fields_only` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_class_fields_only(model: type[BaseModel]) -> set[str]
@@ -20,7 +20,7 @@ Any fields that are on the parent but redefined on the subclass are included.
 
 ## Classes
 
-### `PrefectDescriptorBase` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L31" target="_blank">↗</a></sup>
+### `PrefectDescriptorBase` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for descriptor objects used with PrefectBaseModel
@@ -35,7 +35,7 @@ such descriptors to be used as properties, methods or other bound
 descriptor use cases.
 
 
-### `PrefectBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L60" target="_blank">↗</a></sup>
+### `PrefectBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 
 A base pydantic.BaseModel for all Prefect schemas and pydantic models.
@@ -49,7 +49,7 @@ of Prefect will be able to process those new fields gracefully.
 
 **Methods:**
 
-#### `reset_fields` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L109" target="_blank">↗</a></sup>
+#### `reset_fields` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L109"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset_fields(self: Self) -> Self
@@ -61,7 +61,7 @@ Reset the fields of the model that are in the `_reset_fields` set.
 - A new instance of the model with the reset fields.
 
 
-#### `model_dump_for_orm` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L125" target="_blank">↗</a></sup>
+#### `model_dump_for_orm` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_dump_for_orm(self) -> dict[str, Any]
@@ -92,7 +92,7 @@ value.
 - to SQLAlchemy model constructors, INSERT statements, etc.
 
 
-### `IDBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L192" target="_blank">↗</a></sup>
+### `IDBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L192"><Icon icon="github" size="14" /></a></sup>
 
 
 A PrefectBaseModel with an auto-generated UUID ID value.
@@ -100,14 +100,14 @@ A PrefectBaseModel with an auto-generated UUID ID value.
 The ID is reset on copy() and not included in equality comparisons.
 
 
-### `TimeSeriesBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L207" target="_blank">↗</a></sup>
+### `TimeSeriesBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L207"><Icon icon="github" size="14" /></a></sup>
 
 
 A PrefectBaseModel with a time-oriented UUIDv7 ID value.  Used for models that
 operate like timeseries, such as runs, states, and logs.
 
 
-### `ORMBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L216" target="_blank">↗</a></sup>
+### `ORMBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L216"><Icon icon="github" size="14" /></a></sup>
 
 
 A PrefectBaseModel with an auto-generated UUID ID value and created /
@@ -117,4 +117,4 @@ The ID, created, and updated fields are reset on copy() and not included in
 equality comparisons.
 
 
-### `ActionBaseModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L238" target="_blank">↗</a></sup>
+### `ActionBaseModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/bases.py#L238"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-server-utilities-schemas-serializers.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-schemas-serializers.mdx
@@ -7,7 +7,7 @@ sidebarTitle: serializers
 
 ## Functions
 
-### `orjson_dumps` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/serializers.py#L10" target="_blank">↗</a></sup>
+### `orjson_dumps` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/serializers.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 orjson_dumps(v: Any) -> str
@@ -19,7 +19,7 @@ Utility for dumping a value to JSON using orjson.
 orjson.dumps returns bytes, to match standard json.dumps we need to decode.
 
 
-### `orjson_dumps_extra_compatible` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/schemas/serializers.py#L19" target="_blank">↗</a></sup>
+### `orjson_dumps_extra_compatible` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/schemas/serializers.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 orjson_dumps_extra_compatible(v: Any) -> str

--- a/docs/v3/api-ref/python/prefect-server-utilities-server.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-server.mdx
@@ -12,7 +12,7 @@ Utilities for the Prefect REST API server.
 
 ## Functions
 
-### `method_paths_from_routes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/server.py#L15" target="_blank">↗</a></sup>
+### `method_paths_from_routes` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/server.py#L15"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 method_paths_from_routes(routes: Sequence[BaseRoute]) -> set[str]
@@ -26,7 +26,7 @@ For example, "GET /logs/"
 
 ## Classes
 
-### `PrefectAPIRoute` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/server.py#L30" target="_blank">↗</a></sup>
+### `PrefectAPIRoute` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/server.py#L30"><Icon icon="github" size="14" /></a></sup>
 
 
 A FastAPIRoute class which attaches an async stack to requests that exits before
@@ -41,13 +41,13 @@ scope. This extension adds this stack at `request.state.response_scoped_stack`.
 
 **Methods:**
 
-#### `get_route_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/server.py#L42" target="_blank">↗</a></sup>
+#### `get_route_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/server.py#L42"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]
 ```
 
-### `PrefectRouter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/server.py#L59" target="_blank">↗</a></sup>
+### `PrefectRouter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/server.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 
 A base class for Prefect REST API routers.
@@ -55,7 +55,7 @@ A base class for Prefect REST API routers.
 
 **Methods:**
 
-#### `add_api_route` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/server.py#L68" target="_blank">↗</a></sup>
+#### `add_api_route` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/server.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None

--- a/docs/v3/api-ref/python/prefect-server-utilities-user_templates.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-user_templates.mdx
@@ -10,7 +10,7 @@ Utilities to support safely rendering user-supplied templates
 
 ## Functions
 
-### `register_user_template_filters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L69" target="_blank">↗</a></sup>
+### `register_user_template_filters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L69"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 register_user_template_filters(filters: dict[str, Any]) -> None
@@ -20,25 +20,25 @@ register_user_template_filters(filters: dict[str, Any]) -> None
 Register additional filters that will be available to user templates
 
 
-### `validate_user_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L74" target="_blank">↗</a></sup>
+### `validate_user_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_user_template(template: str) -> None
 ```
 
-### `matching_types_in_templates` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L112" target="_blank">↗</a></sup>
+### `matching_types_in_templates` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L112"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 matching_types_in_templates(templates: list[str], types: set[str]) -> list[str]
 ```
 
-### `maybe_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L124" target="_blank">↗</a></sup>
+### `maybe_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L124"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 maybe_template(possible: str) -> bool
 ```
 
-### `render_user_template_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L143" target="_blank">↗</a></sup>
+### `render_user_template_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 render_user_template_sync(template: str, context: dict[str, Any]) -> str
@@ -46,9 +46,9 @@ render_user_template_sync(template: str, context: dict[str, Any]) -> str
 
 ## Classes
 
-### `UserTemplateEnvironment` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L32" target="_blank">↗</a></sup>
+### `UserTemplateEnvironment` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L32"><Icon icon="github" size="14" /></a></sup>
 
-### `TemplateSecurityError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L60" target="_blank">↗</a></sup>
+### `TemplateSecurityError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/server/utilities/user_templates.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when extended validation of a template fails.

--- a/docs/v3/api-ref/python/prefect-settings-base.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-base.mdx
@@ -7,7 +7,7 @@ sidebarTitle: base
 
 ## Functions
 
-### `build_settings_config` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/base.py#L214" target="_blank">↗</a></sup>
+### `build_settings_config` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/base.py#L214"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_settings_config(path: tuple[str, ...] = tuple(), frozen: bool = False) -> PrefectSettingsConfigDict
@@ -15,11 +15,11 @@ build_settings_config(path: tuple[str, ...] = tuple(), frozen: bool = False) -> 
 
 ## Classes
 
-### `PrefectBaseSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/base.py#L31" target="_blank">↗</a></sup>
+### `PrefectBaseSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/base.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `settings_customise_sources` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/base.py#L33" target="_blank">↗</a></sup>
+#### `settings_customise_sources` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/base.py#L33"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 settings_customise_sources(cls, settings_cls: type[BaseSettings], init_settings: PydanticBaseSettingsSource, env_settings: PydanticBaseSettingsSource, dotenv_settings: PydanticBaseSettingsSource, file_secret_settings: PydanticBaseSettingsSource) -> tuple[PydanticBaseSettingsSource, ...]
@@ -32,7 +32,7 @@ The order of the returned callables decides the priority of inputs; first item i
 See https://docs.pydantic.dev/latest/concepts/pydantic_settings/#customise-settings-sources
 
 
-#### `to_environment_variables` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/base.py#L91" target="_blank">↗</a></sup>
+#### `to_environment_variables` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/base.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_environment_variables(self, exclude_unset: bool = False, include_secrets: bool = True, include_aliases: bool = False) -> dict[str, str]
@@ -41,13 +41,13 @@ to_environment_variables(self, exclude_unset: bool = False, include_secrets: boo
 Convert the settings object to a dictionary of environment variables.
 
 
-#### `ser_model` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/base.py#L134" target="_blank">↗</a></sup>
+#### `ser_model` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/base.py#L134"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ser_model(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> Any
 ```
 
-### `PrefectSettingsConfigDict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/base.py#L179" target="_blank">↗</a></sup>
+### `PrefectSettingsConfigDict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/base.py#L179"><Icon icon="github" size="14" /></a></sup>
 
 
 Configuration for the behavior of Prefect settings models.

--- a/docs/v3/api-ref/python/prefect-settings-context.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-context.mdx
@@ -7,7 +7,7 @@ sidebarTitle: context
 
 ## Functions
 
-### `get_current_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/context.py#L10" target="_blank">↗</a></sup>
+### `get_current_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/context.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_current_settings() -> Settings
@@ -18,7 +18,7 @@ Returns a settings object populated with values from the current settings contex
 or, if no settings context is active, the environment.
 
 
-### `temporary_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/context.py#L25" target="_blank">↗</a></sup>
+### `temporary_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/context.py#L25"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_settings(updates: Optional[Mapping['Setting', Any]] = None, set_defaults: Optional[Mapping['Setting', Any]] = None, restore_defaults: Optional[Iterable['Setting']] = None) -> Generator[Settings, None, None]

--- a/docs/v3/api-ref/python/prefect-settings-legacy.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-legacy.mdx
@@ -7,7 +7,7 @@ sidebarTitle: legacy
 
 ## Classes
 
-### `Setting` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/legacy.py#L16" target="_blank">↗</a></sup>
+### `Setting` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/legacy.py#L16"><Icon icon="github" size="14" /></a></sup>
 
 
 Mimics the old Setting object for compatibility with existing code.
@@ -15,31 +15,31 @@ Mimics the old Setting object for compatibility with existing code.
 
 **Methods:**
 
-#### `name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/legacy.py#L31" target="_blank">↗</a></sup>
+#### `name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/legacy.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 name(self) -> str
 ```
 
-#### `is_secret` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/legacy.py#L35" target="_blank">↗</a></sup>
+#### `is_secret` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/legacy.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_secret(self) -> bool
 ```
 
-#### `default` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/legacy.py#L43" target="_blank">↗</a></sup>
+#### `default` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/legacy.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default(self) -> Any
 ```
 
-#### `value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/legacy.py#L46" target="_blank">↗</a></sup>
+#### `value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/legacy.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 value(self: Self) -> Any
 ```
 
-#### `value_from` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/legacy.py#L61" target="_blank">↗</a></sup>
+#### `value_from` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/legacy.py#L61"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 value_from(self: Self, settings: Settings) -> Any

--- a/docs/v3/api-ref/python/prefect-settings-models-api.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: api
 
 ## Classes
 
-### `APISettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/api.py#L13" target="_blank">↗</a></sup>
+### `APISettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/api.py#L13"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for interacting with the Prefect API

--- a/docs/v3/api-ref/python/prefect-settings-models-cli.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-cli.mdx
@@ -7,7 +7,7 @@ sidebarTitle: cli
 
 ## Classes
 
-### `CLISettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/cli.py#L12" target="_blank">↗</a></sup>
+### `CLISettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/cli.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling CLI behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-client.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-client.mdx
@@ -7,13 +7,13 @@ sidebarTitle: client
 
 ## Classes
 
-### `ClientMetricsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/client.py#L13" target="_blank">↗</a></sup>
+### `ClientMetricsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/client.py#L13"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling metrics reporting from the client
 
 
-### `ClientSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/client.py#L40" target="_blank">↗</a></sup>
+### `ClientSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/client.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling API client behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-cloud.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-cloud.mdx
@@ -7,7 +7,7 @@ sidebarTitle: cloud
 
 ## Functions
 
-### `default_cloud_ui_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/cloud.py#L14" target="_blank">↗</a></sup>
+### `default_cloud_ui_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/cloud.py#L14"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 default_cloud_ui_url(settings: 'CloudSettings') -> Optional[str]
@@ -15,7 +15,7 @@ default_cloud_ui_url(settings: 'CloudSettings') -> Optional[str]
 
 ## Classes
 
-### `CloudSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/cloud.py#L31" target="_blank">↗</a></sup>
+### `CloudSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/cloud.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for interacting with Prefect Cloud
@@ -23,7 +23,7 @@ Settings for interacting with Prefect Cloud
 
 **Methods:**
 
-#### `post_hoc_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/cloud.py#L54" target="_blank">↗</a></sup>
+#### `post_hoc_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/cloud.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 post_hoc_settings(self) -> Self

--- a/docs/v3/api-ref/python/prefect-settings-models-deployments.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-deployments.mdx
@@ -7,7 +7,7 @@ sidebarTitle: deployments
 
 ## Classes
 
-### `DeploymentsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/deployments.py#L9" target="_blank">↗</a></sup>
+### `DeploymentsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/deployments.py#L9"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for configuring deployments defaults

--- a/docs/v3/api-ref/python/prefect-settings-models-experiments.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-experiments.mdx
@@ -7,7 +7,7 @@ sidebarTitle: experiments
 
 ## Classes
 
-### `ExperimentsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/experiments.py#L11" target="_blank">↗</a></sup>
+### `ExperimentsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/experiments.py#L11"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for configuring experimental features

--- a/docs/v3/api-ref/python/prefect-settings-models-flows.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-flows.mdx
@@ -7,7 +7,7 @@ sidebarTitle: flows
 
 ## Classes
 
-### `FlowsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/flows.py#L9" target="_blank">↗</a></sup>
+### `FlowsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/flows.py#L9"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling flow behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-internal.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-internal.mdx
@@ -7,4 +7,4 @@ sidebarTitle: internal
 
 ## Classes
 
-### `InternalSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/internal.py#L10" target="_blank">↗</a></sup>
+### `InternalSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/internal.py#L10"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-settings-models-logging.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-logging.mdx
@@ -7,7 +7,7 @@ sidebarTitle: logging
 
 ## Functions
 
-### `max_log_size_smaller_than_batch_size` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/logging.py#L19" target="_blank">↗</a></sup>
+### `max_log_size_smaller_than_batch_size` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/logging.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 max_log_size_smaller_than_batch_size(values: dict[str, Any]) -> dict[str, Any]
@@ -19,7 +19,7 @@ Validator for settings asserting the batch size and match log size are compatibl
 
 ## Classes
 
-### `LoggingToAPISettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/logging.py#L31" target="_blank">↗</a></sup>
+### `LoggingToAPISettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/logging.py#L31"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling logging to the API
@@ -27,7 +27,7 @@ Settings for controlling logging to the API
 
 **Methods:**
 
-#### `emit_warnings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/logging.py#L79" target="_blank">↗</a></sup>
+#### `emit_warnings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/logging.py#L79"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_warnings(self) -> Self
@@ -36,7 +36,7 @@ emit_warnings(self) -> Self
 Emits warnings for misconfiguration of logging settings.
 
 
-### `LoggingSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/logging.py#L86" target="_blank">↗</a></sup>
+### `LoggingSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/logging.py#L86"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling logging behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-results.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-results.mdx
@@ -7,7 +7,7 @@ sidebarTitle: results
 
 ## Classes
 
-### `ResultsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/results.py#L10" target="_blank">↗</a></sup>
+### `ResultsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/results.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling result storage behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-root.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-root.mdx
@@ -7,7 +7,7 @@ sidebarTitle: root
 
 ## Functions
 
-### `canonical_environment_prefix` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/root.py#L455" target="_blank">↗</a></sup>
+### `canonical_environment_prefix` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/root.py#L455"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 canonical_environment_prefix(settings: 'Settings') -> str
@@ -15,7 +15,7 @@ canonical_environment_prefix(settings: 'Settings') -> str
 
 ## Classes
 
-### `Settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/root.py#L41" target="_blank">↗</a></sup>
+### `Settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/root.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for Prefect using Pydantic settings.
@@ -25,7 +25,7 @@ See https://docs.pydantic.dev/latest/concepts/pydantic_settings
 
 **Methods:**
 
-#### `post_hoc_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/root.py#L177" target="_blank">↗</a></sup>
+#### `post_hoc_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/root.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 post_hoc_settings(self) -> Self
@@ -38,7 +38,7 @@ define dependencies between defaults in a first-class way, we need clean up
 post-hoc default assignments to keep set/unset fields correct after instantiation.
 
 
-#### `emit_warnings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/root.py#L244" target="_blank">↗</a></sup>
+#### `emit_warnings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/root.py#L244"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_warnings(self) -> Self
@@ -47,7 +47,7 @@ emit_warnings(self) -> Self
 More post-hoc validation of settings, including warnings for misconfigurations.
 
 
-#### `copy_with_update` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/root.py#L253" target="_blank">↗</a></sup>
+#### `copy_with_update` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/root.py#L253"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 copy_with_update(self: Self, updates: Optional[Mapping['Setting', Any]] = None, set_defaults: Optional[Mapping['Setting', Any]] = None, restore_defaults: Optional[Iterable['Setting']] = None) -> Self
@@ -66,7 +66,7 @@ the given settings will only be overridden if they were not set.
 - A new Settings object.
 
 
-#### `hash_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/root.py#L324" target="_blank">↗</a></sup>
+#### `hash_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/root.py#L324"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 hash_key(self) -> str

--- a/docs/v3/api-ref/python/prefect-settings-models-runner.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-runner.mdx
@@ -7,13 +7,13 @@ sidebarTitle: runner
 
 ## Classes
 
-### `RunnerServerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/runner.py#L10" target="_blank">↗</a></sup>
+### `RunnerServerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/runner.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling runner server behavior
 
 
-### `RunnerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/runner.py#L45" target="_blank">↗</a></sup>
+### `RunnerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/runner.py#L45"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling runner behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-server-api.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: api
 
 ## Classes
 
-### `ServerAPISettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/api.py#L10" target="_blank">↗</a></sup>
+### `ServerAPISettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/api.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling API server behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-server-database.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-database.mdx
@@ -7,7 +7,7 @@ sidebarTitle: database
 
 ## Functions
 
-### `warn_on_database_password_value_without_usage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L324" target="_blank">↗</a></sup>
+### `warn_on_database_password_value_without_usage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L324"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 warn_on_database_password_value_without_usage(settings: ServerDatabaseSettings) -> None
@@ -19,28 +19,28 @@ Validator for settings warning if the database password is set but not used.
 
 ## Classes
 
-### `SQLAlchemyTLSSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L18" target="_blank">↗</a></sup>
+### `SQLAlchemyTLSSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L18"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling SQLAlchemy mTLS context when
 using a PostgreSQL database.
 
 
-### `SQLAlchemyConnectArgsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L54" target="_blank">↗</a></sup>
+### `SQLAlchemyConnectArgsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling SQLAlchemy connection behavior; note that these settings only take effect when
 using a PostgreSQL database.
 
 
-### `SQLAlchemySettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L89" target="_blank">↗</a></sup>
+### `SQLAlchemySettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling SQLAlchemy behavior; note that these settings only take effect when
 using a PostgreSQL database.
 
 
-### `ServerDatabaseSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L135" target="_blank">↗</a></sup>
+### `ServerDatabaseSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L135"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling server database behavior
@@ -48,7 +48,7 @@ Settings for controlling server database behavior
 
 **Methods:**
 
-#### `set_deprecated_sqlalchemy_settings_on_child_model_and_warn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L289" target="_blank">↗</a></sup>
+#### `set_deprecated_sqlalchemy_settings_on_child_model_and_warn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L289"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_deprecated_sqlalchemy_settings_on_child_model_and_warn(cls, values: dict[str, Any]) -> dict[str, Any]
@@ -57,7 +57,7 @@ set_deprecated_sqlalchemy_settings_on_child_model_and_warn(cls, values: dict[str
 Set deprecated settings on the child model.
 
 
-#### `emit_warnings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/database.py#L318" target="_blank">↗</a></sup>
+#### `emit_warnings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/database.py#L318"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_warnings(self) -> Self

--- a/docs/v3/api-ref/python/prefect-settings-models-server-deployments.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-deployments.mdx
@@ -7,4 +7,4 @@ sidebarTitle: deployments
 
 ## Classes
 
-### `ServerDeploymentsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/deployments.py#L9" target="_blank">↗</a></sup>
+### `ServerDeploymentsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/deployments.py#L9"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-settings-models-server-ephemeral.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-ephemeral.mdx
@@ -7,7 +7,7 @@ sidebarTitle: ephemeral
 
 ## Classes
 
-### `ServerEphemeralSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/ephemeral.py#L9" target="_blank">↗</a></sup>
+### `ServerEphemeralSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/ephemeral.py#L9"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling ephemeral server behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-server-events.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Classes
 
-### `ServerEventsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/events.py#L10" target="_blank">↗</a></sup>
+### `ServerEventsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/events.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling behavior of the events subsystem

--- a/docs/v3/api-ref/python/prefect-settings-models-server-flow_run_graph.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-flow_run_graph.mdx
@@ -7,7 +7,7 @@ sidebarTitle: flow_run_graph
 
 ## Classes
 
-### `ServerFlowRunGraphSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/flow_run_graph.py#L9" target="_blank">↗</a></sup>
+### `ServerFlowRunGraphSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/flow_run_graph.py#L9"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling behavior of the flow run graph

--- a/docs/v3/api-ref/python/prefect-settings-models-server-logs.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-logs.mdx
@@ -7,7 +7,7 @@ sidebarTitle: logs
 
 ## Classes
 
-### `ServerLogsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/logs.py#L11" target="_blank">↗</a></sup>
+### `ServerLogsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/logs.py#L11"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling behavior of the logs subsystem

--- a/docs/v3/api-ref/python/prefect-settings-models-server-root.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-root.mdx
@@ -7,7 +7,7 @@ sidebarTitle: root
 
 ## Classes
 
-### `ServerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/root.py#L22" target="_blank">↗</a></sup>
+### `ServerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/root.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling server behavior

--- a/docs/v3/api-ref/python/prefect-settings-models-server-services.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-services.mdx
@@ -7,63 +7,63 @@ sidebarTitle: services
 
 ## Classes
 
-### `ServicesBaseSetting` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L10" target="_blank">↗</a></sup>
+### `ServicesBaseSetting` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L10"><Icon icon="github" size="14" /></a></sup>
 
-### `ServerServicesCancellationCleanupSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L17" target="_blank">↗</a></sup>
+### `ServerServicesCancellationCleanupSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the cancellation cleanup service
 
 
-### `ServerServicesEventPersisterSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L47" target="_blank">↗</a></sup>
+### `ServerServicesEventPersisterSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the event persister service
 
 
-### `ServerServicesEventLoggerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L99" target="_blank">↗</a></sup>
+### `ServerServicesEventLoggerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L99"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the event logger service
 
 
-### `ServerServicesForemanSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L119" target="_blank">↗</a></sup>
+### `ServerServicesForemanSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the foreman service
 
 
-### `ServerServicesLateRunsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L200" target="_blank">↗</a></sup>
+### `ServerServicesLateRunsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L200"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the late runs service
 
 
-### `ServerServicesSchedulerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L244" target="_blank">↗</a></sup>
+### `ServerServicesSchedulerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L244"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the scheduler service
 
 
-### `ServerServicesPauseExpirationsSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L376" target="_blank">↗</a></sup>
+### `ServerServicesPauseExpirationsSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L376"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the pause expiration service
 
 
-### `ServerServicesTaskRunRecorderSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L412" target="_blank">↗</a></sup>
+### `ServerServicesTaskRunRecorderSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L412"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the task run recorder service
 
 
-### `ServerServicesTriggersSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L432" target="_blank">↗</a></sup>
+### `ServerServicesTriggersSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L432"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling the triggers service
 
 
-### `ServerServicesSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/services.py#L478" target="_blank">↗</a></sup>
+### `ServerServicesSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/services.py#L478"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling server services

--- a/docs/v3/api-ref/python/prefect-settings-models-server-tasks.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-tasks.mdx
@@ -7,13 +7,13 @@ sidebarTitle: tasks
 
 ## Classes
 
-### `ServerTasksSchedulingSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/tasks.py#L10" target="_blank">↗</a></sup>
+### `ServerTasksSchedulingSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/tasks.py#L10"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling server-side behavior related to task scheduling
 
 
-### `ServerTasksSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/tasks.py#L50" target="_blank">↗</a></sup>
+### `ServerTasksSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/tasks.py#L50"><Icon icon="github" size="14" /></a></sup>
 
 
 Settings for controlling server-side behavior related to tasks

--- a/docs/v3/api-ref/python/prefect-settings-models-server-ui.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-ui.mdx
@@ -7,4 +7,4 @@ sidebarTitle: ui
 
 ## Classes
 
-### `ServerUISettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/server/ui.py#L9" target="_blank">↗</a></sup>
+### `ServerUISettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/server/ui.py#L9"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-settings-models-tasks.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-tasks.mdx
@@ -7,8 +7,8 @@ sidebarTitle: tasks
 
 ## Classes
 
-### `TasksRunnerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/tasks.py#L10" target="_blank">↗</a></sup>
+### `TasksRunnerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/tasks.py#L10"><Icon icon="github" size="14" /></a></sup>
 
-### `TasksSchedulingSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/tasks.py#L27" target="_blank">↗</a></sup>
+### `TasksSchedulingSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/tasks.py#L27"><Icon icon="github" size="14" /></a></sup>
 
-### `TasksSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/tasks.py#L53" target="_blank">↗</a></sup>
+### `TasksSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/tasks.py#L53"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-settings-models-testing.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-testing.mdx
@@ -7,4 +7,4 @@ sidebarTitle: testing
 
 ## Classes
 
-### `TestingSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/testing.py#L9" target="_blank">↗</a></sup>
+### `TestingSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/testing.py#L9"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-settings-models-worker.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-worker.mdx
@@ -7,6 +7,6 @@ sidebarTitle: worker
 
 ## Classes
 
-### `WorkerWebserverSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/worker.py#L9" target="_blank">↗</a></sup>
+### `WorkerWebserverSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/worker.py#L9"><Icon icon="github" size="14" /></a></sup>
 
-### `WorkerSettings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/models/worker.py#L25" target="_blank">↗</a></sup>
+### `WorkerSettings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/models/worker.py#L25"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-settings-profiles.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-profiles.mdx
@@ -7,7 +7,7 @@ sidebarTitle: profiles
 
 ## Functions
 
-### `load_profiles` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L302" target="_blank">↗</a></sup>
+### `load_profiles` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L302"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_profiles(include_defaults: bool = True) -> ProfilesCollection
@@ -18,7 +18,7 @@ Load profiles from the current profile path. Optionally include profiles from th
 default profile path.
 
 
-### `load_current_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L341" target="_blank">↗</a></sup>
+### `load_current_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L341"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_current_profile() -> Profile
@@ -31,7 +31,7 @@ This will _not_ include settings from the current settings context. Only setting
 that have been persisted to the profiles file will be saved.
 
 
-### `save_profiles` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L359" target="_blank">↗</a></sup>
+### `save_profiles` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L359"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 save_profiles(profiles: ProfilesCollection) -> None
@@ -41,7 +41,7 @@ save_profiles(profiles: ProfilesCollection) -> None
 Writes all non-default profiles to the current profiles path.
 
 
-### `load_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L369" target="_blank">↗</a></sup>
+### `load_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L369"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_profile(name: str) -> Profile
@@ -51,7 +51,7 @@ load_profile(name: str) -> Profile
 Load a single profile by name.
 
 
-### `update_current_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L380" target="_blank">↗</a></sup>
+### `update_current_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L380"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_current_profile(settings: dict[str | Setting, Any]) -> Profile
@@ -71,7 +71,7 @@ Given settings will be merged with the existing settings as described in
 
 ## Classes
 
-### `Profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L55" target="_blank">↗</a></sup>
+### `Profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 
 A user profile containing settings.
@@ -79,7 +79,7 @@ A user profile containing settings.
 
 **Methods:**
 
-#### `to_environment_variables` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L68" target="_blank">↗</a></sup>
+#### `to_environment_variables` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_environment_variables(self) -> dict[str, str]
@@ -88,7 +88,7 @@ to_environment_variables(self) -> dict[str, str]
 Convert the profile settings to a dictionary of environment variables.
 
 
-#### `validate_settings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L76" target="_blank">↗</a></sup>
+#### `validate_settings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_settings(self) -> None
@@ -98,7 +98,7 @@ Validate all settings in this profile by creating a partial Settings object
 with the nested structure properly constructed using accessor paths.
 
 
-### `ProfilesCollection` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L113" target="_blank">↗</a></sup>
+### `ProfilesCollection` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L113"><Icon icon="github" size="14" /></a></sup>
 
 
 "
@@ -111,7 +111,7 @@ The collection may store the name of the active profile.
 
 **Methods:**
 
-#### `names` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L129" target="_blank">↗</a></sup>
+#### `names` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L129"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 names(self) -> set[str]
@@ -120,7 +120,7 @@ names(self) -> set[str]
 Return a set of profile names in this collection.
 
 
-#### `active_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L136" target="_blank">↗</a></sup>
+#### `active_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 active_profile(self) -> Profile | None
@@ -129,7 +129,7 @@ active_profile(self) -> Profile | None
 Retrieve the active profile in this collection.
 
 
-#### `set_active` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L144" target="_blank">↗</a></sup>
+#### `set_active` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L144"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_active(self, name: str | None, check: bool = True) -> None
@@ -141,7 +141,7 @@ A null value may be passed to indicate that this collection does not determine
 the active profile.
 
 
-#### `update_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L155" target="_blank">↗</a></sup>
+#### `update_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L155"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_profile(self, name: str, settings: dict[Setting, Any], source: Path | None = None) -> Profile
@@ -157,7 +157,7 @@ profile.
 Returns the new profile object.
 
 
-#### `add_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L196" target="_blank">↗</a></sup>
+#### `add_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L196"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_profile(self, profile: Profile) -> None
@@ -168,7 +168,7 @@ Add a profile to the collection.
 If the profile name already exists, an exception will be raised.
 
 
-#### `remove_profile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L209" target="_blank">↗</a></sup>
+#### `remove_profile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L209"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 remove_profile(self, name: str) -> None
@@ -177,7 +177,7 @@ remove_profile(self, name: str) -> None
 Remove a profile from the collection.
 
 
-#### `without_profile_source` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L215" target="_blank">↗</a></sup>
+#### `without_profile_source` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L215"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 without_profile_source(self, path: Path | None) -> 'ProfilesCollection'
@@ -188,7 +188,7 @@ Remove profiles that were loaded from a given path.
 Returns a new collection.
 
 
-#### `to_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L230" target="_blank">↗</a></sup>
+#### `to_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_dict(self) -> dict[str, Any]
@@ -197,7 +197,7 @@ to_dict(self) -> dict[str, Any]
 Convert to a dictionary suitable for writing to disk.
 
 
-#### `items` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/profiles.py#L248" target="_blank">↗</a></sup>
+#### `items` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/profiles.py#L248"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 items(self) -> list[tuple[str, Profile]]

--- a/docs/v3/api-ref/python/prefect-settings-sources.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-sources.mdx
@@ -7,7 +7,7 @@ sidebarTitle: sources
 
 ## Classes
 
-### `EnvFilterSettingsSource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L41" target="_blank">↗</a></sup>
+### `EnvFilterSettingsSource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 
 Custom pydantic settings source to filter out specific environment variables.
@@ -18,9 +18,9 @@ shouldn't be loaded from environment variables. This loader allows use to say wh
 environment variables should be ignored.
 
 
-### `FilteredDotEnvSettingsSource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L84" target="_blank">↗</a></sup>
+### `FilteredDotEnvSettingsSource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L84"><Icon icon="github" size="14" /></a></sup>
 
-### `ProfileSettingsTomlLoader` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L122" target="_blank">↗</a></sup>
+### `ProfileSettingsTomlLoader` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L122"><Icon icon="github" size="14" /></a></sup>
 
 
 Custom pydantic settings source to load profile settings from a toml file.
@@ -30,7 +30,7 @@ See https://docs.pydantic.dev/latest/concepts/pydantic_settings/#customise-setti
 
 **Methods:**
 
-#### `get_field_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L173" target="_blank">↗</a></sup>
+#### `get_field_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L173"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_field_value(self, field: FieldInfo, field_name: str) -> Tuple[Any, str, bool]
@@ -39,11 +39,11 @@ get_field_value(self, field: FieldInfo, field_name: str) -> Tuple[Any, str, bool
 Concrete implementation to get the field value from the profile settings
 
 
-### `TomlConfigSettingsSourceBase` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L226" target="_blank">↗</a></sup>
+### `TomlConfigSettingsSourceBase` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L226"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `get_field_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L235" target="_blank">↗</a></sup>
+#### `get_field_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L235"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]
@@ -52,13 +52,13 @@ get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool
 Concrete implementation to get the field value from toml data
 
 
-### `PrefectTomlConfigSettingsSource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L274" target="_blank">↗</a></sup>
+### `PrefectTomlConfigSettingsSource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L274"><Icon icon="github" size="14" /></a></sup>
 
 
 Custom pydantic settings source to load settings from a prefect.toml file
 
 
-### `PyprojectTomlConfigSettingsSource` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/settings/sources.py#L293" target="_blank">↗</a></sup>
+### `PyprojectTomlConfigSettingsSource` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/settings/sources.py#L293"><Icon icon="github" size="14" /></a></sup>
 
 
 Custom pydantic settings source to load settings from a pyproject.toml file

--- a/docs/v3/api-ref/python/prefect-states.mdx
+++ b/docs/v3/api-ref/python/prefect-states.mdx
@@ -7,7 +7,7 @@ sidebarTitle: states
 
 ## Functions
 
-### `to_state_create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L46" target="_blank">↗</a></sup>
+### `to_state_create` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_state_create(state: State) -> 'StateCreate'
@@ -21,13 +21,13 @@ This method will drop this state's `data` if it is not a result type. Only
 results should be sent to the API. Other data is only available locally.
 
 
-### `format_exception` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L183" target="_blank">↗</a></sup>
+### `format_exception` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L183"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format_exception(exc: BaseException, tb: TracebackType = None) -> str
 ```
 
-### `is_state_iterable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L540" target="_blank">↗</a></sup>
+### `is_state_iterable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L540"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_state_iterable(obj: Any) -> TypeGuard[Iterable[State]]
@@ -44,7 +44,7 @@ Supported iterables are:
 Other iterables will return `False` even if they contain states.
 
 
-### `Scheduled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L626" target="_blank">↗</a></sup>
+### `Scheduled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L626"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Scheduled(cls: Type['State[R]'] = State, scheduled_time: Optional[datetime.datetime] = None, **kwargs: Any) -> 'State[R]'
@@ -57,7 +57,7 @@ Convenience function for creating `Scheduled` states.
 - a Scheduled state
 
 
-### `Completed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L646" target="_blank">↗</a></sup>
+### `Completed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L646"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Completed(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -70,7 +70,7 @@ Convenience function for creating `Completed` states.
 - a Completed state
 
 
-### `Running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L656" target="_blank">↗</a></sup>
+### `Running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L656"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Running(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -83,7 +83,7 @@ Convenience function for creating `Running` states.
 - a Running state
 
 
-### `Failed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L665" target="_blank">↗</a></sup>
+### `Failed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L665"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Failed(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -96,7 +96,7 @@ Convenience function for creating `Failed` states.
 - a Failed state
 
 
-### `Crashed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L674" target="_blank">↗</a></sup>
+### `Crashed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L674"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Crashed(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -109,7 +109,7 @@ Convenience function for creating `Crashed` states.
 - a Crashed state
 
 
-### `Cancelling` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L683" target="_blank">↗</a></sup>
+### `Cancelling` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L683"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Cancelling(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -122,7 +122,7 @@ Convenience function for creating `Cancelling` states.
 - a Cancelling state
 
 
-### `Cancelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L692" target="_blank">↗</a></sup>
+### `Cancelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L692"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Cancelled(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -135,7 +135,7 @@ Convenience function for creating `Cancelled` states.
 - a Cancelled state
 
 
-### `Pending` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L701" target="_blank">↗</a></sup>
+### `Pending` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L701"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Pending(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -148,7 +148,7 @@ Convenience function for creating `Pending` states.
 - a Pending state
 
 
-### `Paused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L710" target="_blank">↗</a></sup>
+### `Paused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L710"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Paused(cls: Type['State[R]'] = State, timeout_seconds: Optional[int] = None, pause_expiration_time: Optional[datetime.datetime] = None, reschedule: bool = False, pause_key: Optional[str] = None, **kwargs: Any) -> 'State[R]'
@@ -161,7 +161,7 @@ Convenience function for creating `Paused` states.
 - a Paused state
 
 
-### `Suspended` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L748" target="_blank">↗</a></sup>
+### `Suspended` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L748"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Suspended(cls: Type['State[R]'] = State, timeout_seconds: Optional[int] = None, pause_expiration_time: Optional[datetime.datetime] = None, pause_key: Optional[str] = None, **kwargs: Any) -> 'State[R]'
@@ -174,7 +174,7 @@ Convenience function for creating `Suspended` states.
 - a Suspended state
 
 
-### `AwaitingRetry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L771" target="_blank">↗</a></sup>
+### `AwaitingRetry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L771"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AwaitingRetry(cls: Type['State[R]'] = State, scheduled_time: Optional[datetime.datetime] = None, **kwargs: Any) -> 'State[R]'
@@ -187,7 +187,7 @@ Convenience function for creating `AwaitingRetry` states.
 - an AwaitingRetry state
 
 
-### `AwaitingConcurrencySlot` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L786" target="_blank">↗</a></sup>
+### `AwaitingConcurrencySlot` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L786"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 AwaitingConcurrencySlot(cls: Type['State[R]'] = State, scheduled_time: Optional[datetime.datetime] = None, **kwargs: Any) -> 'State[R]'
@@ -200,7 +200,7 @@ Convenience function for creating `AwaitingConcurrencySlot` states.
 - an AwaitingConcurrencySlot state
 
 
-### `Retrying` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L801" target="_blank">↗</a></sup>
+### `Retrying` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L801"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Retrying(cls: Type['State[R]'] = State, **kwargs: Any) -> 'State[R]'
@@ -213,7 +213,7 @@ Convenience function for creating `Retrying` states.
 - a Retrying state
 
 
-### `Late` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L810" target="_blank">↗</a></sup>
+### `Late` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L810"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 Late(cls: Type['State[R]'] = State, scheduled_time: Optional[datetime.datetime] = None, **kwargs: Any) -> 'State[R]'
@@ -228,47 +228,47 @@ Convenience function for creating `Late` states.
 
 ## Classes
 
-### `StateGroup` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L563" target="_blank">↗</a></sup>
+### `StateGroup` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L563"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `fail_count` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L574" target="_blank">↗</a></sup>
+#### `fail_count` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L574"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 fail_count(self) -> int
 ```
 
-#### `all_completed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L577" target="_blank">↗</a></sup>
+#### `all_completed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L577"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_completed(self) -> bool
 ```
 
-#### `any_cancelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L580" target="_blank">↗</a></sup>
+#### `any_cancelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L580"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 any_cancelled(self) -> bool
 ```
 
-#### `any_failed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L583" target="_blank">↗</a></sup>
+#### `any_failed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L583"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 any_failed(self) -> bool
 ```
 
-#### `any_paused` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L589" target="_blank">↗</a></sup>
+#### `any_paused` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L589"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 any_paused(self) -> bool
 ```
 
-#### `all_final` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L592" target="_blank">↗</a></sup>
+#### `all_final` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L592"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 all_final(self) -> bool
 ```
 
-#### `counts_message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/states.py#L595" target="_blank">↗</a></sup>
+#### `counts_message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/states.py#L595"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 counts_message(self) -> str

--- a/docs/v3/api-ref/python/prefect-task_engine.mdx
+++ b/docs/v3/api-ref/python/prefect-task_engine.mdx
@@ -7,19 +7,19 @@ sidebarTitle: task_engine
 
 ## Functions
 
-### `run_task_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L1461" target="_blank">↗</a></sup>
+### `run_task_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L1461"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_task_sync(task: 'Task[P, R]', task_run_id: Optional[UUID] = None, task_run: Optional[TaskRun] = None, parameters: Optional[dict[str, Any]] = None, wait_for: Optional['OneOrManyFutureOrResult[Any]'] = None, return_type: Literal['state', 'result'] = 'result', dependencies: Optional[dict[str, set[RunInput]]] = None, context: Optional[dict[str, Any]] = None) -> Union[R, State, None]
 ```
 
-### `run_generator_task_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L1523" target="_blank">↗</a></sup>
+### `run_generator_task_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L1523"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_generator_task_sync(task: 'Task[P, R]', task_run_id: Optional[UUID] = None, task_run: Optional[TaskRun] = None, parameters: Optional[dict[str, Any]] = None, wait_for: Optional['OneOrManyFutureOrResult[Any]'] = None, return_type: Literal['state', 'result'] = 'result', dependencies: Optional[dict[str, set[RunInput]]] = None, context: Optional[dict[str, Any]] = None) -> Generator[R, None, None]
 ```
 
-### `run_task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L1668" target="_blank">↗</a></sup>
+### `run_task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L1668"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_task(task: 'Task[P, Union[R, Coroutine[Any, Any, R]]]', task_run_id: Optional[UUID] = None, task_run: Optional[TaskRun] = None, parameters: Optional[dict[str, Any]] = None, wait_for: Optional['OneOrManyFutureOrResult[Any]'] = None, return_type: Literal['state', 'result'] = 'result', dependencies: Optional[dict[str, set[RunInput]]] = None, context: Optional[dict[str, Any]] = None) -> Union[R, State, None, Coroutine[Any, Any, Union[R, State, None]]]
@@ -47,41 +47,41 @@ required if the task is running on in a remote environment
 
 ## Classes
 
-### `TaskRunTimeoutError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L114" target="_blank">↗</a></sup>
+### `TaskRunTimeoutError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a task run exceeds its timeout.
 
 
-### `BaseTaskRunEngine` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L119" target="_blank">↗</a></sup>
+### `BaseTaskRunEngine` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L142" target="_blank">↗</a></sup>
+#### `state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L142"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 state(self) -> State
 ```
 
-#### `is_cancelled` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L147" target="_blank">↗</a></sup>
+#### `is_cancelled` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L147"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_cancelled(self) -> bool
 ```
 
-#### `compute_transaction_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L156" target="_blank">↗</a></sup>
+#### `compute_transaction_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L156"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 compute_transaction_key(self) -> Optional[str]
 ```
 
-#### `record_terminal_state_timing` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L240" target="_blank">↗</a></sup>
+#### `record_terminal_state_timing` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L240"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 record_terminal_state_timing(self, state: State) -> None
 ```
 
-#### `is_running` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L247" target="_blank">↗</a></sup>
+#### `is_running` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L247"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_running(self) -> bool
@@ -90,65 +90,65 @@ is_running(self) -> bool
 Whether or not the engine is currently running a task.
 
 
-#### `log_finished_message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L253" target="_blank">↗</a></sup>
+#### `log_finished_message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L253"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 log_finished_message(self) -> None
 ```
 
-#### `handle_rollback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L291" target="_blank">↗</a></sup>
+#### `handle_rollback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L291"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_rollback(self, txn: Transaction) -> None
 ```
 
-### `SyncTaskRunEngine` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L308" target="_blank">↗</a></sup>
+### `SyncTaskRunEngine` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L308"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L313" target="_blank">↗</a></sup>
+#### `client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L313"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client(self) -> SyncPrefectClient
 ```
 
-#### `can_retry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L318" target="_blank">↗</a></sup>
+#### `can_retry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L318"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 can_retry(self, exc_or_state: Exception | State[R]) -> bool
 ```
 
-#### `call_hooks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L355" target="_blank">↗</a></sup>
+#### `call_hooks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L355"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_hooks(self, state: Optional[State] = None) -> None
 ```
 
-#### `begin_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L390" target="_blank">↗</a></sup>
+#### `begin_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L390"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 begin_run(self) -> None
 ```
 
-#### `set_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L426" target="_blank">↗</a></sup>
+#### `set_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L426"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_state(self, state: State[R], force: bool = False) -> State[R]
 ```
 
-#### `result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L468" target="_blank">↗</a></sup>
+#### `result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L468"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 result(self, raise_on_failure: bool = True) -> 'Union[R, State, None]'
 ```
 
-#### `handle_success` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L483" target="_blank">↗</a></sup>
+#### `handle_success` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L483"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_success(self, result: R, transaction: Transaction) -> Union[ResultRecord[R], None, Coroutine[Any, Any, R], R]
 ```
 
-#### `handle_retry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L524" target="_blank">↗</a></sup>
+#### `handle_retry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L524"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_retry(self, exc_or_state: Exception | State[R]) -> bool
@@ -161,37 +161,37 @@ Handle any task run retries.
 - If the task has no retries left, or the retry condition is not met, return False.
 
 
-#### `handle_exception` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L575" target="_blank">↗</a></sup>
+#### `handle_exception` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L575"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_exception(self, exc: Exception) -> None
 ```
 
-#### `handle_timeout` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L593" target="_blank">↗</a></sup>
+#### `handle_timeout` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L593"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_timeout(self, exc: TimeoutError) -> None
 ```
 
-#### `handle_crash` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L609" target="_blank">↗</a></sup>
+#### `handle_crash` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L609"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_crash(self, exc: BaseException) -> None
 ```
 
-#### `setup_run_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L620" target="_blank">↗</a></sup>
+#### `setup_run_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L620"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_run_context(self, client: Optional[SyncPrefectClient] = None)
 ```
 
-#### `asset_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L665" target="_blank">↗</a></sup>
+#### `asset_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L665"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 asset_context(self)
 ```
 
-#### `initialize_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L683" target="_blank">↗</a></sup>
+#### `initialize_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L683"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 initialize_run(self, task_run_id: Optional[UUID] = None, dependencies: Optional[dict[str, set[RunInput]]] = None) -> Generator[Self, Any, Any]
@@ -200,25 +200,25 @@ initialize_run(self, task_run_id: Optional[UUID] = None, dependencies: Optional[
 Enters a client context and creates a task run if needed.
 
 
-#### `start` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L777" target="_blank">↗</a></sup>
+#### `start` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L777"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start(self, task_run_id: Optional[UUID] = None, dependencies: Optional[dict[str, set[RunInput]]] = None) -> Generator[None, None, None]
 ```
 
-#### `transaction_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L816" target="_blank">↗</a></sup>
+#### `transaction_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L816"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 transaction_context(self) -> Generator[Transaction, None, None]
 ```
 
-#### `run_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L843" target="_blank">↗</a></sup>
+#### `run_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L843"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_context(self)
 ```
 
-#### `call_task_fn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L863" target="_blank">↗</a></sup>
+#### `call_task_fn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L863"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_task_fn(self, transaction: Transaction) -> Union[ResultRecord[Any], None, Coroutine[Any, Any, R], R]
@@ -228,11 +228,11 @@ Convenience method to call the task function. Returns a coroutine if the
 task is async.
 
 
-### `AsyncTaskRunEngine` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L880" target="_blank">↗</a></sup>
+### `AsyncTaskRunEngine` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L880"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_engine.py#L885" target="_blank">↗</a></sup>
+#### `client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_engine.py#L885"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client(self) -> PrefectClient

--- a/docs/v3/api-ref/python/prefect-task_runners.mdx
+++ b/docs/v3/api-ref/python/prefect-task_runners.mdx
@@ -7,7 +7,7 @@ sidebarTitle: task_runners
 
 ## Classes
 
-### `TaskRunner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L51" target="_blank">↗</a></sup>
+### `TaskRunner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L51"><Icon icon="github" size="14" /></a></sup>
 
 
 Abstract base class for task runners.
@@ -22,7 +22,7 @@ proper cleanup of resources.
 
 **Methods:**
 
-#### `name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L68" target="_blank">↗</a></sup>
+#### `name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 name(self) -> str
@@ -31,7 +31,7 @@ name(self) -> str
 The name of this task runner
 
 
-#### `duplicate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L73" target="_blank">↗</a></sup>
+#### `duplicate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L73"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 duplicate(self) -> Self
@@ -40,25 +40,25 @@ duplicate(self) -> Self
 Return a new instance of this task runner with the same configuration.
 
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L79" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L79"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[P, Coroutine[Any, Any, R]]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> F
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L89" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[Any, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> F
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L98" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[P, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> F
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L106" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L106"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[P, R]', parameters: dict[str, Any | unmapped[Any] | allow_failure[Any]], wait_for: Iterable[PrefectFuture[R]] | None = None) -> PrefectFutureList[F]
@@ -76,7 +76,7 @@ Submit multiple tasks to the task run engine.
 - complete and retrieve the results.
 
 
-### `ThreadPoolTaskRunner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L228" target="_blank">↗</a></sup>
+### `ThreadPoolTaskRunner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L228"><Icon icon="github" size="14" /></a></sup>
 
 
 A task runner that executes tasks in a separate thread pool.
@@ -84,25 +84,25 @@ A task runner that executes tasks in a separate thread pool.
 
 **Methods:**
 
-#### `duplicate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L256" target="_blank">↗</a></sup>
+#### `duplicate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L256"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 duplicate(self) -> 'ThreadPoolTaskRunner[R]'
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L260" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L260"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[P, Coroutine[Any, Any, R]]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> PrefectConcurrentFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L269" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L269"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[Any, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> PrefectConcurrentFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L277" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L277"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[P, R | Coroutine[Any, Any, R]]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> PrefectConcurrentFuture[R]
@@ -120,53 +120,53 @@ Submit a task to the task run engine running in a separate thread.
 - retrieve the result.
 
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L351" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L351"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[P, Coroutine[Any, Any, R]]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None) -> PrefectFutureList[PrefectConcurrentFuture[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L359" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L359"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[Any, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None) -> PrefectFutureList[PrefectConcurrentFuture[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L366" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L366"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[P, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None) -> PrefectFutureList[PrefectConcurrentFuture[R]]
 ```
 
-#### `cancel_all` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L374" target="_blank">↗</a></sup>
+#### `cancel_all` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L374"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cancel_all(self) -> None
 ```
 
-### `PrefectTaskRunner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L405" target="_blank">↗</a></sup>
+### `PrefectTaskRunner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L405"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `duplicate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L409" target="_blank">↗</a></sup>
+#### `duplicate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L409"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 duplicate(self) -> 'PrefectTaskRunner[R]'
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L413" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L413"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[P, Coroutine[Any, Any, R]]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> PrefectDistributedFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L422" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L422"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[Any, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> PrefectDistributedFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L430" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L430"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self, task: 'Task[P, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None, dependencies: dict[str, set[RunInput]] | None = None) -> PrefectDistributedFuture[R]
@@ -184,19 +184,19 @@ Submit a task to the task run engine running in a separate thread.
 - retrieve the result.
 
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L468" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L468"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[P, Coroutine[Any, Any, R]]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None) -> PrefectFutureList[PrefectDistributedFuture[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L476" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L476"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[Any, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None) -> PrefectFutureList[PrefectDistributedFuture[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runners.py#L483" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runners.py#L483"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, task: 'Task[P, R]', parameters: dict[str, Any], wait_for: Iterable[PrefectFuture[Any]] | None = None) -> PrefectFutureList[PrefectDistributedFuture[R]]

--- a/docs/v3/api-ref/python/prefect-task_runs.mdx
+++ b/docs/v3/api-ref/python/prefect-task_runs.mdx
@@ -7,7 +7,7 @@ sidebarTitle: task_runs
 
 ## Classes
 
-### `TaskRunWaiter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runs.py#L24" target="_blank">↗</a></sup>
+### `TaskRunWaiter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runs.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 
 A service used for waiting for a task run to finish.
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
 **Methods:**
 
-#### `start` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runs.py#L88" target="_blank">↗</a></sup>
+#### `start` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runs.py#L88"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start(self) -> None
@@ -67,7 +67,7 @@ start(self) -> None
 Start the TaskRunWaiter service.
 
 
-#### `stop` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runs.py#L151" target="_blank">↗</a></sup>
+#### `stop` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runs.py#L151"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stop(self) -> None
@@ -76,7 +76,7 @@ stop(self) -> None
 Stop the TaskRunWaiter service.
 
 
-#### `add_done_callback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runs.py#L209" target="_blank">↗</a></sup>
+#### `add_done_callback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runs.py#L209"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_done_callback(cls, task_run_id: uuid.UUID, callback: Callable[[], None]) -> None
@@ -89,7 +89,7 @@ Add a callback to be called when a task run finishes.
 - `callback`: The callback to call when the task run finishes.
 
 
-#### `instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_runs.py#L231" target="_blank">↗</a></sup>
+#### `instance` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_runs.py#L231"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 instance(cls) -> Self

--- a/docs/v3/api-ref/python/prefect-task_worker.mdx
+++ b/docs/v3/api-ref/python/prefect-task_worker.mdx
@@ -7,7 +7,7 @@ sidebarTitle: task_worker
 
 ## Functions
 
-### `should_try_to_read_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L67" target="_blank">↗</a></sup>
+### `should_try_to_read_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L67"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_try_to_read_parameters(task: Task[P, R], task_run: TaskRun) -> bool
@@ -17,7 +17,7 @@ should_try_to_read_parameters(task: Task[P, R], task_run: TaskRun) -> bool
 Determines whether a task run should read parameters from the result store.
 
 
-### `create_status_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L410" target="_blank">↗</a></sup>
+### `create_status_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L410"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_status_server(task_worker: TaskWorker) -> FastAPI
@@ -25,13 +25,13 @@ create_status_server(task_worker: TaskWorker) -> FastAPI
 
 ## Classes
 
-### `StopTaskWorker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L61" target="_blank">↗</a></sup>
+### `StopTaskWorker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L61"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when the task worker is stopped.
 
 
-### `TaskWorker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L79" target="_blank">↗</a></sup>
+### `TaskWorker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L79"><Icon icon="github" size="14" /></a></sup>
 
 
 This class is responsible for serving tasks that may be executed in the background
@@ -51,43 +51,43 @@ Pass `None` to remove the limit.
 
 **Methods:**
 
-#### `client_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L140" target="_blank">↗</a></sup>
+#### `client_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L140"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client_id(self) -> str
 ```
 
-#### `started_at` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L144" target="_blank">↗</a></sup>
+#### `started_at` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L144"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 started_at(self) -> Optional[DateTime]
 ```
 
-#### `started` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L148" target="_blank">↗</a></sup>
+#### `started` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L148"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 started(self) -> bool
 ```
 
-#### `limit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L152" target="_blank">↗</a></sup>
+#### `limit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 limit(self) -> Optional[int]
 ```
 
-#### `current_tasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L156" target="_blank">↗</a></sup>
+#### `current_tasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L156"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 current_tasks(self) -> Optional[int]
 ```
 
-#### `available_tasks` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L164" target="_blank">↗</a></sup>
+#### `available_tasks` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L164"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 available_tasks(self) -> Optional[int]
 ```
 
-#### `handle_sigterm` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/task_worker.py#L167" target="_blank">↗</a></sup>
+#### `handle_sigterm` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/task_worker.py#L167"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_sigterm(self, signum: int, frame: object) -> None

--- a/docs/v3/api-ref/python/prefect-tasks.mdx
+++ b/docs/v3/api-ref/python/prefect-tasks.mdx
@@ -12,7 +12,7 @@ Module containing the base workflow task class and decorator - for most use case
 
 ## Functions
 
-### `task_input_hash` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L162" target="_blank">↗</a></sup>
+### `task_input_hash` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task_input_hash(context: 'TaskRunContext', arguments: dict[str, Any]) -> Optional[str]
@@ -32,7 +32,7 @@ indicating that a cache key could not be generated for the given inputs.
 - a string hash if hashing succeeded, else `None`
 
 
-### `exponential_backoff` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L188" target="_blank">↗</a></sup>
+### `exponential_backoff` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L188"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exponential_backoff(backoff_factor: float) -> Callable[[int], list[float]]
@@ -50,7 +50,7 @@ increase the delay time by powers of 2.
 - a callable that can be passed to the task constructor
 
 
-### `task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1811" target="_blank">↗</a></sup>
+### `task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1811"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 task(__fn: Optional[Callable[P, R]] = None)
@@ -158,17 +158,17 @@ Define a task that is cached for a day based on its inputs
 
 ## Classes
 
-### `TaskRunNameCallbackWithParameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L103" target="_blank">↗</a></sup>
+### `TaskRunNameCallbackWithParameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `is_callback_with_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L105" target="_blank">↗</a></sup>
+#### `is_callback_with_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L105"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_callback_with_parameters(cls, callable: Callable[..., str]) -> TypeIs[Self]
 ```
 
-### `TaskOptions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L123" target="_blank">↗</a></sup>
+### `TaskOptions` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L123"><Icon icon="github" size="14" /></a></sup>
 
 
 A TypedDict representing all available task configuration options.
@@ -176,7 +176,7 @@ A TypedDict representing all available task configuration options.
 This can be used with `Unpack` to provide type hints for **kwargs.
 
 
-### `Task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L300" target="_blank">↗</a></sup>
+### `Task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L300"><Icon icon="github" size="14" /></a></sup>
 
 
 A Prefect task definition.
@@ -250,25 +250,25 @@ to its retry policy.
 
 **Methods:**
 
-#### `ismethod` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L613" target="_blank">↗</a></sup>
+#### `ismethod` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L613"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ismethod(self) -> bool
 ```
 
-#### `isclassmethod` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L617" target="_blank">↗</a></sup>
+#### `isclassmethod` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L617"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 isclassmethod(self) -> bool
 ```
 
-#### `isstaticmethod` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L621" target="_blank">↗</a></sup>
+#### `isstaticmethod` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L621"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 isstaticmethod(self) -> bool
 ```
 
-#### `with_options` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L645" target="_blank">↗</a></sup>
+#### `with_options` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L645"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 with_options(self) -> 'Task[P, R]'
@@ -350,61 +350,61 @@ Examples:
     >>>     new_task()
 
 
-#### `on_completion` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L817" target="_blank">↗</a></sup>
+#### `on_completion` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L817"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_completion(self, fn: StateHookCallable) -> StateHookCallable
 ```
 
-#### `on_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L821" target="_blank">↗</a></sup>
+#### `on_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L821"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_failure(self, fn: StateHookCallable) -> StateHookCallable
 ```
 
-#### `on_commit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L825" target="_blank">↗</a></sup>
+#### `on_commit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L825"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_commit(self, fn: Callable[['Transaction'], None]) -> Callable[['Transaction'], None]
 ```
 
-#### `on_rollback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L831" target="_blank">↗</a></sup>
+#### `on_rollback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L831"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_rollback(self, fn: Callable[['Transaction'], None]) -> Callable[['Transaction'], None]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1140" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1140"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self: 'Task[P, R]', *args: P.args, **kwargs: P.kwargs) -> PrefectFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1147" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1147"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self: 'Task[P, Coroutine[Any, Any, R]]', *args: P.args, **kwargs: P.kwargs) -> PrefectFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1156" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1156"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self: 'Task[P, R]', *args: P.args, **kwargs: P.kwargs) -> PrefectFuture[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1165" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1165"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self: 'Task[P, Coroutine[Any, Any, R]]', *args: P.args, **kwargs: P.kwargs) -> State[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1174" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1174"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self: 'Task[P, R]', *args: P.args, **kwargs: P.kwargs) -> State[R]
 ```
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1182" target="_blank">↗</a></sup>
+#### `submit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1182"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 submit(self: 'Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]', *args: Any, **kwargs: Any)
@@ -495,43 +495,43 @@ Examples:
     >>>     y = task_2.submit(wait_for=[x])
 
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1307" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1307"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self: 'Task[P, R]', *args: Any, **kwargs: Any) -> list[State[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1317" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1317"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self: 'Task[P, R]', *args: Any, **kwargs: Any) -> PrefectFutureList[R]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1326" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1326"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self: 'Task[P, R]', *args: Any, **kwargs: Any) -> list[State[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1336" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1336"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self: 'Task[P, R]', *args: Any, **kwargs: Any) -> PrefectFutureList[R]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1345" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1345"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self: 'Task[P, Coroutine[Any, Any, R]]', *args: Any, **kwargs: Any) -> list[State[R]]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1355" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1355"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self: 'Task[P, Coroutine[Any, Any, R]]', *args: Any, **kwargs: Any) -> PrefectFutureList[R]
 ```
 
-#### `map` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1364" target="_blank">↗</a></sup>
+#### `map` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1364"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 map(self, *args: Any, **kwargs: Any) -> Union[list[State[R]], PrefectFutureList[R]]
@@ -650,7 +650,7 @@ Examples:
     [[11, 21], [12, 22], [13, 23]]
 
 
-#### `apply_async` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1530" target="_blank">↗</a></sup>
+#### `apply_async` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1530"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 apply_async(self, args: Optional[tuple[Any, ...]] = None, kwargs: Optional[dict[str, Any]] = None, wait_for: Optional[Iterable[PrefectFuture[R]]] = None, dependencies: Optional[dict[str, set[RunInput]]] = None) -> PrefectDistributedFuture[R]
@@ -712,7 +712,7 @@ Examples:
     >>>     y = task_2.apply_async(wait_for=[x])
 
 
-#### `delay` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L1635" target="_blank">↗</a></sup>
+#### `delay` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L1635"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 delay(self, *args: P.args, **kwargs: P.kwargs) -> PrefectDistributedFuture[R]
@@ -755,7 +755,7 @@ Examples:
         hello marvin
 
 
-### `MaterializingTask` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/tasks.py#L2014" target="_blank">↗</a></sup>
+### `MaterializingTask` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/tasks.py#L2014"><Icon icon="github" size="14" /></a></sup>
 
 
 A task that materializes Assets.

--- a/docs/v3/api-ref/python/prefect-telemetry-bootstrap.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-bootstrap.mdx
@@ -7,7 +7,7 @@ sidebarTitle: bootstrap
 
 ## Functions
 
-### `setup_telemetry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/bootstrap.py#L20" target="_blank">↗</a></sup>
+### `setup_telemetry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/bootstrap.py#L20"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_telemetry() -> Union[tuple['TracerProvider', 'MeterProvider', 'LoggerProvider'], tuple[None, None, None]]

--- a/docs/v3/api-ref/python/prefect-telemetry-instrumentation.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-instrumentation.mdx
@@ -7,13 +7,13 @@ sidebarTitle: instrumentation
 
 ## Functions
 
-### `extract_account_and_workspace_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/instrumentation.py#L43" target="_blank">↗</a></sup>
+### `extract_account_and_workspace_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/instrumentation.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 extract_account_and_workspace_id(url: str) -> tuple[UUID, UUID]
 ```
 
-### `setup_exporters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/instrumentation.py#L64" target="_blank">↗</a></sup>
+### `setup_exporters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/instrumentation.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_exporters(api_url: str, api_key: str) -> 'tuple[TracerProvider, MeterProvider, LoggerProvider]'

--- a/docs/v3/api-ref/python/prefect-telemetry-logging.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-logging.mdx
@@ -7,7 +7,7 @@ sidebarTitle: logging
 
 ## Functions
 
-### `set_log_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/logging.py#L12" target="_blank">↗</a></sup>
+### `set_log_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/logging.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_log_handler(log_handler: Optional['LoggingHandler']) -> None
@@ -17,7 +17,7 @@ set_log_handler(log_handler: Optional['LoggingHandler']) -> None
 Set the OTLP log handler.
 
 
-### `get_log_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/logging.py#L18" target="_blank">↗</a></sup>
+### `get_log_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/logging.py#L18"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_log_handler() -> Optional['LoggingHandler']
@@ -27,7 +27,7 @@ get_log_handler() -> Optional['LoggingHandler']
 Get the OTLP log handler.
 
 
-### `add_telemetry_log_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/logging.py#L24" target="_blank">↗</a></sup>
+### `add_telemetry_log_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/logging.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_telemetry_log_handler(logger: logging.Logger) -> None

--- a/docs/v3/api-ref/python/prefect-telemetry-processors.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-processors.mdx
@@ -7,29 +7,29 @@ sidebarTitle: processors
 
 ## Classes
 
-### `InFlightSpanProcessor` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/processors.py#L13" target="_blank">↗</a></sup>
+### `InFlightSpanProcessor` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/processors.py#L13"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `on_start` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/processors.py#L41" target="_blank">↗</a></sup>
+#### `on_start` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/processors.py#L41"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_start(self, span: 'Span', parent_context: Optional[Context] = None) -> None
 ```
 
-#### `on_end` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/processors.py#L47" target="_blank">↗</a></sup>
+#### `on_end` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/processors.py#L47"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_end(self, span: 'ReadableSpan') -> None
 ```
 
-#### `shutdown` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/processors.py#L54" target="_blank">↗</a></sup>
+#### `shutdown` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/processors.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 shutdown(self) -> None
 ```
 
-#### `force_flush` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/processors.py#L59" target="_blank">↗</a></sup>
+#### `force_flush` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/processors.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 force_flush(self, timeout_millis: int = 30000) -> bool

--- a/docs/v3/api-ref/python/prefect-telemetry-run_telemetry.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-run_telemetry.mdx
@@ -7,7 +7,7 @@ sidebarTitle: run_telemetry
 
 ## Classes
 
-### `OTELSetter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L35" target="_blank">↗</a></sup>
+### `OTELSetter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 
 A setter for OpenTelemetry that supports Prefect's custom labels.
@@ -15,13 +15,13 @@ A setter for OpenTelemetry that supports Prefect's custom labels.
 
 **Methods:**
 
-#### `set` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L40" target="_blank">↗</a></sup>
+#### `set` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set(self, carrier: KeyValueLabels, key: str, value: str) -> None
 ```
 
-### `RunTelemetry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L45" target="_blank">↗</a></sup>
+### `RunTelemetry` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L45"><Icon icon="github" size="14" /></a></sup>
 
 
 A class for managing the telemetry of runs.
@@ -29,19 +29,19 @@ A class for managing the telemetry of runs.
 
 **Methods:**
 
-#### `start_span` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L76" target="_blank">↗</a></sup>
+#### `start_span` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start_span(self, run: FlowOrTaskRun, client: SyncPrefectClient, parameters: dict[str, Any] | None = None) -> Span | None
 ```
 
-#### `traceparent_from_span` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L162" target="_blank">↗</a></sup>
+#### `traceparent_from_span` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 traceparent_from_span(span: Span) -> str | None
 ```
 
-#### `end_span_on_success` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L167" target="_blank">↗</a></sup>
+#### `end_span_on_success` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L167"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 end_span_on_success(self) -> None
@@ -50,7 +50,7 @@ end_span_on_success(self) -> None
 End a span for a run on success.
 
 
-#### `end_span_on_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L176" target="_blank">↗</a></sup>
+#### `end_span_on_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L176"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 end_span_on_failure(self, terminal_message: str | None = None) -> None
@@ -59,7 +59,7 @@ end_span_on_failure(self, terminal_message: str | None = None) -> None
 End a span for a run on failure.
 
 
-#### `record_exception` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L187" target="_blank">↗</a></sup>
+#### `record_exception` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L187"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 record_exception(self, exc: BaseException) -> None
@@ -68,7 +68,7 @@ record_exception(self, exc: BaseException) -> None
 Record an exception on a span.
 
 
-#### `update_state` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L194" target="_blank">↗</a></sup>
+#### `update_state` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L194"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_state(self, new_state: State) -> None
@@ -77,7 +77,7 @@ update_state(self, new_state: State) -> None
 Update a span with the state of a run.
 
 
-#### `update_run_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L209" target="_blank">↗</a></sup>
+#### `update_run_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/run_telemetry.py#L209"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 update_run_name(self, name: str) -> None

--- a/docs/v3/api-ref/python/prefect-telemetry-services.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-services.mdx
@@ -7,47 +7,47 @@ sidebarTitle: services
 
 ## Classes
 
-### `OTLPExporter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L17" target="_blank">↗</a></sup>
+### `OTLPExporter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `export` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L18" target="_blank">↗</a></sup>
+#### `export` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L18"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 export(self, __items: Sequence[T_contra]) -> Any
 ```
 
-#### `shutdown` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L20" target="_blank">↗</a></sup>
+#### `shutdown` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L20"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 shutdown(self) -> Any
 ```
 
-### `BaseQueueingExporter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L23" target="_blank">↗</a></sup>
+### `BaseQueueingExporter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L23"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `shutdown` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L38" target="_blank">↗</a></sup>
+#### `shutdown` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 shutdown(self) -> None
 ```
 
-### `QueueingSpanExporter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L46" target="_blank">↗</a></sup>
+### `QueueingSpanExporter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `export` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L52" target="_blank">↗</a></sup>
+#### `export` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L52"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult
 ```
 
-### `QueueingLogExporter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L60" target="_blank">↗</a></sup>
+### `QueueingLogExporter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `export` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/telemetry/services.py#L66" target="_blank">↗</a></sup>
+#### `export` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/telemetry/services.py#L66"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 export(self, batch: Sequence[LogData]) -> None

--- a/docs/v3/api-ref/python/prefect-testing-cli.mdx
+++ b/docs/v3/api-ref/python/prefect-testing-cli.mdx
@@ -7,7 +7,7 @@ sidebarTitle: cli
 
 ## Functions
 
-### `check_contains` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/cli.py#L16" target="_blank">↗</a></sup>
+### `check_contains` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/cli.py#L16"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_contains(cli_result: Result, content: str, should_contain: bool) -> None
@@ -21,7 +21,7 @@ Utility function to see if content is or is not in a CLI result.
 if False, checks that content is not in cli_result
 
 
-### `invoke_and_assert` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/cli.py#L51" target="_blank">↗</a></sup>
+### `invoke_and_assert` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/cli.py#L51"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 invoke_and_assert(command: str | list[str], user_input: str | None = None, prompts_and_responses: list[tuple[str, str] | tuple[str, str, str]] | None = None, expected_output: str | None = None, expected_output_contains: str | Iterable[str] | None = None, expected_output_does_not_contain: str | Iterable[str] | None = None, expected_line_count: int | None = None, expected_code: int | None = 0, echo: bool = True, temp_dir: str | None = None) -> Result
@@ -46,7 +46,7 @@ the app to exit with an error.
 working directory.
 
 
-### `temporary_console_width` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/cli.py#L199" target="_blank">↗</a></sup>
+### `temporary_console_width` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/cli.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_console_width(console: Console, width: int)

--- a/docs/v3/api-ref/python/prefect-testing-docker.mdx
+++ b/docs/v3/api-ref/python/prefect-testing-docker.mdx
@@ -7,7 +7,7 @@ sidebarTitle: docker
 
 ## Functions
 
-### `capture_builders` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/docker.py#L9" target="_blank">↗</a></sup>
+### `capture_builders` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/docker.py#L9"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 capture_builders() -> Generator[list[ImageBuilder], None, None]

--- a/docs/v3/api-ref/python/prefect-testing-fixtures.mdx
+++ b/docs/v3/api-ref/python/prefect-testing-fixtures.mdx
@@ -7,19 +7,19 @@ sidebarTitle: fixtures
 
 ## Functions
 
-### `add_prefect_loggers_to_caplog` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L46" target="_blank">↗</a></sup>
+### `add_prefect_loggers_to_caplog` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L46"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_prefect_loggers_to_caplog(caplog: pytest.LogCaptureFixture) -> Generator[None, None, None]
 ```
 
-### `is_port_in_use` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L60" target="_blank">↗</a></sup>
+### `is_port_in_use` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_port_in_use(port: int) -> bool
 ```
 
-### `use_hosted_api_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L145" target="_blank">↗</a></sup>
+### `use_hosted_api_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 use_hosted_api_server(hosted_api_server: str) -> Generator[str, None, None]
@@ -29,7 +29,7 @@ use_hosted_api_server(hosted_api_server: str) -> Generator[str, None, None]
 Sets `PREFECT_API_URL` to the test session's hosted API endpoint.
 
 
-### `disable_hosted_api_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L159" target="_blank">↗</a></sup>
+### `disable_hosted_api_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L159"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 disable_hosted_api_server() -> Generator[None, None, None]
@@ -39,7 +39,7 @@ disable_hosted_api_server() -> Generator[None, None, None]
 Disables the hosted API server by setting `PREFECT_API_URL` to `None`.
 
 
-### `enable_ephemeral_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L172" target="_blank">↗</a></sup>
+### `enable_ephemeral_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enable_ephemeral_server(disable_hosted_api_server: None) -> Generator[None, None, None]
@@ -49,7 +49,7 @@ enable_ephemeral_server(disable_hosted_api_server: None) -> Generator[None, None
 Enables the ephemeral server by setting `PREFECT_SERVER_ALLOW_EPHEMERAL_MODE` to `True`.
 
 
-### `mock_anyio_sleep` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L189" target="_blank">↗</a></sup>
+### `mock_anyio_sleep` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 mock_anyio_sleep(monkeypatch: pytest.MonkeyPatch) -> Generator[Callable[[float], None], None, None]
@@ -63,55 +63,55 @@ Provides "assert_sleeps_for" context manager which asserts a sleep time occurred
 within the context while using the actual runtime of the context as a tolerance.
 
 
-### `recorder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L292" target="_blank">↗</a></sup>
+### `recorder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L292"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 recorder() -> Recorder
 ```
 
-### `puppeteer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L297" target="_blank">↗</a></sup>
+### `puppeteer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L297"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 puppeteer() -> Puppeteer
 ```
 
-### `events_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L375" target="_blank">↗</a></sup>
+### `events_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L375"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 events_api_url(events_server: Server, unused_tcp_port: int) -> str
 ```
 
-### `events_cloud_api_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L380" target="_blank">↗</a></sup>
+### `events_cloud_api_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L380"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 events_cloud_api_url(events_server: Server, unused_tcp_port: int) -> str
 ```
 
-### `mock_should_emit_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L385" target="_blank">↗</a></sup>
+### `mock_should_emit_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L385"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 mock_should_emit_events(monkeypatch: pytest.MonkeyPatch) -> mock.Mock
 ```
 
-### `asserting_events_worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L393" target="_blank">↗</a></sup>
+### `asserting_events_worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L393"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 asserting_events_worker(monkeypatch: pytest.MonkeyPatch) -> Generator[EventsWorker, None, None]
 ```
 
-### `asserting_and_emitting_events_worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L406" target="_blank">↗</a></sup>
+### `asserting_and_emitting_events_worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L406"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 asserting_and_emitting_events_worker(monkeypatch: pytest.MonkeyPatch) -> Generator[EventsWorker, None, None]
 ```
 
-### `reset_worker_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L472" target="_blank">↗</a></sup>
+### `reset_worker_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L472"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset_worker_events(asserting_events_worker: EventsWorker) -> Generator[None, None, None]
 ```
 
-### `enable_lineage_events` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L481" target="_blank">↗</a></sup>
+### `enable_lineage_events` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L481"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 enable_lineage_events() -> Generator[None, None, None]
@@ -123,10 +123,10 @@ A fixture that ensures lineage events are enabled.
 
 ## Classes
 
-### `Recorder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L262" target="_blank">↗</a></sup>
+### `Recorder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L262"><Icon icon="github" size="14" /></a></sup>
 
-### `Puppeteer` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L275" target="_blank">↗</a></sup>
+### `Puppeteer` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L275"><Icon icon="github" size="14" /></a></sup>
 
-### `AssertingEventsPipeline` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L422" target="_blank">↗</a></sup>
+### `AssertingEventsPipeline` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L422"><Icon icon="github" size="14" /></a></sup>
 
-### `AssertingAndEmittingEventsPipeline` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/fixtures.py#L459" target="_blank">↗</a></sup>
+### `AssertingAndEmittingEventsPipeline` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/fixtures.py#L459"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-testing-utilities.mdx
+++ b/docs/v3/api-ref/python/prefect-testing-utilities.mdx
@@ -12,7 +12,7 @@ Internal utilities for tests.
 
 ## Functions
 
-### `exceptions_equal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L40" target="_blank">↗</a></sup>
+### `exceptions_equal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L40"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exceptions_equal(a: Exception, b: Exception) -> bool
@@ -24,13 +24,13 @@ will fail if the exception is serialized/deserialized so this utility does its
 best to assert equality using the type and args used to initialize the exception
 
 
-### `kubernetes_environments_equal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L60" target="_blank">↗</a></sup>
+### `kubernetes_environments_equal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 kubernetes_environments_equal(actual: list[dict[str, str]], expected: list[dict[str, str]] | dict[str, str]) -> bool
 ```
 
-### `assert_does_not_warn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L97" target="_blank">↗</a></sup>
+### `assert_does_not_warn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L97"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_does_not_warn(ignore_warnings: list[type[Warning]] | None = None) -> Generator[None, None, None]
@@ -44,7 +44,7 @@ Parameters:
 - ignore_warnings: List of warning types to ignore. Example: [DeprecationWarning, UserWarning]
 
 
-### `prefect_test_harness` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L120" target="_blank">↗</a></sup>
+### `prefect_test_harness` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prefect_test_harness(server_startup_timeout: int | None = 30)
@@ -72,19 +72,19 @@ Defaults to 30 seconds. If set to `None`, the value of
 >>>     assert my_flow() == 'Done!' # run against temporary db
 
 
-### `assert_blocks_equal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L202" target="_blank">↗</a></sup>
+### `assert_blocks_equal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L202"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_blocks_equal(found: Block, expected: Block, exclude_private: bool = True, **kwargs: Any) -> None
 ```
 
-### `a_test_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L283" target="_blank">↗</a></sup>
+### `a_test_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L283"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 a_test_step(**kwargs: Any) -> dict[str, Any]
 ```
 
-### `b_test_step` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/testing/utilities.py#L294" target="_blank">↗</a></sup>
+### `b_test_step` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/testing/utilities.py#L294"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 b_test_step(**kwargs: Any) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-transactions.mdx
+++ b/docs/v3/api-ref/python/prefect-transactions.mdx
@@ -7,13 +7,13 @@ sidebarTitle: transactions
 
 ## Functions
 
-### `get_transaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L643" target="_blank">↗</a></sup>
+### `get_transaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L643"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_transaction() -> BaseTransaction | None
 ```
 
-### `transaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L648" target="_blank">↗</a></sup>
+### `transaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L648"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 transaction(key: str | None = None, store: ResultStore | None = None, commit_mode: CommitMode | None = None, isolation_level: IsolationLevel | None = None, overwrite: bool = False, write_on_commit: bool = True, logger: logging.Logger | LoggingAdapter | None = None) -> Generator[Transaction, None, None]
@@ -36,13 +36,13 @@ available, the value of `PREFECT_RESULTS_PERSIST_BY_DEFAULT` will be used.
 
 ## Classes
 
-### `IsolationLevel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L48" target="_blank">↗</a></sup>
+### `IsolationLevel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L48"><Icon icon="github" size="14" /></a></sup>
 
-### `CommitMode` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L53" target="_blank">↗</a></sup>
+### `CommitMode` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L53"><Icon icon="github" size="14" /></a></sup>
 
-### `TransactionState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L59" target="_blank">↗</a></sup>
+### `TransactionState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L59"><Icon icon="github" size="14" /></a></sup>
 
-### `BaseTransaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L67" target="_blank">↗</a></sup>
+### `BaseTransaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L67"><Icon icon="github" size="14" /></a></sup>
 
 
 A base model for transaction state.
@@ -50,7 +50,7 @@ A base model for transaction state.
 
 **Methods:**
 
-#### `set` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L89" target="_blank">↗</a></sup>
+#### `set` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L89"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set(self, name: str, value: Any) -> None
@@ -73,7 +73,7 @@ with transaction() as txn:
 ```
 
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L108" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L108"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(self, name: str, default: Any = NotSet) -> Any
@@ -127,37 +127,37 @@ with transaction() as txn:
 ```
 
 
-#### `is_committed` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L170" target="_blank">↗</a></sup>
+#### `is_committed` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L170"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_committed(self) -> bool
 ```
 
-#### `is_rolled_back` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L173" target="_blank">↗</a></sup>
+#### `is_rolled_back` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L173"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_rolled_back(self) -> bool
 ```
 
-#### `is_staged` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L176" target="_blank">↗</a></sup>
+#### `is_staged` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L176"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_staged(self) -> bool
 ```
 
-#### `is_pending` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L179" target="_blank">↗</a></sup>
+#### `is_pending` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L179"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_pending(self) -> bool
 ```
 
-#### `is_active` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L182" target="_blank">↗</a></sup>
+#### `is_active` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L182"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_active(self) -> bool
 ```
 
-#### `prepare_transaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L185" target="_blank">↗</a></sup>
+#### `prepare_transaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L185"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prepare_transaction(self) -> None
@@ -166,19 +166,19 @@ prepare_transaction(self) -> None
 Helper method to prepare transaction state and validate configuration.
 
 
-#### `add_child` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L216" target="_blank">↗</a></sup>
+#### `add_child` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L216"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_child(self, transaction: Self) -> None
 ```
 
-#### `get_parent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L219" target="_blank">↗</a></sup>
+#### `get_parent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L219"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parent(self) -> Self | None
 ```
 
-#### `stage` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L230" target="_blank">↗</a></sup>
+#### `stage` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stage(self, value: Any, on_rollback_hooks: Optional[list[Callable[..., Any]]] = None, on_commit_hooks: Optional[list[Callable[..., Any]]] = None) -> None
@@ -187,13 +187,13 @@ stage(self, value: Any, on_rollback_hooks: Optional[list[Callable[..., Any]]] = 
 Stage a value to be committed later.
 
 
-#### `get_active` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L249" target="_blank">↗</a></sup>
+#### `get_active` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L249"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_active(cls: Type[Self]) -> Optional[Self]
 ```
 
-### `Transaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L253" target="_blank">↗</a></sup>
+### `Transaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L253"><Icon icon="github" size="14" /></a></sup>
 
 
 A model representing the state of a transaction.
@@ -201,43 +201,43 @@ A model representing the state of a transaction.
 
 **Methods:**
 
-#### `begin` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L293" target="_blank">↗</a></sup>
+#### `begin` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L293"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 begin(self) -> None
 ```
 
-#### `read` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L309" target="_blank">↗</a></sup>
+#### `read` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L309"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 read(self) -> ResultRecord[Any] | None
 ```
 
-#### `reset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L314" target="_blank">↗</a></sup>
+#### `reset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L314"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 reset(self) -> None
 ```
 
-#### `commit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L329" target="_blank">↗</a></sup>
+#### `commit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L329"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 commit(self) -> bool
 ```
 
-#### `run_hook` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L383" target="_blank">↗</a></sup>
+#### `run_hook` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L383"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_hook(self, hook: Callable[..., Any], hook_type: str) -> None
 ```
 
-#### `rollback` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L408" target="_blank">↗</a></sup>
+#### `rollback` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L408"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 rollback(self) -> bool
 ```
 
-### `AsyncTransaction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/transactions.py#L442" target="_blank">↗</a></sup>
+### `AsyncTransaction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/transactions.py#L442"><Icon icon="github" size="14" /></a></sup>
 
 
 A model representing the state of an asynchronous transaction.

--- a/docs/v3/api-ref/python/prefect-types-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-types-__init__.mdx
@@ -7,19 +7,19 @@ sidebarTitle: __init__
 
 ## Functions
 
-### `check_variable_value` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/__init__.py#L60" target="_blank">↗</a></sup>
+### `check_variable_value` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/__init__.py#L60"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 check_variable_value(value: object) -> object
 ```
 
-### `cast_none_to_empty_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/__init__.py#L80" target="_blank">↗</a></sup>
+### `cast_none_to_empty_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/__init__.py#L80"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cast_none_to_empty_dict(value: Any) -> dict[str, Any]
 ```
 
-### `validate_set_T_from_delim_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/__init__.py#L102" target="_blank">↗</a></sup>
+### `validate_set_T_from_delim_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/__init__.py#L102"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_set_T_from_delim_string(value: Union[str, T, set[T], None], type_: Any, delim: str | None = None) -> set[T]
@@ -32,7 +32,7 @@ e.g. `PREFECT_CLIENT_RETRY_EXTRA_CODES=429,502,503` -> `{429, 502, 503}`
 e.g. `PREFECT_CLIENT_RETRY_EXTRA_CODES=429` -> `{429}`
 
 
-### `parse_retry_delay_input` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/__init__.py#L136" target="_blank">↗</a></sup>
+### `parse_retry_delay_input` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/__init__.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parse_retry_delay_input(value: Any) -> Any
@@ -44,7 +44,7 @@ for TaskRetryDelaySeconds (int, float, list\[float], or None).
 Handles comma-separated strings for lists of delays.
 
 
-### `convert_none_to_empty_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/__init__.py#L187" target="_blank">↗</a></sup>
+### `convert_none_to_empty_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/__init__.py#L187"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 convert_none_to_empty_dict(v: Optional[KeyValueLabels]) -> KeyValueLabels
@@ -52,4 +52,4 @@ convert_none_to_empty_dict(v: Optional[KeyValueLabels]) -> KeyValueLabels
 
 ## Classes
 
-### `SecretDict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/__init__.py#L98" target="_blank">↗</a></sup>
+### `SecretDict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/__init__.py#L98"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-types-entrypoint.mdx
+++ b/docs/v3/api-ref/python/prefect-types-entrypoint.mdx
@@ -7,7 +7,7 @@ sidebarTitle: entrypoint
 
 ## Classes
 
-### `EntrypointType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/entrypoint.py#L4" target="_blank">↗</a></sup>
+### `EntrypointType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/entrypoint.py#L4"><Icon icon="github" size="14" /></a></sup>
 
 
 Enum representing a entrypoint type.

--- a/docs/v3/api-ref/python/prefect-types-names.mdx
+++ b/docs/v3/api-ref/python/prefect-types-names.mdx
@@ -7,31 +7,31 @@ sidebarTitle: names
 
 ## Functions
 
-### `raise_on_name_alphanumeric_dashes_only` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/names.py#L26" target="_blank">↗</a></sup>
+### `raise_on_name_alphanumeric_dashes_only` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/names.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_on_name_alphanumeric_dashes_only(value: str | None, field_name: str = 'value') -> str | None
 ```
 
-### `raise_on_name_alphanumeric_underscores_only` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/names.py#L50" target="_blank">↗</a></sup>
+### `raise_on_name_alphanumeric_underscores_only` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/names.py#L50"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_on_name_alphanumeric_underscores_only(value: str | None, field_name: str = 'value') -> str | None
 ```
 
-### `raise_on_name_alphanumeric_dashes_underscores_only` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/names.py#L63" target="_blank">↗</a></sup>
+### `raise_on_name_alphanumeric_dashes_underscores_only` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/names.py#L63"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_on_name_alphanumeric_dashes_underscores_only(value: str, field_name: str = 'value') -> str
 ```
 
-### `non_emptyish` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/names.py#L83" target="_blank">↗</a></sup>
+### `non_emptyish` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/names.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 non_emptyish(value: str) -> str
 ```
 
-### `validate_uri` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/types/names.py#L146" target="_blank">↗</a></sup>
+### `validate_uri` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/types/names.py#L146"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_uri(value: str) -> str

--- a/docs/v3/api-ref/python/prefect-utilities-annotations.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-annotations.mdx
@@ -7,7 +7,7 @@ sidebarTitle: annotations
 
 ## Classes
 
-### `BaseAnnotation` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L12" target="_blank">↗</a></sup>
+### `BaseAnnotation` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 
 Base class for Prefect annotation types.
@@ -17,19 +17,19 @@ Inherits from `tuple` for unpacking support in other tools.
 
 **Methods:**
 
-#### `unwrap` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L27" target="_blank">↗</a></sup>
+#### `unwrap` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L27"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unwrap(self) -> T
 ```
 
-#### `rewrap` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L30" target="_blank">↗</a></sup>
+#### `rewrap` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L30"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 rewrap(self, value: T) -> Self
 ```
 
-### `unmapped` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L42" target="_blank">↗</a></sup>
+### `unmapped` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L42"><Icon icon="github" size="14" /></a></sup>
 
 
 Wrapper for iterables.
@@ -38,7 +38,7 @@ Indicates that this input should be sent as-is to all runs created during a mapp
 operation instead of being split.
 
 
-### `allow_failure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L55" target="_blank">↗</a></sup>
+### `allow_failure` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 
 Wrapper for states or futures.
@@ -53,7 +53,7 @@ If the input is from a failed run, the attached exception will be passed to your
 function.
 
 
-### `quote` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L70" target="_blank">↗</a></sup>
+### `quote` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L70"><Icon icon="github" size="14" /></a></sup>
 
 
 Simple wrapper to mark an expression as a different type so it will not be coerced
@@ -80,21 +80,21 @@ def my_flow():
 
 **Methods:**
 
-#### `unquote` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L94" target="_blank">↗</a></sup>
+#### `unquote` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L94"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unquote(self) -> T
 ```
 
-### `Quote` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L99" target="_blank">↗</a></sup>
+### `Quote` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L99"><Icon icon="github" size="14" /></a></sup>
 
-### `NotSet` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L109" target="_blank">↗</a></sup>
+### `NotSet` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L109"><Icon icon="github" size="14" /></a></sup>
 
 
 Singleton to distinguish `None` from a value that is not provided by the user.
 
 
-### `freeze` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L115" target="_blank">↗</a></sup>
+### `freeze` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 
 Wrapper for parameters in deployments.
@@ -114,7 +114,7 @@ deployment = my_flow.deploy(parameters={"customer_id": freeze("customer123")})
 
 **Methods:**
 
-#### `unfreeze` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/annotations.py#L139" target="_blank">↗</a></sup>
+#### `unfreeze` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/annotations.py#L139"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unfreeze(self) -> T

--- a/docs/v3/api-ref/python/prefect-utilities-asyncutils.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-asyncutils.mdx
@@ -12,13 +12,13 @@ Utilities for interoperability with async functions and workers from various con
 
 ## Functions
 
-### `get_thread_limiter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L69" target="_blank">↗</a></sup>
+### `get_thread_limiter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L69"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_thread_limiter() -> anyio.CapacityLimiter
 ```
 
-### `is_async_fn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L78" target="_blank">↗</a></sup>
+### `is_async_fn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L78"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_async_fn(func: _SyncOrAsyncCallable[P, R]) -> TypeGuard[Callable[P, Coroutine[Any, Any, Any]]]
@@ -30,7 +30,7 @@ Returns `True` if a function returns a coroutine.
 See https://github.com/microsoft/pyright/issues/2142 for an example use
 
 
-### `is_async_gen_fn` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L90" target="_blank">↗</a></sup>
+### `is_async_gen_fn` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L90"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_async_gen_fn(func: Callable[P, Any]) -> TypeGuard[Callable[P, AsyncGenerator[Any, Any]]]
@@ -40,7 +40,7 @@ is_async_gen_fn(func: Callable[P, Any]) -> TypeGuard[Callable[P, AsyncGenerator[
 Returns `True` if a function is an async generator.
 
 
-### `create_task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L100" target="_blank">↗</a></sup>
+### `create_task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_task(coroutine: Coroutine[Any, Any, R]) -> asyncio.Task[R]
@@ -56,7 +56,7 @@ See https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
 for details (and essentially this implementation)
 
 
-### `run_coro_as_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L144" target="_blank">↗</a></sup>
+### `run_coro_as_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L144"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_coro_as_sync(coroutine: Coroutine[Any, Any, R]) -> Optional[R]
@@ -88,13 +88,13 @@ event loop and return immediately, where it will eventually be run. Defaults to 
 - The result of the coroutine if wait_for_result is True, otherwise None.
 
 
-### `call_with_mark` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L241" target="_blank">↗</a></sup>
+### `call_with_mark` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L241"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_with_mark(call: Callable[..., R]) -> R
 ```
 
-### `run_async_from_worker_thread` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L246" target="_blank">↗</a></sup>
+### `run_async_from_worker_thread` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L246"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_async_from_worker_thread(__fn: Callable[P, Awaitable[R]], *args: P.args, **kwargs: P.kwargs) -> R
@@ -105,31 +105,31 @@ Runs an async function in the main thread's event loop, blocking the worker
 thread until completion
 
 
-### `run_async_in_new_loop` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L257" target="_blank">↗</a></sup>
+### `run_async_in_new_loop` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L257"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 run_async_in_new_loop(__fn: Callable[P, Awaitable[R]], *args: P.args, **kwargs: P.kwargs) -> R
 ```
 
-### `mark_as_worker_thread` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L263" target="_blank">↗</a></sup>
+### `mark_as_worker_thread` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L263"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 mark_as_worker_thread() -> None
 ```
 
-### `in_async_worker_thread` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L267" target="_blank">↗</a></sup>
+### `in_async_worker_thread` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L267"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 in_async_worker_thread() -> bool
 ```
 
-### `in_async_main_thread` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L271" target="_blank">↗</a></sup>
+### `in_async_main_thread` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L271"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 in_async_main_thread() -> bool
 ```
 
-### `sync_compatible` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L281" target="_blank">↗</a></sup>
+### `sync_compatible` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L281"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 sync_compatible(async_fn: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, Union[R, Coroutine[Any, Any, R]]]
@@ -156,7 +156,7 @@ python result: Coroutine = sync_compatible(my_async_function)(arg1, arg2) # type
 ```
 
 
-### `sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L383" target="_blank">↗</a></sup>
+### `sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L383"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 sync(__async_fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T
@@ -169,7 +169,7 @@ If in an asynchronous context, we will run the code in a separate loop instead o
 failing but a warning will be displayed since this is not recommended.
 
 
-### `create_gather_task_group` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L525" target="_blank">↗</a></sup>
+### `create_gather_task_group` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L525"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_gather_task_group() -> GatherTaskGroup
@@ -181,13 +181,13 @@ Create a new task group that gathers results
 
 ## Classes
 
-### `GatherIncomplete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L456" target="_blank">↗</a></sup>
+### `GatherIncomplete` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L456"><Icon icon="github" size="14" /></a></sup>
 
 
 Used to indicate retrieving gather results before completion
 
 
-### `GatherTaskGroup` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L460" target="_blank">↗</a></sup>
+### `GatherTaskGroup` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L460"><Icon icon="github" size="14" /></a></sup>
 
 
 A task group that gathers results.
@@ -202,16 +202,16 @@ This class should be instantiated with `create_gather_task_group`.
 
 **Methods:**
 
-#### `start_soon` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L485" target="_blank">↗</a></sup>
+#### `start_soon` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L485"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start_soon(self, func: Callable[[Unpack[PosArgsT]], Awaitable[Any]], *args: Unpack[PosArgsT]) -> UUID
 ```
 
-#### `get_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L504" target="_blank">↗</a></sup>
+#### `get_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L504"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_result(self, key: UUID) -> Any
 ```
 
-### `LazySemaphore` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/asyncutils.py#L547" target="_blank">↗</a></sup>
+### `LazySemaphore` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/asyncutils.py#L547"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-utilities-callables.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-callables.mdx
@@ -12,7 +12,7 @@ Utilities for working with Python callables.
 
 ## Functions
 
-### `get_call_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L43" target="_blank">↗</a></sup>
+### `get_call_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_call_parameters(fn: Callable[..., Any], call_args: tuple[Any, ...], call_kwargs: dict[str, Any], apply_defaults: bool = True) -> dict[str, Any]
@@ -34,7 +34,7 @@ Raises a ParameterBindError if the arguments/kwargs are not valid for the
 function
 
 
-### `get_parameter_defaults` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L83" target="_blank">↗</a></sup>
+### `get_parameter_defaults` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_parameter_defaults(fn: Callable[..., Any]) -> dict[str, Any]
@@ -44,7 +44,7 @@ get_parameter_defaults(fn: Callable[..., Any]) -> dict[str, Any]
 Get default parameter values for a callable.
 
 
-### `explode_variadic_parameter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L100" target="_blank">↗</a></sup>
+### `explode_variadic_parameter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L100"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 explode_variadic_parameter(fn: Callable[..., Any], parameters: dict[str, Any]) -> dict[str, Any]
@@ -66,7 +66,7 @@ Example:
     ```
 
 
-### `collapse_variadic_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L134" target="_blank">↗</a></sup>
+### `collapse_variadic_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L134"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 collapse_variadic_parameters(fn: Callable[..., Any], parameters: dict[str, Any]) -> dict[str, Any]
@@ -88,7 +88,7 @@ Example:
     ```
 
 
-### `parameters_to_args_kwargs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L178" target="_blank">↗</a></sup>
+### `parameters_to_args_kwargs` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parameters_to_args_kwargs(fn: Callable[..., Any], parameters: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]
@@ -101,7 +101,7 @@ The function _must_ have an identical signature to the original function or this
 will return an empty tuple and dict.
 
 
-### `call_with_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L201" target="_blank">↗</a></sup>
+### `call_with_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L201"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_with_parameters(fn: Callable[..., R], parameters: dict[str, Any]) -> R
@@ -115,7 +115,7 @@ will fail. If you need to send to a function with a different signature, extract
 the args/kwargs using `parameters_to_positional_and_keyword` directly
 
 
-### `cloudpickle_wrapped_call` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L213" target="_blank">↗</a></sup>
+### `cloudpickle_wrapped_call` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L213"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 cloudpickle_wrapped_call(__fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Callable[[], bytes]
@@ -130,7 +130,7 @@ built-in pickler (e.g. `anyio.to_process` and `multiprocessing`) but may require
 a wider range of pickling support.
 
 
-### `parameter_docstrings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L254" target="_blank">↗</a></sup>
+### `parameter_docstrings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L254"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parameter_docstrings(docstring: Optional[str]) -> dict[str, str]
@@ -147,19 +147,19 @@ and return a dictionary that maps parameter names to docstring.
 - Mapping from parameter names to docstrings.
 
 
-### `process_v1_params` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L282" target="_blank">↗</a></sup>
+### `process_v1_params` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L282"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_v1_params(param: inspect.Parameter) -> tuple[str, Any, Any]
 ```
 
-### `create_v1_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L313" target="_blank">↗</a></sup>
+### `create_v1_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L313"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_v1_schema(name_: str, model_cfg: type[Any], model_fields: Optional[dict[str, Any]] = None) -> dict[str, Any]
 ```
 
-### `parameter_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L331" target="_blank">↗</a></sup>
+### `parameter_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L331"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parameter_schema(fn: Callable[..., Any]) -> ParameterSchema
@@ -181,7 +181,7 @@ of the function's arguments, including:
 - the argument schema
 
 
-### `parameter_schema_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L357" target="_blank">↗</a></sup>
+### `parameter_schema_from_entrypoint` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L357"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parameter_schema_from_entrypoint(entrypoint: str) -> ParameterSchema
@@ -204,7 +204,7 @@ should be in the format of `module.path.to.function\:do_stuff`.
 - The parameter schema for the function.
 
 
-### `generate_parameter_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L391" target="_blank">↗</a></sup>
+### `generate_parameter_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L391"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_parameter_schema(signature: inspect.Signature, docstrings: dict[str, str]) -> ParameterSchema
@@ -224,7 +224,7 @@ To get a signature from a function, use `inspect.signature(fn)` or
 - The parameter schema.
 
 
-### `raise_for_reserved_arguments` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L447" target="_blank">↗</a></sup>
+### `raise_for_reserved_arguments` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L447"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_for_reserved_arguments(fn: Callable[..., Any], reserved_arguments: Iterable[str]) -> None
@@ -235,7 +235,7 @@ Raise a ReservedArgumentError if `fn` has any parameters that conflict
 with the names contained in `reserved_arguments`.
 
 
-### `expand_mapping_parameters` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L661" target="_blank">↗</a></sup>
+### `expand_mapping_parameters` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L661"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 expand_mapping_parameters(func: Callable[..., Any], parameters: dict[str, Any]) -> list[dict[str, Any]]
@@ -256,7 +256,7 @@ call in the mapping operation
 
 ## Classes
 
-### `ParameterSchema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L238" target="_blank">↗</a></sup>
+### `ParameterSchema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L238"><Icon icon="github" size="14" /></a></sup>
 
 
 Simple data model corresponding to an OpenAPI `Schema`.
@@ -264,10 +264,10 @@ Simple data model corresponding to an OpenAPI `Schema`.
 
 **Methods:**
 
-#### `model_dump_for_openapi` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L247" target="_blank">↗</a></sup>
+#### `model_dump_for_openapi` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L247"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_dump_for_openapi(self) -> dict[str, Any]
 ```
 
-### `ModelConfig` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/callables.py#L419" target="_blank">↗</a></sup>
+### `ModelConfig` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/callables.py#L419"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-utilities-collections.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-collections.mdx
@@ -12,7 +12,7 @@ Utilities for extensions of and operations on Python collections.
 
 ## Functions
 
-### `dict_to_flatdict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L88" target="_blank">↗</a></sup>
+### `dict_to_flatdict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L88"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 dict_to_flatdict(dct: NestedDict[KT, VT]) -> dict[tuple[KT, ...], VT]
@@ -31,7 +31,7 @@ for the corresponding value.
 - A flattened dict of the same type as dct
 
 
-### `flatdict_to_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L117" target="_blank">↗</a></sup>
+### `flatdict_to_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 flatdict_to_dict(dct: dict[tuple[KT, ...], VT]) -> NestedDict[KT, VT]
@@ -48,7 +48,7 @@ Returns
     A nested dict of the same type as dct
 
 
-### `isiterable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L154" target="_blank">↗</a></sup>
+### `isiterable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L154"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 isiterable(obj: Any) -> bool
@@ -63,19 +63,19 @@ Excludes types that are iterable but typically used as singletons:
 - IO objects
 
 
-### `ensure_iterable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L171" target="_blank">↗</a></sup>
+### `ensure_iterable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L171"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 ensure_iterable(obj: Union[T, Iterable[T]]) -> Collection[T]
 ```
 
-### `listrepr` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L178" target="_blank">↗</a></sup>
+### `listrepr` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L178"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 listrepr(objs: Iterable[Any], sep: str = ' ') -> str
 ```
 
-### `extract_instances` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L182" target="_blank">↗</a></sup>
+### `extract_instances` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L182"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 extract_instances(objects: Iterable[Any], types: Union[type[T], tuple[type[T], ...]] = object) -> Union[list[T], dict[type[T], list[T]]]
@@ -93,7 +93,7 @@ Extract objects from a file and returns a dict of type -> instances
 - If a tuple of types is given: a mapping of type to a list of instances
 
 
-### `batched_iterable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L215" target="_blank">↗</a></sup>
+### `batched_iterable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L215"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 batched_iterable(iterable: Iterable[T], size: int) -> Generator[tuple[T, ...], None, None]
@@ -107,7 +107,7 @@ Yield batches of a certain size from an iterable
 - `size`: The batch size to return
 
 
-### `visit_collection` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L310" target="_blank">↗</a></sup>
+### `visit_collection` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L310"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 visit_collection(expr: Any, visit_fn: Union[Callable[[Any, dict[str, VT]], Any], Callable[[Any], Any]]) -> Optional[Any]
@@ -169,7 +169,7 @@ prevents infinite recursion when visiting recursive data structures.
 - The modified collection if `return_data` is `True`, otherwise `None`.
 
 
-### `remove_nested_keys` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L544" target="_blank">↗</a></sup>
+### `remove_nested_keys` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L544"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 remove_nested_keys(keys_to_remove: list[HashableT], obj: Union[NestedDict[HashableT, VT], Any]) -> Union[NestedDict[HashableT, VT], Any]
@@ -188,13 +188,13 @@ from.
 dictionary. `obj` if `obj` is not a dictionary.
 
 
-### `distinct` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L578" target="_blank">↗</a></sup>
+### `distinct` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L578"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 distinct(iterable: Iterable[Union[T, HashableT]], key: Optional[Callable[[T], Hashable]] = None) -> Iterator[Union[T, HashableT]]
 ```
 
-### `get_from_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L608" target="_blank">↗</a></sup>
+### `get_from_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L608"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_from_dict(dct: NestedDict[str, VT], keys: Union[str, list[str]], default: Optional[R] = None) -> Union[VT, R, None]
@@ -229,7 +229,7 @@ get_from_dict({'a': {'b': [0, {'c': [1, 2]}]}}, 'a.b.1.c.2', 'default') # 'defau
 ```
 
 
-### `set_in_dict` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L657" target="_blank">↗</a></sup>
+### `set_in_dict` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L657"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set_in_dict(dct: NestedDict[str, VT], keys: Union[str, list[str]], value: VT) -> None
@@ -256,7 +256,7 @@ dot-separated string or a list of keys.
 - `KeyError`: If the key path exists and is not a dictionary.
 
 
-### `deep_merge` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L691" target="_blank">↗</a></sup>
+### `deep_merge` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L691"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 deep_merge(dct: NestedDict[str, VT1], merge: NestedDict[str, VT2]) -> NestedDict[str, Union[VT1, VT2]]
@@ -273,7 +273,7 @@ Recursively merges `merge` into `dct`.
 - A new dictionary with the merged contents.
 
 
-### `deep_merge_dicts` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L718" target="_blank">↗</a></sup>
+### `deep_merge_dicts` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L718"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 deep_merge_dicts(*dicts: NestedDict[str, Any]) -> NestedDict[str, Any]
@@ -291,7 +291,7 @@ Recursively merges multiple dictionaries.
 
 ## Classes
 
-### `AutoEnum` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L44" target="_blank">↗</a></sup>
+### `AutoEnum` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L44"><Icon icon="github" size="14" /></a></sup>
 
 
 An enum class that automatically generates value from variable names.
@@ -307,7 +307,7 @@ See https://docs.python.org/3/library/enum.html#using-automatic-values
 
 **Methods:**
 
-#### `auto` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L69" target="_blank">↗</a></sup>
+#### `auto` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L69"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 auto() -> str
@@ -316,7 +316,7 @@ auto() -> str
 Exposes `enum.auto()` to avoid requiring a second import to use `AutoEnum`
 
 
-### `StopVisiting` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/collections.py#L236" target="_blank">↗</a></sup>
+### `StopVisiting` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/collections.py#L236"><Icon icon="github" size="14" /></a></sup>
 
 
 A special exception used to stop recursive visits in `visit_collection`.

--- a/docs/v3/api-ref/python/prefect-utilities-context.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-context.mdx
@@ -7,25 +7,25 @@ sidebarTitle: context
 
 ## Functions
 
-### `temporary_context` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/context.py#L12" target="_blank">↗</a></sup>
+### `temporary_context` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/context.py#L12"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 temporary_context(context: Context) -> Generator[None, Any, None]
 ```
 
-### `get_task_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/context.py#L24" target="_blank">↗</a></sup>
+### `get_task_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/context.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_task_run_id() -> Optional[UUID]
 ```
 
-### `get_flow_run_id` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/context.py#L33" target="_blank">↗</a></sup>
+### `get_flow_run_id` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/context.py#L33"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_run_id() -> Optional[UUID]
 ```
 
-### `get_task_and_flow_run_ids` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/context.py#L42" target="_blank">↗</a></sup>
+### `get_task_and_flow_run_ids` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/context.py#L42"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_task_and_flow_run_ids() -> tuple[Optional[UUID], Optional[UUID]]

--- a/docs/v3/api-ref/python/prefect-utilities-dispatch.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-dispatch.mdx
@@ -30,7 +30,7 @@ lookup_type(Base, key) # Foo
 
 ## Functions
 
-### `get_registry_for_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dispatch.py#L33" target="_blank">↗</a></sup>
+### `get_registry_for_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dispatch.py#L33"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_registry_for_type(cls: T) -> Optional[dict[str, T]]
@@ -42,7 +42,7 @@ Get the first matching registry for a class or any of its base classes.
 If not found, `None` is returned.
 
 
-### `get_dispatch_key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dispatch.py#L57" target="_blank">↗</a></sup>
+### `get_dispatch_key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dispatch.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_dispatch_key(cls_or_instance: Any, allow_missing: bool = False) -> Optional[str]
@@ -58,7 +58,7 @@ If `allow_missing` is `False`, an exception will be raised if the attribute is n
 defined or the key is null. If `True`, `None` will be returned in these cases.
 
 
-### `register_base_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dispatch.py#L114" target="_blank">↗</a></sup>
+### `register_base_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dispatch.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 register_base_type(cls: T) -> T
@@ -72,7 +72,7 @@ The base class may or may not define a `__dispatch_key__` to allow lookups of th
 base type.
 
 
-### `register_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dispatch.py#L140" target="_blank">↗</a></sup>
+### `register_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dispatch.py#L140"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 register_type(cls: T) -> T
@@ -86,7 +86,7 @@ The type or one of its parents must define a unique `__dispatch_key__`.
 One of the classes base types must be registered using `register_base_type`.
 
 
-### `lookup_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dispatch.py#L197" target="_blank">↗</a></sup>
+### `lookup_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dispatch.py#L197"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 lookup_type(cls: T, dispatch_key: str) -> T

--- a/docs/v3/api-ref/python/prefect-utilities-dockerutils.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-dockerutils.mdx
@@ -7,19 +7,19 @@ sidebarTitle: dockerutils
 
 ## Functions
 
-### `python_version_minor` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L34" target="_blank">↗</a></sup>
+### `python_version_minor` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 python_version_minor() -> str
 ```
 
-### `python_version_micro` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L38" target="_blank">↗</a></sup>
+### `python_version_micro` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L38"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 python_version_micro() -> str
 ```
 
-### `get_prefect_image_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L42" target="_blank">↗</a></sup>
+### `get_prefect_image_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L42"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_prefect_image_name(prefect_version: Optional[str] = None, python_version: Optional[str] = None, flavor: Optional[str] = None) -> str
@@ -35,13 +35,13 @@ minor level e.g. '3.9'.
 - `flavor`: An optional alternative image flavor to build, like 'conda'
 
 
-### `silence_docker_warnings` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L87" target="_blank">↗</a></sup>
+### `silence_docker_warnings` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L87"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 silence_docker_warnings() -> Generator[None, None, None]
 ```
 
-### `docker_client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L115" target="_blank">↗</a></sup>
+### `docker_client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 docker_client() -> Generator['DockerClient', None, None]
@@ -51,7 +51,7 @@ docker_client() -> Generator['DockerClient', None, None]
 Get the environmentally-configured Docker client
 
 
-### `build_image` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L143" target="_blank">↗</a></sup>
+### `build_image` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_image(context: Path, dockerfile: str = 'Dockerfile', tag: Optional[str] = None, pull: bool = False, platform: Optional[str] = None, stream_progress_to: Optional[TextIO] = None, **kwargs: Any) -> str
@@ -72,7 +72,7 @@ will collect the build output as it is reported by Docker
 - The image ID
 
 
-### `push_image` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L413" target="_blank">↗</a></sup>
+### `push_image` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L413"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 push_image(image_id: str, registry_url: str, name: str, tag: Optional[str] = None, stream_progress_to: Optional[TextIO] = None) -> str
@@ -98,7 +98,7 @@ will collect the build output as it is reported by Docker
 - A registry-qualified tag, like my-registry.example.com/my-image:abcdefg
 
 
-### `to_run_command` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L470" target="_blank">↗</a></sup>
+### `to_run_command` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L470"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_run_command(command: list[str]) -> str
@@ -109,7 +109,7 @@ Convert a process-style list of command arguments to a single Dockerfile RUN
 instruction.
 
 
-### `parse_image_tag` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L494" target="_blank">↗</a></sup>
+### `parse_image_tag` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L494"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parse_image_tag(name: str) -> tuple[str, Optional[str]]
@@ -130,7 +130,7 @@ Parse Docker Image String
 - `name`: Name of Docker Image
 
 
-### `split_repository_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L542" target="_blank">↗</a></sup>
+### `split_repository_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L542"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 split_repository_path(repository_path: str) -> tuple[Optional[str], str]
@@ -148,7 +148,7 @@ Splits a Docker repository path into its namespace and repository components.
 - repository (Optionals[str]): The repository name.
 
 
-### `format_outlier_version_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L573" target="_blank">↗</a></sup>
+### `format_outlier_version_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L573"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 format_outlier_version_name(version: str) -> str
@@ -168,7 +168,7 @@ Formats outlier docker version names to pass `packaging.version.parse` validatio
 - value that can pass `packaging.version.parse` validation
 
 
-### `generate_default_dockerfile` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L591" target="_blank">↗</a></sup>
+### `generate_default_dockerfile` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L591"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_default_dockerfile(context: Optional[Path] = None)
@@ -186,13 +186,13 @@ the current working directory.
 
 ## Classes
 
-### `BuildError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L132" target="_blank">↗</a></sup>
+### `BuildError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L132"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a Docker build fails
 
 
-### `ImageBuilder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L207" target="_blank">↗</a></sup>
+### `ImageBuilder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L207"><Icon icon="github" size="14" /></a></sup>
 
 
 An interface for preparing Docker build contexts and building images
@@ -200,7 +200,7 @@ An interface for preparing Docker build contexts and building images
 
 **Methods:**
 
-#### `add_line` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L266" target="_blank">↗</a></sup>
+#### `add_line` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L266"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_line(self, line: str) -> None
@@ -209,7 +209,7 @@ add_line(self, line: str) -> None
 Add a line to this image's Dockerfile
 
 
-#### `add_lines` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L270" target="_blank">↗</a></sup>
+#### `add_lines` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L270"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_lines(self, lines: Iterable[str]) -> None
@@ -218,7 +218,7 @@ add_lines(self, lines: Iterable[str]) -> None
 Add lines to this image's Dockerfile
 
 
-#### `copy` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L274" target="_blank">↗</a></sup>
+#### `copy` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L274"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 copy(self, source: Union[str, Path], destination: Union[str, PurePosixPath]) -> None
@@ -227,13 +227,13 @@ copy(self, source: Union[str, Path], destination: Union[str, PurePosixPath]) -> 
 Copy a file to this image
 
 
-#### `write_text` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L300" target="_blank">↗</a></sup>
+#### `write_text` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L300"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 write_text(self, text: str, destination: Union[str, PurePosixPath]) -> None
 ```
 
-#### `build` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L311" target="_blank">↗</a></sup>
+#### `build` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L311"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build(self, pull: bool = False, stream_progress_to: Optional[TextIO] = None) -> str
@@ -250,7 +250,7 @@ that will collect the build output as it is reported by Docker
 - The image ID
 
 
-#### `assert_has_line` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L340" target="_blank">↗</a></sup>
+#### `assert_has_line` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L340"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_has_line(self, line: str) -> None
@@ -259,7 +259,7 @@ assert_has_line(self, line: str) -> None
 Asserts that the given line is in the Dockerfile
 
 
-#### `assert_line_absent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L350" target="_blank">↗</a></sup>
+#### `assert_line_absent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L350"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_line_absent(self, line: str) -> None
@@ -268,7 +268,7 @@ assert_line_absent(self, line: str) -> None
 Asserts that the given line is absent from the Dockerfile
 
 
-#### `assert_line_before` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L370" target="_blank">↗</a></sup>
+#### `assert_line_before` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L370"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_line_before(self, first: str, second: str) -> None
@@ -277,7 +277,7 @@ assert_line_before(self, first: str, second: str) -> None
 Asserts that the first line appears before the second line
 
 
-#### `assert_line_after` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L395" target="_blank">↗</a></sup>
+#### `assert_line_after` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L395"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_line_after(self, second: str, first: str) -> None
@@ -286,7 +286,7 @@ assert_line_after(self, second: str, first: str) -> None
 Asserts that the second line appears after the first line
 
 
-#### `assert_has_file` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L399" target="_blank">↗</a></sup>
+#### `assert_has_file` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L399"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 assert_has_file(self, source: Path, container_path: PurePosixPath) -> None
@@ -296,7 +296,7 @@ Asserts that the given file or directory will be copied into the container
 at the given path
 
 
-### `PushError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/dockerutils.py#L408" target="_blank">↗</a></sup>
+### `PushError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/dockerutils.py#L408"><Icon icon="github" size="14" /></a></sup>
 
 
 Raised when a Docker image push fails

--- a/docs/v3/api-ref/python/prefect-utilities-engine.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-engine.mdx
@@ -7,7 +7,7 @@ sidebarTitle: engine
 
 ## Functions
 
-### `collect_task_run_inputs_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L117" target="_blank">↗</a></sup>
+### `collect_task_run_inputs_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 collect_task_run_inputs_sync(expr: Any, future_cls: Any = PrefectFuture, max_depth: int = -1) -> set[Union[TaskRunResult, FlowRunResult]]
@@ -27,13 +27,13 @@ task_inputs = {
 ```
 
 
-### `capture_sigterm` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L172" target="_blank">↗</a></sup>
+### `capture_sigterm` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 capture_sigterm() -> Generator[None, Any, None]
 ```
 
-### `propose_state_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L413" target="_blank">↗</a></sup>
+### `propose_state_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L413"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 propose_state_sync(client: 'SyncPrefectClient', state: State[Any], flow_run_id: UUID, force: bool = False) -> State[Any]
@@ -67,7 +67,7 @@ error will be raised.
 the Prefect API
 
 
-### `get_state_for_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L507" target="_blank">↗</a></sup>
+### `get_state_for_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L507"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_state_for_result(obj: Any) -> Optional[tuple[State, RunType]]
@@ -79,7 +79,7 @@ Get the state related to a result object.
 `link_state_to_result` must have been called first.
 
 
-### `link_state_to_flow_run_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L518" target="_blank">↗</a></sup>
+### `link_state_to_flow_run_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L518"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 link_state_to_flow_run_result(state: State, result: Any) -> None
@@ -89,7 +89,7 @@ link_state_to_flow_run_result(state: State, result: Any) -> None
 Creates a link between a state and flow run result
 
 
-### `link_state_to_task_run_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L523" target="_blank">↗</a></sup>
+### `link_state_to_task_run_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L523"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 link_state_to_task_run_result(state: State, result: Any) -> None
@@ -99,7 +99,7 @@ link_state_to_task_run_result(state: State, result: Any) -> None
 Creates a link between a state and task run result
 
 
-### `link_state_to_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L528" target="_blank">↗</a></sup>
+### `link_state_to_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L528"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 link_state_to_result(state: State, result: Any, run_type: RunType) -> None
@@ -138,19 +138,19 @@ We do not set an attribute, e.g. `__prefect_state__`, on the result because:
 - We cannot set this attribute on Python built-ins.
 
 
-### `should_log_prints` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L589" target="_blank">↗</a></sup>
+### `should_log_prints` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L589"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 should_log_prints(flow_or_task: Union['Flow[..., Any]', 'Task[..., Any]']) -> bool
 ```
 
-### `emit_task_run_state_change_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L619" target="_blank">↗</a></sup>
+### `emit_task_run_state_change_event` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L619"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 emit_task_run_state_change_event(task_run: TaskRun, initial_state: Optional[State[Any]], validated_state: State[Any], follows: Optional[Event] = None) -> Optional[Event]
 ```
 
-### `resolve_to_final_result` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L709" target="_blank">↗</a></sup>
+### `resolve_to_final_result` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L709"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resolve_to_final_result(expr: Any, context: dict[str, Any]) -> Any
@@ -161,7 +161,7 @@ Resolve any `PrefectFuture`, or `State` types nested in parameters into
 data. Designed to be use with `visit_collection`.
 
 
-### `resolve_inputs_sync` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/engine.py#L780" target="_blank">↗</a></sup>
+### `resolve_inputs_sync` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/engine.py#L780"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 resolve_inputs_sync(parameters: dict[str, Any], return_data: bool = True, max_depth: int = -1) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-utilities-filesystem.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-filesystem.mdx
@@ -12,7 +12,7 @@ Utilities for working with file systems
 
 ## Functions
 
-### `create_default_ignore_file` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L22" target="_blank">↗</a></sup>
+### `create_default_ignore_file` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L22"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 create_default_ignore_file(path: str) -> bool
@@ -23,7 +23,7 @@ Creates default ignore file in the provided path if one does not already exist; 
 whether a file was created.
 
 
-### `filter_files` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L37" target="_blank">↗</a></sup>
+### `filter_files` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L37"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 filter_files(root: str = '.', ignore_patterns: Optional[Iterable[AnyStr]] = None, include_dirs: bool = True) -> set[str]
@@ -36,7 +36,7 @@ a list of files that excludes those that should be ignored.
 The specification matches that of [.gitignore files](https://git-scm.com/docs/gitignore).
 
 
-### `tmpchdir` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L82" target="_blank">↗</a></sup>
+### `tmpchdir` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L82"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 tmpchdir(path: str)
@@ -47,7 +47,7 @@ Change current-working directories for the duration of the context,
 with special handling for UNC paths on Windows.
 
 
-### `filename` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L107" target="_blank">↗</a></sup>
+### `filename` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L107"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 filename(path: str) -> str
@@ -57,7 +57,7 @@ filename(path: str) -> str
 Extract the file name from a path with remote file system support
 
 
-### `is_local_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L117" target="_blank">↗</a></sup>
+### `is_local_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_local_path(path: Union[str, pathlib.Path, Any]) -> bool
@@ -67,7 +67,7 @@ is_local_path(path: Union[str, pathlib.Path, Any]) -> bool
 Check if the given path points to a local or remote file system
 
 
-### `to_display_path` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L133" target="_blank">↗</a></sup>
+### `to_display_path` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L133"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_display_path(path: Union[pathlib.Path, str], relative_to: Optional[Union[pathlib.Path, str]] = None) -> str
@@ -78,7 +78,7 @@ Convert a path to a displayable path. The absolute path or relative path to the
 current (or given) directory will be returned, whichever is shorter.
 
 
-### `relative_path_to_current_platform` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L150" target="_blank">↗</a></sup>
+### `relative_path_to_current_platform` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L150"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 relative_path_to_current_platform(path_str: str) -> Path
@@ -89,7 +89,7 @@ Converts a relative path generated on any platform to a relative path for the
 current platform.
 
 
-### `get_open_file_limit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/filesystem.py#L159" target="_blank">↗</a></sup>
+### `get_open_file_limit` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/filesystem.py#L159"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_open_file_limit() -> int

--- a/docs/v3/api-ref/python/prefect-utilities-generics.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-generics.mdx
@@ -7,7 +7,7 @@ sidebarTitle: generics
 
 ## Functions
 
-### `validate_list` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/generics.py#L17" target="_blank">↗</a></sup>
+### `validate_list` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/generics.py#L17"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_list(model: type[T], input: Any) -> list[T]

--- a/docs/v3/api-ref/python/prefect-utilities-hashing.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-hashing.mdx
@@ -7,7 +7,7 @@ sidebarTitle: hashing
 
 ## Functions
 
-### `stable_hash` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/hashing.py#L14" target="_blank">↗</a></sup>
+### `stable_hash` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/hashing.py#L14"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stable_hash(*args: Union[str, bytes]) -> str
@@ -26,7 +26,7 @@ Supports bytes and strings. Strings will be UTF-8 encoded.
 - A hex hash.
 
 
-### `file_hash` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/hashing.py#L34" target="_blank">↗</a></sup>
+### `file_hash` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/hashing.py#L34"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 file_hash(path: str, hash_algo: Callable[..., Any] = _md5) -> str
@@ -43,7 +43,7 @@ Given a path to a file, produces a stable hash of the file contents.
 - a hash of the file contents
 
 
-### `hash_objects` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/hashing.py#L48" target="_blank">↗</a></sup>
+### `hash_objects` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/hashing.py#L48"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 hash_objects(*args: Any, **kwargs: Any) -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-utilities-importtools.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-importtools.mdx
@@ -7,7 +7,7 @@ sidebarTitle: importtools
 
 ## Functions
 
-### `to_qualified_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L32" target="_blank">↗</a></sup>
+### `to_qualified_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L32"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 to_qualified_name(obj: Any) -> str
@@ -24,7 +24,7 @@ Python import path.
 - the qualified name
 
 
-### `from_qualified_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L50" target="_blank">↗</a></sup>
+### `from_qualified_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L50"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 from_qualified_name(name: str) -> Any
@@ -47,7 +47,7 @@ Import an object given a fully-qualified name.
 True
 
 
-### `load_script_as_module` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L81" target="_blank">↗</a></sup>
+### `load_script_as_module` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L81"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_script_as_module(path: str) -> ModuleType
@@ -63,7 +63,7 @@ If an exception occurs during execution of the script, a
 `prefect.exceptions.ScriptError` is created to wrap the exception and raised.
 
 
-### `load_module` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L125" target="_blank">↗</a></sup>
+### `load_module` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 load_module(module_name: str) -> ModuleType
@@ -73,7 +73,7 @@ load_module(module_name: str) -> ModuleType
 Import a module with support for relative imports within the module.
 
 
-### `import_object` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L140" target="_blank">↗</a></sup>
+### `import_object` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L140"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 import_object(import_path: str) -> Any
@@ -92,7 +92,7 @@ Import paths can be formatted as one of:
 This function is not thread safe as it modifies the 'sys' module during execution.
 
 
-### `lazy_import` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L199" target="_blank">↗</a></sup>
+### `lazy_import` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L199"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 lazy_import(name: str, error_on_import: bool = False, help_message: Optional[str] = None) -> ModuleType
@@ -116,7 +116,7 @@ Adapted from the [Python documentation][1] and [lazy_loader][2]
 [2]: https://github.com/scientific-python/lazy_loader
 
 
-### `safe_load_namespace` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L319" target="_blank">↗</a></sup>
+### `safe_load_namespace` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L319"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 safe_load_namespace(source_code: str, filepath: Optional[str] = None) -> dict[str, Any]
@@ -139,7 +139,7 @@ and use of it in threaded contexts may result in undesirable behavior.
 
 ## Classes
 
-### `DelayedImportErrorModule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L177" target="_blank">↗</a></sup>
+### `DelayedImportErrorModule` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 
 A fake module returned by `lazy_import` when the module cannot be found. When any
@@ -150,7 +150,7 @@ Adapted from [lazy_loader][1]
 [1]: https://github.com/scientific-python/lazy_loader
 
 
-### `AliasedModuleDefinition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L252" target="_blank">↗</a></sup>
+### `AliasedModuleDefinition` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L252"><Icon icon="github" size="14" /></a></sup>
 
 
 A definition for the `AliasedModuleFinder`.
@@ -161,11 +161,11 @@ A definition for the `AliasedModuleFinder`.
 - `callback`: A function to call when the alias module is loaded
 
 
-### `AliasedModuleFinder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L267" target="_blank">↗</a></sup>
+### `AliasedModuleFinder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L267"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `find_spec` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L276" target="_blank">↗</a></sup>
+#### `find_spec` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L276"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 find_spec(self, fullname: str, path: Optional[Sequence[str]] = None, target: Optional[ModuleType] = None) -> Optional[ModuleSpec]
@@ -176,11 +176,11 @@ for "foo" then on import of "phi.bar" we will find the spec for "foo.bar" and
 create a new spec for "phi.bar" that points to "foo.bar".
 
 
-### `AliasedModuleLoader` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L301" target="_blank">↗</a></sup>
+### `AliasedModuleLoader` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L301"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `exec_module` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/importtools.py#L312" target="_blank">↗</a></sup>
+#### `exec_module` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/importtools.py#L312"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exec_module(self, module: ModuleType) -> None

--- a/docs/v3/api-ref/python/prefect-utilities-math.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-math.mdx
@@ -7,7 +7,7 @@ sidebarTitle: math
 
 ## Functions
 
-### `poisson_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/math.py#L5" target="_blank">↗</a></sup>
+### `poisson_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/math.py#L5"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 poisson_interval(average_interval: float, lower: float = 0, upper: float = 1) -> float
@@ -21,13 +21,13 @@ method. Can optionally be passed a lower and upper bound between (0, 1] to clamp
 the potential output values.
 
 
-### `exponential_cdf` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/math.py#L21" target="_blank">↗</a></sup>
+### `exponential_cdf` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/math.py#L21"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 exponential_cdf(x: float, average_interval: float) -> float
 ```
 
-### `lower_clamp_multiple` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/math.py#L26" target="_blank">↗</a></sup>
+### `lower_clamp_multiple` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/math.py#L26"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 lower_clamp_multiple(k: float) -> float
@@ -43,7 +43,7 @@ c * average_interval) where the probability mass between the lower bound and the
 median is equal to the probability mass between the median and the upper bound.
 
 
-### `clamped_poisson_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/math.py#L43" target="_blank">↗</a></sup>
+### `clamped_poisson_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/math.py#L43"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 clamped_poisson_interval(average_interval: float, clamping_factor: float = 0.3) -> float
@@ -56,7 +56,7 @@ The upper bound for this random variate is: average_interval * (1 + clamping_fac
 A lower bound is picked so that the average interval remains approximately fixed.
 
 
-### `bounded_poisson_interval` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/math.py#L64" target="_blank">↗</a></sup>
+### `bounded_poisson_interval` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/math.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 bounded_poisson_interval(lower_bound: float, upper_bound: float) -> float

--- a/docs/v3/api-ref/python/prefect-utilities-names.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-names.mdx
@@ -7,7 +7,7 @@ sidebarTitle: names
 
 ## Functions
 
-### `generate_slug` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/names.py#L29" target="_blank">↗</a></sup>
+### `generate_slug` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/names.py#L29"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 generate_slug(n_words: int) -> str
@@ -20,7 +20,7 @@ Generates a random slug.
 - `-`: the number of words in the slug
 
 
-### `obfuscate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/names.py#L45" target="_blank">↗</a></sup>
+### `obfuscate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/names.py#L45"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 obfuscate(s: Any, show_tail: bool = False) -> str
@@ -30,7 +30,7 @@ obfuscate(s: Any, show_tail: bool = False) -> str
 Obfuscates any data type's string representation. See `obfuscate_string`.
 
 
-### `obfuscate_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/names.py#L55" target="_blank">↗</a></sup>
+### `obfuscate_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/names.py#L55"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 obfuscate_string(s: str, show_tail: bool = False) -> str

--- a/docs/v3/api-ref/python/prefect-utilities-processutils.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-processutils.mdx
@@ -7,7 +7,7 @@ sidebarTitle: processutils
 
 ## Functions
 
-### `forward_signal_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L383" target="_blank">↗</a></sup>
+### `forward_signal_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L383"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 forward_signal_handler(pid: int, signum: int, *signums: int) -> None
@@ -17,7 +17,7 @@ forward_signal_handler(pid: int, signum: int, *signums: int) -> None
 Forward subsequent signum events (e.g. interrupts) to respective signums.
 
 
-### `setup_signal_handlers_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L418" target="_blank">↗</a></sup>
+### `setup_signal_handlers_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L418"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_signal_handlers_server(pid: int, process_name: str, print_fn: PrintFn) -> None
@@ -27,7 +27,7 @@ setup_signal_handlers_server(pid: int, process_name: str, print_fn: PrintFn) -> 
 Handle interrupts of the server gracefully.
 
 
-### `setup_signal_handlers_agent` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L437" target="_blank">↗</a></sup>
+### `setup_signal_handlers_agent` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L437"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_signal_handlers_agent(pid: int, process_name: str, print_fn: PrintFn) -> None
@@ -37,7 +37,7 @@ setup_signal_handlers_agent(pid: int, process_name: str, print_fn: PrintFn) -> N
 Handle interrupts of the agent gracefully.
 
 
-### `setup_signal_handlers_worker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L455" target="_blank">↗</a></sup>
+### `setup_signal_handlers_worker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L455"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 setup_signal_handlers_worker(pid: int, process_name: str, print_fn: PrintFn) -> None
@@ -47,7 +47,7 @@ setup_signal_handlers_worker(pid: int, process_name: str, print_fn: PrintFn) -> 
 Handle interrupts of workers gracefully.
 
 
-### `get_sys_executable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L475" target="_blank">↗</a></sup>
+### `get_sys_executable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L475"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_sys_executable() -> str
@@ -55,57 +55,57 @@ get_sys_executable() -> str
 
 ## Classes
 
-### `StreamReaderWrapper` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L61" target="_blank">↗</a></sup>
+### `StreamReaderWrapper` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L61"><Icon icon="github" size="14" /></a></sup>
 
-### `StreamWriterWrapper` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L75" target="_blank">↗</a></sup>
+### `StreamWriterWrapper` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L75"><Icon icon="github" size="14" /></a></sup>
 
-### `Process` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L86" target="_blank">↗</a></sup>
+### `Process` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L86"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `terminate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L105" target="_blank">↗</a></sup>
+#### `terminate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L105"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 terminate(self) -> None
 ```
 
-#### `kill` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L108" target="_blank">↗</a></sup>
+#### `kill` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L108"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 kill(self) -> None
 ```
 
-#### `send_signal` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L111" target="_blank">↗</a></sup>
+#### `send_signal` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L111"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 send_signal(self, signal: int) -> None
 ```
 
-#### `pid` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L115" target="_blank">↗</a></sup>
+#### `pid` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 pid(self) -> int
 ```
 
-#### `returncode` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L119" target="_blank">↗</a></sup>
+#### `returncode` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 returncode(self) -> Union[int, None]
 ```
 
-#### `stdin` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L123" target="_blank">↗</a></sup>
+#### `stdin` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L123"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stdin(self) -> Union[anyio.abc.ByteSendStream, None]
 ```
 
-#### `stdout` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L127" target="_blank">↗</a></sup>
+#### `stdout` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stdout(self) -> Union[anyio.abc.ByteReceiveStream, None]
 ```
 
-#### `stderr` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L131" target="_blank">↗</a></sup>
+#### `stderr` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/processutils.py#L131"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stderr(self) -> Union[anyio.abc.ByteReceiveStream, None]

--- a/docs/v3/api-ref/python/prefect-utilities-pydantic.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-pydantic.mdx
@@ -7,7 +7,7 @@ sidebarTitle: pydantic
 
 ## Functions
 
-### `add_cloudpickle_reduction` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L64" target="_blank">↗</a></sup>
+### `add_cloudpickle_reduction` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_cloudpickle_reduction(__model_cls: Optional[type[M]] = None, **kwargs: Any) -> Union[type[M], Callable[[type[M]], type[M]]]
@@ -29,7 +29,7 @@ compiled Pydantic installation may encounter pickling issues.
 See related issue at https://github.com/cloudpipe/cloudpickle/issues/408
 
 
-### `get_class_fields_only` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L93" target="_blank">↗</a></sup>
+### `get_class_fields_only` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L93"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_class_fields_only(model: type[BaseModel]) -> set[str]
@@ -40,7 +40,7 @@ Gets all the field names defined on the model class but not any parent classes.
 Any fields that are on the parent but redefined on the subclass are included.
 
 
-### `add_type_dispatch` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L110" target="_blank">↗</a></sup>
+### `add_type_dispatch` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L110"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_type_dispatch(model_cls: type[M]) -> type[M]
@@ -67,13 +67,13 @@ to the model and the dispatch key can be tracked separately, the lower level
 utilities in `prefect.utilities.dispatch` should be used directly.
 
 
-### `custom_pydantic_encoder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L259" target="_blank">↗</a></sup>
+### `custom_pydantic_encoder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L259"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 custom_pydantic_encoder(type_encoders: dict[Any, Callable[[type[Any]], Any]], obj: Any) -> Any
 ```
 
-### `parse_obj_as` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L277" target="_blank">↗</a></sup>
+### `parse_obj_as` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L277"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 parse_obj_as(type_: type[T], data: Any, mode: Literal['python', 'json', 'strings'] = 'python') -> T
@@ -94,7 +94,7 @@ Defaults to `python`, where `data` should be a Python object (e.g. `dict`).
 - The parsed `data` as the given `type_`.
 
 
-### `handle_secret_render` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L339" target="_blank">↗</a></sup>
+### `handle_secret_render` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L339"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handle_secret_render(value: object, context: dict[str, Any]) -> object
@@ -102,7 +102,7 @@ handle_secret_render(value: object, context: dict[str, Any]) -> object
 
 ## Classes
 
-### `PartialModel` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L198" target="_blank">↗</a></sup>
+### `PartialModel` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L198"><Icon icon="github" size="14" /></a></sup>
 
 
 A utility for creating a Pydantic model in several steps.
@@ -118,19 +118,19 @@ a field already has a value.
 
 **Methods:**
 
-#### `finalize` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L230" target="_blank">↗</a></sup>
+#### `finalize` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L230"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 finalize(self, **kwargs: Any) -> M
 ```
 
-#### `raise_if_already_set` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L236" target="_blank">↗</a></sup>
+#### `raise_if_already_set` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L236"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_if_already_set(self, name: str) -> None
 ```
 
-#### `raise_if_not_in_model` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/pydantic.py#L240" target="_blank">↗</a></sup>
+#### `raise_if_not_in_model` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/pydantic.py#L240"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 raise_if_not_in_model(self, name: str) -> None

--- a/docs/v3/api-ref/python/prefect-utilities-render_swagger.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-render_swagger.mdx
@@ -7,7 +7,7 @@ sidebarTitle: render_swagger
 
 ## Functions
 
-### `swagger_lib` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/render_swagger.py#L56" target="_blank">↗</a></sup>
+### `swagger_lib` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/render_swagger.py#L56"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 swagger_lib(config: MkDocsConfig) -> dict[str, Any]
@@ -19,11 +19,11 @@ Provides the actual swagger library used
 
 ## Classes
 
-### `SwaggerPlugin` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/render_swagger.py#L82" target="_blank">↗</a></sup>
+### `SwaggerPlugin` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/render_swagger.py#L82"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `on_page_markdown` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/render_swagger.py#L83" target="_blank">↗</a></sup>
+#### `on_page_markdown` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/render_swagger.py#L83"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 on_page_markdown() -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-utilities-schema_tools-hydration.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-schema_tools-hydration.mdx
@@ -7,43 +7,43 @@ sidebarTitle: hydration
 
 ## Functions
 
-### `handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L172" target="_blank">↗</a></sup>
+### `handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L172"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 handler(kind: PrefectKind) -> Callable[[Handler], Handler]
 ```
 
-### `call_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L180" target="_blank">↗</a></sup>
+### `call_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L180"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 call_handler(kind: PrefectKind, obj: dict[str, Any], ctx: HydrationContext) -> Any
 ```
 
-### `null_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L191" target="_blank">↗</a></sup>
+### `null_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L191"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 null_handler(obj: dict[str, Any], ctx: HydrationContext)
 ```
 
-### `json_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L200" target="_blank">↗</a></sup>
+### `json_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L200"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 json_handler(obj: dict[str, Any], ctx: HydrationContext)
 ```
 
-### `jinja_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L226" target="_blank">↗</a></sup>
+### `jinja_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L226"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 jinja_handler(obj: dict[str, Any], ctx: HydrationContext) -> Any
 ```
 
-### `workspace_variable_handler` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L257" target="_blank">↗</a></sup>
+### `workspace_variable_handler` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L257"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 workspace_variable_handler(obj: dict[str, Any], ctx: HydrationContext) -> Any
 ```
 
-### `hydrate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L287" target="_blank">↗</a></sup>
+### `hydrate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L287"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 hydrate(obj: dict[str, Any], ctx: Optional[HydrationContext] = None) -> dict[str, Any]
@@ -51,118 +51,118 @@ hydrate(obj: dict[str, Any], ctx: Optional[HydrationContext] = None) -> dict[str
 
 ## Classes
 
-### `HydrationContext` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L14" target="_blank">↗</a></sup>
+### `HydrationContext` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L14"><Icon icon="github" size="14" /></a></sup>
 
-### `Placeholder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L59" target="_blank">↗</a></sup>
+### `Placeholder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `is_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L64" target="_blank">↗</a></sup>
+#### `is_error` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_error(self) -> bool
 ```
 
-### `RemoveValue` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L68" target="_blank">↗</a></sup>
+### `RemoveValue` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L68"><Icon icon="github" size="14" /></a></sup>
 
-### `HydrationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L76" target="_blank">↗</a></sup>
+### `HydrationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L76"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `is_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L81" target="_blank">↗</a></sup>
+#### `is_error` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L81"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_error(self) -> bool
 ```
 
-#### `message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L86" target="_blank">↗</a></sup>
+#### `message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L86"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 message(self) -> str
 ```
 
-### `KeyNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L96" target="_blank">↗</a></sup>
+### `KeyNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L96"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L98" target="_blank">↗</a></sup>
+#### `message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L98"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 message(self) -> str
 ```
 
-#### `key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L103" target="_blank">↗</a></sup>
+#### `key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L103"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 key(self) -> str
 ```
 
-### `ValueNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L107" target="_blank">↗</a></sup>
+### `ValueNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L107"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L109" target="_blank">↗</a></sup>
+#### `key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L109"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 key(self) -> str
 ```
 
-### `TemplateNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L113" target="_blank">↗</a></sup>
+### `TemplateNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L113"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L115" target="_blank">↗</a></sup>
+#### `key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L115"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 key(self) -> str
 ```
 
-### `VariableNameNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L119" target="_blank">↗</a></sup>
+### `VariableNameNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L119"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `key` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L121" target="_blank">↗</a></sup>
+#### `key` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L121"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 key(self) -> str
 ```
 
-### `InvalidJSON` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L125" target="_blank">↗</a></sup>
+### `InvalidJSON` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L127" target="_blank">↗</a></sup>
+#### `message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L127"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 message(self) -> str
 ```
 
-### `InvalidJinja` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L134" target="_blank">↗</a></sup>
+### `InvalidJinja` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L134"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L136" target="_blank">↗</a></sup>
+#### `message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 message(self) -> str
 ```
 
-### `WorkspaceVariableNotFound` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L143" target="_blank">↗</a></sup>
+### `WorkspaceVariableNotFound` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L143"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `variable_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L145" target="_blank">↗</a></sup>
+#### `variable_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L145"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 variable_name(self) -> str
 ```
 
-#### `message` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L150" target="_blank">↗</a></sup>
+#### `message` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L150"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 message(self) -> str
 ```
 
-### `WorkspaceVariable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L154" target="_blank">↗</a></sup>
+### `WorkspaceVariable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L154"><Icon icon="github" size="14" /></a></sup>
 
-### `ValidJinja` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L164" target="_blank">↗</a></sup>
+### `ValidJinja` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/hydration.py#L164"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-utilities-schema_tools-validation.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-schema_tools-validation.mdx
@@ -7,43 +7,43 @@ sidebarTitle: validation
 
 ## Functions
 
-### `is_valid_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L65" target="_blank">↗</a></sup>
+### `is_valid_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L65"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_valid_schema(schema: ObjectSchema, preprocess: bool = True) -> None
 ```
 
-### `validate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L74" target="_blank">↗</a></sup>
+### `validate` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L74"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate(obj: dict[str, Any], schema: ObjectSchema, raise_on_error: bool = False, preprocess: bool = True, ignore_required: bool = False, allow_none_with_default: bool = False) -> list[JSONSchemaValidationError]
 ```
 
-### `is_valid` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L112" target="_blank">↗</a></sup>
+### `is_valid` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L112"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_valid(obj: dict[str, Any], schema: ObjectSchema) -> bool
 ```
 
-### `prioritize_placeholder_errors` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L117" target="_blank">↗</a></sup>
+### `prioritize_placeholder_errors` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L117"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prioritize_placeholder_errors(errors: list[JSONSchemaValidationError]) -> list[JSONSchemaValidationError]
 ```
 
-### `build_error_obj` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L141" target="_blank">↗</a></sup>
+### `build_error_obj` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L141"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_error_obj(errors: list[JSONSchemaValidationError]) -> dict[str, Any]
 ```
 
-### `process_properties` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L232" target="_blank">↗</a></sup>
+### `process_properties` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L232"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 process_properties(properties: dict[str, dict[str, Any]], required_fields: list[str], allow_none_with_default: bool = False) -> None
 ```
 
-### `preprocess_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L246" target="_blank">↗</a></sup>
+### `preprocess_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L246"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 preprocess_schema(schema: ObjectSchema, allow_none_with_default: bool = False) -> ObjectSchema
@@ -51,6 +51,6 @@ preprocess_schema(schema: ObjectSchema, allow_none_with_default: bool = False) -
 
 ## Classes
 
-### `CircularSchemaRefError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L18" target="_blank">↗</a></sup>
+### `CircularSchemaRefError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L18"><Icon icon="github" size="14" /></a></sup>
 
-### `ValidationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L22" target="_blank">↗</a></sup>
+### `ValidationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/schema_tools/validation.py#L22"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-utilities-services.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-services.mdx
@@ -7,7 +7,7 @@ sidebarTitle: services
 
 ## Functions
 
-### `start_client_metrics_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/services.py#L162" target="_blank">↗</a></sup>
+### `start_client_metrics_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/services.py#L162"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start_client_metrics_server() -> None
@@ -18,7 +18,7 @@ Start the process-wide Prometheus metrics server for client metrics (if enabled
 with `PREFECT_CLIENT_METRICS_ENABLED`) on the port `PREFECT_CLIENT_METRICS_PORT`.
 
 
-### `stop_client_metrics_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/services.py#L177" target="_blank">↗</a></sup>
+### `stop_client_metrics_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/services.py#L177"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 stop_client_metrics_server() -> None

--- a/docs/v3/api-ref/python/prefect-utilities-templating.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-templating.mdx
@@ -7,7 +7,7 @@ sidebarTitle: templating
 
 ## Functions
 
-### `determine_placeholder_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/templating.py#L52" target="_blank">↗</a></sup>
+### `determine_placeholder_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/templating.py#L52"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 determine_placeholder_type(name: str) -> PlaceholderType
@@ -23,7 +23,7 @@ Determines the type of a placeholder based on its name.
 - The type of the placeholder
 
 
-### `find_placeholders` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/templating.py#L72" target="_blank">↗</a></sup>
+### `find_placeholders` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/templating.py#L72"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 find_placeholders(template: T) -> set[Placeholder]
@@ -39,7 +39,7 @@ Finds all placeholders in a template.
 - A set of all placeholders in the template
 
 
-### `apply_values` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/templating.py#L126" target="_blank">↗</a></sup>
+### `apply_values` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/templating.py#L126"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 apply_values(template: T, values: dict[str, Any], remove_notset: bool = True, warn_on_notset: bool = False) -> Union[T, type[NotSet]]
@@ -76,6 +76,6 @@ the key will be removed in the return value unless `remove_notset` is set to Fal
 
 ## Classes
 
-### `PlaceholderType` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/templating.py#L39" target="_blank">↗</a></sup>
+### `PlaceholderType` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/templating.py#L39"><Icon icon="github" size="14" /></a></sup>
 
-### `Placeholder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/templating.py#L46" target="_blank">↗</a></sup>
+### `Placeholder` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/templating.py#L46"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-utilities-text.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-text.mdx
@@ -7,13 +7,13 @@ sidebarTitle: text
 
 ## Functions
 
-### `truncated_to` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/text.py#L6" target="_blank">↗</a></sup>
+### `truncated_to` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/text.py#L6"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 truncated_to(length: int, value: Optional[str]) -> str
 ```
 
-### `fuzzy_match_string` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/text.py#L24" target="_blank">↗</a></sup>
+### `fuzzy_match_string` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/text.py#L24"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 fuzzy_match_string(word: str, possibilities: Iterable[str]) -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-utilities-timeout.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-timeout.mdx
@@ -7,19 +7,19 @@ sidebarTitle: timeout
 
 ## Functions
 
-### `fail_if_not_timeout_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/timeout.py#L11" target="_blank">↗</a></sup>
+### `fail_if_not_timeout_error` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/timeout.py#L11"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 fail_if_not_timeout_error(timeout_exc_type: type[Exception]) -> None
 ```
 
-### `timeout_async` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/timeout.py#L19" target="_blank">↗</a></sup>
+### `timeout_async` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/timeout.py#L19"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 timeout_async(seconds: Optional[float] = None, timeout_exc_type: type[TimeoutError] = TimeoutError)
 ```
 
-### `timeout` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/timeout.py#L36" target="_blank">↗</a></sup>
+### `timeout` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/timeout.py#L36"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 timeout(seconds: Optional[float] = None, timeout_exc_type: type[TimeoutError] = TimeoutError)

--- a/docs/v3/api-ref/python/prefect-utilities-urls.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-urls.mdx
@@ -7,7 +7,7 @@ sidebarTitle: urls
 
 ## Functions
 
-### `validate_restricted_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/urls.py#L68" target="_blank">↗</a></sup>
+### `validate_restricted_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/urls.py#L68"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_restricted_url(url: str) -> None
@@ -26,7 +26,7 @@ or in-cluster Kubernetes services)
 - `ValueError`: If the URL is a restricted URL.
 
 
-### `convert_class_to_name` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/urls.py#L116" target="_blank">↗</a></sup>
+### `convert_class_to_name` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/urls.py#L116"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 convert_class_to_name(obj: Any) -> str
@@ -36,7 +36,7 @@ convert_class_to_name(obj: Any) -> str
 Convert CamelCase class name to dash-separated lowercase name
 
 
-### `url_for` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/urls.py#L125" target="_blank">↗</a></sup>
+### `url_for` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/urls.py#L125"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 url_for(obj: Union['PrefectFuture[Any]', 'Block', 'Variable', 'Automation', 'Resource', 'ReceivedEvent', BaseModel, str], obj_id: Optional[Union[str, UUID]] = None, url_type: URLType = 'ui', default_base_url: Optional[str] = None, **additional_format_kwargs: Any) -> Optional[str]

--- a/docs/v3/api-ref/python/prefect-utilities-visualization.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-visualization.mdx
@@ -12,13 +12,13 @@ Utilities for working with Flow.visualize()
 
 ## Functions
 
-### `get_task_viz_tracker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L35" target="_blank">↗</a></sup>
+### `get_task_viz_tracker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L35"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_task_viz_tracker() -> Optional['TaskVizTracker']
 ```
 
-### `track_viz_task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L57" target="_blank">↗</a></sup>
+### `track_viz_task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L57"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 track_viz_task(is_async: bool, task_name: str, parameters: dict[str, Any], viz_return_value: Optional[Any] = None) -> Union[Coroutine[Any, Any, Any], Any]
@@ -28,7 +28,7 @@ track_viz_task(is_async: bool, task_name: str, parameters: dict[str, Any], viz_r
 Return a result if sync otherwise return a coroutine that returns the result
 
 
-### `build_task_dependencies` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L152" target="_blank">↗</a></sup>
+### `build_task_dependencies` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L152"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_task_dependencies(task_run_tracker: TaskVizTracker) -> graphviz.Digraph
@@ -51,7 +51,7 @@ Raises:
   specifying a `viz_return_value`.
 
 
-### `visualize_task_dependencies` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L189" target="_blank">↗</a></sup>
+### `visualize_task_dependencies` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L189"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 visualize_task_dependencies(graph: graphviz.Digraph, flow_run_name: str) -> None
@@ -76,29 +76,29 @@ Raises:
 
 ## Classes
 
-### `FlowVisualizationError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L15" target="_blank">↗</a></sup>
+### `FlowVisualizationError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L15"><Icon icon="github" size="14" /></a></sup>
 
-### `VisualizationUnsupportedError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L19" target="_blank">↗</a></sup>
+### `VisualizationUnsupportedError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L19"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskVizTrackerState` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L23" target="_blank">↗</a></sup>
+### `TaskVizTrackerState` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L23"><Icon icon="github" size="14" /></a></sup>
 
-### `GraphvizImportError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L27" target="_blank">↗</a></sup>
+### `GraphvizImportError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L27"><Icon icon="github" size="14" /></a></sup>
 
-### `GraphvizExecutableNotFoundError` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L31" target="_blank">↗</a></sup>
+### `GraphvizExecutableNotFoundError` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L31"><Icon icon="github" size="14" /></a></sup>
 
-### `VizTask` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L104" target="_blank">↗</a></sup>
+### `VizTask` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L104"><Icon icon="github" size="14" /></a></sup>
 
-### `TaskVizTracker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L114" target="_blank">↗</a></sup>
+### `TaskVizTracker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L114"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `add_task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L120" target="_blank">↗</a></sup>
+#### `add_task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L120"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 add_task(self, task: VizTask) -> None
 ```
 
-#### `link_viz_return_value_to_viz_task` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/visualization.py#L136" target="_blank">↗</a></sup>
+#### `link_viz_return_value_to_viz_task` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/utilities/visualization.py#L136"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 link_viz_return_value_to_viz_task(self, viz_return_value: Any, viz_task: VizTask) -> None

--- a/docs/v3/api-ref/python/prefect-variables.mdx
+++ b/docs/v3/api-ref/python/prefect-variables.mdx
@@ -7,7 +7,7 @@ sidebarTitle: variables
 
 ## Classes
 
-### `Variable` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/variables.py#L14" target="_blank">↗</a></sup>
+### `Variable` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/variables.py#L14"><Icon icon="github" size="14" /></a></sup>
 
 
 Variables are named, mutable JSON values that can be shared across tasks and flows.
@@ -20,7 +20,7 @@ Variables are named, mutable JSON values that can be shared across tasks and flo
 
 **Methods:**
 
-#### `set` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/variables.py#L91" target="_blank">↗</a></sup>
+#### `set` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/variables.py#L91"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 set(cls, name: str, value: StrictVariableValue, tags: Optional[list[str]] = None, overwrite: bool = False) -> 'Variable'
@@ -37,7 +37,7 @@ Returns the newly set variable object.
 - `-`: Whether to overwrite the variable if it already exists.
 
 
-#### `get` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/variables.py#L171" target="_blank">↗</a></sup>
+#### `get` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/variables.py#L171"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get(cls, name: str, default: StrictVariableValue = None) -> StrictVariableValue
@@ -52,7 +52,7 @@ If the variable does not exist, return the default value.
 - `-`: The default value to return if the variable does not exist.
 
 
-#### `unset` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/variables.py#L231" target="_blank">↗</a></sup>
+#### `unset` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/variables.py#L231"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 unset(cls, name: str) -> bool

--- a/docs/v3/api-ref/python/prefect-workers-base.mdx
+++ b/docs/v3/api-ref/python/prefect-workers-base.mdx
@@ -7,17 +7,17 @@ sidebarTitle: base
 
 ## Classes
 
-### `BaseJobConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L102" target="_blank">↗</a></sup>
+### `BaseJobConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L102"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `is_using_a_runner` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L134" target="_blank">↗</a></sup>
+#### `is_using_a_runner` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L134"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_using_a_runner(self) -> bool
 ```
 
-#### `json_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L205" target="_blank">↗</a></sup>
+#### `json_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L205"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 json_template(cls) -> dict[str, Any]
@@ -36,7 +36,7 @@ e.g.
 ```
 
 
-#### `prepare_for_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L229" target="_blank">↗</a></sup>
+#### `prepare_for_flow_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L229"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prepare_for_flow_run(self, flow_run: 'FlowRun', deployment: 'DeploymentResponse | None' = None, flow: 'APIFlow | None' = None, work_pool: 'WorkPool | None' = None, worker_name: str | None = None) -> None
@@ -56,11 +56,11 @@ the flow run.
 - `worker_name`: The name of the worker that is submitting the flow run.
 
 
-### `BaseVariables` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L372" target="_blank">↗</a></sup>
+### `BaseVariables` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L372"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `model_json_schema` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L396" target="_blank">↗</a></sup>
+#### `model_json_schema` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L396"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 model_json_schema(cls, by_alias: bool = True, ref_template: str = '#/definitions/{model}', schema_generator: Type[GenerateJsonSchema] = GenerateJsonSchema, mode: Literal['validation', 'serialization'] = 'validation') -> dict[str, Any]
@@ -69,55 +69,55 @@ model_json_schema(cls, by_alias: bool = True, ref_template: str = '#/definitions
 TODO\: stop overriding this method - use GenerateSchema in ConfigDict instead?
 
 
-### `BaseWorkerResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L423" target="_blank">↗</a></sup>
+### `BaseWorkerResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L423"><Icon icon="github" size="14" /></a></sup>
 
-### `BaseWorker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L438" target="_blank">↗</a></sup>
+### `BaseWorker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L438"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `client` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L514" target="_blank">↗</a></sup>
+#### `client` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L514"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 client(self) -> PrefectClient
 ```
 
-#### `work_pool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L522" target="_blank">↗</a></sup>
+#### `work_pool` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L522"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 work_pool(self) -> WorkPool
 ```
 
-#### `limiter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L530" target="_blank">↗</a></sup>
+#### `limiter` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L530"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 limiter(self) -> anyio.CapacityLimiter
 ```
 
-#### `get_documentation_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L538" target="_blank">↗</a></sup>
+#### `get_documentation_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L538"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_documentation_url(cls) -> str
 ```
 
-#### `get_logo_url` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L542" target="_blank">↗</a></sup>
+#### `get_logo_url` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L542"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_logo_url(cls) -> str
 ```
 
-#### `get_description` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L546" target="_blank">↗</a></sup>
+#### `get_description` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L546"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_description(cls) -> str
 ```
 
-#### `get_default_base_job_template` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L550" target="_blank">↗</a></sup>
+#### `get_default_base_job_template` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L550"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_default_base_job_template(cls) -> dict[str, Any]
 ```
 
-#### `get_worker_class_from_type` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L568" target="_blank">↗</a></sup>
+#### `get_worker_class_from_type` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L568"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_worker_class_from_type(type: str) -> Optional[Type['BaseWorker[Any, Any, Any]']]
@@ -127,7 +127,7 @@ Returns the worker class for a given worker type. If the worker type
 is not recognized, returns None.
 
 
-#### `get_all_available_worker_types` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L581" target="_blank">↗</a></sup>
+#### `get_all_available_worker_types` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L581"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_all_available_worker_types() -> list[str]
@@ -136,19 +136,19 @@ get_all_available_worker_types() -> list[str]
 Returns all worker types available in the local registry.
 
 
-#### `get_name_slug` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L591" target="_blank">↗</a></sup>
+#### `get_name_slug` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L591"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_name_slug(self) -> str
 ```
 
-#### `get_flow_run_logger` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L594" target="_blank">↗</a></sup>
+#### `get_flow_run_logger` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L594"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_flow_run_logger(self, flow_run: 'FlowRun') -> PrefectLogAdapter
 ```
 
-#### `is_worker_still_polling` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L955" target="_blank">↗</a></sup>
+#### `is_worker_still_polling` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L955"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 is_worker_still_polling(self, query_interval_seconds: float) -> bool
@@ -166,7 +166,7 @@ The instance property `self._last_polled_time`
 is currently set/updated in `get_and_submit_flow_runs()`
 
 
-#### `get_status` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/base.py#L1344" target="_blank">↗</a></sup>
+#### `get_status` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/base.py#L1344"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 get_status(self) -> dict[str, Any]

--- a/docs/v3/api-ref/python/prefect-workers-process.mdx
+++ b/docs/v3/api-ref/python/prefect-workers-process.mdx
@@ -24,28 +24,28 @@ checkout out the [Prefect docs](/concepts/work-pools/).
 
 ## Classes
 
-### `ProcessJobConfiguration` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/process.py#L53" target="_blank">↗</a></sup>
+### `ProcessJobConfiguration` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/process.py#L53"><Icon icon="github" size="14" /></a></sup>
 
 **Methods:**
 
-#### `validate_working_dir` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/process.py#L59" target="_blank">↗</a></sup>
+#### `validate_working_dir` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/process.py#L59"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 validate_working_dir(cls, v: Path | str | None) -> Path | None
 ```
 
-#### `prepare_for_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/process.py#L64" target="_blank">↗</a></sup>
+#### `prepare_for_flow_run` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/process.py#L64"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 prepare_for_flow_run(self, flow_run: 'FlowRun', deployment: 'DeploymentResponse | None' = None, flow: 'APIFlow | None' = None, work_pool: 'WorkPool | None' = None, worker_name: str | None = None) -> None
 ```
 
-### `ProcessVariables` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/process.py#L90" target="_blank">↗</a></sup>
+### `ProcessVariables` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/process.py#L90"><Icon icon="github" size="14" /></a></sup>
 
-### `ProcessWorkerResult` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/process.py#L109" target="_blank">↗</a></sup>
+### `ProcessWorkerResult` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/process.py#L109"><Icon icon="github" size="14" /></a></sup>
 
 
 Contains information about the final state of a completed process
 
 
-### `ProcessWorker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/process.py#L113" target="_blank">↗</a></sup>
+### `ProcessWorker` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/process.py#L113"><Icon icon="github" size="14" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-workers-server.mdx
+++ b/docs/v3/api-ref/python/prefect-workers-server.mdx
@@ -7,7 +7,7 @@ sidebarTitle: server
 
 ## Functions
 
-### `build_healthcheck_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/server.py#L14" target="_blank">↗</a></sup>
+### `build_healthcheck_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/server.py#L14"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 build_healthcheck_server(worker: BaseWorker[Any, Any, Any], query_interval_seconds: float, log_level: str = 'error') -> uvicorn.Server
@@ -21,7 +21,7 @@ Build a healthcheck FastAPI server for a worker.
 - `log_level`: the log
 
 
-### `start_healthcheck_server` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/workers/server.py#L54" target="_blank">↗</a></sup>
+### `start_healthcheck_server` <sup><a href="https://github.com/prefecthq/prefect/blob/main/src/prefect/workers/server.py#L54"><Icon icon="github" size="14" /></a></sup>
 
 ```python
 start_healthcheck_server(worker: BaseWorker[Any, Any, Any], query_interval_seconds: float, log_level: str = 'error') -> None

--- a/src/prefect/artifacts.py
+++ b/src/prefect/artifacts.py
@@ -55,7 +55,7 @@ class Artifact(ArtifactRequest):
             client: The PrefectClient
 
         Returns:
-            - The created artifact.
+            The created artifact.
         """
 
         local_client_context = asyncnullcontext(client) if client else get_client()
@@ -93,7 +93,7 @@ class Artifact(ArtifactRequest):
             client: The PrefectClient
 
         Returns:
-            - The created artifact.
+            The created artifact.
         """
 
         # Create sync client since this is a sync method.
@@ -417,6 +417,23 @@ def create_link_artifact(
 
     Returns:
         The table artifact ID.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect.artifacts import create_link_artifact
+
+        @flow
+        def my_flow():
+            create_link_artifact(
+                link="https://www.prefect.io",
+                link_text="Prefect",
+                key="prefect-link",
+                description="This is a link to the Prefect website",
+            )
+
+        my_flow()
+        ```
     """
     new_artifact = LinkArtifact(
         key=key,
@@ -475,6 +492,22 @@ def create_markdown_artifact(
 
     Returns:
         The table artifact ID.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect.artifacts import create_markdown_artifact
+
+        @flow
+        def my_flow():
+            create_markdown_artifact(
+                markdown="## Prefect",
+                key="prefect-markdown",
+                description="This is a markdown artifact",
+            )
+
+        my_flow()
+        ```
     """
     new_artifact = MarkdownArtifact(
         key=key,
@@ -533,6 +566,22 @@ def create_table_artifact(
 
     Returns:
         The table artifact ID.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect.artifacts import create_table_artifact
+
+        @flow
+        def my_flow():
+            create_table_artifact(
+                table=[{"name": "John", "age": 30}, {"name": "Jane", "age": 25}],
+                key="prefect-table",
+                description="This is a table artifact",
+            )
+
+        my_flow()
+        ```
     """
 
     new_artifact = TableArtifact(


### PR DESCRIPTION
[preview](https://prefect-bd373955-minor-updates.mintlify.app/v3/api-ref/python/prefect-artifacts)

removes some extraneous bullet characters and adds examples to `prefect.artifacts`

Previously, the arrow that linked to the symbol's source code was getting pulled into the right-hand nav, and it was like a dead extra character in the right-hand nav. This PR updates MDXify to use a GitHub icon that links to the source code that does not show up in the right-hand nav.