### PR TITLE
add `prefect automation create` command

### DIFF
--- a/docs/v3/api-ref/cli/artifact.mdx
+++ b/docs/v3/api-ref/cli/artifact.mdx
@@ -132,6 +132,10 @@ View details about an artifact.
     The maximum number of artifacts to return.
 </ResponseField>
 
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
 </Accordion>
 
 </AccordionGroup>

--- a/docs/v3/api-ref/cli/automation.mdx
+++ b/docs/v3/api-ref/cli/automation.mdx
@@ -383,13 +383,13 @@ Delete an automation.
 
 
 ```command
-prefect automation create [OPTIONS] AUTOMATION_SPEC
+prefect automation create [OPTIONS]
 ```
 
 
 
 <Info>
-Create an automation from a YAML or JSON specification.
+Create one or more automations from a file or JSON string.
 </Info>
 
 
@@ -400,12 +400,18 @@ Create an automation from a YAML or JSON specification.
 <AccordionGroup>
 
 
-<Accordion title="Arguments" defaultOpen>
-<ResponseField name="AUTOMATION_SPEC" type="string" required>
-    Path to YAML/JSON file or JSON string defining the automation  \[required]
+
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--from-file">
+    Path to YAML or JSON file containing automation(s)
 </ResponseField>
+
+<ResponseField name="--from-json">
+    JSON string containing automation(s)
+</ResponseField>
+
 </Accordion>
-
-
 
 </AccordionGroup>

--- a/docs/v3/api-ref/cli/automation.mdx
+++ b/docs/v3/api-ref/cli/automation.mdx
@@ -76,7 +76,8 @@ Examples:
 
     \$ prefect automation inspect "my-automation" --yaml
 
-    \$ prefect automation inspect "my-automation" --json
+    \$ prefect automation inspect "my-automation" --output json
+    \$ prefect automation inspect "my-automation" --output yaml
 </Info>
 
 
@@ -107,6 +108,10 @@ Examples:
 
 <ResponseField name="--json">
     Output as JSON
+</ResponseField>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json, yaml
 </ResponseField>
 
 </Accordion>
@@ -368,5 +373,39 @@ Delete an automation.
 </ResponseField>
 
 </Accordion>
+
+</AccordionGroup>
+
+
+
+## `prefect automation create`
+
+
+
+```command
+prefect automation create [OPTIONS] AUTOMATION_SPEC
+```
+
+
+
+<Info>
+Create an automation from a YAML or JSON specification.
+</Info>
+
+
+
+
+
+
+<AccordionGroup>
+
+
+<Accordion title="Arguments" defaultOpen>
+<ResponseField name="AUTOMATION_SPEC" type="string" required>
+    Path to YAML/JSON file or JSON string defining the automation  \[required]
+</ResponseField>
+</Accordion>
+
+
 
 </AccordionGroup>

--- a/docs/v3/api-ref/cli/automations.mdx
+++ b/docs/v3/api-ref/cli/automations.mdx
@@ -383,13 +383,13 @@ Delete an automation.
 
 
 ```command
-prefect automations create [OPTIONS] AUTOMATION_SPEC
+prefect automations create [OPTIONS]
 ```
 
 
 
 <Info>
-Create an automation from a YAML or JSON specification.
+Create one or more automations from a file or JSON string.
 </Info>
 
 
@@ -400,12 +400,18 @@ Create an automation from a YAML or JSON specification.
 <AccordionGroup>
 
 
-<Accordion title="Arguments" defaultOpen>
-<ResponseField name="AUTOMATION_SPEC" type="string" required>
-    Path to YAML/JSON file or JSON string defining the automation  \[required]
+
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--from-file">
+    Path to YAML or JSON file containing automation(s)
 </ResponseField>
+
+<ResponseField name="--from-json">
+    JSON string containing automation(s)
+</ResponseField>
+
 </Accordion>
-
-
 
 </AccordionGroup>

