### PR TITLE
Account for null pull steps in CLI

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -379,8 +379,10 @@ class RunnerDeployment(BaseModel):
                     pull_steps = self.storage.to_pull_step()
                     if isinstance(pull_steps, list):
                         create_payload["pull_steps"] = pull_steps
-                    else:
+                    elif pull_steps:
                         create_payload["pull_steps"] = [pull_steps]
+                    else:
+                        create_payload["pull_steps"] = []
                 else:
                     create_payload["pull_steps"] = []
 
@@ -426,7 +428,7 @@ class RunnerDeployment(BaseModel):
 
         if self.storage:
             pull_steps = self.storage.to_pull_step()
-            if not isinstance(pull_steps, list):
+            if pull_steps and not isinstance(pull_steps, list):
                 pull_steps = [pull_steps]
             update_payload["pull_steps"] = pull_steps
         else:


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/17303

In following the code paths it seems like when using docker build steps + running the CLI non-interactively, `pull_steps` could in fact be `None`, which would cause the validation errors in that issue.