### PR TITLE
Enforce asset key characters + length

### DIFF
--- a/src/prefect/assets/core.py
+++ b/src/prefect/assets/core.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Optional
 from pydantic import ConfigDict, Field
 
 from prefect._internal.schemas.bases import PrefectBaseModel
-from prefect.types import URILike
+from prefect.types import ValidAssetKey
 
 
 class AssetProperties(PrefectBaseModel):
@@ -37,7 +37,7 @@ class Asset(PrefectBaseModel):
 
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
-    key: URILike
+    key: ValidAssetKey
     properties: Optional[AssetProperties] = Field(
         default=None,
         description="Properties of the asset. "

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -15,6 +15,7 @@ from .names import (
     WITHOUT_BANNED_CHARACTERS,
     MAX_VARIABLE_NAME_LENGTH,
     URILike,
+    ValidAssetKey,
 )
 from pydantic import (
     BeforeValidator,
@@ -216,6 +217,7 @@ __all__ = [
     "Name",
     "NameOrEmpty",
     "NonEmptyishName",
+    "ValidAssetKey",
     "SecretDict",
     "StatusCode",
     "StrictVariableValue",

--- a/src/prefect/types/names.py
+++ b/src/prefect/types/names.py
@@ -162,6 +162,8 @@ URILike = Annotated[
 ]
 
 
+MAX_ASSET_KEY_LENGTH = 512
+
 RESTRICTED_ASSET_CHARACTERS = [
     "\n",
     "\r",
@@ -193,8 +195,8 @@ def validate_valid_asset_key(value: str) -> str:
         if char in value:
             raise ValueError(f"Asset key cannot contain '{char}'")
 
-    if len(value) > 512:
-        raise ValueError("Asset key cannot exceed 512 characters")
+    if len(value) > MAX_ASSET_KEY_LENGTH:
+        raise ValueError(f"Asset key cannot exceed {MAX_ASSET_KEY_LENGTH} characters")
 
     return validate_uri(value)
 
@@ -203,8 +205,8 @@ ValidAssetKey = Annotated[
     str,
     AfterValidator(validate_valid_asset_key),
     Field(
-        max_length=512,
-        description="A URI-like string with a lowercase protocol, restricted characters, and max 512 characters",
+        max_length=MAX_ASSET_KEY_LENGTH,
+        description=f"A URI-like string with a lowercase protocol, restricted characters, and max {MAX_ASSET_KEY_LENGTH} characters",
         examples=["s3://bucket/folder/data.csv", "postgres://dbtable"],
     ),
 ]

--- a/src/prefect/types/names.py
+++ b/src/prefect/types/names.py
@@ -160,3 +160,51 @@ URILike = Annotated[
         examples=["s3://bucket/folder/data.csv", "postgres://dbtable"],
     ),
 ]
+
+
+RESTRICTED_ASSET_CHARACTERS = [
+    "\n",
+    "\r",
+    "\t",
+    "\0",
+    " ",
+    "#",
+    "?",
+    "&",
+    "%",
+    '"',
+    "'",
+    "<",
+    ">",
+    "[",
+    "]",
+    "{",
+    "}",
+    "|",
+    "\\",
+    "^",
+    "`",
+]
+
+
+def validate_valid_asset_key(value: str) -> str:
+    """Validate asset key with character restrictions and length limit."""
+    for char in RESTRICTED_ASSET_CHARACTERS:
+        if char in value:
+            raise ValueError(f"Asset key cannot contain '{char}'")
+
+    if len(value) > 512:
+        raise ValueError("Asset key cannot exceed 512 characters")
+
+    return validate_uri(value)
+
+
+ValidAssetKey = Annotated[
+    str,
+    AfterValidator(validate_valid_asset_key),
+    Field(
+        max_length=512,
+        description="A URI-like string with a lowercase protocol, restricted characters, and max 512 characters",
+        examples=["s3://bucket/folder/data.csv", "postgres://dbtable"],
+    ),
+]


### PR DESCRIPTION
This PR keeps `Asset.key` a little more restricted by adding:
- a list of characters you can't include
- enforcing a maximum length of 512 characters