--- a/docs/v3/api-ref/cli/automations.mdx
+++ b/docs/v3/api-ref/cli/automations.mdx
@@ -76,7 +76,8 @@ Examples:
 
     \$ prefect automation inspect "my-automation" --yaml
 
-    \$ prefect automation inspect "my-automation" --json
+    \$ prefect automation inspect "my-automation" --output json
+    \$ prefect automation inspect "my-automation" --output yaml
 </Info>
 
 
@@ -107,6 +108,10 @@ Examples:
 
 <ResponseField name="--json">
     Output as JSON
+</ResponseField>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json, yaml
 </ResponseField>
 
 </Accordion>
@@ -368,5 +373,39 @@ Delete an automation.
 </ResponseField>
 
 </Accordion>
+
+</AccordionGroup>
+
+
+
+## `prefect automations create`
+
+
+
+```command
+prefect automations create [OPTIONS] AUTOMATION_SPEC
+```
+
+
+
+<Info>
+Create an automation from a YAML or JSON specification.
+</Info>
+
+
+
+
+
+
+<AccordionGroup>
+
+
+<Accordion title="Arguments" defaultOpen>
+<ResponseField name="AUTOMATION_SPEC" type="string" required>
+    Path to YAML/JSON file or JSON string defining the automation  \[required]
+</ResponseField>
+</Accordion>
+
+
 
 </AccordionGroup>

--- a/docs/v3/api-ref/cli/concurrency-limit.mdx
+++ b/docs/v3/api-ref/cli/concurrency-limit.mdx
@@ -95,6 +95,14 @@ which are currently using a concurrency slot.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/concurrency-limits.mdx
+++ b/docs/v3/api-ref/cli/concurrency-limits.mdx
@@ -95,6 +95,14 @@ which are currently using a concurrency slot.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/deployment.mdx
+++ b/docs/v3/api-ref/cli/deployment.mdx
@@ -41,6 +41,7 @@ View details about a deployment.
 Example:
     
     \$ prefect deployment inspect "hello-world/my-deployment"
+    \$ prefect deployment inspect "hello-world/my-deployment" --output json
     &#123;
         'id': '610df9c3-0fb4-4856-b330-67f588d20201',
         'created': '2022-08-01T18:36:25.192102+00:00',
@@ -90,6 +91,14 @@ Example:
 </Accordion>
 
 
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
 
 </AccordionGroup>
 
@@ -257,6 +266,10 @@ Examples:
 
 <ResponseField name="--id">
     A deployment id to search for if no name is given
+</ResponseField>
+
+<ResponseField name="--all">
+    Delete all deployments
 </ResponseField>
 
 </Accordion>

--- a/docs/v3/api-ref/cli/deployments.mdx
+++ b/docs/v3/api-ref/cli/deployments.mdx
@@ -41,6 +41,7 @@ View details about a deployment.
 Example:
     
     \$ prefect deployment inspect "hello-world/my-deployment"
+    \$ prefect deployment inspect "hello-world/my-deployment" --output json
     &#123;
         'id': '610df9c3-0fb4-4856-b330-67f588d20201',
         'created': '2022-08-01T18:36:25.192102+00:00',
@@ -90,6 +91,14 @@ Example:
 </Accordion>
 
 
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
 
 </AccordionGroup>
 
@@ -257,6 +266,10 @@ Examples:
 
 <ResponseField name="--id">
     A deployment id to search for if no name is given
+</ResponseField>
+
+<ResponseField name="--all">
+    Delete all deployments
 </ResponseField>
 
 </Accordion>

--- a/docs/v3/api-ref/cli/dev.mdx
+++ b/docs/v3/api-ref/cli/dev.mdx
@@ -242,7 +242,7 @@ Build a docker image for development.
 </ResponseField>
 
 <ResponseField name="--python-version">
