### PR TITLE
Fix MinIOCredentials documentation to use correct boto3 parameter name

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/credentials.py
+++ b/src/integrations/prefect-aws/prefect_aws/credentials.py
@@ -251,7 +251,7 @@ class MinIOCredentials(CredentialsBlock):
                 minio_root_password = "minio_root_password"
             )
             s3_client = minio_credentials.get_boto3_session().client(
-                service="s3",
+                service_name="s3",
                 endpoint_url="http://localhost:9000"
             )
             ```


### PR DESCRIPTION
## Summary
Fixes the MinIOCredentials documentation example to use the correct boto3 parameter name.

## Changes
- Updated the example code to use `service_name="s3"` instead of `service="s3"` when calling `boto3.Session.client()`
- This matches the actual boto3 API signature where the first parameter is `service_name`

Closes #13039

🤖 Generated with [Claude Code](https://claude.ai/code)