### PR TITLE
Update Slack footer link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1411,7 +1411,7 @@
     "socials": {
       "github": "https://github.com/PrefectHQ/prefect",
       "linkedin": "https://www.linkedin.com/company/prefect/mycompany/",
-      "slack": "https://communityinviter.com/apps/prefect-community/prefect-community",
+      "slack": "https://prefect.io/slack",
       "twitter": "https://x.com/prefectio",
       "youtube": "https://www.youtube.com/c/PrefectIO"
     }


### PR DESCRIPTION
Use redirect on Prefect website to access the invite page.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

Replace Community Inviter link for Slack Community. `prefect.io/slack` is a 301 redirect to the Slack invite page and managed inside the website repo.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