-    The Python version to build the container for. Defaults to the version of the host Python. [default: 3.12]
+    The Python version to build the container for. Defaults to the version of the host Python. [default: 3.13]
 </ResponseField>
 
 <ResponseField name="--flavor">
@@ -304,24 +304,3 @@ Run a docker container with local code mounted and installed.
 </Accordion>
 
 </AccordionGroup>
-
-
-
-## `prefect dev kubernetes-manifest`
-
-
-
-```command
-prefect dev kubernetes-manifest [OPTIONS]
-```
-
-
-
-<Info>
-Generates a Kubernetes manifest for development.
-</Info>
-
-
-
-
-

--- a/docs/v3/api-ref/cli/flow-run.mdx
+++ b/docs/v3/api-ref/cli/flow-run.mdx
@@ -54,6 +54,18 @@ View details about a flow run.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--web">
+    Open the flow run in a web browser.
+</ResponseField>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/flow-runs.mdx
+++ b/docs/v3/api-ref/cli/flow-runs.mdx
@@ -54,6 +54,18 @@ View details about a flow run.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--web">
+    Open the flow run in a web browser.
+</ResponseField>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/gcl.mdx
+++ b/docs/v3/api-ref/cli/gcl.mdx
@@ -78,7 +78,7 @@ Inspect a global concurrency limit.
 <Accordion title="Options" defaultOpen>
 
 <ResponseField name="--output">
-    Output format for the command.
+    Specify an output format. Currently supports: json
 </ResponseField>
 
 <ResponseField name="--file">

--- a/docs/v3/api-ref/cli/global-concurrency-limit.mdx
+++ b/docs/v3/api-ref/cli/global-concurrency-limit.mdx
@@ -78,7 +78,7 @@ Inspect a global concurrency limit.
 <Accordion title="Options" defaultOpen>
 
 <ResponseField name="--output">
-    Output format for the command.
+    Specify an output format. Currently supports: json
 </ResponseField>
 
 <ResponseField name="--file">

--- a/docs/v3/api-ref/cli/profile.mdx
+++ b/docs/v3/api-ref/cli/profile.mdx
@@ -222,6 +222,14 @@ Display settings from a given profile; defaults to active.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/profiles.mdx
+++ b/docs/v3/api-ref/cli/profiles.mdx
@@ -222,6 +222,14 @@ Display settings from a given profile; defaults to active.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/task-run.mdx
+++ b/docs/v3/api-ref/cli/task-run.mdx
@@ -54,6 +54,18 @@ View details about a task run.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--web">
+    Open the task run in a web browser.
+</ResponseField>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/task-runs.mdx
+++ b/docs/v3/api-ref/cli/task-runs.mdx
@@ -54,6 +54,18 @@ View details about a task run.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--web">
+    Open the task run in a web browser.
+</ResponseField>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/task.mdx
+++ b/docs/v3/api-ref/cli/task.mdx
@@ -29,7 +29,7 @@ Work with task scheduling.
 
 
 ```command
-prefect task serve [OPTIONS] ENTRYPOINTS...
+prefect task serve [OPTIONS] [ENTRYPOINTS]...
 ```
 
 
@@ -48,14 +48,18 @@ executed in the engine.
 
 
 <Accordion title="Arguments" defaultOpen>
