### PR TITLE
Resolve dbt profiles and other improvements

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -177,7 +177,7 @@ class PrefectDbtRunner:
     def graph(self) -> Graph:
         if self._graph is None:
             self._set_graph_from_manifest()
-            assert self._graph is not None  # for type checking
+            assert self._graph is not None 
         return self._graph
 
     def _set_graph_from_manifest(self, add_test_edges: bool = False):

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -529,10 +529,13 @@ class PrefectDbtRunner:
             **kwargs,
         }
 
-        res = dbtRunner(callbacks=callbacks).invoke(  # type: ignore[reportUnknownMemberType]
-            args_copy,
-            **invoke_kwargs,
-        )
+        with self.settings.resolve_profiles_yml() as profiles_dir:
+            invoke_kwargs["profiles_dir"] = profiles_dir
+
+            res = dbtRunner(callbacks=callbacks).invoke(  # type: ignore[reportUnknownMemberType]
+                args_copy,
+                **invoke_kwargs,
+            )
 
         if not res.success and res.exception:
             raise ValueError(

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -22,7 +22,9 @@ from dbt.config.renderer import DbtProjectYamlRenderer
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ManifestNode
-from dbt.contracts.state import load_result_state
+from dbt.contracts.state import (
+    load_result_state,  # type: ignore[reportUnknownMemberType]
+)
 from dbt.graph.graph import Graph, UniqueId
 from dbt_common.events.base_types import EventLevel, EventMsg
 from google.protobuf.json_format import MessageToDict
@@ -489,7 +491,7 @@ class PrefectDbtRunner:
                             or node_status in FAILURE_STATUSES
                         ):
                             self._set_graph_from_manifest(add_test_edges=add_test_edges)
-                            for dep_node_id in self.graph.get_dependent_nodes(
+                            for dep_node_id in self.graph.get_dependent_nodes(  # type: ignore[reportUnknownMemberType]
                                 UniqueId(node_id)
                             ):  # type: ignore[reportUnknownMemberType]
                                 self._skipped_nodes.add(dep_node_id)  # type: ignore[reportUnknownMemberType]
@@ -593,11 +595,11 @@ class PrefectDbtRunner:
 
         callbacks = (
             [
+                self._create_logging_callback(task_state, self.log_level, context),
                 self._create_node_started_callback(task_state, context),
                 self._create_node_finished_callback(
                     task_state, add_test_edges=add_test_edges
                 ),
-                self._create_logging_callback(task_state, self.log_level, context),
             ]
             if in_flow_or_task_run or self._force_nodes_as_tasks
             else []

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -16,7 +16,8 @@ from dbt.artifacts.schemas.results import (
 )
 from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.cli.main import dbtRunner
-from dbt.config.runtime import RuntimeConfig
+from dbt.config.project import Project
+from dbt.config.renderer import DbtProjectYamlRenderer
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ManifestNode
 from dbt_common.events.base_types import EventLevel, EventMsg
@@ -123,7 +124,7 @@ class PrefectDbtRunner:
         self.include_compiled_code = include_compiled_code
         self._force_nodes_as_tasks = _force_nodes_as_tasks
 
-        self._project: Optional[RuntimeConfig] = None
+        self._project: Optional[Project] = None
         self._target_path: Optional[Path] = None
         self._profiles_dir: Optional[Path] = None
         self._project_dir: Optional[Path] = None
@@ -153,7 +154,7 @@ class PrefectDbtRunner:
         return self._manifest
 
     @property
-    def project(self) -> RuntimeConfig:
+    def project(self) -> Project:
         if self._project is None:
             self._set_project_from_project_dir()
             assert self._project is not None  # for type checking
@@ -171,7 +172,8 @@ class PrefectDbtRunner:
             )
 
     def _set_project_from_project_dir(self):
-        self._project = RuntimeConfig.from_args(self.project_dir)
+        renderer = DbtProjectYamlRenderer(profile=None, cli_vars=None)
+        self._project = Project.from_project_root(str(self.project_dir), renderer)
 
     def _get_node_prefect_config(
         self, manifest_node: ManifestNode

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -177,7 +177,7 @@ class PrefectDbtRunner:
     def graph(self) -> Graph:
         if self._graph is None:
             self._set_graph_from_manifest()
-            assert self._graph is not None 
+            assert self._graph is not None
         return self._graph
 
     def _set_graph_from_manifest(self, add_test_edges: bool = False):

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -182,7 +182,6 @@ class PrefectDbtRunner:
         linker = Linker()
         linker.link_graph(self.manifest)
         if add_test_edges:
-            print("Building graph with test edges")
             self.manifest.build_parent_and_child_maps()
             linker.add_test_edges(self.manifest)
         self._graph = Graph(linker.graph)
@@ -494,7 +493,6 @@ class PrefectDbtRunner:
                                 UniqueId(node_id)
                             ):  # type: ignore[reportUnknownMemberType]
                                 self._skipped_nodes.add(dep_node_id)  # type: ignore[reportUnknownMemberType]
-                            print(f"Skipping nodes: {self._skipped_nodes}")
                     except Exception as e:
                         print(e)
 

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -1,10 +1,10 @@
 """
-Unit tests for PrefectDbtRunner - focusing on outcomes.
+Tests for the PrefectDbtRunner class and related functionality.
 """
 
+import json
 from pathlib import Path
-from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from dbt.artifacts.resources.types import NodeType
@@ -13,435 +13,371 @@ from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ManifestNode
 from dbt_common.events.base_types import EventLevel, EventMsg
+from prefect_dbt.core._tracker import NodeTaskTracker
 from prefect_dbt.core.runner import PrefectDbtRunner, execute_dbt_node
 from prefect_dbt.core.settings import PrefectDbtSettings
 
-
-@pytest.fixture
-def mock_dbt_runner_instance():
-    """Fixture providing a mock dbt runner instance."""
-    mock_instance = Mock()
-    mock_instance.invoke.return_value = Mock(success=True, exception=None)
-    return mock_instance
-
-
-@pytest.fixture
-def mock_dbt_runner_class(mock_dbt_runner_instance, monkeypatch):
-    """Fixture providing a mock dbt runner class."""
-    mock_class = Mock(return_value=mock_dbt_runner_instance)
-    monkeypatch.setattr("prefect_dbt.core.runner.dbtRunner", mock_class)
-    return mock_class
-
-
-@pytest.fixture
-def mock_settings():
-    """Fixture providing a mock settings object with resolve_profiles_yml method."""
-    mock_settings = Mock()
-    mock_settings.resolve_profiles_yml.return_value.__enter__ = Mock(
-        return_value="/mock/profiles/dir"
-    )
-    mock_settings.resolve_profiles_yml.return_value.__exit__ = Mock(return_value=None)
-    return mock_settings
-
-
-@pytest.fixture
-def mock_log_level():
-    """Fixture providing a mock log level with value attribute."""
-    mock_log_level = Mock()
-    mock_log_level.value = "info"
-    return mock_log_level
-
-
-@pytest.fixture
-def mock_runner_with_common_mocks(monkeypatch, mock_settings, mock_log_level):
-    """Fixture providing a runner with common mocks applied."""
-    runner = PrefectDbtRunner()
-
-    # Mock the callback methods
-    monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-    monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-    monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-    # Mock the log_level property
-    monkeypatch.setattr(
-        PrefectDbtRunner, "log_level", property(lambda self: mock_log_level)
-    )
-
-    # Set mock settings
-    runner.settings = mock_settings
-
-    return runner
-
-
-@pytest.fixture
-def mock_manifest_node():
-    """Fixture providing a mock manifest node."""
-    mock_node = Mock(spec=ManifestNode)
-    mock_node.resource_type = NodeType.Model
-    mock_node.unique_id = "test_node"
-    mock_node.relation_name = "test_relation"
-    mock_node.name = "test_model"
-    mock_node.description = "Test model"
-    mock_node.config = Mock()
-    mock_node.config.meta = {}
-    return mock_node
+from prefect import flow
+from prefect.assets import Asset
+from prefect.client.orchestration import PrefectClient
+from prefect.context import AssetContext
+from prefect.tasks import MaterializingTask, Task
 
 
 @pytest.fixture
 def mock_manifest():
-    """Fixture providing a mock manifest."""
-    mock_manifest = Mock(spec=Manifest)
-    mock_manifest.metadata = Mock()
-    mock_manifest.metadata.adapter_type = "snowflake"
-    mock_manifest.nodes = {}
-    return mock_manifest
-
-
-@pytest.fixture
-def mock_successful_result():
-    """Fixture providing a mock successful dbt result."""
-    mock_result = Mock()
-    mock_result.success = True
-    mock_result.exception = None
-    return mock_result
-
-
-@pytest.fixture
-def mock_dbt_runner_with_success(mock_successful_result):
-    """Fixture providing a mock dbt runner instance that returns successful results."""
-    mock_instance = Mock()
-    mock_instance.invoke.return_value = mock_successful_result
-    return mock_instance
-
-
-@pytest.fixture
-def mock_dbt_runner_class_with_success(mock_dbt_runner_with_success, monkeypatch):
-    """Fixture providing a mock dbt runner class that returns successful results."""
-    mock_class = Mock(return_value=mock_dbt_runner_with_success)
-    monkeypatch.setattr("prefect_dbt.core.runner.dbtRunner", mock_class)
-    return mock_class
-
-
-@pytest.fixture
-def mock_runner_with_all_mocks(
-    monkeypatch, mock_settings, mock_log_level, mock_dbt_runner_class_with_success
-):
-    """Fixture providing a runner with all common mocks applied."""
-    runner = PrefectDbtRunner()
-
-    # Mock the callback methods
-    monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-    monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-    monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-    # Mock the log_level property
-    monkeypatch.setattr(
-        PrefectDbtRunner, "log_level", property(lambda self: mock_log_level)
-    )
-
-    # Set mock settings
-    runner.settings = mock_settings
-
-    return runner
-
-
-@pytest.fixture
-def mock_context_manager():
-    """Fixture providing a mock context manager for hydrated_context."""
-    mock_context = Mock()
-    mock_context.__enter__ = Mock()
-    mock_context.__exit__ = Mock()
-    return mock_context
-
-
-@pytest.fixture
-def mock_context_manager_with_patch(monkeypatch, mock_context_manager):
-    """Fixture providing a mock context manager with monkeypatch applied."""
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.hydrated_context",
-        Mock(return_value=mock_context_manager),
-    )
-    return mock_context_manager
-
-
-@pytest.fixture
-def mock_failed_result():
-    """Fixture providing a mock failed dbt result."""
-    mock_result = Mock()
-    mock_result.success = False
-    mock_result.exception = "Test exception"
-    return mock_result
-
-
-@pytest.fixture
-def mock_dbt_runner_with_failure(mock_failed_result):
-    """Fixture providing a mock dbt runner instance that returns failed results."""
-    mock_instance = Mock()
-    mock_instance.invoke.return_value = mock_failed_result
-    return mock_instance
-
-
-@pytest.fixture
-def mock_dbt_runner_class_with_failure(mock_dbt_runner_with_failure, monkeypatch):
-    """Fixture providing a mock dbt runner class that returns failed results."""
-    mock_class = Mock(return_value=mock_dbt_runner_with_failure)
-    monkeypatch.setattr("prefect_dbt.core.runner.dbtRunner", mock_class)
-    return mock_class
-
-
-@pytest.fixture
-def mock_runner_with_callback_mocks(monkeypatch, mock_settings, mock_log_level):
-    """Fixture providing a runner with callback mocks applied."""
-    runner = PrefectDbtRunner()
-
-    # Mock the callback methods
-    mock_logging_callback = Mock()
-    mock_node_started_callback = Mock()
-    mock_node_finished_callback = Mock()
-    monkeypatch.setattr(
-        runner, "_create_logging_callback", Mock(return_value=mock_logging_callback)
-    )
-    monkeypatch.setattr(
-        runner,
-        "_create_node_started_callback",
-        Mock(return_value=mock_node_started_callback),
-    )
-    monkeypatch.setattr(
-        runner,
-        "_create_node_finished_callback",
-        Mock(return_value=mock_node_finished_callback),
-    )
-
-    # Mock the log_level property
-    monkeypatch.setattr(
-        PrefectDbtRunner, "log_level", property(lambda self: mock_log_level)
-    )
-
-    # Set mock settings
-    runner.settings = mock_settings
-
-    return (
-        runner,
-        mock_logging_callback,
-        mock_node_started_callback,
-        mock_node_finished_callback,
-    )
-
-
-@pytest.fixture
-def mock_runner_with_force_nodes_as_tasks(monkeypatch, mock_settings, mock_log_level):
-    """Fixture providing a runner with _force_nodes_as_tasks=True and common mocks."""
-    runner = PrefectDbtRunner(_force_nodes_as_tasks=True)
-
-    # Mock the callback methods
-    mock_logging_callback = Mock()
-    mock_node_started_callback = Mock()
-    mock_node_finished_callback = Mock()
-    monkeypatch.setattr(
-        runner, "_create_logging_callback", Mock(return_value=mock_logging_callback)
-    )
-    monkeypatch.setattr(
-        runner,
-        "_create_node_started_callback",
-        Mock(return_value=mock_node_started_callback),
-    )
-    monkeypatch.setattr(
-        runner,
-        "_create_node_finished_callback",
-        Mock(return_value=mock_node_finished_callback),
-    )
-
-    # Mock the log_level property
-    monkeypatch.setattr(
-        PrefectDbtRunner, "log_level", property(lambda self: mock_log_level)
-    )
-
-    # Set mock settings
-    runner.settings = mock_settings
-
-    return (
-        runner,
-        mock_logging_callback,
-        mock_node_started_callback,
-        mock_node_finished_callback,
-    )
-
-
-@pytest.fixture
-def mock_flow_context(monkeypatch):
-    """Fixture providing a mock flow context."""
-    context = {"flow_run_context": {"foo": "bar"}}
-    monkeypatch.setattr(
-        "prefect_dbt.core.runner.serialize_context",
-        Mock(return_value=context),
-    )
-    return context
-
-
-@pytest.fixture
-def mock_task_context(monkeypatch):
-    """Fixture providing a mock task context."""
-    context = {"task_run_context": {"foo": "bar"}}
-    monkeypatch.setattr(
-        "prefect_dbt.core.runner.serialize_context",
-        Mock(return_value=context),
-    )
-    return context
-
-
-@pytest.fixture
-def mock_empty_context(monkeypatch):
-    """Fixture providing a mock empty context."""
-    context = {}
-    monkeypatch.setattr(
-        "prefect_dbt.core.runner.serialize_context",
-        Mock(return_value=context),
-    )
-    return context
+    """Create a mock dbt manifest."""
+    manifest = Mock(spec=Manifest)
+    manifest.nodes = {}
+    manifest.metadata = {"adapter_type": "snowflake"}
+    return manifest
 
 
 @pytest.fixture
 def mock_project():
-    """Fixture providing a mock project."""
-    mock_project = Mock()
-    mock_project.project_name = "test_project"
-    return mock_project
+    """Create a mock dbt project."""
+    project = Mock()
+    project.project_name = "test_project"
+    return project
 
 
 @pytest.fixture
-def mock_file_operations(monkeypatch):
-    """Fixture providing mock file operations."""
-    mock_open = Mock()
-    mock_open.return_value.__enter__ = Mock(return_value=Mock())
-    mock_open.return_value.__exit__ = Mock(return_value=None)
-    monkeypatch.setattr("builtins.open", mock_open)
-    return mock_open
+def mock_manifest_node():
+    """Create a mock dbt manifest node."""
+    node = Mock(spec=ManifestNode)
+    node.unique_id = "model.test_project.test_model"
+    node.name = "test_model"
+    node.resource_type = NodeType.Model
+    node.original_file_path = "models/test_model.sql"
+    node.relation_name = "test_model"
+    node.config = {"materialized": "table"}
+    return node
 
 
-class TestPrefectDbtRunner:
-    """Test cases focusing on PrefectDbtRunner outcomes and behavior."""
+@pytest.fixture
+def mock_settings():
+    """Create mock PrefectDbtSettings."""
+    settings = Mock(spec=PrefectDbtSettings)
+    settings.target_path = Path("target")
+    settings.profiles_dir = Path("profiles")
+    settings.project_dir = Path("project")
+    settings.log_level = EventLevel.INFO
+    return settings
 
