### PR TITLE
Fix dbt logging behavior, improve context handling

### DIFF
--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.4.6",
+  "prefect>=3.4.7",
   "dbt-core>=1.7.0",
   "prefect_shell>=0.3.0",
   "sgqlc>=16.0.0",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
This includes a few improvements to `prefect-dbt`:
- More descriptive docstrings for public interfaces
- Disables logging directly to the terminal from dbt if in a prefect run context
- By default, only creates task runs for dbt nodes if already in a prefect run context
  - adds an option to force creation of task runs for dbt nodes regardless of run context
- Fixes command spacing on error messages
- Fixes target path determination by using the dbt project name instead of the project dir

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