-<ResponseField name="ENTRYPOINTS..." type="string" required>
-    The paths to one or more tasks, in the form of \`./path/to/file.py:task_func_name\`.  \[required]
+<ResponseField name="ENTRYPOINTS..." type="string">
+    The paths to one or more tasks, in the form of \`./path/to/file.py:task_func_name\`.
 </ResponseField>
 </Accordion>
 
 
 
 <Accordion title="Options" defaultOpen>
+
+<ResponseField name="--module">
+    The module(s) to import the tasks from.
+</ResponseField>
 
 <ResponseField name="--limit">
     The maximum number of tasks that can be run concurrently. Defaults to 10.

--- a/docs/v3/api-ref/cli/variable.mdx
+++ b/docs/v3/api-ref/cli/variable.mdx
@@ -90,6 +90,14 @@ View details about a variable.
 
 
 
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
 </AccordionGroup>
 
 

--- a/docs/v3/api-ref/cli/work-pool.mdx
+++ b/docs/v3/api-ref/cli/work-pool.mdx
@@ -157,6 +157,7 @@ Inspect a work pool.
 
 Examples:
     \$ prefect work-pool inspect "my-pool"
+    \$ prefect work-pool inspect "my-pool" --output json
 </Info>
 
 
@@ -174,6 +175,14 @@ Examples:
 </Accordion>
 
 
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
 
 </AccordionGroup>
 
@@ -588,6 +597,240 @@ Examples:
 
 <ResponseField name="-h">
     The number of hours to look ahead; defaults to 1 hour
+</ResponseField>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+
+## `prefect work-pool storage`
+
+
+
+```command
+prefect work-pool storage [OPTIONS] COMMAND [ARGS]...
+```
+
+
+
+<Info>
+EXPERIMENTAL: Manage work pool storage.
+</Info>
+
+
+
+
+
+
+
+
+### `prefect work-pool storage inspect`
+
+
+
+```command
+prefect work-pool storage inspect [OPTIONS] WORK_POOL_NAME
+```
+
+
+
+<Info>
+EXPERIMENTAL: Inspect the storage configuration for a work pool.
+</Info>
+
+
+
+
+
+
+<AccordionGroup>
+
+
+<Accordion title="Arguments" defaultOpen>
+<ResponseField name="WORK_POOL_NAME" type="string" required>
+    The name of the work pool to display storage configuration for.  \[required]
+</ResponseField>
+</Accordion>
+
+
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+
+### `prefect work-pool storage configure`
+
+
+
+```command
+prefect work-pool storage configure [OPTIONS] COMMAND [ARGS]...
+```
+
+
+
+<Info>
+EXPERIMENTAL: Configure work pool storage.
+</Info>
+
+
+
+
+
+
+
+
+#### `prefect work-pool storage configure s3`
+
+
+
+```command
+prefect work-pool storage configure s3 [OPTIONS] WORK_POOL_NAME
+```
+
+
+
+<Info>
+EXPERIMENTAL: Configure AWS S3 storage for a work pool.
+
+
+Examples:
+    \$ prefect work-pool storage configure s3 "my-pool" --bucket my-bucket --aws-credentials-block-name my-credentials
+</Info>
+
+
+
+
+
+
+<AccordionGroup>
+
+
+<Accordion title="Arguments" defaultOpen>
+<ResponseField name="WORK_POOL_NAME" type="string" required>
+    The name of the work pool to configure storage for.  \[required]
+</ResponseField>
+</Accordion>
+
+
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--bucket">
+    The name of the S3 bucket to use.
+</ResponseField>
+
+<ResponseField name="--aws-credentials-block-name">
+    The name of the AWS credentials block to use.
+</ResponseField>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+
+#### `prefect work-pool storage configure gcs`
+
+
+
+```command
+prefect work-pool storage configure gcs [OPTIONS] WORK_POOL_NAME
+```
+
+
+
+<Info>
+EXPERIMENTAL: Configure Google Cloud storage for a work pool.
+
+
+Examples:
+    \$ prefect work-pool storage configure gcs "my-pool" --bucket my-bucket --gcp-credentials-block-name my-credentials
+</Info>
+
+
+
+
+
+
+<AccordionGroup>
+
+
+<Accordion title="Arguments" defaultOpen>
+<ResponseField name="WORK_POOL_NAME" type="string" required>
+    The name of the work pool to configure storage for.  \[required]
+</ResponseField>
+</Accordion>
+
+
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--bucket">
+    The name of the Google Cloud Storage bucket to use.
+</ResponseField>
+
+<ResponseField name="--gcp-credentials-block-name">
+    The name of the Google Cloud credentials block to use.
+</ResponseField>
+
+</Accordion>
+
+</AccordionGroup>
+
+
+
+#### `prefect work-pool storage configure azure-blob-storage`
+
+
+
+```command
+prefect work-pool storage configure azure-blob-storage [OPTIONS] WORK_POOL_NAME
+```
+
+
+
+<Info>
+EXPERIMENTAL: Configure Azure Blob Storage for a work pool.
+
+
+Examples:
+    \$ prefect work-pool storage configure azure-blob-storage "my-pool" --container my-container --azure-blob-storage-credentials-block-name my-credentials
+</Info>
+
+
+
+
+
+
+<AccordionGroup>
+
+
+<Accordion title="Arguments" defaultOpen>
+<ResponseField name="WORK_POOL_NAME" type="string" required>
+    The name of the work pool to configure storage for.  \[required]
+</ResponseField>
+</Accordion>
+
+
+
+<Accordion title="Options" defaultOpen>
+
+<ResponseField name="--container">
+    The name of the Azure Blob Storage container to use.
+</ResponseField>
+
+<ResponseField name="--azure-blob-storage-credentials-block-name">
+    The name of the Azure Blob Storage credentials block to use.
 </ResponseField>
 
 </Accordion>

--- a/docs/v3/api-ref/cli/work-queue.mdx
+++ b/docs/v3/api-ref/cli/work-queue.mdx
@@ -281,6 +281,10 @@ Inspect a work queue by ID.
     The name of the work pool that the work queue belongs to.
 </ResponseField>
 
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
 </Accordion>
 
 </AccordionGroup>

--- a/docs/v3/api-ref/cli/work-queues.mdx
+++ b/docs/v3/api-ref/cli/work-queues.mdx
@@ -281,6 +281,10 @@ Inspect a work queue by ID.
     The name of the work pool that the work queue belongs to.
 </ResponseField>
 
+<ResponseField name="--output">
+    Specify an output format. Currently supports: json
+</ResponseField>
+
 </Accordion>
 
 </AccordionGroup>

--- a/docs/v3/how-to-guides/automations/creating-automations.mdx
+++ b/docs/v3/how-to-guides/automations/creating-automations.mdx
@@ -18,6 +18,36 @@ import { automations } from "/snippets/resource-management/vars.mdx"
 <COMBINED name="automations" hrefTF={automations.tf} hrefAPI={automations.api} hrefCLI={automations.cli} />
 
 
+### Create automations with the CLI
+
+You can create automations from YAML or JSON files using the Prefect CLI:
+
+```bash
+# Create from a YAML file
+prefect automation create automation.yaml
+
+# Create from a JSON file  
+prefect automation create automation.json
+
+# Create from a JSON string
+prefect automation create '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
+```
+
+Here's an example YAML file that creates an automation to cancel long-running flows:
+
+```yaml
+name: Cancel Long Running Flows
+description: Cancels flows running longer than 5 minutes
+enabled: true
+trigger:
+  type: event
+  posture: Reactive
+  match_state_name: RUNNING
+  match_state_duration_s: 300  # 5 minutes
+actions:
+  - type: cancel-flow-run
+```
+
 ### Create automations with the Python SDK
 
 You can create and access any automation with the Python SDK's `Automation` class and its methods.

--- a/docs/v3/how-to-guides/automations/creating-automations.mdx
+++ b/docs/v3/how-to-guides/automations/creating-automations.mdx
@@ -52,7 +52,7 @@ actions:
 
 #### Multiple automations example
 
-You can also create multiple automations at once by using the `automations:` key:
+You can also create multiple automations at once by using the `automations:` key. If any automation fails to create, the command will continue with the remaining automations and report both successes and failures:
 
 ```yaml
 automations:

