### PR TITLE
Enhance BitBucket Credentials Block: Support Special Characters in Username and Escape Git URL Credentials

### DIFF
--- a/src/integrations/prefect-bitbucket/prefect_bitbucket/credentials.py
+++ b/src/integrations/prefect-bitbucket/prefect_bitbucket/credentials.py
@@ -69,15 +69,15 @@ class BitBucketCredentials(CredentialsBlock):
 
     @field_validator("username")
     def _validate_username(cls, value: str) -> str:
-        """When username provided, will validate it."""
-        pattern = "^[A-Za-z0-9_-]*$"
+        """Allow common special characters used in Bitbucket usernames, such as email addresses."""
+        pattern = r"^[A-Za-z0-9@._+-]+$"
 
         if not re.match(pattern, value):
             raise ValueError(
-                "Username must be alpha, num, dash and/or underscore only."
+                "Username contains invalid characters. Allowed: letters, numbers, @ . _ + -"
             )
-        if not len(value) <= 30:
-            raise ValueError("Username cannot be longer than 30 chars.")
+        if len(value) > 100:
+            raise ValueError("Username cannot be longer than 100 characters.")
         return value
 
     def get_client(

--- a/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
+++ b/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from shutil import copytree
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Union
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 from pydantic import Field, model_validator
 from typing_extensions import Self
@@ -123,8 +123,11 @@ class BitBucketRepository(ReadableDeploymentStorage):
             username = self.bitbucket_credentials.username
             if username is None:
                 username = "x-token-auth"
+            # Encode special characters in username and token
+            safe_username = quote(username or "")
+            safe_token = quote(token or "")
             updated_components = url_components._replace(
-                netloc=f"{username}:{token}@{url_components.netloc}"
+                netloc=f"{safe_username}:{safe_token}@{url_components.netloc}"
             )
             full_url = urlunparse(updated_components)
         else:

--- a/src/integrations/prefect-bitbucket/tests/test_credentials.py
+++ b/src/integrations/prefect-bitbucket/tests/test_credentials.py
@@ -50,3 +50,11 @@ def test_bitbucket_get_client(client_type):
         assert isinstance(client, Bitbucket)
     else:
         assert isinstance(client, Cloud)
+
+
+def test_bitbucket_username_with_email_passes():
+    """Ensure email-style usernames are accepted."""
+    creds = BitBucketCredentials(
+        token="dummy-token", username="devops.team+ci@scalefocus.com"
+    )
+    assert creds.username == "devops.team+ci@scalefocus.com"

--- a/src/integrations/prefect-bitbucket/tests/test_credentials.py
+++ b/src/integrations/prefect-bitbucket/tests/test_credentials.py
@@ -26,12 +26,11 @@ def test_bitbucket_username_invalid_char():
         BitBucketCredentials(token="token", username="invalid!username")
 
 
-def test_bitbucket_username_over_max_length():
-    """Ensure username of greater than max allowed length raises."""
-    with pytest.raises(ValueError):
-        BitBucketCredentials(
-            token="token", username="usernamethatisoverthirtycharacters"
-        )
+def test_bitbucket_username_at_max_length_passes():
+    """Ensure a username of exactly 100 characters is allowed."""
+    username = "a" * 100
+    creds = BitBucketCredentials(token="token", username=username)
+    assert creds.username == username
 
 
 @pytest.mark.parametrize(

--- a/src/integrations/prefect-bitbucket/tests/test_repository.py
+++ b/src/integrations/prefect-bitbucket/tests/test_repository.py
@@ -275,3 +275,20 @@ class TestBitBucketRepository:
 
                 assert set(os.listdir(tmp_dst)) == set([sub_dir_name])
                 assert set(os.listdir(Path(tmp_dst) / sub_dir_name)) == child_contents
+
+    def test_create_repo_url_escapes_username_and_token(self):
+        """Ensure special characters in username and token are properly escaped."""
+        credentials = BitBucketCredentials(
+            username="devops.team+ci@scalefocus.com", token="p@ss:word#1"
+        )
+
+        block = BitBucketRepository(
+            repository="https://bitbucket.org/my-team/my-repo.git",
+            bitbucket_credentials=credentials,
+        )
+
+        url = block._create_repo_url()
+        assert (
+            url
+            == "https://devops.team%2Bci%40scalefocus.com:p%40ss%3Aword%231@bitbucket.org/my-team/my-repo.git"
+        )


### PR DESCRIPTION
This pull request improves the functionality and flexibility of the BitBucketCredentials block within the Prefect Bitbucket integration by addressing real-world authentication scenarios involving special characters and longer usernames.

### What’s Improved

**1. Expanded Username Validation**
	•Updated the username field to allow special characters commonly used in Bitbucket usernames (such as @, ., _, +, and -).
	•Enables use of email addresses and other valid Bitbucket username formats.

**2. Increased Username Length Limit**
	•Raised the character limit from 30 to 100, supporting long email-based usernames.

**3. Secure Git URL Construction**
	•Properly escapes special characters in username and token using urllib.parse.quote.
	•Ensures safe and valid Git URLs for cloning private repositories.

### 4. Improved Test Coverage
	•Added and updated unit tests to cover:
	•Valid usernames with special characters
	•Invalid usernames
	•Boundary testing for length

### Testing & Compatibility
	•Verified that all updated validators behave as expected.
	•Confirmed block still functions with valid credentials and Git URLs.
	•Note: Skipped check-ui-v2 due to local environment issue with nvm; unrelated to functionality of this PR.

### Related Issue
Closes [#18437]