### PR TITLE
Migrate LocalFileSystem from sync_compatible to async_dispatch

### DIFF
--- a/src/prefect/_internal/compatibility/async_dispatch.py
+++ b/src/prefect/_internal/compatibility/async_dispatch.py
@@ -93,6 +93,9 @@ def async_dispatch(
             fn = sync_fn if should_run_sync else async_impl
             return fn(*args, **kwargs)
 
+        # Add the .aio attribute for compatibility with existing code that expects it
+        # (e.g., CLI commands, tests that mock .aio)
+        wrapper.aio = async_impl  # type: ignore
         return wrapper
 
     return decorator

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -107,7 +107,7 @@ async def test_graceful_retries_reraise_last_error_while_retrieving_missing_resu
     now = time.monotonic()
     with pytest.raises(FileNotFoundError):
         with mock.patch(
-            "prefect.filesystems.LocalFileSystem.read_path.aio",
+            "prefect.filesystems.LocalFileSystem.aread_path",
             new=mock.AsyncMock(
                 side_effect=[
                     OSError,
@@ -147,7 +147,7 @@ async def test_graceful_retries_eventually_succeed_while(
     # even if it misses a couple times, it will eventually return the data
     now = time.monotonic()
     with mock.patch(
-        "prefect.filesystems.LocalFileSystem.read_path.aio",
+        "prefect.filesystems.LocalFileSystem.aread_path",
         new=mock.AsyncMock(
             side_effect=[
                 FileNotFoundError,


### PR DESCRIPTION
Part of #15008

## Summary
This PR migrates `LocalFileSystem` methods from using the `sync_compatible` decorator to the new `async_dispatch` pattern.

## Changes
- Replaced `sync_compatible` with `async_dispatch` for all LocalFileSystem methods
- Created explicit async versions with 'a' prefix (e.g., `aget_directory`, `aput_directory`)
- Implemented native sync versions that don't rely on wrapping async code
- Updated sync implementations to avoid async dependencies like `_get_ignore_func`

## Methods migrated
- `get_directory` → `aget_directory` (async) + `get_directory` (sync)
- `put_directory` → `aput_directory` (async) + `put_directory` (sync)
- `read_path` → `aread_path` (async) + `read_path` (sync)
- `write_path` → `awrite_path` (async) + `write_path` (sync)

## Test plan
- [x] All existing LocalFileSystem tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)