### PR TITLE
Allow infrastructure bound flows to be dispatched to existing workers

### DIFF
--- a/src/prefect/_experimental/bundles/__init__.py
+++ b/src/prefect/_experimental/bundles/__init__.py
@@ -246,9 +246,6 @@ def convert_step_to_command(
     return command
 
 
-def 
-
-
 __all__ = [
     "execute_bundle_from_file",
     "convert_step_to_command",

--- a/src/prefect/_experimental/bundles/__init__.py
+++ b/src/prefect/_experimental/bundles/__init__.py
@@ -246,6 +246,9 @@ def convert_step_to_command(
     return command
 
 
+def 
+
+
 __all__ = [
     "execute_bundle_from_file",
     "convert_step_to_command",

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2151,7 +2151,7 @@ class InfrastructureBoundFlow(Flow[P, R]):
 
         This method will spin up a local worker to submit the flow to remote infrastructure. To
         submit the flow to remote infrastructure without spinning up a local worker, use
-        `dispatch` instead.
+        `submit_to_work_pool` instead.
 
         Args:
             *args: Positional arguments to pass to the flow.
@@ -2189,12 +2189,14 @@ class InfrastructureBoundFlow(Flow[P, R]):
 
         return run_coro_as_sync(submit_func())
 
-    def dispatch(self, *args: P.args, **kwargs: P.kwargs) -> PrefectFlowRunFuture[R]:
+    def submit_to_work_pool(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> PrefectFlowRunFuture[R]:
         """
         EXPERIMENTAL: This method is experimental and may be removed or changed in future
             releases.
 
-        Dispatch the flow to run on remote infrastructure.
+        Submits the flow to run on remote infrastructure.
 
         This method will create a flow run for an existing worker to submit to remote infrastructure.
         If you don't have a worker available, use `submit` instead.
@@ -2218,7 +2220,7 @@ class InfrastructureBoundFlow(Flow[P, R]):
             def my_flow(x: int, y: int):
                 return x + y
 
-            future = my_flow.dispatch(x=1, y=2)
+            future = my_flow.submit_to_work_pool(x=1, y=2)
             result = future.result()
             print(result)
             ```

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2223,6 +2223,11 @@ class InfrastructureBoundFlow(Flow[P, R]):
             print(result)
             ```
         """
+        warnings.warn(
+            "Dispatching flows to remote infrastructure is experimental. The interface "
+            "and behavior of this method are subject to change.",
+            category=FutureWarning,
+        )
         from prefect import get_client
         from prefect._experimental.bundles import (
             convert_step_to_command,
@@ -2233,6 +2238,9 @@ class InfrastructureBoundFlow(Flow[P, R]):
         from prefect.results import get_result_store, resolve_result_storage
         from prefect.states import Pending, Scheduled
         from prefect.tasks import Task
+
+        # Get parameters to error early if they are invalid
+        parameters = get_call_parameters(self, args, kwargs)
 
         with get_client(sync_client=True) as client:
             work_pool = client.read_work_pool(self.work_pool)
@@ -2287,7 +2295,6 @@ class InfrastructureBoundFlow(Flow[P, R]):
             job_variables = (self.job_variables or {}) | {
                 "command": " ".join(execute_command)
             }
-            parameters = get_call_parameters(self, args, kwargs)
 
             # Create a parent task run if this is a child flow run to ensure it shows up as a child flow in the UI
             parent_task_run = None

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import abc
 import asyncio
 import datetime
-import json
-import subprocess
-import tempfile
 import threading
 import uuid
 import warnings
@@ -762,9 +759,10 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         task_status: anyio.abc.TaskStatus["FlowRun"] | None = None,
     ):
         """
-        Submits a flow run to the Kubernetes worker.
+        Submits a flow for the worker to kick off execution for.
         """
         from prefect._experimental.bundles import (
+            aupload_bundle_to_storage,
             convert_step_to_command,
             create_bundle_for_flow_run,
         )
@@ -860,27 +858,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         )
 
         bundle = create_bundle_for_flow_run(flow=flow, flow_run=flow_run)
-
-        # Write the bundle to a temporary directory so it can be uploaded to the bundle storage
-        # via the upload command
-        with tempfile.TemporaryDirectory() as temp_dir:
-            await (
-                anyio.Path(temp_dir)
-                .joinpath(bundle_key)
-                .write_bytes(json.dumps(bundle).encode("utf-8"))
-            )
-
-            try:
-                full_command = upload_command + [bundle_key]
-                logger.debug(
-                    "Uploading execution bundle with command: %s", full_command
-                )
-                await anyio.run_process(
-                    full_command,
-                    cwd=temp_dir,
-                )
-            except subprocess.CalledProcessError as e:
-                raise RuntimeError(e.stderr.decode("utf-8")) from e
+        await aupload_bundle_to_storage(bundle, bundle_key, upload_command)
 
         logger.debug("Successfully uploaded execution bundle")
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1200,8 +1200,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         if flow_run.deployment_id:
             try:
-                await self.client.read_deployment(getattr(flow_run, "deployment_id"))
-            except (ObjectNotFound, AttributeError):
+                await self.client.read_deployment(flow_run.deployment_id)
+            except ObjectNotFound:
                 self._logger.exception(
                     f"Deployment {flow_run.deployment_id} no longer exists. "
                     f"Flow run {flow_run.id} will not be submitted for"

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import inspect
 import os

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -397,7 +397,7 @@ class TestInfrastructureBoundFlow:
             flow=my_flow, work_pool=work_pool.name, worker_cls=ProcessWorker
         )
 
-        future = infrastructure_bound_flow.dispatch(x=1, y=2)
+        future = infrastructure_bound_flow.submit_to_work_pool(x=1, y=2)
         assert future.state.is_scheduled()
         expected_upload_command = [
             "uv",
@@ -464,7 +464,7 @@ class TestInfrastructureBoundFlow:
         with pytest.raises(
             RuntimeError, match="Storage is not configured for work pool"
         ):
-            infrastructure_bound_flow.dispatch(x=1, y=2)
+            infrastructure_bound_flow.submit_to_work_pool(x=1, y=2)
 
     @pytest.mark.filterwarnings("ignore::FutureWarning")
     @pytest.mark.usefixtures("mock_subprocess_check_call")
@@ -484,7 +484,7 @@ class TestInfrastructureBoundFlow:
         @flow
         async def parent_flow():
             flow_run_ctx = FlowRunContext.get()
-            future = infrastructure_bound_flow.dispatch()
+            future = infrastructure_bound_flow.submit_to_work_pool()
             flow_run = getattr(flow_run_ctx, "flow_run", None)
             flow_run_id = flow_run.id if flow_run else None
             return flow_run_id, future.flow_run_id
@@ -546,7 +546,7 @@ class TestInfrastructureBoundFlow:
             flow=unprepared_flow, work_pool=work_pool.name, worker_cls=ProcessWorker
         )
 
-        future = infrastructure_bound_flow.dispatch()
+        future = infrastructure_bound_flow.submit_to_work_pool()
 
         # Start the worker to pick up and "run" the flow
         await SubmitterOfUnpreparedFlows(work_pool_name=work_pool.name).start(


### PR DESCRIPTION
This PR adds a `.submit_to_work_pool` method to `InfrastructureBoundFlow`, which can be used to create a flow run for an `InfrastructureBoundFlow`, but will not spin up a local worker for submission. This new method is helpful if you want to dynamically configure job variables and run portions on your workflow on remote infrastructure **and** you have one or more workers already for the work pools you're submitting to. This can also help you consolidate permission grants (e.g. `ecs:RunTask`) to your workers while retaining the benefits of ad-hoc flow submission.

### Example
On the surface, it works pretty much the same as `.submit`:
```python
from prefect_kubernetes.experimental import kubernetes

from prefect import flow


@kubernetes(work_pool="olympic")
@flow
def my_flow(name: str):
    return f"Hello, {name}!"


if __name__ == "__main__":
    future = my_flow.submit_to_work_pool(name="world")
    print(future.result())
```

### Notes
- The ordering is a little tricky because a flow run needs to be created in the API before bundle creation (a serialized version of the flow run is included in the bundle). To avoid workers picking up runs too early, the flow run is created in `PENDING` and then moved to `SCHEDULED` after the bundle is uploaded. 

Related to https://github.com/PrefectHQ/prefect/issues/17194