### PR TITLE
Migrate RemoteFileSystem from sync_compatible to async_dispatch

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -10,6 +10,7 @@ import anyio
 import fsspec
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
+from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.schemas.validators import (
     stringify_path,
     validate_basepath,
@@ -306,8 +307,32 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         return f"{self.basepath.rstrip('/')}/{urlpath.lstrip('/')}"
 
-    @sync_compatible
-    async def get_directory(
+    async def aget_directory(
+        self, from_path: Optional[str] = None, local_path: Optional[str] = None
+    ) -> None:
+        """
+        Downloads a directory from a given remote path to a local directory.
+
+        Defaults to downloading the entire contents of the block's basepath to the current working directory.
+        """
+        if from_path is None:
+            from_path = str(self.basepath)
+        else:
+            from_path = self._resolve_path(from_path)
+
+        if local_path is None:
+            local_path = Path(".").absolute()
+
+        # validate that from_path has a trailing slash for proper fsspec behavior across versions
+        if not from_path.endswith("/"):
+            from_path += "/"
+
+        return await run_sync_in_worker_thread(
+            self.filesystem.get, from_path, local_path, recursive=True
+        )
+
+    @async_dispatch(aget_directory)
+    def get_directory(
         self, from_path: Optional[str] = None, local_path: Optional[str] = None
     ) -> None:
         """
@@ -329,8 +354,68 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         return self.filesystem.get(from_path, local_path, recursive=True)
 
-    @sync_compatible
-    async def put_directory(
+    async def aput_directory(
+        self,
+        local_path: Optional[str] = None,
+        to_path: Optional[str] = None,
+        ignore_file: Optional[str] = None,
+        overwrite: bool = True,
+    ) -> int:
+        """
+        Uploads a directory from a given local path to a remote directory.
+
+        Defaults to uploading the entire contents of the current working directory to the block's basepath.
+        """
+        if to_path is None:
+            to_path = str(self.basepath)
+        else:
+            to_path = self._resolve_path(to_path)
+
+        if local_path is None:
+            local_path = "."
+
+        included_files = None
+        if ignore_file:
+            with open(ignore_file) as f:
+                ignore_patterns = f.readlines()
+
+            included_files = filter_files(
+                local_path, ignore_patterns, include_dirs=True
+            )
+
+        async def _put_files():
+            counter = 0
+            for f in Path(local_path).rglob("*"):
+                relative_path = f.relative_to(local_path)
+                if included_files and str(relative_path) not in included_files:
+                    continue
+
+                if to_path.endswith("/"):
+                    fpath = to_path + relative_path.as_posix()
+                else:
+                    fpath = to_path + "/" + relative_path.as_posix()
+
+                if f.is_dir():
+                    pass
+                else:
+                    f = f.as_posix()
+                    if overwrite:
+                        await run_sync_in_worker_thread(
+                            self.filesystem.put_file, f, fpath, overwrite=True
+                        )
+                    else:
+                        await run_sync_in_worker_thread(
+                            self.filesystem.put_file, f, fpath
+                        )
+
+                    counter += 1
+
+            return counter
+
+        return await _put_files()
+
+    @async_dispatch(aput_directory)
+    def put_directory(
         self,
         local_path: Optional[str] = None,
         to_path: Optional[str] = None,
@@ -383,8 +468,7 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         return counter
 
-    @sync_compatible
-    async def read_path(self, path: str) -> bytes:
+    async def aread_path(self, path: str) -> bytes:
         path = self._resolve_path(path)
 
         with self.filesystem.open(path, "rb") as file:
@@ -392,15 +476,36 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         return content
 
-    @sync_compatible
-    async def write_path(self, path: str, content: bytes) -> str:
+    @async_dispatch(aread_path)
+    def read_path(self, path: str) -> bytes:
+        path = self._resolve_path(path)
+
+        with self.filesystem.open(path, "rb") as file:
+            content = file.read()
+
+        return content
+
+    async def awrite_path(self, path: str, content: bytes) -> str:
+        path = self._resolve_path(path)
+        dirpath = path[: path.rindex("/")]
+
+        await run_sync_in_worker_thread(
+            self.filesystem.makedirs, dirpath, exist_ok=True
+        )
+
+        with self.filesystem.open(path, "wb") as file:
+            await run_sync_in_worker_thread(file.write, content)
+        return path
+
+    @async_dispatch(awrite_path)
+    def write_path(self, path: str, content: bytes) -> str:
         path = self._resolve_path(path)
         dirpath = path[: path.rindex("/")]
 
         self.filesystem.makedirs(dirpath, exist_ok=True)
 
         with self.filesystem.open(path, "wb") as file:
-            await run_sync_in_worker_thread(file.write, content)
+            file.write(content)
         return path
 
     @property


### PR DESCRIPTION
Part of #15008

## Summary
This PR migrates `RemoteFileSystem` methods from using the `sync_compatible` decorator to the new `async_dispatch` pattern.

## Changes
- Replaced `sync_compatible` with `async_dispatch` for all RemoteFileSystem methods
- Created explicit async versions with 'a' prefix (e.g., `aget_directory`, `aput_directory`)
- Implemented native sync versions that don't rely on wrapping async code
- Properly handled async filesystem operations using `run_sync_in_worker_thread` where needed

## Methods migrated
- `get_directory` → `aget_directory` (async) + `get_directory` (sync)
- `put_directory` → `aput_directory` (async) + `put_directory` (sync)
- `read_path` → `aread_path` (async) + `read_path` (sync)
- `write_path` → `awrite_path` (async) + `write_path` (sync)

## Test plan
- [x] All existing RemoteFileSystem tests pass (22 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)