### PR TITLE
Update `RetryFailedFlows` orchestration policy to clear retry type on exhausted retries

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -690,6 +690,11 @@ class RetryFailedFlows(FlowRunOrchestrationRule):
         run_count = context.run.run_count
 
         if run_settings.retries is None or run_count > run_settings.retries:
+            # Clear retry type to allow for future infrastructure level retries (e.g. via the UI)
+            updated_policy = context.run.empirical_policy.model_dump()
+            updated_policy["retry_type"] = None
+            context.run.empirical_policy = core.FlowRunPolicy(**updated_policy)
+
             return  # Retry count exceeded, allow transition to failed
 
         scheduled_start_time = now("UTC") + datetime.timedelta(


### PR DESCRIPTION
When initiating a manual retry from the UI after a flow has already performed in-process retries, the flow run will be stuck in `AwaitingRetry` because the retry type will remain set to `in_process`, which will cause the flow run to not be sent to workers. The `HandleFlowTerminalStateTransitions` orchestration policy is supposed to clear the retry type, but the UI forces the state transition, so that orchestration policy isn't run.

These changes fix the bug by clearing the retry type on exhausted retries in the `RetryFailedFlows` orchestration policy.

Closes https://github.com/PrefectHQ/prefect/issues/17913