--- a/docs/v3/how-to-guides/automations/creating-automations.mdx
+++ b/docs/v3/how-to-guides/automations/creating-automations.mdx
@@ -24,13 +24,17 @@ You can create automations from YAML or JSON files using the Prefect CLI:
 
 ```bash
 # Create from a YAML file
-prefect automation create automation.yaml
+prefect automation create --from-file automation.yaml
+# or use the short form
+prefect automation create -f automation.yaml
 
 # Create from a JSON file  
-prefect automation create automation.json
+prefect automation create --from-file automation.json
 
 # Create from a JSON string
-prefect automation create '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
+prefect automation create --from-json '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
+# or use the short form
+prefect automation create -j '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
 ```
 
 #### Single automation example

--- a/docs/v3/how-to-guides/automations/creating-automations.mdx
+++ b/docs/v3/how-to-guides/automations/creating-automations.mdx
@@ -33,6 +33,8 @@ prefect automation create automation.json
 prefect automation create '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
 ```
 
+#### Single automation example
+
 Here's an example YAML file that creates an automation to cancel long-running flows:
 
 ```yaml
@@ -46,6 +48,58 @@ trigger:
   match_state_duration_s: 300  # 5 minutes
 actions:
   - type: cancel-flow-run
+```
+
+#### Multiple automations example
+
+You can also create multiple automations at once by using the `automations:` key:
+
+```yaml
+automations:
+  - name: Cancel Long Running Flows
+    description: Cancels flows running longer than 30 minutes
+    enabled: true
+    trigger:
+      type: event
+      posture: Reactive
+      expect:
+        - prefect.flow-run.Running
+      threshold: 1
+      for_each:
+        - prefect.resource.id
+    actions:
+      - type: cancel-flow-run
+        
+  - name: Notify on Flow Failure
+    description: Send notification when flows fail
+    enabled: true
+    trigger:
+      type: event
+      posture: Reactive
+      expect:
+        - prefect.flow-run.Failed
+      threshold: 1
+    actions:
+      - type: send-notification
+        subject: "Flow Failed: {{ event.resource.name }}"
+        body: "Flow run {{ event.resource.name }} has failed."
+```
+
+Or as a JSON array:
+
+```json
+[
+  {
+    "name": "First Automation",
+    "trigger": {...},
+    "actions": [...]
+  },
+  {
+    "name": "Second Automation", 
+    "trigger": {...},
+    "actions": [...]
+  }
+]
 ```
 
 ### Create automations with the Python SDK

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -715,7 +715,7 @@ def test_creating_automation_validation_error(
     invoke_and_assert(
         ["automations", "create", str(yaml_file)],
         expected_code=1,
-        expected_output_contains=["Failed to create automation:"],
+        expected_output_contains=["Failed to create 1 automation(s):"],
     )
 
     create_automation.assert_not_called()
@@ -764,7 +764,7 @@ def test_creating_multiple_automations_with_automations_key(
         ["automations", "create", str(yaml_file)],
         expected_code=0,
         expected_output_contains=[
-            "Created 2 automations:",
+            "Created 2 automation(s):",
             f"'First Automation' with id {automation_ids[0]}",
             f"'Second Automation' with id {automation_ids[1]}",
         ],
@@ -814,7 +814,7 @@ def test_creating_multiple_automations_as_list(
         ["automations", "create", str(json_file)],
         expected_code=0,
         expected_output_contains=[
-            "Created 2 automations:",
+            "Created 2 automation(s):",
             f"'First Automation' with id {automation_ids[0]}",
             f"'Second Automation' with id {automation_ids[1]}",
         ],

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -823,9 +823,8 @@ def test_creating_multiple_automations_as_list(
     assert create_automation.await_count == 2
 
 
-def test_creating_multiple_automations_rollback_on_error(
+def test_creating_multiple_automations_with_partial_failure(
     create_automation: mock.AsyncMock,
-    delete_automation: mock.AsyncMock,
     tmp_path,
 ):
     # First automation succeeds, second fails
@@ -868,11 +867,11 @@ def test_creating_multiple_automations_rollback_on_error(
         ["automations", "create", str(yaml_file)],
         expected_code=1,
         expected_output_contains=[
-            "Failed to create automation: Validation error",
-            "Rolled back 1 automations that were created",
+            "Failed to create 1 automation(s):",
+            "Bad Automation: Validation error",
+            "Created 1 automation(s):",
+            f"'Good Automation' with id {automation_id}",
         ],
     )
 
-    # Should have tried to create 2, then rolled back 1
     assert create_automation.await_count == 2
-    delete_automation.assert_awaited_once_with(mock.ANY, automation_id)


### PR DESCRIPTION
## Summary

This PR adds a `prefect automation create` command to the CLI, allowing users to create automations programmatically from YAML/JSON files or JSON strings. The command supports creating single or multiple automations at once.

closes #18451

## Implementation Details

- Added `create` command to `src/prefect/events/cli/automations.py`
- Uses explicit `--from-file`/`-f` and `--from-json`/`-j` flags for input
- Auto-detects file format based on extension (.yaml, .yml, .json)
- **Supports multiple automations** via `automations:` key or JSON array
- **No rollback behavior** - continues processing all automations and reports both successes and failures
- Uses existing `AutomationCore` schema validation and `client.create_automation()` method

## Usage

### Single automation

```bash
# Create from YAML file
prefect automation create --from-file automation.yaml
# or use short form
prefect automation create -f automation.yaml

