### PR TITLE
Improve reliability of integration tests

### DIFF
--- a/integration-tests/test_schedule_statefulness.py
+++ b/integration-tests/test_schedule_statefulness.py
@@ -23,6 +23,7 @@ import pytest
 
 from prefect import flow, get_client
 from prefect.client.schemas.objects import DeploymentSchedule
+from prefect.client.schemas.schedules import CronSchedule
 from prefect.schedules import Cron
 
 
@@ -64,6 +65,10 @@ def test_schedule_statefulness(deployment_name: str):
     print("\nTest case 1: Schedule without slug")
     run_serve_with_schedule(
         serve_kwargs={"name": deployment_name, "schedules": [Cron("0 9 * * *")]}
+    )
+    schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
+    assert any(s.schedule == CronSchedule(cron="0 9 * * *") for s in schedules), (
+        f"Expected schedule to persist: {schedules}"
     )
     run_serve_with_schedule(serve_kwargs={"name": deployment_name, "schedules": []})
     schedules = check_deployment_schedules(f"my-flow/{deployment_name}")

--- a/integration-tests/test_schedule_statefulness.py
+++ b/integration-tests/test_schedule_statefulness.py
@@ -44,7 +44,12 @@ def create_check_handler(
     timeout: int = 2,
 ):
     def handler(signum: int, frame: Any):
-        schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
+        try:
+            schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
+        except Exception as e:
+            print(f"Error checking schedules: {e}")
+            schedules = []
+
         if check_function(schedules) or num_checks <= 0:
             raise KeyboardInterrupt("Simulating user interruption")
         else:

--- a/integration-tests/test_schedule_statefulness.py
+++ b/integration-tests/test_schedule_statefulness.py
@@ -16,7 +16,7 @@ this integration test should
 """
 
 import signal
-from typing import Any
+from typing import Any, Callable
 from uuid import uuid4
 
 import pytest
@@ -24,7 +24,7 @@ import pytest
 from prefect import flow, get_client
 from prefect.client.schemas.objects import DeploymentSchedule
 from prefect.client.schemas.schedules import CronSchedule
-from prefect.schedules import Cron
+from prefect.schedules import Cron, Schedule
 
 
 @pytest.fixture()
@@ -37,17 +37,43 @@ def my_flow():
     print("Hello, world!")
 
 
-def _handler(signum: int, frame: Any):
-    raise KeyboardInterrupt("Simulating user interruption")
+def create_check_handler(
+    deployment_name: str,
+    check_function: Callable[[list[DeploymentSchedule]], bool] = lambda schedules: True,
+    num_checks: int = 5,
+    timeout: int = 2,
+):
+    def handler(signum: int, frame: Any):
+        schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
+        if check_function(schedules) or num_checks <= 0:
+            raise KeyboardInterrupt("Simulating user interruption")
+        else:
+            print(f"Checking {num_checks} more times")
+            signal.signal(
+                signal.SIGALRM,
+                create_check_handler(
+                    deployment_name, check_function, num_checks - 1, timeout
+                ),
+            )
+            signal.alarm(timeout)
+
+    return handler
 
 
 def run_serve_with_schedule(
-    timeout: int = 5, serve_kwargs: dict[str, Any] | None = None
+    deployment_name: str,
+    check_function: Callable[[list[DeploymentSchedule]], bool] = lambda schedules: True,
+    schedules: list[Schedule] | None = None,
+    timeout: int = 2,
+    num_checks: int = 3,
 ):
-    signal.signal(signal.SIGALRM, _handler)
+    signal.signal(
+        signal.SIGALRM,
+        create_check_handler(deployment_name, check_function, num_checks, timeout),
+    )
     signal.alarm(timeout)
     try:
-        my_flow.serve(**(serve_kwargs or {}))
+        my_flow.serve(name=deployment_name, schedules=schedules)
     except KeyboardInterrupt:
         print("Serve interrupted")
     finally:
@@ -64,13 +90,19 @@ def test_schedule_statefulness(deployment_name: str):
     # case 1: Schedule without slug
     print("\nTest case 1: Schedule without slug")
     run_serve_with_schedule(
-        serve_kwargs={"name": deployment_name, "schedules": [Cron("0 9 * * *")]}
+        deployment_name,
+        schedules=[Cron("0 9 * * *")],
+        check_function=lambda schedules: any(
+            s.schedule == CronSchedule(cron="0 9 * * *") for s in schedules
+        ),
     )
     schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
     assert any(s.schedule == CronSchedule(cron="0 9 * * *") for s in schedules), (
         f"Expected schedule to persist: {schedules}"
     )
-    run_serve_with_schedule(serve_kwargs={"name": deployment_name, "schedules": []})
+    run_serve_with_schedule(
+        deployment_name, schedules=[], check_function=lambda schedules: not schedules
+    )
     schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
     assert not schedules, (
         f"Expected no schedules after removing unnamed schedule: {schedules}"
@@ -79,12 +111,13 @@ def test_schedule_statefulness(deployment_name: str):
     # case 2: Schedule with slug
     print("\nTest case 2: Schedule with slug")
     run_serve_with_schedule(
-        serve_kwargs={
-            "name": deployment_name,
-            "schedules": [Cron("0 9 * * *", slug="every-day-at-9am")],
-        }
+        deployment_name,
+        schedules=[Cron("0 9 * * *", slug="every-day-at-9am")],
+        check_function=lambda schedules: any(
+            s.slug == "every-day-at-9am" for s in schedules
+        ),
     )
-    run_serve_with_schedule(serve_kwargs={"schedules": []})
+    run_serve_with_schedule(deployment_name, schedules=[])
     schedules = check_deployment_schedules(f"my-flow/{deployment_name}")
     assert any(s.slug == "every-day-at-9am" for s in schedules), (
         f"Expected named schedule to persist: {schedules}"

--- a/integration-tests/test_schedule_statefulness.py
+++ b/integration-tests/test_schedule_statefulness.py
@@ -41,7 +41,7 @@ def create_check_handler(
     deployment_name: str,
     check_function: Callable[[list[DeploymentSchedule]], bool] = lambda schedules: True,
     num_checks: int = 5,
-    timeout: int = 2,
+    timeout: int = 5,
 ):
     def handler(signum: int, frame: Any):
         try:
@@ -69,8 +69,8 @@ def run_serve_with_schedule(
     deployment_name: str,
     check_function: Callable[[list[DeploymentSchedule]], bool] = lambda schedules: True,
     schedules: list[Schedule] | None = None,
-    timeout: int = 2,
-    num_checks: int = 3,
+    timeout: int = 5,
+    num_checks: int = 5,
 ):
     signal.signal(
         signal.SIGALRM,

--- a/integration-tests/test_serve_a_flow.py
+++ b/integration-tests/test_serve_a_flow.py
@@ -23,7 +23,7 @@ def count_runs(counter_dir: Path):
 
 
 def test_serve_a_flow(tmp_path: Path):
-    TIMEOUT: int = 15
+    TIMEOUT: int = 20
     INTERVAL_SECONDS: int = 3
 
     MINIMUM_EXPECTED_N_FLOW_RUNS: int = 3


### PR DESCRIPTION
This PR follows up https://github.com/PrefectHQ/prefect/pull/18468 to attempt to deflake the schedule statefullness integration test. With these changes, the script will verify the expected schedule operation has taken place before stopping the serve process.