-    def test_runner_initializes_with_working_configuration(self):
-        """Test that runner initializes with a working configuration."""
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Prefect client."""
+    return Mock(spec=PrefectClient)
+
+
+@pytest.fixture
+def mock_task_state():
+    """Create a mock NodeTaskTracker."""
+    task_state = Mock(spec=NodeTaskTracker)
+    task_state.get_node_status.return_value = {
+        "event_data": {"node_info": {"node_status": "success"}}
+    }
+    return task_state
+
+
+@pytest.fixture
+def mock_dbt_runner():
+    """Create a mock dbt runner."""
+    runner = Mock()
+    runner.invoke.return_value = Mock(success=True, result=None)
+    return runner
+
+
+@pytest.fixture
+def mock_event():
+    """Create a mock dbt event."""
+    event = Mock(spec=EventMsg)
+    event.info.name = "NodeFinished"
+    event.data = Mock()
+    return event
+
+
+class TestPrefectDbtRunnerInitialization:
+    """Test PrefectDbtRunner initialization and configuration."""
+
+    def test_initializes_with_defaults(self):
+        """Test that runner initializes with sensible defaults."""
         runner = PrefectDbtRunner()
 
-        # Verify runner has all required components
         assert runner.settings is not None
         assert isinstance(runner.settings, PrefectDbtSettings)
         assert runner.raise_on_failure is True
         assert runner.client is not None
+        assert runner.include_compiled_code is False
         assert runner._force_nodes_as_tasks is False
 
-    def test_runner_accepts_custom_configuration(self):
+    def test_accepts_custom_configuration(
+        self, mock_manifest, mock_settings, mock_client
+    ):
         """Test that runner accepts and uses custom configuration."""
-        custom_settings = PrefectDbtSettings()
-        custom_manifest = Mock(spec=Manifest)
-        custom_client = Mock()
-
         runner = PrefectDbtRunner(
-            manifest=custom_manifest,
-            settings=custom_settings,
+            manifest=mock_manifest,
+            settings=mock_settings,
             raise_on_failure=False,
-            client=custom_client,
+            client=mock_client,
             include_compiled_code=True,
             _force_nodes_as_tasks=True,
         )
 
-        # Verify custom configuration is used
-        assert runner.settings == custom_settings
+        assert runner.settings == mock_settings
         assert runner.raise_on_failure is False
-        assert runner.client == custom_client
+        assert runner.client == mock_client
         assert runner.include_compiled_code is True
         assert runner._force_nodes_as_tasks is True
 
-    def test_runner_handles_manifest_loading_successfully(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner can load manifest successfully."""
-        mock_manifest = Mock(spec=Manifest)
+    def test_property_accessors_work_correctly(self, mock_settings):
+        """Test that property accessors return expected values."""
+        runner = PrefectDbtRunner(settings=mock_settings)
 
-        # Mock file operations
-        mock_open = Mock()
-        mock_open.return_value.__enter__ = Mock(return_value=Mock())
-        mock_open.return_value.__exit__ = Mock(return_value=None)
+        # Test that properties access the underlying settings
+        assert runner.target_path == mock_settings.target_path
+        assert runner.profiles_dir == mock_settings.profiles_dir
+        assert runner.project_dir == mock_settings.project_dir
+        assert runner.log_level == mock_settings.log_level
 
-        monkeypatch.setattr("builtins.open", mock_open)
-        monkeypatch.setattr("json.load", Mock(return_value={"test": "data"}))
-        monkeypatch.setattr(Manifest, "from_dict", Mock(return_value=mock_manifest))
 
-        runner = PrefectDbtRunner()
-        runner._target_path = Path("target")
-        runner._project_dir = Path("/test/project")
+class TestPrefectDbtRunnerManifestLoading:
+    """Test manifest loading functionality."""
 
-        # Access manifest property to trigger loading
-        result = runner.manifest
+    def test_manifest_loading_success(self, tmp_path: Path):
+        """Test successful manifest loading from file."""
+        # Create a mock manifest file
+        manifest_data = {"nodes": {}, "metadata": {"adapter_type": "snowflake"}}
+        manifest_path = tmp_path / "target" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True)
 
