### PR TITLE
Remove restricted characters from dbt asset keys

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/utilities.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/utilities.py
@@ -8,6 +8,11 @@ from typing import Any
 
 import slugify
 
+from prefect.types.names import (
+    MAX_ASSET_KEY_LENGTH,
+    RESTRICTED_ASSET_CHARACTERS,
+)
+
 
 def find_profiles_dir() -> Path:
     """
@@ -54,7 +59,15 @@ def format_resource_id(adapter_type: str, relation_name: str) -> str:
         relation_name: The name of the relation to format
 
     Returns:
-        The formatted relation name
+        The formatted asset key
     """
     relation_name = relation_name.replace('"', "").replace(".", "/")
-    return f"{adapter_type}://{relation_name}"
+    for char in RESTRICTED_ASSET_CHARACTERS:
+        relation_name = relation_name.replace(char, "")
+
+    asset_key = f"{adapter_type}://{relation_name}"
+
+    if len(asset_key) > MAX_ASSET_KEY_LENGTH:
+        asset_key = asset_key[:MAX_ASSET_KEY_LENGTH]
+
+    return asset_key


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Closes #18475

Now that asset keys have an extensive restricted character list, we need to remove those characters from asset keys build from dbt relation names.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