# Create from JSON file
prefect automation create --from-file automation.json

# Create from JSON string
prefect automation create --from-json '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
# or use short form
prefect automation create -j '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
```

### Multiple automations

Create multiple automations at once using the `automations:` key in YAML:

```yaml
automations:
  - name: Cancel Long Running Flows
    description: Cancels flows running longer than 30 minutes
    enabled: true
    trigger:
      type: event
      posture: Reactive
      expect:
        - prefect.flow-run.Running
      threshold: 1
    actions:
      - type: cancel-flow-run
      
  - name: Notify on Failure
    description: Send notification when flows fail
    enabled: true
    trigger:
      type: event
      posture: Reactive
      expect:
        - prefect.flow-run.Failed
      threshold: 1
    actions:
      - type: send-notification
        subject: "Flow Failed"
```

Or as a JSON array:

```json
[
  {
    "name": "First Automation",
    "description": "First automation",
    "enabled": true,
    "trigger": {
      "type": "event",
      "posture": "Reactive",
      "expect": ["test.event"],
      "threshold": 1
    },
    "actions": [{"type": "do-nothing"}]
  },
  {
    "name": "Second Automation",
    "description": "Second automation",
    "enabled": true,
    "trigger": {
      "type": "event",
      "posture": "Reactive",
      "expect": ["test.event2"],
      "threshold": 1
    },
    "actions": [{"type": "do-nothing"}]
  }
]
```

### Partial Failure Handling

When creating multiple automations, if any fail, the command will:
- Continue attempting to create all automations
- Report which automations succeeded with their IDs
- Report which automations failed with error messages
- Exit with code 1 if any failures occurred

## Tests

Added comprehensive test coverage:
- ✅ Creating from YAML file
- ✅ Creating from JSON file  
- ✅ Creating from JSON string
- ✅ Invalid file extension error
- ✅ File not found error
- ✅ Invalid JSON string error
- ✅ No input provided error
- ✅ Both inputs provided error
- ✅ Schema validation error
- ✅ Creating multiple automations with `automations:` key
- ✅ Creating multiple automations as JSON array
- ✅ Partial failure handling (reports both successes and failures)

## Documentation

Updated the automation creation guide to include CLI examples for both single and multiple automations, with a note about partial failure behavior.

## Checklist

- [x] This pull request includes a label categorizing the change e.g. `enhancement`, `fix`, `feature`, `docs`, etc.
- [x] This pull request has been tested manually or has unit tests that cover the changes.
- [x] This pull request includes documentation updates if applicable.