-        assert result == mock_manifest
-
-    def test_runner_handles_manifest_file_not_found(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner handles missing manifest file gracefully."""
-        monkeypatch.setattr("builtins.open", Mock(side_effect=FileNotFoundError()))
+        with open(manifest_path, "w") as f:
+            json.dump(manifest_data, f)
 
         runner = PrefectDbtRunner()
+        runner._project_dir = tmp_path
         runner._target_path = Path("target")
-        runner._project_dir = Path("/test/project")
+
+        with patch("prefect_dbt.core.runner.Manifest.from_dict") as mock_from_dict:
+            mock_manifest = Mock(spec=Manifest)
+            mock_from_dict.return_value = mock_manifest
+
+            result = runner.manifest
+
+            assert result == mock_manifest
+            mock_from_dict.assert_called_once_with(manifest_data)
+
+    def test_manifest_loading_file_not_found(self, tmp_path: Path):
+        """Test that missing manifest file raises appropriate error."""
+        runner = PrefectDbtRunner()
+        runner._project_dir = tmp_path
+        runner._target_path = Path("target")
 
         with pytest.raises(ValueError, match="Manifest file not found"):
             _ = runner.manifest
 
-    def test_runner_processes_dbt_events_correctly(self):
-        """Test that runner processes dbt events correctly."""
-        event = Mock(spec=EventMsg)
-        event.info = Mock()
-        event.info.msg = "Test dbt event message"
+    def test_manifest_loading_with_preloaded_manifest(self, mock_manifest):
+        """Test that preloaded manifest is used without file access."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
 
-        result = PrefectDbtRunner.get_dbt_event_msg(event)
-        assert result == "Test dbt event message"
+        result = runner.manifest
 
-    def test_runner_extracts_node_id_from_events(self):
-        """Test that runner extracts node IDs from dbt events."""
+        assert result == mock_manifest
+
+
+class TestPrefectDbtRunnerProjectLoading:
+    """Test project loading functionality."""
+
+    def test_project_loading_success(self, tmp_path: Path):
+        """Test successful project loading."""
         runner = PrefectDbtRunner()
+        runner._project_dir = tmp_path
 
-        event = Mock(spec=EventMsg)
-        event.data = Mock()
-        event.data.node_info = Mock()
-        event.data.node_info.unique_id = "test_node_id"
+        with patch(
+            "prefect_dbt.core.runner.Project.from_project_root"
+        ) as mock_from_project:
+            mock_project = Mock()
+            mock_from_project.return_value = mock_project
 
-        result = runner._get_dbt_event_node_id(event)
-        assert result == "test_node_id"
+            result = runner.project
 
-    def test_runner_handles_cli_argument_parsing(self):
-        """Test that runner handles CLI argument parsing correctly."""
+            assert result == mock_project
+            mock_from_project.assert_called_once()
+
+    def test_project_loading_uses_settings_project_dir(
+        self, tmp_path: Path, mock_settings
+    ):
+        """Test that project loading uses settings.project_dir when available."""
+        mock_settings.project_dir = tmp_path
+        runner = PrefectDbtRunner(settings=mock_settings)
+
+        with patch(
+            "prefect_dbt.core.runner.Project.from_project_root"
+        ) as mock_from_project:
+            mock_project = Mock()
+            mock_from_project.return_value = mock_project
+
+            result = runner.project
+
+            assert result == mock_project
+            mock_from_project.assert_called_once()
+
+
+class TestPrefectDbtRunnerGraphLoading:
+    """Test graph loading functionality."""
+
+    def test_graph_loading_creates_linker_and_graph(self, mock_manifest):
+        """Test that graph loading creates linker and graph correctly."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+
+        with (
+            patch("prefect_dbt.core.runner.Linker") as mock_linker_class,
+            patch("prefect_dbt.core.runner.Graph") as mock_graph_class,
+        ):
+            mock_linker = Mock()
+            mock_linker_class.return_value = mock_linker
+
+            mock_graph = Mock()
+            mock_graph_class.return_value = mock_graph
+
+            result = runner.graph
+
+            assert result == mock_graph
+            mock_linker.link_graph.assert_called_once_with(mock_manifest)
+            mock_graph_class.assert_called_once_with(mock_linker.graph)
+
+    def test_graph_loading_with_test_edges(self, mock_manifest):
+        """Test that graph loading can include test edges."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+
+        with patch.object(runner, "_set_graph_from_manifest") as mock_set_graph:
+            runner._set_graph_from_manifest(add_test_edges=True)
+
+            mock_set_graph.assert_called_once_with(add_test_edges=True)
+
+
+class TestPrefectDbtRunnerCompiledCode:
+    """Test compiled code functionality."""
+
+    def test_get_compiled_code_path_uses_project_name(
+        self, tmp_path: Path, mock_project, mock_manifest_node
+    ):
+        """Test that compiled code path uses project name correctly."""
         runner = PrefectDbtRunner()
+        runner._project_dir = tmp_path
+        runner._target_path = Path("target")
+        runner._project = mock_project
 
-        # Test extracting flag values
+        result = runner._get_compiled_code_path(mock_manifest_node)
+
+        expected_path = (
+            tmp_path
+            / "target"
+            / "compiled"
+            / "test_project"
+            / "models"
+            / "test_model.sql"
+        )
+        assert result == expected_path
+
+    def test_get_compiled_code_returns_empty_when_disabled(self, mock_manifest_node):
+        """Test that compiled code returns empty when disabled."""
+        runner = PrefectDbtRunner(include_compiled_code=False)
+
+        result = runner._get_compiled_code(mock_manifest_node)
+
+        assert result == ""
+
+    def test_get_compiled_code_returns_formatted_sql_when_enabled(
+        self, tmp_path: Path, mock_project, mock_manifest_node
+    ):
+        """Test that compiled code returns formatted SQL when enabled."""
+        runner = PrefectDbtRunner(include_compiled_code=True)
+        runner._project_dir = tmp_path
+        runner._target_path = Path("target")
+        runner._project = mock_project
+
+        # Create compiled SQL file
+        compiled_path = tmp_path / "target" / "compiled" / "test_project" / "models"
+        compiled_path.mkdir(parents=True)
+        sql_file = compiled_path / "test_model.sql"
+        sql_file.write_text("SELECT * FROM test_table")
+
+        result = runner._get_compiled_code(mock_manifest_node)
+
+        assert "SELECT * FROM test_table" in result
+
+    def test_get_compiled_code_returns_empty_when_file_not_found(
+        self, tmp_path: Path, mock_project, mock_manifest_node
+    ):
+        """Test that compiled code returns empty when file not found."""
+        runner = PrefectDbtRunner(include_compiled_code=True)
+        runner._project_dir = tmp_path
+        runner._target_path = Path("target")
+        runner._project = mock_project
+
+        result = runner._get_compiled_code(mock_manifest_node)
+
+        assert result == ""
+
+
+class TestPrefectDbtRunnerEventProcessing:
+    """Test event processing functionality."""
+
+    def test_get_dbt_event_msg_extracts_message(self, mock_event):
+        """Test that event message extraction works correctly."""
+        mock_event.data.msg = "Test message"
+
+        result = PrefectDbtRunner.get_dbt_event_msg(mock_event)
+
+        assert result == "Test message"
+
+    def test_get_dbt_event_node_id_extracts_node_id(self, mock_event):
+        """Test that node ID extraction works correctly."""
+        mock_event.data.node_info = {"unique_id": "model.test_project.test_model"}
+
+        runner = PrefectDbtRunner()
+        result = runner._get_dbt_event_node_id(mock_event)
+
+        assert result == "model.test_project.test_model"
+
+
+class TestPrefectDbtRunnerCLIArgumentHandling:
+    """Test CLI argument handling functionality."""
+
+    def test_extract_flag_value_finds_flag(self):
+        """Test that flag value extraction works correctly."""
+        runner = PrefectDbtRunner()
         args = ["--target-path", "/custom/path", "run"]
-        result_args, value = runner._extract_flag_value(args, "--target-path")
+
+        result_args, result_value = runner._extract_flag_value(args, "--target-path")
 
         assert result_args == ["run"]
-        assert value == "/custom/path"
+        assert result_value == "/custom/path"
 
-        # Test handling missing flags
+    def test_extract_flag_value_handles_missing_flag(self):
+        """Test that missing flag is handled correctly."""
+        runner = PrefectDbtRunner()
         args = ["run"]
-        result_args, value = runner._extract_flag_value(args, "--target-path")
+
+        result_args, result_value = runner._extract_flag_value(args, "--target-path")
 
         assert result_args == ["run"]
-        assert value is None
+        assert result_value is None
 
-    def test_runner_updates_settings_from_kwargs(self):
-        """Test that runner updates settings from kwargs."""
+    def test_update_setting_from_kwargs(self):
+        """Test that settings are updated from kwargs."""
         runner = PrefectDbtRunner()
         kwargs = {"target_path": "/custom/path"}
 
         runner._update_setting_from_kwargs("target_path", kwargs)
 
         assert runner._target_path == "/custom/path"
-        assert "target_path" not in kwargs  # Should be removed
+        assert "target_path" not in kwargs
 
-    def test_runner_updates_settings_from_cli_flags(self):
-        """Test that runner updates settings from CLI flags."""
+    def test_update_setting_from_cli_flag(self):
+        """Test that settings are updated from CLI flags."""
         runner = PrefectDbtRunner()
         args = ["--target-path", "/custom/path", "run"]
 
@@ -452,1367 +388,553 @@ class TestPrefectDbtRunner:
         assert result_args == ["run"]
         assert runner._target_path == Path("/custom/path")
 
-    def test_runner_invokes_dbt_successfully(
-        self,
-        mock_runner_with_all_mocks,
-        mock_dbt_runner_class_with_success,
-        monkeypatch,
-    ):
-        """Test that runner invokes dbt commands successfully."""
-        runner = mock_runner_with_all_mocks
 
-        # Mock context to simulate no flow/task run
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context", Mock(return_value={})
+class TestPrefectDbtRunnerInvoke:
+    """Test the main invoke method."""
+
+    @pytest.fixture
+    def mock_dbt_runner_class(self):
+        """Mock the dbtRunner class."""
+        with patch("prefect_dbt.core.runner.dbtRunner") as mock_class:
+            mock_instance = Mock()
+            mock_class.return_value = mock_instance
+            yield mock_instance
+
+    @pytest.fixture
+    def mock_settings_context_manager(self):
+        """Mock the settings context manager."""
+        with patch.object(PrefectDbtSettings, "resolve_profiles_yml") as mock_cm:
+            mock_cm.return_value.__enter__.return_value = "/profiles/dir"
+            yield mock_cm
+
+    def test_invoke_successful_command(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test successful command invocation."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        result = runner.invoke(["run"])
+
+        assert result.success is True
+        mock_dbt_runner_class.invoke.assert_called_once()
+
+    def test_invoke_with_callbacks_in_flow_context(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that callbacks are created when in flow context."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        @flow
+        def test_flow():
+            return runner.invoke(["run"])
+
+        with patch("prefect_dbt.core.runner.serialize_context") as mock_context:
+            mock_context.return_value = {"flow_run_context": {"id": "test"}}
+            result = test_flow()
+
+        assert result.success is True
+        # Verify callbacks were created
+        mock_dbt_runner_class.assert_called_once()
+        call_args = mock_dbt_runner_class.call_args
+        assert len(call_args[1]["callbacks"]) == 3
+
+    def test_invoke_with_force_nodes_as_tasks(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that callbacks are created when force_nodes_as_tasks is True."""
+        runner = PrefectDbtRunner(_force_nodes_as_tasks=True)
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        with patch("prefect_dbt.core.runner.serialize_context") as mock_context:
+            mock_context.return_value = {}
+            result = runner.invoke(["run"])
+
+        assert result.success is True
+        # Verify callbacks were created
+        mock_dbt_runner_class.assert_called_once()
+        call_args = mock_dbt_runner_class.call_args
+        assert len(call_args[1]["callbacks"]) == 3
+
+    def test_invoke_sets_log_level_none_in_context(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that log level is set to none when in flow context."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        @flow
+        def test_flow():
+            return runner.invoke(["run"])
+
+        with patch("prefect_dbt.core.runner.serialize_context") as mock_context:
+            mock_context.return_value = {"flow_run_context": {"id": "test"}}
+            test_flow()
+
+        # Verify log_level was set to "none"
+        call_args = mock_dbt_runner_class.call_args
+        assert call_args[1]["log_level"] == "none"
+
+    def test_invoke_uses_original_log_level_outside_context(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that original log level is used outside flow context."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        with patch("prefect_dbt.core.runner.serialize_context") as mock_context:
+            mock_context.return_value = {}
+            runner.invoke(["run"])
+
+        # Verify log_level was set to the original value
+        call_args = mock_dbt_runner_class.call_args
+        assert call_args[1]["log_level"] == str(EventLevel.INFO.value)
+
+    def test_invoke_handles_dbt_exceptions(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that dbt exceptions are handled correctly."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(
+            success=False, exception="dbt error"
         )
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # No assertion about callbacks in invoke call; callbacks are passed to dbtRunner constructor only.
-
-    def test_runner_invokes_dbt_with_callbacks_in_flow_context(
-        self,
-        mock_runner_with_callback_mocks,
-        mock_dbt_runner_class_with_success,
-        mock_flow_context,
-    ):
-        """Test that runner adds callbacks when in flow context."""
-        (
-            runner,
-            mock_logging_callback,
-            mock_node_started_callback,
-            mock_node_finished_callback,
-        ) = mock_runner_with_callback_mocks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify callbacks are added when in flow context
-        mock_dbt_runner_class_with_success.assert_called_once_with(
-            callbacks=[
-                mock_logging_callback,
-                mock_node_started_callback,
-                mock_node_finished_callback,
-            ]
-        )
-
-    def test_runner_invokes_dbt_with_callbacks_in_task_context(
-        self,
-        mock_runner_with_callback_mocks,
-        mock_dbt_runner_class_with_success,
-        mock_task_context,
-    ):
-        """Test that runner adds callbacks when in task context."""
-        (
-            runner,
-            mock_logging_callback,
-            mock_node_started_callback,
-            mock_node_finished_callback,
-        ) = mock_runner_with_callback_mocks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify callbacks are added when in task context
-        mock_dbt_runner_class_with_success.assert_called_once_with(
-            callbacks=[
-                mock_logging_callback,
-                mock_node_started_callback,
-                mock_node_finished_callback,
-            ]
-        )
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "none"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_invokes_dbt_with_force_nodes_as_tasks(
-        self,
-        mock_runner_with_force_nodes_as_tasks,
-        mock_dbt_runner_class_with_success,
-        mock_empty_context,
-    ):
-        """Test that runner adds callbacks when force_nodes_as_tasks is True."""
-        (
-            runner,
-            mock_logging_callback,
-            mock_node_started_callback,
-            mock_node_finished_callback,
-        ) = mock_runner_with_force_nodes_as_tasks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify callbacks are added when _force_nodes_as_tasks is True
-        mock_dbt_runner_class_with_success.assert_called_once_with(
-            callbacks=[
-                mock_logging_callback,
-                mock_node_started_callback,
-                mock_node_finished_callback,
-            ]
-        )
-
-    def test_runner_sets_log_level_none_in_flow_context(
-        self,
-        mock_runner_with_all_mocks,
-        mock_dbt_runner_class_with_success,
-        monkeypatch,
-    ):
-        """Test that runner sets log_level to 'none' when in flow context."""
-        runner = mock_runner_with_all_mocks
-
-        # Mock context to simulate flow run (non-empty dict)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context",
-            Mock(return_value={"flow_run_context": {"foo": "bar"}}),
-        )
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify log_level is set to 'none' and log_level_file uses the original level as string
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "none"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_sets_log_level_none_in_task_context(
-        self,
-        mock_runner_with_callback_mocks,
-        mock_dbt_runner_class_with_success,
-        mock_task_context,
-    ):
-        """Test that runner sets log_level to 'none' when in task context."""
-        runner, _, _, _ = mock_runner_with_callback_mocks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify log_level is set to 'none' and log_level_file uses the original level as string
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "none"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_uses_original_log_level_outside_context(
-        self,
-        mock_runner_with_callback_mocks,
-        mock_dbt_runner_class_with_success,
-        mock_empty_context,
-    ):
-        """Test that runner uses original log_level when not in flow/task context."""
-        runner, _, _, _ = mock_runner_with_callback_mocks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify log_level uses the original level when not in context
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "info"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_uses_original_log_level_with_force_nodes_as_tasks(
-        self,
-        mock_runner_with_force_nodes_as_tasks,
-        mock_dbt_runner_class_with_success,
-        mock_empty_context,
-    ):
-        """Test that runner uses original log_level when force_nodes_as_tasks is True but not in context."""
-        runner, _, _, _ = mock_runner_with_force_nodes_as_tasks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify log_level uses the original level even with _force_nodes_as_tasks
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "info"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_force_nodes_as_tasks_with_flow_context(
-        self,
-        mock_runner_with_force_nodes_as_tasks,
-        mock_dbt_runner_class_with_success,
-        mock_flow_context,
-    ):
-        """Test that runner behavior when _force_nodes_as_tasks is True and in flow context."""
-        (
-            runner,
-            mock_logging_callback,
-            mock_node_started_callback,
-            mock_node_finished_callback,
-        ) = mock_runner_with_force_nodes_as_tasks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify callbacks are added and log_level is 'none' when in flow context
-        mock_dbt_runner_class_with_success.assert_called_once_with(
-            callbacks=[
-                mock_logging_callback,
-                mock_node_started_callback,
-                mock_node_finished_callback,
-            ]
-        )
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "none"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_force_nodes_as_tasks_with_task_context(
-        self,
-        mock_runner_with_force_nodes_as_tasks,
-        mock_dbt_runner_class_with_success,
-        mock_task_context,
-    ):
-        """Test that runner behavior when _force_nodes_as_tasks is True and in task context."""
-        (
-            runner,
-            mock_logging_callback,
-            mock_node_started_callback,
-            mock_node_finished_callback,
-        ) = mock_runner_with_force_nodes_as_tasks
-
-        result = runner.invoke(["run"])
-
-        assert result.success is True
-        assert result.exception is None
-        mock_dbt_runner_class_with_success.return_value.invoke.assert_called_once()
-        # Verify callbacks are added and log_level is 'none' when in task context
-        mock_dbt_runner_class_with_success.assert_called_once_with(
-            callbacks=[
-                mock_logging_callback,
-                mock_node_started_callback,
-                mock_node_finished_callback,
-            ]
-        )
-        call_kwargs = mock_dbt_runner_class_with_success.return_value.invoke.call_args[
-            1
-        ]
-        assert call_kwargs["log_level"] == "none"
-        assert call_kwargs["log_level_file"] == "info"
-
-    def test_runner_handles_dbt_exceptions(
-        self,
-        mock_runner_with_callback_mocks,
-        mock_dbt_runner_class_with_failure,
-        mock_empty_context,
-    ):
-        """Test that runner handles dbt exceptions gracefully."""
-        runner, _, _, _ = mock_runner_with_callback_mocks
 
         with pytest.raises(ValueError, match="Failed to invoke dbt command"):
             runner.invoke(["run"])
 
-    def test_runner_handles_dbt_failures_with_raise_on_failure_true(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_invoke_handles_dbt_failures_with_raise_on_failure_true(
+        self, mock_dbt_runner_class, mock_settings_context_manager
     ):
-        """Test that runner raises on dbt failures when raise_on_failure is True."""
+        """Test that dbt failures raise when raise_on_failure is True."""
         runner = PrefectDbtRunner(raise_on_failure=True)
 
-        mock_result = Mock()
-        mock_result.success = False
-        mock_result.exception = None
-        mock_result.result = Mock(spec=RunExecutionResult)
-        mock_result.result.results = [
-            Mock(
-                status=RunStatus.Error,
-                node=Mock(resource_type="model", name="test_model"),
-                message="Test error",
-            )
+        # Create a mock result with failures
+        mock_result = Mock(spec=RunExecutionResult)
+        mock_node = Mock()
+        mock_node.resource_type = "model"
+        mock_node.name = "test_model"
+        mock_result.results = [
+            Mock(status=RunStatus.Error, node=mock_node, message="Test error")
         ]
 
-        mock_dbt_runner_instance = Mock()
-        mock_dbt_runner_instance.invoke.return_value = mock_result
-
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.dbtRunner",
-            Mock(return_value=mock_dbt_runner_instance),
+        mock_dbt_runner_class.invoke.return_value = Mock(
+            success=False, exception=None, result=mock_result
         )
 
-        # Mock the callback methods
-        monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-        # Mock context to simulate no flow/task run
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context", Mock(return_value={})
-        )
-
-        # Mock the settings resolve_profiles_yml method to prevent file access
-        mock_settings = Mock()
-        mock_settings.resolve_profiles_yml.return_value.__enter__ = Mock(
-            return_value="/mock/profiles/dir"
-        )
-        mock_settings.resolve_profiles_yml.return_value.__exit__ = Mock(
-            return_value=None
-        )
-        runner.settings = mock_settings
-
-        with pytest.raises(ValueError, match="Failures detected during invocation"):
+        with pytest.raises(ValueError, match="Failures detected"):
             runner.invoke(["run"])
 
-    def test_runner_handles_dbt_failures_with_raise_on_failure_false(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_invoke_handles_dbt_failures_with_raise_on_failure_false(
+        self, mock_dbt_runner_class, mock_settings_context_manager
     ):
-        """Test that runner doesn't raise on dbt failures when raise_on_failure is False."""
+        """Test that dbt failures don't raise when raise_on_failure is False."""
         runner = PrefectDbtRunner(raise_on_failure=False)
 
-        mock_result = Mock()
-        mock_result.success = False
-        mock_result.exception = None
-        mock_result.result = Mock(spec=RunExecutionResult)
-        mock_result.result.results = [
-            Mock(
-                status=RunStatus.Error,
-                node=Mock(resource_type="model", name="test_model"),
-                message="Test error",
-            )
+        # Create a mock result with failures
+        mock_result = Mock(spec=RunExecutionResult)
+        mock_node = Mock()
+        mock_node.resource_type = "model"
+        mock_node.name = "test_model"
+        mock_result.results = [
+            Mock(status=RunStatus.Error, node=mock_node, message="Test error")
         ]
 
-        mock_dbt_runner_instance = Mock()
-        mock_dbt_runner_instance.invoke.return_value = mock_result
-
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.dbtRunner",
-            Mock(return_value=mock_dbt_runner_instance),
+        mock_dbt_runner_class.invoke.return_value = Mock(
+            success=False, exception=None, result=mock_result
         )
-
-        # Mock the callback methods
-        monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-        # Mock context to simulate no flow/task run
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context", Mock(return_value={})
-        )
-
-        # Mock the settings resolve_profiles_yml method to prevent file access
-        mock_settings = Mock()
-        mock_settings.resolve_profiles_yml.return_value.__enter__ = Mock(
-            return_value="/mock/profiles/dir"
-        )
-        mock_settings.resolve_profiles_yml.return_value.__exit__ = Mock(
-            return_value=None
-        )
-        runner.settings = mock_settings
 
         result = runner.invoke(["run"])
-        assert result == mock_result
+        assert result.success is False
 
-    def test_runner_creates_callbacks_successfully(self):
-        """Test that runner creates all required callbacks successfully."""
-        runner = PrefectDbtRunner()
-        task_state = Mock()
-        context = {"test": "context"}
-        log_level = EventLevel.INFO
-
-        # Test logging callback creation
-        logging_callback = runner._create_logging_callback(
-            task_state, log_level, context
-        )
-        assert callable(logging_callback)
-
-        # Test node started callback creation
-        node_started_callback = runner._create_node_started_callback(
-            task_state, context
-        )
-        assert callable(node_started_callback)
-
-        # Test node finished callback creation
-        node_finished_callback = runner._create_node_finished_callback(task_state)
-        assert callable(node_finished_callback)
-
-    def test_runner_handles_kwargs_and_cli_flags_together(
-        self,
-        mock_runner_with_callback_mocks,
-        mock_dbt_runner_class_with_success,
-        mock_empty_context,
+    def test_invoke_handles_kwargs_and_cli_flags_together(
+        self, mock_dbt_runner_class, mock_settings_context_manager
     ):
-        """Test that runner handles both kwargs and CLI flags together."""
-        runner, _, _, _ = mock_runner_with_callback_mocks
+        """Test that kwargs and CLI flags are handled together."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
 
-        # Test with both kwargs and CLI flags
         result = runner.invoke(
             ["--target-path", "/cli/path", "run"], target_path="/kwargs/path"
         )
 
         assert result.success is True
-        assert result.exception is None
-        # CLI flag should take precedence
-        assert runner._target_path == Path("/cli/path")
+        # Verify the kwargs path takes precedence
+        call_args = mock_dbt_runner_class.call_args
+        assert call_args[1]["target_path"] == "/kwargs/path"
+
+    def test_invoke_uses_resolve_profiles_yml_context_manager(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that the profiles.yml context manager is used."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        runner.invoke(["run"])
+
+        mock_settings_context_manager.assert_called_once()
+
+
+class TestPrefectDbtRunnerCallbackCreation:
+    """Test callback creation functionality."""
+
+    def test_create_logging_callback_returns_callable(self, mock_task_state):
+        """Test that logging callback creation returns a callable."""
+        runner = PrefectDbtRunner()
+        context = {"test": "context"}
+
+        callback = runner._create_logging_callback(
+            mock_task_state, EventLevel.INFO, context
+        )
+
+        assert callable(callback)
+
+    def test_create_node_started_callback_returns_callable(self, mock_task_state):
+        """Test that node started callback creation returns a callable."""
+        runner = PrefectDbtRunner()
+        context = {"test": "context"}
+
+        callback = runner._create_node_started_callback(mock_task_state, context)
+
+        assert callable(callback)
+
+    def test_create_node_finished_callback_returns_callable(self, mock_task_state):
+        """Test that node finished callback creation returns a callable."""
+        runner = PrefectDbtRunner()
+
+        callback = runner._create_node_finished_callback(mock_task_state)
+
+        assert callable(callback)
+
+    def test_create_node_finished_callback_with_add_test_edges(self, mock_task_state):
+        """Test that node finished callback works with add_test_edges."""
+        runner = PrefectDbtRunner()
+
+        callback = runner._create_node_finished_callback(
+            mock_task_state, add_test_edges=True
+        )
+
+        assert callable(callback)
+
+
+class TestPrefectDbtRunnerManifestNodeOperations:
+    """Test manifest node operations."""
 
     def test_get_upstream_manifest_nodes_and_configs_returns_correct_structure(
-        self, mock_manifest
+        self, mock_manifest, mock_manifest_node
     ):
-        """Test that _get_upstream_manifest_nodes_and_configs returns correct structure."""
-        runner = PrefectDbtRunner()
+        """Test that upstream nodes and configs are returned correctly."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
 
-        # Create properly configured mock nodes
-        mock_node_1 = Mock(spec=ManifestNode)
-        mock_node_1.relation_name = "test_relation_1"
-        mock_node_1.config = Mock()
-        mock_node_1.config.meta = {"prefect": {"enable_assets": True}}
+        # Mock the manifest to return upstream nodes
+        upstream_node = Mock(spec=ManifestNode)
+        upstream_node.unique_id = "model.test_project.upstream_model"
+        upstream_node.config = {"materialized": "view"}
 
-        mock_node_2 = Mock(spec=ManifestNode)
-        mock_node_2.relation_name = "test_relation_2"
-        mock_node_2.config = Mock()
-        mock_node_2.config.meta = {"prefect": {"enable_assets": False}}
+        mock_manifest.nodes = {"model.test_project.upstream_model": upstream_node}
+        mock_manifest_node.depends_on.nodes = ["model.test_project.upstream_model"]
 
-        mock_manifest.nodes = {
-            "upstream_node_1": mock_node_1,
-            "upstream_node_2": mock_node_2,
-        }
+        result = runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
 
-        runner._manifest = mock_manifest
-
-        # Create a mock manifest node with dependencies
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.depends_on_nodes = ["upstream_node_1", "upstream_node_2"]
-
-        result = runner._get_upstream_manifest_nodes_and_configs(mock_node)
-
-        # Verify structure: list of tuples (ManifestNode, dict)
-        assert isinstance(result, list)
-        assert len(result) == 2
-
-        for item in result:
-            assert isinstance(item, tuple)
-            assert len(item) == 2
-            assert isinstance(item[0], Mock)  # ManifestNode
-            assert isinstance(item[1], dict)  # config dict
+        assert len(result) == 1
+        assert result[0][0] == upstream_node
+        assert result[0][1] == {"materialized": "view"}
 
     def test_get_upstream_manifest_nodes_and_configs_handles_missing_nodes(
-        self, mock_manifest
+        self, mock_manifest, mock_manifest_node
     ):
-        """Test that _get_upstream_manifest_nodes_and_configs handles missing nodes gracefully."""
-        runner = PrefectDbtRunner()
+        """Test that missing upstream nodes are handled gracefully."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+        mock_manifest.nodes = {}
+        mock_manifest_node.depends_on.nodes = ["model.test_project.missing_model"]
 
-        # Mock manifest with missing nodes
-        mock_manifest.nodes = {}  # Empty nodes dict
-        runner._manifest = mock_manifest
+        result = runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
 
-        # Create a mock manifest node with dependencies
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.depends_on_nodes = ["missing_node_1", "missing_node_2"]
-
-        result = runner._get_upstream_manifest_nodes_and_configs(mock_node)
-
-        # Should return empty list when nodes are missing
         assert result == []
 
     def test_get_upstream_manifest_nodes_and_configs_handles_missing_relation_name(
-        self, mock_manifest
-    ):
-        """Test that _get_upstream_manifest_nodes_and_configs handles missing relation_name."""
-        runner = PrefectDbtRunner()
-
-        # Mock manifest and nodes
-        mock_node_without_relation = Mock(spec=ManifestNode)
-        mock_node_without_relation.relation_name = None  # Missing relation_name
-        mock_node_without_relation.config = Mock()
-        mock_node_without_relation.config.meta = {}
-        mock_manifest.nodes = {"upstream_node": mock_node_without_relation}
-        runner._manifest = mock_manifest
-
-        # Create a mock manifest node with dependencies
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.depends_on_nodes = ["upstream_node"]
-
-        with pytest.raises(ValueError, match="Relation name not found in manifest"):
-            runner._get_upstream_manifest_nodes_and_configs(mock_node)
-
-    def test_call_task_with_enable_assets_true_creates_materializing_task(
-        self, mock_manifest, mock_manifest_node, monkeypatch
-    ):
-        """Test that _call_task creates MaterializingTask when enable_assets is True."""
-        runner = PrefectDbtRunner()
-
-        runner._manifest = mock_manifest
-
-        # Mock task state
-        mock_task_state = Mock()
-
-        # Mock the upstream nodes method to return empty list
-        monkeypatch.setattr(
-            runner, "_get_upstream_manifest_nodes_and_configs", Mock(return_value=[])
-        )
-
-        # Mock task creation methods
-        mock_asset = Mock()
-        monkeypatch.setattr(
-            runner, "_create_asset_from_node", Mock(return_value=mock_asset)
-        )
-        mock_task_options = {"task_run_name": "test_task", "cache_policy": Mock()}
-        monkeypatch.setattr(
-            runner, "_create_task_options", Mock(return_value=mock_task_options)
-        )
-
-        # Mock MaterializingTask creation
-        mock_materializing_task = Mock()
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.MaterializingTask",
-            Mock(return_value=mock_materializing_task),
-        )
-
-        # Mock format_resource_id
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.format_resource_id",
-            Mock(return_value="test_asset_id"),
-        )
-
-        context = {"test": "context"}
-        enable_assets = True
-
-        runner._call_task(mock_task_state, mock_manifest_node, context, enable_assets)
-
-        # Verify MaterializingTask was created and started
-        mock_task_state.start_task.assert_called_once_with(
-            "test_node", mock_materializing_task
-        )
-        mock_task_state.set_node_dependencies.assert_called_once_with("test_node", [])
-        mock_task_state.run_task_in_thread.assert_called_once()
-
-    def test_call_task_with_enable_assets_false_creates_regular_task(
-        self, mock_manifest, mock_manifest_node, monkeypatch
-    ):
-        """Test that _call_task creates regular Task when enable_assets is False."""
-        runner = PrefectDbtRunner()
-
-        runner._manifest = mock_manifest
-
-        # Mock task state
-        mock_task_state = Mock()
-
-        # Mock the upstream nodes method to return empty list
-        monkeypatch.setattr(
-            runner, "_get_upstream_manifest_nodes_and_configs", Mock(return_value=[])
-        )
-
-        # Mock task creation methods
-        mock_task_options = {"task_run_name": "test_task", "cache_policy": Mock()}
-        monkeypatch.setattr(
-            runner, "_create_task_options", Mock(return_value=mock_task_options)
-        )
-
-        # Mock Task creation
-        mock_task = Mock()
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.Task", Mock(return_value=mock_task)
-        )
-
-        context = {"test": "context"}
-        enable_assets = False
-
-        runner._call_task(mock_task_state, mock_manifest_node, context, enable_assets)
-
-        # Verify regular Task was created and started
-        mock_task_state.start_task.assert_called_once_with("test_node", mock_task)
-        mock_task_state.set_node_dependencies.assert_called_once_with("test_node", [])
-        mock_task_state.run_task_in_thread.assert_called_once()
-
-    def test_call_task_handles_missing_adapter_type(
         self, mock_manifest, mock_manifest_node
     ):
-        """Test that _call_task handles missing adapter type gracefully."""
+        """Test that missing relation_name is handled gracefully."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+
+        # Create a node without relation_name
+        upstream_node = Mock(spec=ManifestNode)
+        upstream_node.unique_id = "model.test_project.upstream_model"
+        upstream_node.config = {"materialized": "view"}
+        upstream_node.relation_name = None
+
+        mock_manifest.nodes = {"model.test_project.upstream_model": upstream_node}
+        mock_manifest_node.depends_on.nodes = ["model.test_project.upstream_model"]
+
+        result = runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
+
+        assert len(result) == 1
+        assert result[0][0] == upstream_node
+        assert result[0][1] == {"materialized": "view"}
+
+
+class TestPrefectDbtRunnerTaskCreation:
+    """Test task creation functionality."""
+
+    def test_call_task_with_enable_assets_true_creates_materializing_task(
+        self, mock_task_state, mock_manifest_node
+    ):
+        """Test that materializing tasks are created when assets are enabled."""
         runner = PrefectDbtRunner()
-
-        # Mock manifest without adapter type
-        mock_manifest.metadata.adapter_type = None
-        runner._manifest = mock_manifest
-
-        # Mock task state
-        mock_task_state = Mock()
-
         context = {"test": "context"}
-        enable_assets = True
 
-        with pytest.raises(ValueError, match="Adapter type not found in manifest"):
+        with patch(
+            "prefect_dbt.core.runner.MaterializingTask"
+        ) as mock_materializing_task:
+            mock_task = Mock(spec=MaterializingTask)
+            mock_materializing_task.return_value = mock_task
+
             runner._call_task(
-                mock_task_state, mock_manifest_node, context, enable_assets
+                mock_task_state, mock_manifest_node, context, enable_assets=True
             )
 
-    def test_call_task_handles_missing_relation_name_for_assets(
-        self, mock_manifest, monkeypatch
+            mock_materializing_task.assert_called_once()
+
+    def test_call_task_with_enable_assets_false_creates_regular_task(
+        self, mock_task_state, mock_manifest_node
     ):
-        """Test that _call_task handles missing relation_name when creating assets."""
+        """Test that regular tasks are created when assets are disabled."""
         runner = PrefectDbtRunner()
-
-        runner._manifest = mock_manifest
-
-        # Mock manifest node without relation_name
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.resource_type = NodeType.Model
-        mock_node.unique_id = "test_node"
-        mock_node.relation_name = None  # Missing relation_name
-        mock_node.config = Mock()
-        mock_node.config.meta = {}
-
-        # Mock task state
-        mock_task_state = Mock()
-
-        # Mock the upstream nodes method to return empty list
-        monkeypatch.setattr(
-            runner, "_get_upstream_manifest_nodes_and_configs", Mock(return_value=[])
-        )
-
         context = {"test": "context"}
-        enable_assets = True
 
-        with pytest.raises(ValueError, match="Relation name not found in manifest"):
-            runner._call_task(mock_task_state, mock_node, context, enable_assets)
+        with patch("prefect_dbt.core.runner.Task") as mock_task_class:
+            mock_task = Mock(spec=Task)
+            mock_task_class.return_value = mock_task
 
-    def test_runner_handles_project_loading_successfully(
-        self, monkeypatch: pytest.MonkeyPatch
+            runner._call_task(
+                mock_task_state, mock_manifest_node, context, enable_assets=False
+            )
+
+            mock_task_class.assert_called_once()
+
+    def test_call_task_handles_missing_adapter_type(
+        self, mock_task_state, mock_manifest_node
     ):
-        """Test that runner can load project successfully."""
-        mock_project = Mock()
-
-        # Mock Project.from_project_root
-        mock_from_project_root = Mock(return_value=mock_project)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.Project.from_project_root",
-            mock_from_project_root,
-        )
-
+        """Test that missing adapter type is handled gracefully."""
         runner = PrefectDbtRunner()
-        runner._project_dir = Path("/test/project")
+        context = {"test": "context"}
 
-        # Access project property to trigger loading
-        result = runner.project
+        # Remove adapter_type from manifest metadata
+        runner.manifest.metadata = {}
 
-        assert result == mock_project
-        mock_from_project_root.assert_called_once()
+        with patch("prefect_dbt.core.runner.Task") as mock_task_class:
+            mock_task = Mock(spec=Task)
+            mock_task_class.return_value = mock_task
 
-    def test_runner_handles_project_loading_with_settings(
-        self, monkeypatch: pytest.MonkeyPatch
+            runner._call_task(
+                mock_task_state, mock_manifest_node, context, enable_assets=True
+            )
+
+            # Should still create a task even without adapter_type
+            mock_task_class.assert_called_once()
+
+    def test_call_task_handles_missing_relation_name_for_assets(
+        self, mock_task_state, mock_manifest_node
     ):
-        """Test that runner uses settings.project_dir when _project_dir is not set."""
-        mock_project = Mock()
-
-        # Mock Project.from_project_root
-        mock_from_project_root = Mock(return_value=mock_project)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.Project.from_project_root",
-            mock_from_project_root,
-        )
-
-        # Create settings with project_dir
-        settings = PrefectDbtSettings()
-        settings.project_dir = Path("/settings/project")
-
-        runner = PrefectDbtRunner(settings=settings)
-
-        # Access project property to trigger loading
-        result = runner.project
-
-        assert result == mock_project
-        mock_from_project_root.assert_called_once()
-
-    def test_runner_get_compiled_code_path_uses_project_name(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that _get_compiled_code_path uses project.project_name correctly."""
+        """Test that missing relation_name is handled when creating assets."""
         runner = PrefectDbtRunner()
-        runner._project_dir = Path("/test/project")
+        context = {"test": "context"}
+
+        # Remove relation_name from manifest node
+        mock_manifest_node.relation_name = None
+
+        with patch("prefect_dbt.core.runner.Task") as mock_task_class:
+            mock_task = Mock(spec=Task)
+            mock_task_class.return_value = mock_task
+
+            runner._call_task(
+                mock_task_state, mock_manifest_node, context, enable_assets=True
+            )
+
+            # Should still create a task even without relation_name
+            mock_task_class.assert_called_once()
+
+
+class TestPrefectDbtRunnerBuildCommands:
+    """Test build command specific functionality."""
+
+    def test_invoke_build_command_sets_add_test_edges_true(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that build commands set add_test_edges to True."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        with patch("prefect_dbt.core.runner.serialize_context") as mock_context:
+            mock_context.return_value = {"flow_run_context": {"id": "test"}}
+            runner.invoke(["build"])
+
+        # Verify callbacks were created with add_test_edges=True
+        mock_dbt_runner_class.assert_called_once()
+        call_args = mock_dbt_runner_class.call_args
+        assert len(call_args[1]["callbacks"]) == 3
+
+    def test_invoke_retry_build_command_sets_add_test_edges_true(
+        self, mock_dbt_runner_class, mock_settings_context_manager, tmp_path: Path
+    ):
+        """Test that retry build commands set add_test_edges to True."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.invoke.return_value = Mock(success=True, result=None)
+
+        # Create mock run_results.json
+        results_path = tmp_path / "target" / "run_results.json"
+        results_path.parent.mkdir(parents=True)
+        results_data = {"args": {"which": "build"}, "results": []}
+        with open(results_path, "w") as f:
+            json.dump(results_data, f)
+
+        runner._project_dir = tmp_path
         runner._target_path = Path("target")
 
-        # Mock project with project_name
-        mock_project = Mock()
-        mock_project.project_name = "test_project"
-        runner._project = mock_project
+        with patch("prefect_dbt.core.runner.serialize_context") as mock_context:
+            mock_context.return_value = {"flow_run_context": {"id": "test"}}
+            runner.invoke(["retry"])
 
-        # Mock manifest node
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.original_file_path = "models/test_model.sql"
+        # Verify callbacks were created with add_test_edges=True
+        mock_dbt_runner_class.assert_called_once()
+        call_args = mock_dbt_runner_class.call_args
+        assert len(call_args[1]["callbacks"]) == 3
 
-        result = runner._get_compiled_code_path(mock_node)
-
-        # Should use project.project_name instead of project_dir name
-        expected_path = (
-            Path("/test/project")
-            / "target"
-            / "compiled"
-            / "test_project"
-            / "models/test_model.sql"
-        )
-        assert result == expected_path
-
-    def test_runner_get_compiled_code_path_triggers_project_loading(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_invoke_retry_without_previous_results_raises_error(
+        self, mock_dbt_runner_class, mock_settings_context_manager, tmp_path: Path
     ):
-        """Test that _get_compiled_code_path triggers project loading when needed."""
+        """Test that retry without previous results raises an error."""
         runner = PrefectDbtRunner()
-        runner._project_dir = Path("/test/project")
+        runner._project_dir = tmp_path
         runner._target_path = Path("target")
 
-        # Mock project with project_name
-        mock_project = Mock()
-        mock_project.project_name = "test_project"
-
-        # Mock Project.from_project_root
-        mock_from_project_root = Mock(return_value=mock_project)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.Project.from_project_root",
-            mock_from_project_root,
-        )
-
-        # Mock manifest node
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.original_file_path = "models/test_model.sql"
-
-        result = runner._get_compiled_code_path(mock_node)
-
-        # Should trigger project loading
-        mock_from_project_root.assert_called_once()
-        expected_path = (
-            Path("/test/project")
-            / "target"
-            / "compiled"
-            / "test_project"
-            / "models/test_model.sql"
-        )
-        assert result == expected_path
-
-    def test_runner_get_compiled_code_with_include_compiled_code_true(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that _get_compiled_code works correctly when include_compiled_code is True."""
-        runner = PrefectDbtRunner(include_compiled_code=True)
-        runner._project_dir = Path("/test/project")
-        runner._target_path = Path("target")
-
-        # Mock project with project_name
-        mock_project = Mock()
-        mock_project.project_name = "test_project"
-        runner._project = mock_project
-
-        # Mock manifest node
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.original_file_path = "models/test_model.sql"
-
-        # Mock file operations
-        mock_open = Mock()
-        mock_open.return_value.__enter__ = Mock(return_value=Mock())
-        mock_open.return_value.__exit__ = Mock(return_value=None)
-        monkeypatch.setattr("builtins.open", mock_open)
-
-        # Mock os.path.exists to return True
-        monkeypatch.setattr("os.path.exists", Mock(return_value=True))
-
-        # Mock file read
-        mock_file_content = Mock()
-        mock_file_content.read.return_value = "SELECT * FROM test_table"
-        mock_open.return_value.__enter__.return_value = mock_file_content
-
-        result = runner._get_compiled_code(mock_node)
-
-        # Should return compiled code with SQL formatting
-        expected_result = "\n ### Compiled code\n```sql\nSELECT * FROM test_table\n```"
-        assert result == expected_result
-
-        # Verify the correct path was used
-        expected_path = (
-            Path("/test/project")
-            / "target"
-            / "compiled"
-            / "test_project"
-            / "models/test_model.sql"
-        )
-        mock_open.assert_called_once_with(expected_path, "r")
-
-    def test_runner_get_compiled_code_with_include_compiled_code_false(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that _get_compiled_code returns empty string when include_compiled_code is False."""
-        runner = PrefectDbtRunner(include_compiled_code=False)
-
-        # Mock manifest node
-        mock_node = Mock(spec=ManifestNode)
-
-        result = runner._get_compiled_code(mock_node)
-
-        # Should return empty string when include_compiled_code is False
-        assert result == ""
-
-    def test_runner_get_compiled_code_with_file_not_found(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that _get_compiled_code handles missing compiled code file gracefully."""
-        runner = PrefectDbtRunner(include_compiled_code=True)
-        runner._project_dir = Path("/test/project")
-        runner._target_path = Path("target")
-
-        # Mock project with project_name
-        mock_project = Mock()
-        mock_project.project_name = "test_project"
-        runner._project = mock_project
-
-        # Mock manifest node
-        mock_node = Mock(spec=ManifestNode)
-        mock_node.original_file_path = "models/test_model.sql"
-
-        # Mock os.path.exists to return False (file doesn't exist)
-        monkeypatch.setattr("os.path.exists", Mock(return_value=False))
-
-        result = runner._get_compiled_code(mock_node)
-
-        # Should return empty string when file doesn't exist
-        assert result == ""
-
-    def test_runner_invoke_uses_resolve_profiles_yml_context_manager(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that invoke method uses resolve_profiles_yml context manager with actual templated profiles.yml."""
-        runner = PrefectDbtRunner()
-
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.exception = None
-
-        mock_dbt_runner_instance = Mock()
-        mock_dbt_runner_instance.invoke.return_value = mock_result
-
-        mock_dbt_runner_class = Mock(return_value=mock_dbt_runner_instance)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.dbtRunner",
-            mock_dbt_runner_class,
-        )
-
-        # Mock the callback methods
-        monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-        # Mock context to simulate no flow/task run
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context", Mock(return_value={})
-        )
-
-        # Create a mock profiles.yml with templated values
-        mock_profiles_yml = {
-            "my_project": {
-                "targets": {
-                    "dev": {
-                        "type": "snowflake",
-                        "account": "{{ prefect.blocks.snowflake-credentials.account }}",
-                        "user": "{{ prefect.blocks.snowflake-credentials.user }}",
-                        "password": "{{ prefect.blocks.snowflake-credentials.password }}",
-                        "database": "{{ prefect.variables.database_name }}",
-                        "warehouse": "{{ prefect.variables.warehouse_name }}",
-                        "schema": "{{ prefect.variables.schema_name }}",
-                    }
-                }
-            }
-        }
-
-        # Mock the load_profiles_yml method to return our templated profiles
-        mock_load_method = Mock(return_value=mock_profiles_yml)
-        monkeypatch.setattr(
-            "prefect_dbt.core.settings.PrefectDbtSettings.load_profiles_yml",
-            mock_load_method,
-        )
-
-        # Mock the resolve functions to return resolved values
-        mock_resolved_profiles = {
-            "my_project": {
-                "targets": {
-                    "dev": {
-                        "type": "snowflake",
-                        "account": "test-account.snowflakecomputing.com",
-                        "user": "test_user",
-                        "password": "test_password",
-                        "database": "test_database",
-                        "warehouse": "test_warehouse",
-                        "schema": "test_schema",
-                    }
-                }
-            }
-        }
-
-        # Mock the resolve_block_document_references function
-        mock_resolve_blocks = Mock(return_value=mock_resolved_profiles)
-        monkeypatch.setattr(
-            "prefect_dbt.core.settings.resolve_block_document_references",
-            mock_resolve_blocks,
-        )
-
-        # Mock the resolve_variables function
-        mock_resolve_vars = Mock(return_value=mock_resolved_profiles)
-        monkeypatch.setattr(
-            "prefect_dbt.core.settings.resolve_variables",
-            mock_resolve_vars,
-        )
-
-        # Mock run_coro_as_sync to return the resolved profiles directly
-        def mock_run_coro(coro) -> Any:
-            return mock_resolved_profiles
-
-        mock_run_coro_func = Mock(side_effect=mock_run_coro)
-        monkeypatch.setattr(
-            "prefect_dbt.core.settings.run_coro_as_sync",
-            mock_run_coro_func,
-        )
-
-        # Mock yaml.dump to verify it's called with resolved profiles
-        mock_yaml_dump = Mock()
-        monkeypatch.setattr("prefect_dbt.core.settings.yaml.dump", mock_yaml_dump)
-
-        # Mock Path.write_text to verify the resolved profiles are written
-        mock_write_text = Mock()
-        monkeypatch.setattr("pathlib.Path.write_text", mock_write_text)
-
-        # Call invoke with additional kwargs to test preservation
-        result = runner.invoke(["run"], target="dev", threads=4, custom_arg="value")
-
-        assert result == mock_result
-
-        # Verify the profiles were loaded and resolved
-        mock_load_method.assert_called_once()
-        mock_run_coro_func.assert_called()
-        mock_yaml_dump.assert_called_once_with(
-            mock_resolved_profiles, default_style=None, default_flow_style=False
-        )
-        mock_write_text.assert_called_once()
-
-        # Verify dbtRunner was called with the resolved profiles_dir and preserved kwargs
-        mock_dbt_runner_instance.invoke.assert_called_once()
-        call_kwargs = mock_dbt_runner_instance.invoke.call_args[1]
-        assert call_kwargs["target"] == "dev"
-        assert call_kwargs["threads"] == 4
-        assert call_kwargs["custom_arg"] == "value"
-
-        # Verify the profiles_dir was changed from the original (indicating resolution was used)
-        assert call_kwargs["profiles_dir"] != str(runner.profiles_dir)
-
-    def test_runner_loads_graph(self, monkeypatch: pytest.MonkeyPatch):
-        """Test that runner loads graph."""
-        runner = PrefectDbtRunner()
-
-        # Mock manifest
-        mock_manifest = Mock(spec=Manifest)
-        runner._manifest = mock_manifest
-
-        # Mock Linker
-        mock_linker = Mock()
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.Linker", Mock(return_value=mock_linker)
-        )
-
-        # Mock Graph
-        mock_graph = Mock()
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.Graph", Mock(return_value=mock_graph)
-        )
-
-        # Access graph property to trigger loading (graph is None initially)
-        result = runner.graph
-
-        # Verify graph was created correctly
-        assert result == mock_graph
-        # Verify Linker was used to link the graph
-        mock_linker.link_graph.assert_called_once_with(mock_manifest)
-
-    def test_runner_loads_graph_with_test_edges_for_build_command(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner loads graph with test edges when 'build' is in args."""
-        runner = PrefectDbtRunner()
-
-        # Mock manifest
-        mock_manifest = Mock(spec=Manifest)
-        runner._manifest = mock_manifest
-
-        # Mock _set_graph_from_manifest method
-        mock_set_graph = Mock()
-        monkeypatch.setattr(runner, "_set_graph_from_manifest", mock_set_graph)
-
-        # Mock dbtRunner and successful result
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.exception = None
-
-        mock_dbt_runner_instance = Mock()
-        mock_dbt_runner_instance.invoke.return_value = mock_result
-
-        mock_dbt_runner_class = Mock(return_value=mock_dbt_runner_instance)
-        monkeypatch.setattr("prefect_dbt.core.runner.dbtRunner", mock_dbt_runner_class)
-
-        # Mock the callback methods
-        monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-        # Mock context to simulate flow run (so callbacks are created)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context",
-            Mock(return_value={"flow_run_context": {"foo": "bar"}}),
-        )
-
-        # Mock settings
-        mock_settings = Mock()
-        mock_settings.resolve_profiles_yml.return_value.__enter__ = Mock(
-            return_value="/mock/profiles/dir"
-        )
-        mock_settings.resolve_profiles_yml.return_value.__exit__ = Mock(
-            return_value=None
-        )
-        runner.settings = mock_settings
-
-        # Call invoke with 'build' command
-        runner.invoke(["build"])
-
-        # Verify _create_node_finished_callback was called with add_test_edges=True
-        runner._create_node_finished_callback.assert_called_once()
-        call_args = runner._create_node_finished_callback.call_args
-        assert call_args[1]["add_test_edges"] is True
-
-    def test_runner_loads_graph_with_test_edges_for_retry_build(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner loads graph with test edges when retrying 'build' command."""
-        runner = PrefectDbtRunner()
-
-        # Mock manifest
-        mock_manifest = Mock(spec=Manifest)
-        runner._manifest = mock_manifest
-
-        # Mock _set_graph_from_manifest method
-        mock_set_graph = Mock()
-        monkeypatch.setattr(runner, "_set_graph_from_manifest", mock_set_graph)
-
-        # Mock dbtRunner and successful result
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.exception = None
-
-        mock_dbt_runner_instance = Mock()
-        mock_dbt_runner_instance.invoke.return_value = mock_result
-
-        mock_dbt_runner_class = Mock(return_value=mock_dbt_runner_instance)
-        monkeypatch.setattr("prefect_dbt.core.runner.dbtRunner", mock_dbt_runner_class)
-
-        # Mock the callback methods
-        monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-        # Mock context to simulate flow run (so callbacks are created)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context",
-            Mock(return_value={"flow_run_context": {"foo": "bar"}}),
-        )
-
-        # Mock settings
-        mock_settings = Mock()
-        mock_settings.resolve_profiles_yml.return_value.__enter__ = Mock(
-            return_value="/mock/profiles/dir"
-        )
-        mock_settings.resolve_profiles_yml.return_value.__exit__ = Mock(
-            return_value=None
-        )
-        runner.settings = mock_settings
-
-        # Mock load_result_state to return previous build results
-        mock_previous_results = Mock()
-        mock_previous_results.args = {"which": "build"}
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.load_result_state",
-            Mock(return_value=mock_previous_results),
-        )
-
-        # Mock project_dir and target_path
-        runner._project_dir = Path("/test/project")
-        runner._target_path = Path("target")
-
-        # Call invoke with 'retry' command
-        runner.invoke(["retry"])
-
-        # Verify _create_node_finished_callback was called with add_test_edges=True
-        runner._create_node_finished_callback.assert_called_once()
-        call_args = runner._create_node_finished_callback.call_args
-        assert call_args[1]["add_test_edges"] is True
-
-    def test_runner_does_not_load_test_edges_for_non_build_commands(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner does not load test edges for non-build commands."""
-        runner = PrefectDbtRunner()
-
-        # Mock manifest
-        mock_manifest = Mock(spec=Manifest)
-        runner._manifest = mock_manifest
-
-        # Mock _set_graph_from_manifest method
-        mock_set_graph = Mock()
-        monkeypatch.setattr(runner, "_set_graph_from_manifest", mock_set_graph)
-
-        # Mock dbtRunner and successful result
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.exception = None
-
-        mock_dbt_runner_instance = Mock()
-        mock_dbt_runner_instance.invoke.return_value = mock_result
-
-        mock_dbt_runner_class = Mock(return_value=mock_dbt_runner_instance)
-        monkeypatch.setattr("prefect_dbt.core.runner.dbtRunner", mock_dbt_runner_class)
-
-        # Mock the callback methods
-        monkeypatch.setattr(runner, "_create_logging_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_started_callback", Mock())
-        monkeypatch.setattr(runner, "_create_node_finished_callback", Mock())
-
-        # Mock context to simulate flow run (so callbacks are created)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.serialize_context",
-            Mock(return_value={"flow_run_context": {"foo": "bar"}}),
-        )
-
-        # Mock settings
-        mock_settings = Mock()
-        mock_settings.resolve_profiles_yml.return_value.__enter__ = Mock(
-            return_value="/mock/profiles/dir"
-        )
-        mock_settings.resolve_profiles_yml.return_value.__exit__ = Mock(
-            return_value=None
-        )
-        runner.settings = mock_settings
-
-        # Call invoke with 'run' command (not build)
-        runner.invoke(["run"])
-
-        # Verify _create_node_finished_callback was called with add_test_edges=False
-        runner._create_node_finished_callback.assert_called_once()
-        call_args = runner._create_node_finished_callback.call_args
-        assert call_args[1]["add_test_edges"] is False
-
-    def test_runner_handles_retry_without_previous_results(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner handles retry when no previous results exist."""
-        runner = PrefectDbtRunner()
-
-        # Mock project_dir and target_path
-        runner._project_dir = Path("/test/project")
-        runner._target_path = Path("target")
-
-        # Mock load_result_state to return None (no previous results)
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.load_result_state", Mock(return_value=None)
-        )
-
-        # Call invoke with 'retry' command
         with pytest.raises(ValueError, match="Cannot retry. No previous results found"):
             runner.invoke(["retry"])
 
-    def test_runner_node_finished_callback_rebuilds_graph_with_test_edges(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that the node finished callback rebuilds graph with test edges when needed."""
-        runner = PrefectDbtRunner()
-
-        # Mock _set_graph_from_manifest method
-        mock_set_graph = Mock()
-        monkeypatch.setattr(runner, "_set_graph_from_manifest", mock_set_graph)
-
-        # Mock graph with get_dependent_nodes method
-        mock_graph = Mock()
-        mock_graph.get_dependent_nodes.return_value = ["dep1", "dep2"]
-        runner._graph = mock_graph
-
-        # Create task state
-        task_state = Mock()
-
-        # Create callback with add_test_edges=True
-        callback = runner._create_node_finished_callback(
-            task_state, add_test_edges=True
-        )
-
-        # Create mock event for failed node
-        mock_event = Mock()
-        mock_event.info.name = "NodeFinished"
-        mock_event.data.node_info.unique_id = "test_node"
-
-        # Mock MessageToDict to return event data with failed status
-        mock_event_data = {"node_info": {"node_status": "error"}}
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.MessageToDict", Mock(return_value=mock_event_data)
-        )
-
-        # Mock get_dbt_event_msg
-        monkeypatch.setattr(
-            runner, "get_dbt_event_msg", Mock(return_value="Node failed")
-        )
-
-        # Mock _get_manifest_node_and_config to return a node
-        mock_node = Mock()
-        monkeypatch.setattr(
-            runner, "_get_manifest_node_and_config", Mock(return_value=(mock_node, {}))
-        )
-
-        # Call the callback
-        callback(mock_event)
-
-        # Verify graph was rebuilt with test edges
-        mock_set_graph.assert_called_once_with(add_test_edges=True)
-
-        # Verify dependent nodes were added to skipped nodes
-        assert "dep1" in runner._skipped_nodes
-        assert "dep2" in runner._skipped_nodes
-
-    def test_runner_does_not_create_tasks_for_skipped_nodes(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that runner does not create tasks for nodes that are marked as skipped."""
-        runner = PrefectDbtRunner()
-
-        # Add a node to the skipped nodes set
-        skipped_node_id = "skipped_node"
-        runner._skipped_nodes.add(skipped_node_id)
-
-        # Create task state
-        task_state = Mock()
-
-        # Create the node started callback
-        callback = runner._create_node_started_callback(task_state, {})
-
-        # Create mock event for the skipped node
-        mock_event = Mock()
-        mock_event.info.name = "NodeStart"
-        mock_event.data.node_info.unique_id = skipped_node_id
-
-        # Mock _get_manifest_node_and_config to return a node (should not be called)
-        mock_node = Mock()
-        mock_get_config = Mock(return_value=(mock_node, {}))
-        monkeypatch.setattr(runner, "_get_manifest_node_and_config", mock_get_config)
-
-        # Mock _call_task (should not be called)
-        mock_call_task = Mock()
-        monkeypatch.setattr(runner, "_call_task", mock_call_task)
-
-        # Call the callback
-        callback(mock_event)
-
-        # Verify that _get_manifest_node_and_config was not called
-        mock_get_config.assert_not_called()
-
-        # Verify that _call_task was not called
-        mock_call_task.assert_not_called()
-
 
 class TestExecuteDbtNode:
-    """Test cases focusing on execute_dbt_node behavior."""
+    """Test the execute_dbt_node function."""
 
-    def test_execute_dbt_node_completes_successfully(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_execute_dbt_node_completes_successfully(self, mock_task_state):
         """Test that execute_dbt_node completes successfully."""
-        task_state = Mock()
-        node_id = "test_node"
+        node_id = "model.test_project.test_model"
         asset_id = "test_asset"
 
         # Mock successful completion
-        task_state.get_node_status.return_value = {
-            "event_data": {"node_info": {"node_status": RunStatus.Success}}
+        mock_task_state.get_node_status.return_value = {
+            "event_data": {"node_info": {"node_status": "success"}}
         }
 
-        mock_logger = Mock()
-        monkeypatch.setattr(
-            "prefect_dbt.core.runner.get_run_logger", Mock(return_value=mock_logger)
-        )
+        execute_dbt_node(mock_task_state, node_id, asset_id)
 
-        execute_dbt_node(task_state, node_id, asset_id)
+        mock_task_state.wait_for_node_completion.assert_called_once_with(node_id)
+        mock_task_state.get_node_status.assert_called_once_with(node_id)
 
-        # Verify expected interactions
-        task_state.wait_for_node_completion.assert_called_once_with(node_id)
-        task_state.get_node_status.assert_called_once_with(node_id)
-
-    def test_execute_dbt_node_handles_failure_status(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test that execute_dbt_node handles failure status correctly."""
-        task_state = Mock()
-        node_id = "test_node"
+    def test_execute_dbt_node_handles_failure_status(self, mock_task_state):
+        """Test that execute_dbt_node handles failure status."""
+        node_id = "model.test_project.test_model"
         asset_id = "test_asset"
 
         # Mock failure status
-        task_state.get_node_status.return_value = {
-            "event_data": {"node_info": {"node_status": RunStatus.Error}}
+        mock_task_state.get_node_status.return_value = {
+            "event_data": {"node_info": {"node_status": "error"}}
         }
 
-        monkeypatch.setattr("prefect_dbt.core.runner.get_run_logger", Mock())
+        with pytest.raises(Exception, match="Node .* finished with status error"):
+            execute_dbt_node(mock_task_state, node_id, asset_id)
 
-        with pytest.raises(
-            Exception, match="Node test_node finished with status error"
-        ):
-            execute_dbt_node(task_state, node_id, asset_id)
-
-    def test_execute_dbt_node_handles_no_status(self, monkeypatch: pytest.MonkeyPatch):
-        """Test that execute_dbt_node handles missing status gracefully."""
-        task_state = Mock()
-        node_id = "test_node"
+    def test_execute_dbt_node_handles_no_status(self, mock_task_state):
+        """Test that execute_dbt_node handles missing status."""
+        node_id = "model.test_project.test_model"
         asset_id = "test_asset"
 
-        # Mock no status returned
-        task_state.get_node_status.return_value = None
+        # Mock no status
+        mock_task_state.get_node_status.return_value = None
 
-        monkeypatch.setattr("prefect_dbt.core.runner.get_run_logger", Mock())
+        execute_dbt_node(mock_task_state, node_id, asset_id)
 
-        execute_dbt_node(task_state, node_id, asset_id)
+        # Should complete without error when no status is available
+        mock_task_state.wait_for_node_completion.assert_called_once_with(node_id)
 
-        # Verify function completes without error
-        task_state.wait_for_node_completion.assert_called_once_with(node_id)
-        task_state.get_node_status.assert_called_once_with(node_id)
-
-    def test_execute_dbt_node_with_asset_context(self, monkeypatch: pytest.MonkeyPatch):
+    def test_execute_dbt_node_with_asset_context(self, mock_task_state):
         """Test that execute_dbt_node works with asset context."""
-        task_state = Mock()
-        node_id = "test_node"
+        node_id = "model.test_project.test_model"
         asset_id = "test_asset"
 
         # Mock successful completion with node info
-        node_info = {"node_status": RunStatus.Success, "name": "test_model"}
-        task_state.get_node_status.return_value = {
-            "event_data": {"node_info": node_info}
+        mock_task_state.get_node_status.return_value = {
+            "event_data": {"node_info": {"node_status": "success", "test_info": "test"}}
         }
 
-        monkeypatch.setattr("prefect_dbt.core.runner.get_run_logger", Mock())
+        with AssetContext() as context:
+            execute_dbt_node(mock_task_state, node_id, asset_id)
 
-        mock_context = Mock()
-        mock_asset_context = Mock()
-        mock_asset_context.get.return_value = mock_context
-        monkeypatch.setattr("prefect_dbt.core.runner.AssetContext", mock_asset_context)
+            # Verify asset metadata was added
+            assert context.asset_metadata == {
+                asset_id: {"node_status": "success", "test_info": "test"}
+            }
 
-        execute_dbt_node(task_state, node_id, asset_id)
 
-        # Verify asset metadata was added
-        mock_context.add_asset_metadata.assert_called_once_with(asset_id, node_info)
+class TestPrefectDbtRunnerAssetCreation:
+    """Test asset creation functionality."""
+
+    def test_create_asset_from_node_creates_asset(self, mock_manifest_node):
+        """Test that assets are created correctly from manifest nodes."""
+        runner = PrefectDbtRunner()
+        adapter_type = "snowflake"
+
+        with patch("prefect_dbt.core.runner.Asset") as mock_asset_class:
+            mock_asset = Mock(spec=Asset)
+            mock_asset_class.return_value = mock_asset
+
+            result = runner._create_asset_from_node(mock_manifest_node, adapter_type)
+
+            assert result == mock_asset
+            mock_asset_class.assert_called_once()
+
+    def test_create_task_options_creates_options(self, mock_manifest_node):
+        """Test that task options are created correctly."""
+        runner = PrefectDbtRunner()
+        upstream_assets = [Mock(spec=Asset)]
+
+        with patch("prefect_dbt.core.runner.TaskOptions") as mock_options_class:
+            mock_options = Mock()
+            mock_options_class.return_value = mock_options
+
+            result = runner._create_task_options(mock_manifest_node, upstream_assets)
+
+            assert result == mock_options
+            mock_options_class.assert_called_once()
+
+
+class TestPrefectDbtRunnerManifestNodeLookup:
+    """Test manifest node lookup functionality."""
+
+    def test_get_manifest_node_and_config_returns_node_and_config(
+        self, mock_manifest, mock_manifest_node
+    ):
+        """Test that manifest node and config are returned correctly."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+        node_id = "model.test_project.test_model"
+
+        mock_manifest.nodes = {node_id: mock_manifest_node}
+
+        result_node, result_config = runner._get_manifest_node_and_config(node_id)
+
+        assert result_node == mock_manifest_node
+        assert result_config == {"materialized": "table"}
+
+    def test_get_manifest_node_and_config_returns_none_for_missing_node(
+        self, mock_manifest
+    ):
+        """Test that None is returned for missing nodes."""
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+        node_id = "model.test_project.missing_model"
+
+        mock_manifest.nodes = {}
+
+        result_node, result_config = runner._get_manifest_node_and_config(node_id)
+
+        assert result_node is None
+        assert result_config == {}

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -3,13 +3,13 @@ Unit tests for PrefectDbtRunner - focusing on outcomes.
 """
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.schemas.results import RunStatus
 from dbt.artifacts.schemas.run import RunExecutionResult
-from dbt.config.project import Project
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ManifestNode
 from dbt_common.events.base_types import EventLevel, EventMsg
@@ -1093,9 +1093,10 @@ class TestPrefectDbtRunner:
         mock_project = Mock()
 
         # Mock Project.from_project_root
+        mock_from_project_root = Mock(return_value=mock_project)
         monkeypatch.setattr(
             "prefect_dbt.core.runner.Project.from_project_root",
-            Mock(return_value=mock_project),
+            mock_from_project_root,
         )
 
         runner = PrefectDbtRunner()
@@ -1105,7 +1106,7 @@ class TestPrefectDbtRunner:
         result = runner.project
 
         assert result == mock_project
-        Project.from_project_root.assert_called_once()
+        mock_from_project_root.assert_called_once()
 
     def test_runner_handles_project_loading_with_settings(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1114,9 +1115,10 @@ class TestPrefectDbtRunner:
         mock_project = Mock()
 
         # Mock Project.from_project_root
+        mock_from_project_root = Mock(return_value=mock_project)
         monkeypatch.setattr(
             "prefect_dbt.core.runner.Project.from_project_root",
-            Mock(return_value=mock_project),
+            mock_from_project_root,
         )
 
         # Create settings with project_dir
@@ -1129,7 +1131,7 @@ class TestPrefectDbtRunner:
         result = runner.project
 
         assert result == mock_project
-        Project.from_project_root.assert_called_once()
+        mock_from_project_root.assert_called_once()
 
     def test_runner_get_compiled_code_path_uses_project_name(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1231,9 +1233,10 @@ class TestPrefectDbtRunner:
         mock_project.project_name = "test_project"
 
         # Mock Project.from_project_root
+        mock_from_project_root = Mock(return_value=mock_project)
         monkeypatch.setattr(
             "prefect_dbt.core.runner.Project.from_project_root",
-            Mock(return_value=mock_project),
+            mock_from_project_root,
         )
 
         # Mock manifest node
@@ -1243,7 +1246,7 @@ class TestPrefectDbtRunner:
         result = runner._get_compiled_code_path(mock_node)
 
         # Should trigger project loading
-        Project.from_project_root.assert_called_once()
+        mock_from_project_root.assert_called_once()
         expected_path = (
             Path("/test/project")
             / "target"
@@ -1424,7 +1427,7 @@ class TestPrefectDbtRunner:
         )
 
         # Mock run_coro_as_sync to return the resolved profiles directly
-        def mock_run_coro(coro):
+        def mock_run_coro(coro) -> Any:
             return mock_resolved_profiles
 
         mock_run_coro_func = Mock(side_effect=mock_run_coro)
@@ -1489,7 +1492,6 @@ class TestExecuteDbtNode:
         execute_dbt_node(task_state, node_id, asset_id)
 
         # Verify expected interactions
-        task_state.set_task_logger.assert_called_once_with(node_id, mock_logger)
         task_state.wait_for_node_completion.assert_called_once_with(node_id)
         task_state.get_node_status.assert_called_once_with(node_id)
 
@@ -1527,7 +1529,6 @@ class TestExecuteDbtNode:
         execute_dbt_node(task_state, node_id, asset_id)
 
         # Verify function completes without error
-        task_state.set_task_logger.assert_called_once()
         task_state.wait_for_node_completion.assert_called_once_with(node_id)
         task_state.get_node_status.assert_called_once_with(node_id)
 

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -9,7 +9,7 @@ import pytest
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.schemas.results import RunStatus
 from dbt.artifacts.schemas.run import RunExecutionResult
-from dbt.config.runtime import RuntimeConfig
+from dbt.config.project import Project
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ManifestNode
 from dbt_common.events.base_types import EventLevel, EventMsg
@@ -1092,9 +1092,9 @@ class TestPrefectDbtRunner:
         """Test that runner can load project successfully."""
         mock_project = Mock()
 
-        # Mock RuntimeConfig.from_args
+        # Mock Project.from_project_root
         monkeypatch.setattr(
-            "prefect_dbt.core.runner.RuntimeConfig.from_args",
+            "prefect_dbt.core.runner.Project.from_project_root",
             Mock(return_value=mock_project),
         )
 
@@ -1105,7 +1105,7 @@ class TestPrefectDbtRunner:
         result = runner.project
 
         assert result == mock_project
-        RuntimeConfig.from_args.assert_called_once_with(Path("/test/project"))
+        Project.from_project_root.assert_called_once()
 
     def test_runner_handles_project_loading_with_settings(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1113,9 +1113,9 @@ class TestPrefectDbtRunner:
         """Test that runner uses settings.project_dir when _project_dir is not set."""
         mock_project = Mock()
 
-        # Mock RuntimeConfig.from_args
+        # Mock Project.from_project_root
         monkeypatch.setattr(
-            "prefect_dbt.core.runner.RuntimeConfig.from_args",
+            "prefect_dbt.core.runner.Project.from_project_root",
             Mock(return_value=mock_project),
         )
 
@@ -1129,7 +1129,7 @@ class TestPrefectDbtRunner:
         result = runner.project
 
         assert result == mock_project
-        RuntimeConfig.from_args.assert_called_once_with(Path("/settings/project"))
+        Project.from_project_root.assert_called_once()
 
     def test_runner_get_compiled_code_path_uses_project_name(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1230,9 +1230,9 @@ class TestPrefectDbtRunner:
         mock_project = Mock()
         mock_project.project_name = "test_project"
 
-        # Mock RuntimeConfig.from_args
+        # Mock Project.from_project_root
         monkeypatch.setattr(
-            "prefect_dbt.core.runner.RuntimeConfig.from_args",
+            "prefect_dbt.core.runner.Project.from_project_root",
             Mock(return_value=mock_project),
         )
 
@@ -1243,7 +1243,7 @@ class TestPrefectDbtRunner:
         result = runner._get_compiled_code_path(mock_node)
 
         # Should trigger project loading
-        RuntimeConfig.from_args.assert_called_once_with(Path("/test/project"))
+        Project.from_project_root.assert_called_once()
         expected_path = (
             Path("/test/project")
             / "target"

--- a/src/integrations/prefect-dbt/tests/core/test_settings.py
+++ b/src/integrations/prefect-dbt/tests/core/test_settings.py
@@ -503,27 +503,3 @@ class TestPrefectDbtSettingsProfilesResolution:
                 "",
                 "{{ prefect.variables.ANOTHER_MISSING }}",
             ]
-
-
-class TestPrefectDbtSettingsEdgeCases:
-    """Test edge cases and error conditions."""
-
-    def test_settings_with_nonexistent_profiles_dir(self):
-        """Test settings behavior with nonexistent profiles directory."""
-        nonexistent_dir = Path("/nonexistent/directory")
-        settings = PrefectDbtSettings(profiles_dir=nonexistent_dir)
-
-        # Should not raise on initialization
-        assert settings.profiles_dir == nonexistent_dir
-
-        # Should raise when trying to load profiles
-        with pytest.raises(ValueError, match="No profiles.yml found"):
-            settings.load_profiles_yml()
-
-    def test_settings_with_empty_profiles_dir(self, temp_profiles_dir: Path):
-        """Test settings behavior with empty profiles directory."""
-        settings = PrefectDbtSettings(profiles_dir=temp_profiles_dir)
-
-        # Should raise when trying to load profiles from empty directory
-        with pytest.raises(ValueError, match="No profiles.yml found"):
-            settings.load_profiles_yml()

--- a/src/integrations/prefect-dbt/tests/core/test_tracker.py
+++ b/src/integrations/prefect-dbt/tests/core/test_tracker.py
@@ -150,15 +150,6 @@ class TestNodeTaskTrackerStatusManagement:
         # Verify event is now set
         assert tracker._node_events[sample_node_id].is_set()
 
-    def test_get_node_status_returns_none_for_unknown_node(self):
-        """Test that get_node_status returns None for unknown nodes."""
-        tracker = NodeTaskTracker()
-        unknown_node_id = "unknown.node"
-
-        status = tracker.get_node_status(unknown_node_id)
-
-        assert status is None
-
 
 class TestNodeTaskTrackerCompletionWaiting:
     """Test node completion waiting functionality."""
@@ -289,31 +280,6 @@ class TestNodeTaskTrackerTaskRunNames:
         # Verify name matches
         assert retrieved_name == task_run_name
         assert tracker._task_run_names[sample_node_id] == task_run_name
-
-
-class TestNodeTaskTrackerUnknownNodeHandling:
-    """Test behavior for unknown nodes across all getter methods."""
-
-    @pytest.mark.parametrize(
-        "method_name,expected_result",
-        [
-            ("get_node_status", None),
-            ("is_node_complete", False),
-            ("get_task_result", None),
-            ("get_node_dependencies", []),
-            ("get_task_run_id", None),
-            ("get_task_run_name", None),
-        ],
-    )
-    def test_unknown_node_handling(self, method_name, expected_result):
-        """Test that all getter methods handle unknown nodes correctly."""
-        tracker = NodeTaskTracker()
-        unknown_node_id = "unknown.node"
-
-        method = getattr(tracker, method_name)
-        result = method(unknown_node_id)
-
-        assert result == expected_result
 
 
 class TestNodeTaskTrackerLogging:

--- a/src/integrations/prefect-dbt/tests/core/test_tracker.py
+++ b/src/integrations/prefect-dbt/tests/core/test_tracker.py
@@ -1,441 +1,642 @@
 """
-Unit tests for NodeTaskTracker - focusing on outcomes.
+Tests for NodeTaskTracker class and related functionality.
 """
 
 import threading
 import time
+from typing import Any, Dict
 from unittest.mock import Mock
+from uuid import UUID
 
 import pytest
 from prefect_dbt.core._tracker import NodeTaskTracker
 
-from prefect._internal.uuid7 import uuid7
-
-
-@pytest.fixture
-def tracker():
-    """Fixture providing a NodeTaskTracker instance."""
-    return NodeTaskTracker()
+from prefect.client.schemas.objects import Flow, State
+from prefect.logging.loggers import PrefectLogAdapter
+from prefect.tasks import Task
 
 
 @pytest.fixture
 def mock_task():
-    """Fixture providing a mock task."""
-    return Mock()
+    """Create a mock Task instance."""
+    task = Mock(spec=Task)
+    task.name = "test_task"
+    return task
+
+
+@pytest.fixture
+def mock_flow():
+    """Create a mock Flow instance."""
+    flow = Mock(spec=Flow)
+    flow.name = "test_flow"
+    return flow
 
 
 @pytest.fixture
 def mock_state():
-    """Fixture providing a mock state."""
-    return Mock()
-
-
-@pytest.fixture
-def mock_context_manager(monkeypatch):
-    """Fixture providing a mock context manager for hydrated_context."""
-    mock_context = Mock()
-    mock_context.__enter__ = Mock()
-    mock_context.__exit__ = Mock()
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.hydrated_context",
-        Mock(return_value=mock_context),
-    )
-    return mock_context
-
-
-@pytest.fixture
-def mock_run_task_sync(monkeypatch, mock_state):
-    """Fixture providing a mock run_task_sync function."""
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.run_task_sync", Mock(return_value=mock_state)
-    )
-    return mock_state
+    """Create a mock State instance."""
+    state = Mock(spec=State)
+    state.id = "test-state-id"
+    return state
 
 
 @pytest.fixture
 def sample_node_id():
-    """Fixture providing a sample node ID."""
-    return "test_node"
+    """Sample node ID for testing."""
+    return "model.test_project.test_model"
 
 
 @pytest.fixture
 def sample_task_run_id():
-    """Fixture providing a sample task run ID."""
-    return uuid7()
+    """Sample task run ID for testing."""
+    return UUID("12345678-1234-5678-9abc-123456789abc")
 
 
 @pytest.fixture
-def sample_parameters():
-    """Fixture providing sample parameters."""
-    return {"param": "value"}
+def sample_event_data():
+    """Sample event data for testing."""
+    return {
+        "node_info": {
+            "unique_id": "model.test_project.test_model",
+            "node_status": "success",
+        },
+        "status": "success",
+    }
 
 
 @pytest.fixture
-def sample_context():
-    """Fixture providing sample context."""
-    return {"context": "data"}
+def sample_flow_run_context():
+    """Sample flow run context for testing."""
+    return {
+        "id": "test-flow-run-id",
+        "name": "test_flow_run",
+    }
 
 
-def test_tracker_manages_node_lifecycle(tracker, sample_node_id, mock_task):
-    """Test that tracker properly manages the complete lifecycle of a node."""
-    # Start the node
-    tracker.start_task(sample_node_id, mock_task)
-    assert not tracker.is_node_complete(sample_node_id)
+class TestNodeTaskTrackerInitialization:
+    """Test NodeTaskTracker initialization and basic functionality."""
 
-    # Set node status (completes the node)
-    event_data = {"status": "success", "node_info": {"node_status": "success"}}
-    tracker.set_node_status(sample_node_id, event_data, "Node completed successfully")
+    def test_initializes_with_empty_state(self):
+        """Test that tracker initializes with empty internal state."""
+        tracker = NodeTaskTracker()
 
-    # Verify node is complete
-    assert tracker.is_node_complete(sample_node_id)
-    status = tracker.get_node_status(sample_node_id)
-    assert status is not None
-    assert status["event_data"] == event_data
-    assert status["event_message"] == "Node completed successfully"
+        # Verify all internal collections are empty by testing public methods
+        assert tracker.get_task_result("unknown") is None
+        assert tracker.get_node_status("unknown") is None
+        assert tracker.is_node_complete("unknown") is False
+        assert tracker.get_node_dependencies("unknown") == []
+        assert tracker.get_task_run_id("unknown") is None
+        assert tracker.get_task_run_name("unknown") is None
 
+    def test_start_task_registers_task_and_creates_event(
+        self, mock_task: Mock, sample_node_id: str
+    ):
+        """Test that start_task properly registers a task and creates completion event."""
+        tracker = NodeTaskTracker()
 
-def test_tracker_handles_multiple_nodes_independently(tracker, mock_task):
-    """Test that tracker can manage multiple nodes without interference."""
-    # Set up two nodes
-    tracker.start_task("node1", mock_task)
-    tracker.start_task("node2", mock_task)
+        tracker.start_task(sample_node_id, mock_task)
 
-    # Complete one node
-    tracker.set_node_status("node1", {"status": "success"}, "Node 1 done")
+        # Verify node is marked as incomplete initially
+        assert tracker.is_node_complete(sample_node_id) is False
 
-    # Verify states are independent
-    assert tracker.is_node_complete("node1") is True
-    assert tracker.is_node_complete("node2") is False
+        # Verify we can wait for completion (indicates event was created)
+        # Start a thread to complete the node
+        def complete_node():
+            time.sleep(0.01)
+            tracker.set_node_status(sample_node_id, {}, "completed")
 
-    # Complete second node
-    tracker.set_node_status("node2", {"status": "running"}, "Node 2 running")
-    assert tracker.is_node_complete("node2") is True
+        thread = threading.Thread(target=complete_node)
+        thread.daemon = True
+        thread.start()
 
-
-def test_tracker_provides_thread_safe_completion_waiting():
-    """Test that tracker provides thread-safe waiting for node completion."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    tracker.start_task(node_id, Mock())
-
-    # Start a thread that will complete the node after a delay
-    def complete_node():
-        time.sleep(0.05)
-        tracker.set_node_status(node_id, {"status": "success"}, "completed")
-
-    thread = threading.Thread(target=complete_node)
-    thread.daemon = True
-    thread.start()
-
-    # Wait for completion from main thread
-    result = tracker.wait_for_node_completion(node_id, timeout=1.0)
-    assert result is True
-    assert tracker.is_node_complete(node_id) is True
+        # Wait for completion
+        result = tracker.wait_for_node_completion(sample_node_id, timeout=0.1)
+        assert result is True
 
 
-def test_tracker_handles_timeout_gracefully():
-    """Test that tracker handles timeout scenarios gracefully."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    tracker.start_task(node_id, Mock())
+class TestNodeTaskTrackerStatusManagement:
+    """Test node status management functionality."""
 
-    # Try to wait for completion with short timeout
-    result = tracker.wait_for_node_completion(node_id, timeout=0.1)
-    assert result is False
-    assert not tracker.is_node_complete(node_id)
+    def test_set_node_status_stores_status_and_marks_complete(
+        self, sample_node_id: str, sample_event_data: Dict[str, Any]
+    ):
+        """Test that set_node_status stores status and marks node as complete."""
+        tracker = NodeTaskTracker()
+        event_message = "Node completed successfully"
+
+        tracker.set_node_status(sample_node_id, sample_event_data, event_message)
+
+        # Verify status is stored
+        stored_status = tracker.get_node_status(sample_node_id)
+        assert stored_status is not None
+        assert stored_status["event_data"] == sample_event_data
+        assert stored_status["event_message"] == event_message
+        # Verify node is marked as complete
+        assert tracker.is_node_complete(sample_node_id) is True
+
+    def test_set_node_status_signals_completion_event(
+        self, sample_node_id, sample_event_data
+    ):
+        """Test that set_node_status signals the completion event."""
+        tracker = NodeTaskTracker()
+        tracker.start_task(sample_node_id, Mock(spec=Task))
+
+        # Verify event is not set initially
+        assert not tracker._node_events[sample_node_id].is_set()
+
+        # Set status
+        tracker.set_node_status(sample_node_id, sample_event_data, "completed")
+
+        # Verify event is now set
+        assert tracker._node_events[sample_node_id].is_set()
+
+    def test_get_node_status_returns_none_for_unknown_node(self):
+        """Test that get_node_status returns None for unknown nodes."""
+        tracker = NodeTaskTracker()
+        unknown_node_id = "unknown.node"
+
+        status = tracker.get_node_status(unknown_node_id)
+
+        assert status is None
 
 
-def test_tracker_manages_task_results():
-    """Test that tracker properly manages task results."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
+class TestNodeTaskTrackerCompletionWaiting:
+    """Test node completion waiting functionality."""
 
-    # Set and retrieve task result
-    mock_result = Mock()
-    tracker.set_task_result(node_id, mock_result)
-    retrieved_result = tracker.get_task_result(node_id)
-    assert retrieved_result == mock_result
-
-    # Test with None result
-    tracker.set_task_result(node_id, None)
-    assert tracker.get_task_result(node_id) is None
-
-
-def test_tracker_manages_dependencies():
-    """Test that tracker properly manages node dependencies."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    dependencies = ["dep1", "dep2", "dep3"]
-
-    # Set dependencies
-    tracker.set_node_dependencies(node_id, dependencies)
-    retrieved_deps = tracker.get_node_dependencies(node_id)
-    assert retrieved_deps == dependencies
-
-    # Test default empty list for unknown node
-    assert tracker.get_node_dependencies("unknown_node") == []
-
-
-def test_tracker_thread_execution_outcomes(
-    tracker,
-    sample_node_id,
-    mock_task,
-    sample_task_run_id,
-    sample_parameters,
-    sample_context,
-    mock_run_task_sync,
-    mock_context_manager,
-):
-    """Test that tracker properly handles thread execution outcomes."""
-    # Mock successful execution is already set up by mock_run_task_sync fixture
-
-    tracker.run_task_in_thread(
-        sample_node_id, mock_task, sample_task_run_id, sample_parameters, sample_context
+    @pytest.mark.parametrize(
+        "timeout,expected_result",
+        [
+            (1.0, True),
+            (None, True),
+        ],
     )
+    def test_wait_for_node_completion_when_complete(
+        self, sample_node_id, sample_event_data, timeout, expected_result
+    ):
+        """Test that wait_for_node_completion returns True when node is already complete."""
+        tracker = NodeTaskTracker()
+        tracker.set_node_status(sample_node_id, sample_event_data, "completed")
 
-    # Wait for thread completion
-    time.sleep(0.2)
+        result = tracker.wait_for_node_completion(sample_node_id, timeout=timeout)
 
-    # Verify result was stored
-    result = tracker.get_task_result(sample_node_id)
-    assert result == mock_run_task_sync
+        assert result == expected_result
+
+    def test_wait_for_node_completion_waits_for_completion(
+        self, sample_node_id, sample_event_data
+    ):
+        """Test that wait_for_node_completion waits for node to complete."""
+        tracker = NodeTaskTracker()
+        tracker.start_task(sample_node_id, Mock(spec=Task))
+
+        # Start a thread that will complete the node after a delay
+        def complete_node():
+            time.sleep(0.05)
+            tracker.set_node_status(sample_node_id, sample_event_data, "completed")
+
+        thread = threading.Thread(target=complete_node)
+        thread.daemon = True
+        thread.start()
+
+        # Wait for completion
+        result = tracker.wait_for_node_completion(sample_node_id, timeout=1.0)
+
+        assert result is True
+        assert tracker.is_node_complete(sample_node_id) is True
 
 
-def test_tracker_handles_execution_with_dependencies(monkeypatch: pytest.MonkeyPatch):
-    """Test that tracker handles execution with dependencies correctly."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    mock_task = Mock()
-    task_run_id = uuid7()
+class TestNodeTaskTrackerTaskResults:
+    """Test task result management functionality."""
 
-    # Set up dependencies with results
-    tracker.set_node_dependencies(node_id, ["dep1", "dep2"])
-    mock_dep_state1 = Mock()
-    mock_dep_state2 = Mock()
-    tracker.set_task_result("dep1", mock_dep_state1)
-    tracker.set_task_result("dep2", mock_dep_state2)
-
-    parameters = {"param": "value"}
-    context = {"context": "data"}
-
-    # Mock execution that should receive dependencies
-    mock_state = Mock()
-
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.run_task_sync", Mock(return_value=mock_state)
+    @pytest.mark.parametrize(
+        "result_value",
+        [
+            Mock(spec=State),
+            None,
+        ],
     )
+    def test_task_result_set_and_get(self, sample_node_id, result_value):
+        """Test that set_task_result stores and get_task_result retrieves the result."""
+        tracker = NodeTaskTracker()
 
-    # Set up context manager mock
-    mock_context = Mock()
-    mock_context.__enter__ = Mock()
-    mock_context.__exit__ = Mock()
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.hydrated_context",
-        Mock(return_value=mock_context),
+        # Set result
+        tracker.set_task_result(sample_node_id, result_value)
+
+        # Get result
+        retrieved_result = tracker.get_task_result(sample_node_id)
+
+        # Verify result matches
+        assert retrieved_result == result_value
+        assert tracker._task_results[sample_node_id] == result_value
+
+
+class TestNodeTaskTrackerDependencies:
+    """Test dependency management functionality."""
+
+    @pytest.mark.parametrize(
+        "dependencies",
+        [
+            ["dep1", "dep2", "dep3"],
+            [],
+        ],
     )
+    def test_node_dependencies_set_and_get(self, sample_node_id, dependencies):
+        """Test that set_node_dependencies stores and get_node_dependencies retrieves dependencies."""
+        tracker = NodeTaskTracker()
 
-    tracker.run_task_in_thread(node_id, mock_task, task_run_id, parameters, context)
+        # Set dependencies
+        tracker.set_node_dependencies(sample_node_id, dependencies)
 
-    # Wait for thread completion
-    time.sleep(0.2)
+        # Get dependencies
+        retrieved_dependencies = tracker.get_node_dependencies(sample_node_id)
 
-    # Verify result was stored
-    result = tracker.get_task_result(node_id)
-    assert result == mock_state
+        # Verify dependencies match
+        assert retrieved_dependencies == dependencies
+        assert tracker._node_dependencies[sample_node_id] == dependencies
 
 
-def test_tracker_handles_execution_failures(monkeypatch: pytest.MonkeyPatch):
-    """Test that tracker properly handles execution failures."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    mock_task = Mock()
-    task_run_id = uuid7()
-    parameters = {"param": "value"}
-    context = {"context": "data"}
+class TestNodeTaskTrackerTaskRunIds:
+    """Test task run ID management functionality."""
 
-    # Mock execution that raises an exception
-    test_exception = Exception("Task execution failed")
+    def test_task_run_id_set_and_get(self, sample_node_id, sample_task_run_id):
+        """Test that set_task_run_id stores and get_task_run_id retrieves the task run ID."""
+        tracker = NodeTaskTracker()
 
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.run_task_sync", Mock(side_effect=test_exception)
+        # Set task run ID
+        tracker.set_task_run_id(sample_node_id, sample_task_run_id)
+
+        # Get task run ID
+        retrieved_id = tracker.get_task_run_id(sample_node_id)
+
+        # Verify ID matches
+        assert retrieved_id == sample_task_run_id
+        assert tracker._task_run_ids[sample_node_id] == sample_task_run_id
+
+
+class TestNodeTaskTrackerTaskRunNames:
+    """Test task run name management functionality."""
+
+    def test_task_run_name_set_and_get(self, sample_node_id):
+        """Test that set_task_run_name stores and get_task_run_name retrieves the task run name."""
+        tracker = NodeTaskTracker()
+        task_run_name = "test_task_run"
+
+        # Set task run name
+        tracker.set_task_run_name(sample_node_id, task_run_name)
+
+        # Get task run name
+        retrieved_name = tracker.get_task_run_name(sample_node_id)
+
+        # Verify name matches
+        assert retrieved_name == task_run_name
+        assert tracker._task_run_names[sample_node_id] == task_run_name
+
+
+class TestNodeTaskTrackerUnknownNodeHandling:
+    """Test behavior for unknown nodes across all getter methods."""
+
+    @pytest.mark.parametrize(
+        "method_name,expected_result",
+        [
+            ("get_node_status", None),
+            ("is_node_complete", False),
+            ("get_task_result", None),
+            ("get_node_dependencies", []),
+            ("get_task_run_id", None),
+            ("get_task_run_name", None),
+        ],
     )
+    def test_unknown_node_handling(self, method_name, expected_result):
+        """Test that all getter methods handle unknown nodes correctly."""
+        tracker = NodeTaskTracker()
+        unknown_node_id = "unknown.node"
 
-    # Set up context manager mock
-    mock_context = Mock()
-    mock_context.__enter__ = Mock()
-    mock_context.__exit__ = Mock()
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.hydrated_context",
-        Mock(return_value=mock_context),
+        method = getattr(tracker, method_name)
+        result = method(unknown_node_id)
+
+        assert result == expected_result
+
+
+class TestNodeTaskTrackerLogging:
+    """Test logging functionality."""
+
+    @pytest.mark.parametrize(
+        "flow_context",
+        [
+            (None, None),
+            ({"id": "test-id", "name": "test_name"}, None),
+            (None, Mock(spec=Flow)),
+            ({"id": "test-flow-run-id", "name": "test_flow_run"}, Mock(spec=Flow)),
+        ],
     )
+    def test_get_task_logger_with_various_contexts(
+        self, sample_node_id, sample_task_run_id, flow_context
+    ):
+        """Test that get_task_logger works with various flow context combinations."""
+        tracker = NodeTaskTracker()
+        tracker.set_task_run_id(sample_node_id, sample_task_run_id)
+        tracker.set_task_run_name(sample_node_id, "test_task_run")
 
-    # The exception should cause the thread to fail, but we can't easily test that
-    # since the exception would be raised in the thread context
-    # Instead, we test that the function can be called without error
-    tracker.run_task_in_thread(node_id, mock_task, task_run_id, parameters, context)
+        flow_run, flow = flow_context
 
-    # Wait for thread completion
-    time.sleep(0.2)
+        # Configure mock flow if present
+        if flow is not None:
+            flow.name = "test_flow"
 
-    # The result should be None since the exception would prevent state from being set
-    result = tracker.get_task_result(node_id)
-    # Note: In the actual implementation, exceptions in threads are not caught
-    # and would cause the thread to fail silently
-    assert result is None
+        logger = tracker.get_task_logger(
+            sample_node_id,
+            flow_run=flow_run,
+            flow=flow,
+        )
+
+        assert isinstance(logger, PrefectLogAdapter)
+        assert logger.extra["task_run_id"] == sample_task_run_id
+        assert logger.extra["task_run_name"] == "test_task_run"
+        assert logger.extra["task_name"] == "execute_dbt_node"
+
+        # Verify flow context
+        if flow_run:
+            assert logger.extra["flow_run_id"] == flow_run["id"]
+            assert logger.extra["flow_run_name"] == flow_run["name"]
+        else:
+            assert logger.extra["flow_run_id"] == "<unknown>"
+            assert logger.extra["flow_run_name"] == "<unknown>"
+
+        if flow:
+            assert logger.extra["flow_name"] == flow.name
+        else:
+            assert logger.extra["flow_name"] == "<unknown>"
+
+    def test_get_task_logger_with_additional_kwargs(
+        self, sample_node_id, sample_task_run_id
+    ):
+        """Test that get_task_logger includes additional kwargs in extra data."""
+        tracker = NodeTaskTracker()
+        tracker.set_task_run_id(sample_node_id, sample_task_run_id)
+
+        logger = tracker.get_task_logger(
+            sample_node_id,
+            custom_key="custom_value",
+            another_key=123,
+        )
+
+        assert logger.extra["custom_key"] == "custom_value"
+        assert logger.extra["another_key"] == 123
+
+    def test_get_task_logger_without_task_run_id(self, sample_node_id):
+        """Test that get_task_logger works without task run ID."""
+        tracker = NodeTaskTracker()
+
+        logger = tracker.get_task_logger(sample_node_id)
+
+        assert logger.extra["task_run_id"] is None
+        assert logger.extra["task_run_name"] is None
 
 
-def test_tracker_handles_no_state_returned(monkeypatch: pytest.MonkeyPatch):
-    """Test that tracker handles cases where no state is returned."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    mock_task = Mock()
-    task_run_id = uuid7()
-    parameters = {"param": "value"}
-    context = {"context": "data"}
+class TestNodeTaskTrackerThreadExecution:
+    """Test thread execution functionality."""
 
-    # Mock execution that returns None
+    @pytest.fixture
+    def mock_thread_execution_setup(self, monkeypatch):
+        """Set up common mocking for thread execution tests."""
+        # Mock run_task_sync
+        mock_run_task = Mock(return_value=Mock(spec=State))
+        monkeypatch.setattr("prefect_dbt.core._tracker.run_task_sync", mock_run_task)
 
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.run_task_sync", Mock(return_value=None)
+        # Mock hydrated_context
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock()
+        mock_context_manager.__exit__ = Mock()
+        monkeypatch.setattr(
+            "prefect_dbt.core._tracker.hydrated_context",
+            Mock(return_value=mock_context_manager),
+        )
+
+        return mock_run_task
+
+    @pytest.mark.parametrize(
+        "return_value,expected_result",
+        [
+            (Mock(spec=State), Mock(spec=State)),
+            (None, None),
+        ],
     )
+    def test_run_task_in_thread_stores_result(
+        self,
+        sample_node_id,
+        mock_task,
+        sample_task_run_id,
+        mock_thread_execution_setup,
+        return_value,
+        expected_result,
+    ):
+        """Test that run_task_in_thread stores the correct result."""
+        tracker = NodeTaskTracker()
+        parameters = {"param": "value"}
+        context = {"context": "data"}
 
-    # Set up context manager mock
-    mock_context = Mock()
-    mock_context.__enter__ = Mock()
-    mock_context.__exit__ = Mock()
-    monkeypatch.setattr(
-        "prefect_dbt.core._tracker.hydrated_context",
-        Mock(return_value=mock_context),
+        # Configure mock to return specified value
+        mock_thread_execution_setup.return_value = return_value
+
+        tracker.run_task_in_thread(
+            sample_node_id, mock_task, sample_task_run_id, parameters, context
+        )
+
+        # Wait for thread to complete
+        time.sleep(0.2)
+
+        # Verify result was stored
+        result = tracker.get_task_result(sample_node_id)
+        if return_value is not None:
+            # For mock objects, just verify it's a mock with the same spec
+            assert isinstance(result, Mock)
+            assert result._spec_class == return_value._spec_class
+        else:
+            assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "dependencies_setup,expected_wait_count",
+        [
+            ({"dep1": Mock(spec=State), "dep2": Mock(spec=State)}, 2),
+            ({"dep1": Mock(spec=State)}, 1),
+            ({}, 0),
+        ],
     )
+    def test_run_task_in_thread_with_dependencies(
+        self,
+        sample_node_id,
+        mock_task,
+        sample_task_run_id,
+        mock_state,
+        mock_thread_execution_setup,
+        dependencies_setup,
+        expected_wait_count,
+    ):
+        """Test that run_task_in_thread handles dependencies correctly."""
+        tracker = NodeTaskTracker()
+        parameters = {"param": "value"}
+        context = {"context": "data"}
 
-    tracker.run_task_in_thread(node_id, mock_task, task_run_id, parameters, context)
+        # Set up dependencies
+        dependencies = list(dependencies_setup.keys())
+        tracker.set_node_dependencies(sample_node_id, dependencies)
 
-    # Wait for thread completion
-    time.sleep(0.2)
+        # Set up dependency results
+        for dep_id, result in dependencies_setup.items():
+            tracker.set_task_result(dep_id, result)
 
-    # Verify None was stored as result
-    result = tracker.get_task_result(node_id)
-    assert result is None
+        # Configure mock
+        mock_thread_execution_setup.return_value = mock_state
 
+        tracker.run_task_in_thread(
+            sample_node_id, mock_task, sample_task_run_id, parameters, context
+        )
 
-def test_get_task_logger_creates_logger_with_task_id():
-    """Test that get_task_logger creates a logger with the correct task ID."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    task_run_id = uuid7()
+        # Wait for thread to complete
+        time.sleep(0.2)
 
-    # Set up task run ID
-    tracker.set_task_run_id(node_id, task_run_id)
-    tracker.set_task_run_name(node_id, "test_task_run")
+        # Verify run_task_sync was called with correct dependencies
+        mock_thread_execution_setup.assert_called_once()
+        call_args = mock_thread_execution_setup.call_args
+        assert len(call_args[1]["wait_for"]) == expected_wait_count
 
-    # Create logger
-    logger = tracker.get_task_logger(node_id)
+    def test_run_task_in_thread_starts_daemon_thread(
+        self, sample_node_id, mock_task, sample_task_run_id, mock_thread_execution_setup
+    ):
+        """Test that run_task_in_thread starts a daemon thread."""
+        tracker = NodeTaskTracker()
+        parameters = {"param": "value"}
+        context = {"context": "data"}
 
-    # Verify logger has correct task run ID
-    assert logger.extra["task_run_id"] == task_run_id
-    assert logger.extra["task_run_name"] == "test_task_run"
-    assert logger.extra["task_name"] == "execute_dbt_node"
+        tracker.run_task_in_thread(
+            sample_node_id, mock_task, sample_task_run_id, parameters, context
+        )
 
+        # Wait for thread to start and potentially complete
+        time.sleep(0.1)
 
-def test_get_task_logger_with_flow_context():
-    """Test that get_task_logger includes flow context when provided."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    task_run_id = uuid7()
-
-    tracker.set_task_run_id(node_id, task_run_id)
-    tracker.set_task_run_name(node_id, "test_task_run")
-
-    flow_run = {"id": "flow-run-123", "name": "test_flow_run"}
-    flow = Mock()
-    flow.name = "test_flow"
-
-    logger = tracker.get_task_logger(node_id, flow_run=flow_run, flow=flow)
-
-    assert logger.extra["flow_run_id"] == "flow-run-123"
-    assert logger.extra["flow_run_name"] == "test_flow_run"
-    assert logger.extra["flow_name"] == "test_flow"
-
-
-def test_task_id_tracking():
-    """Test that task run IDs and names are properly tracked."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
-    task_run_id = uuid7()
-    task_run_name = "my_task_run"
-
-    # Initially no task run ID should be set
-    assert tracker.get_task_run_id(node_id) is None
-    assert tracker.get_task_run_name(node_id) is None
-
-    # Set task run ID and name
-    tracker.set_task_run_id(node_id, task_run_id)
-    tracker.set_task_run_name(node_id, task_run_name)
-
-    # Verify they are stored correctly
-    assert tracker.get_task_run_id(node_id) == task_run_id
-    assert tracker.get_task_run_name(node_id) == task_run_name
+        # Verify run_task_sync was called
+        mock_thread_execution_setup.assert_called_once()
 
 
-def test_task_run_name_tracking():
-    """Test that task run names are properly tracked and updated."""
-    tracker = NodeTaskTracker()
-    node_id = "test_node"
+class TestNodeTaskTrackerIntegration:
+    """Test integration scenarios and complex workflows."""
 
-    # Initially no task run name should be set
-    assert tracker.get_task_run_name(node_id) is None
+    def test_comprehensive_workflow_with_multiple_nodes(self):
+        """Test a comprehensive workflow with multiple nodes and dependencies."""
+        tracker = NodeTaskTracker()
 
-    # Set initial task run name
-    initial_name = "initial_task_run"
-    tracker.set_task_run_name(node_id, initial_name)
-    assert tracker.get_task_run_name(node_id) == initial_name
+        # Set up multiple nodes
+        nodes = ["model_1", "model_2", "model_3"]
+        mock_tasks = {node: Mock(spec=Task) for node in nodes}
 
-    # Update task run name
-    updated_name = "updated_task_run"
-    tracker.set_task_run_name(node_id, updated_name)
-    assert tracker.get_task_run_name(node_id) == updated_name
+        # Start all nodes
+        for node in nodes:
+            tracker.start_task(node, mock_tasks[node])
 
-    # Test with different node
-    other_node = "other_node"
-    other_name = "other_task_run"
-    tracker.set_task_run_name(other_node, other_name)
-    assert tracker.get_task_run_name(other_node) == other_name
-    assert tracker.get_task_run_name(node_id) == updated_name  # Original unchanged
+        # Set up dependencies: model_3 depends on model_1 and model_2
+        tracker.set_node_dependencies("model_3", ["model_1", "model_2"])
 
+        # Complete model_1 and model_2
+        tracker.set_node_status("model_1", {"status": "success"}, "Model 1 complete")
+        tracker.set_node_status("model_2", {"status": "success"}, "Model 2 complete")
 
-def test_tracker_comprehensive_workflow() -> None:
-    """Test a comprehensive workflow using the tracker."""
-    tracker = NodeTaskTracker()
+        # Set task results for dependencies
+        tracker.set_task_result("model_1", Mock(spec=State))
+        tracker.set_task_result("model_2", Mock(spec=State))
 
-    # Set up a complex scenario with multiple nodes and dependencies
-    nodes = ["model_1", "model_2", "model_3"]
-    mock_tasks = {node: Mock() for node in nodes}
+        # Verify all nodes are in expected states
+        assert tracker.is_node_complete("model_1") is True
+        assert tracker.is_node_complete("model_2") is True
+        assert tracker.is_node_complete("model_3") is False
 
-    # Start all nodes
-    for node in nodes:
-        tracker.start_task(node, mock_tasks[node])
+        # Verify dependencies are correctly stored
+        deps = tracker.get_node_dependencies("model_3")
+        assert deps == ["model_1", "model_2"]
 
-    # Set up dependencies: model_3 depends on model_1 and model_2
-    tracker.set_node_dependencies("model_3", ["model_1", "model_2"])
+        # Verify loggers are available
+        assert tracker.get_task_logger("model_1") is not None
+        assert tracker.get_task_logger("model_2") is not None
+        assert tracker.get_task_logger("model_3") is not None
 
-    # Complete model_1 and model_2
-    tracker.set_node_status("model_1", {"status": "success"}, "Model 1 complete")
-    tracker.set_node_status("model_2", {"status": "success"}, "Model 2 complete")
+    def test_concurrent_node_completion(self):
+        """Test that multiple nodes can complete concurrently."""
+        tracker = NodeTaskTracker()
+        nodes = ["node_1", "node_2", "node_3"]
 
-    # Set task results for dependencies
-    tracker.set_task_result("model_1", Mock())
-    tracker.set_task_result("model_2", Mock())
+        # Start all nodes
+        for node in nodes:
+            tracker.start_task(node, Mock(spec=Task))
 
-    # Verify all nodes are in expected states
-    assert tracker.is_node_complete("model_1") is True
-    assert tracker.is_node_complete("model_2") is True
-    assert tracker.is_node_complete("model_3") is False
+        # Complete nodes concurrently
+        def complete_node(node_id: str, delay: float):
+            time.sleep(delay)
+            tracker.set_node_status(
+                node_id, {"status": "success"}, f"{node_id} complete"
+            )
 
-    # Verify dependencies are correctly stored
-    deps = tracker.get_node_dependencies("model_3")
-    assert deps == ["model_1", "model_2"]
+        threads = []
+        for i, node in enumerate(nodes):
+            thread = threading.Thread(target=complete_node, args=(node, i * 0.05))
+            thread.daemon = True
+            threads.append(thread)
+            thread.start()
 
-    # Verify loggers are available
-    assert tracker.get_task_logger("model_1") is not None
-    assert tracker.get_task_logger("model_2") is not None
-    assert tracker.get_task_logger("model_3") is not None
+        # Wait for all nodes to complete
+        for node in nodes:
+            assert tracker.wait_for_node_completion(node, timeout=1.0) is True
+            assert tracker.is_node_complete(node) is True
+
+        # Wait for all threads to finish
+        for thread in threads:
+            thread.join(timeout=1.0)
+
+    def test_node_lifecycle_with_task_execution(
+        self, sample_node_id, mock_task, sample_task_run_id, mock_state, monkeypatch
+    ):
+        """Test complete node lifecycle including task execution."""
+        tracker = NodeTaskTracker()
+
+        # Mock run_task_sync
+        monkeypatch.setattr(
+            "prefect_dbt.core._tracker.run_task_sync", Mock(return_value=mock_state)
+        )
+
+        # Mock hydrated_context
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock()
+        mock_context_manager.__exit__ = Mock()
+        monkeypatch.setattr(
+            "prefect_dbt.core._tracker.hydrated_context",
+            Mock(return_value=mock_context_manager),
+        )
+
+        # Start the node
+        tracker.start_task(sample_node_id, mock_task)
+        assert not tracker.is_node_complete(sample_node_id)
+
+        # Set up task run ID and name
+        tracker.set_task_run_id(sample_node_id, sample_task_run_id)
+        tracker.set_task_run_name(sample_node_id, "test_task_run")
+
+        # Run task in thread
+        parameters = {"param": "value"}
+        context = {"context": "data"}
+        tracker.run_task_in_thread(
+            sample_node_id, mock_task, sample_task_run_id, parameters, context
+        )
+
+        # Wait for task to complete
+        time.sleep(0.2)
+
+        # Verify task result was stored
+        result = tracker.get_task_result(sample_node_id)
+        assert result == mock_state
+
+        # Complete the node
+        tracker.set_node_status(sample_node_id, {"status": "success"}, "completed")
+        assert tracker.is_node_complete(sample_node_id) is True
+
+        # Verify logger has correct information
+        logger = tracker.get_task_logger(sample_node_id)
+        assert logger.extra["task_run_id"] == sample_task_run_id
+        assert logger.extra["task_run_name"] == "test_task_run"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Closes #18430

This PR makes a number of improvements and fixes to `prefect-dbt` intended for inclusion in `prefect-dbt==0.7.2`:
- Fixes resolution of templated Prefect blocks and Prefect variables in `profiles.yml`
- Fixes a logging race condition, ensuring all logs about a node are associated with their corresponding Prefect task run
- Prevents skipped nodes from getting task runs so skipped nodes don't give a false impression that they ran, and don't create or update assets. Includes children of nodes whose tests fail if using or retrying the `build` command

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
