### PR TITLE
fail loudly if we cant connect to custom dask cluster

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -353,10 +353,9 @@ class DaskTaskRunner(TaskRunner):
                     self._connect_to = self._cluster = self._exit_stack.enter_context(
                         class_to_instantiate(**self.cluster_kwargs)
                     )
-                except Exception as e:
+                except Exception:
                     self.logger.error(
-                        f"Failed to create {cluster_name} cluster: "
-                        f"{type(e).__name__}: {str(e)}"
+                        f"Failed to create {cluster_name} cluster: ", exc_info=True
                     )
                     raise
 

--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -358,17 +358,7 @@ class DaskTaskRunner(TaskRunner):
                         f"Failed to create {cluster_name} cluster: "
                         f"{type(e).__name__}: {str(e)}"
                     )
-
-                    # If not LocalCluster, try falling back
-                    if class_to_instantiate != distributed.LocalCluster:
-                        self.logger.warning(
-                            "Falling back to LocalCluster due to cluster creation failure"
-                        )
-                        self._connect_to = self._cluster = (
-                            self._exit_stack.enter_context(distributed.LocalCluster())
-                        )
-                    else:
-                        raise
+                    raise
 
                 if self.adapt_kwargs:
                     # self._cluster should be non-None here after instantiation


### PR DESCRIPTION
## Summary

This PR adds error logging to the DaskTaskRunner when cluster creation fails. Previously, when a cloud cluster (e.g., FargateCluster) failed to initialize, users would see an error but without clear context about what went wrong.

## Changes

- Added try-except block around cluster instantiation in `DaskTaskRunner.client` property
- Logs the specific error message before re-raising the exception
- Preserves existing behavior (no automatic fallback to LocalCluster)

## Why this matters

Users were confused when trying to use cloud clusters. When `FargateCluster` failed (e.g., due potentially to missing AWS credentials), they would get an error but no clear indication of what went wrong. This change makes debugging much easier by logging exceptions instead of falling back silently

```
ERROR: Failed to create dask_cloudprovider.aws.FargateCluster cluster: RuntimeError: Unable to connect to AWS: No credentials found
```

## Testing

The error logging has been tested with a mock failing cluster class to verify the error messages appear correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)