### PR TITLE
Add foreign key for flow_run_id in logs (closes #10000)

### DIFF
--- a/src/prefect/server/database/_migrations/versions/postgresql/2025_07_14_093357_ffa2a93baefa_add_log_flow_run_id_and_task_run_id_fk.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2025_07_14_093357_ffa2a93baefa_add_log_flow_run_id_and_task_run_id_fk.py
@@ -1,0 +1,72 @@
+"""add_log_flow_run_id_and_task_run_id_fk
+
+Revision ID: ffa2a93baefa
+Revises: 3b86c5ea017a
+Create Date: 2025-07-14 09:33:57.991124
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ffa2a93baefa"
+down_revision = "3b86c5ea017a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # remove rows which should have been deleted by the cascade delete
+    op.execute("""
+        DELETE FROM
+            log
+        WHERE
+        (
+            task_run_id IS NOT NULL
+            AND NOT EXISTS (
+            SELECT
+                1
+            FROM
+                task_run
+            WHERE
+                task_run.id = log.task_run_id
+            )
+        )
+        OR (
+            flow_run_id IS NOT NULL
+            AND NOT EXISTS (
+            SELECT
+                1
+            FROM
+                flow_run
+            WHERE
+                flow_run.id = log.flow_run_id
+            )
+        )
+    """)
+
+    # add foreign keys
+    op.create_foreign_key(
+        op.f("fk_log__flow_run_id__flow_run"),
+        "log",
+        "flow_run",
+        ["flow_run_id"],
+        ["id"],
+        ondelete="CASCADE",
+        use_alter=True,
+    )
+    op.create_foreign_key(
+        op.f("fk_log__task_run_id__task_run"),
+        "log",
+        "task_run",
+        ["task_run_id"],
+        ["id"],
+        ondelete="CASCADE",
+        use_alter=True,
+    )
+
+
+def downgrade():
+    # drop foreign keys
+    op.drop_constraint(op.f("fk_log__task_run_id__task_run"), "log", type_="foreignkey")
+    op.drop_constraint(op.f("fk_log__flow_run_id__flow_run"), "log", type_="foreignkey")

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_07_14_093336_385812ff8d32_add_log_flow_run_id_and_task_run_id_fk.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_07_14_093336_385812ff8d32_add_log_flow_run_id_and_task_run_id_fk.py
@@ -1,0 +1,47 @@
+"""add_log_flow_run_id_and_task_run_id_fk
+
+Revision ID: 385812ff8d32
+Revises: 8bb517bae6f9
+Create Date: 2025-07-14 09:33:36.223352
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "385812ff8d32"
+down_revision = "8bb517bae6f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # add foreign keys
+    with op.batch_alter_table("log", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            batch_op.f("fk_log__task_run_id__task_run"),
+            "task_run",
+            ["task_run_id"],
+            ["id"],
+            ondelete="CASCADE",
+            use_alter=True,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_log__flow_run_id__flow_run"),
+            "flow_run",
+            ["flow_run_id"],
+            ["id"],
+            ondelete="CASCADE",
+            use_alter=True,
+        )
+
+
+def downgrade():
+    # drop foreign keys
+    with op.batch_alter_table("log", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            batch_op.f("fk_log__flow_run_id__flow_run"), type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            batch_op.f("fk_log__task_run_id__task_run"), type_="foreignkey"
+        )

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -923,8 +923,14 @@ class Log(Base):
 
     name: Mapped[str]
     level: Mapped[int] = mapped_column(sa.SmallInteger, index=True)
-    flow_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(index=True)
-    task_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(index=True)
+    flow_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        sa.ForeignKey("flow_run.id", ondelete="CASCADE", use_alter=True),
+        index=True,
+    )
+    task_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        sa.ForeignKey("task_run.id", ondelete="CASCADE", use_alter=True),
+        index=True,
+    )
     message: Mapped[str] = mapped_column(sa.Text)
 
     # The client-side timestamp of this logged statement.

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1443,7 +1443,10 @@ async def test_create_then_read_autonomous_task_runs(prefect_client: PrefectClie
 
 
 async def test_read_filtered_logs(session, prefect_client, deployment):
-    flow_runs = [uuid4() for i in range(5)]
+    flow_runs = [
+        (await prefect_client.create_flow_run_from_deployment(deployment.id)).id
+        for i in range(5)
+    ]
     logs = [
         LogCreate(
             name="prefect.flow_runs",

--- a/tests/server/api/test_logs.py
+++ b/tests/server/api/test_logs.py
@@ -26,13 +26,13 @@ READ_LOGS_URL = "/logs/filter"
 
 
 @pytest.fixture
-def flow_run_id():
-    yield uuid1()
+def flow_run_id(flow_run):
+    yield flow_run.id
 
 
 @pytest.fixture
-def task_run_id():
-    yield uuid1()
+def task_run_id(task_run):
+    yield task_run.id
 
 
 @pytest.fixture

--- a/tests/server/models/test_logs.py
+++ b/tests/server/models/test_logs.py
@@ -16,22 +16,17 @@ NOW = now("UTC")
 
 
 @pytest.fixture
-def flow_run_id():
-    yield uuid4()
+def flow_run_id(flow_run):
+    yield flow_run.id
 
 
 @pytest.fixture
-def task_run_id():
-    yield uuid4()
+def task_run_id(task_run):
+    yield task_run.id
 
 
 @pytest.fixture
-def other_flow_run_id():
-    yield uuid4()
-
-
-@pytest.fixture
-def log_data(client, flow_run_id, task_run_id, other_flow_run_id):
+def log_data(client, flow_run_id, task_run_id):
     yield [
         LogCreate(
             name="prefect.flow_run",
@@ -144,14 +139,16 @@ class TestReadLogs:
 class TestLogSchemaConversion:
     """Tests for LogCreate to Log schema conversion - the core issue that was fixed"""
 
-    async def test_create_logs_with_logcreate_publishes_logs_with_ids(self, session):
+    async def test_create_logs_with_logcreate_publishes_logs_with_ids(
+        self, flow_run_id, session
+    ):
         """Test calling create_logs with LogCreate objects results in Log objects with IDs being published"""
         log_create = LogCreate(
             name="test.logger",
             level=20,
             message="Test message",
             timestamp=NOW,
-            flow_run_id=uuid4(),
+            flow_run_id=flow_run_id,
         )
 
         # Mock publish_logs to capture what gets passed to messaging

--- a/tests/server/models/test_orm.py
+++ b/tests/server/models/test_orm.py
@@ -733,7 +733,9 @@ class TestExpectedStartTimeDelta:
 
 
 class TestLog:
-    async def test_create_log_with_flow_run_id_and_task_run_id(self, session, db):
+    async def test_create_log_with_flow_run_id_and_task_run_id(
+        self, task_run, session, db
+    ):
         now_dt = now("UTC")
         fifteen_mins_ago = now_dt - datetime.timedelta(minutes=15)
 
@@ -742,8 +744,8 @@ class TestLog:
             level=logging.INFO,
             message="Ahoy, captain",
             timestamp=now_dt,
-            flow_run_id=uuid4(),
-            task_run_id=uuid4(),
+            flow_run_id=task_run.flow_run_id,
+            task_run_id=task_run.id,
         )
 
         session.add(log)
@@ -758,7 +760,7 @@ class TestLog:
         result = await session.execute(query)
         assert result.scalar() == log
 
-    async def test_create_log_without_task_run_id(self, session, db):
+    async def test_create_log_without_task_run_id(self, flow_run, session, db):
         now_dt = now("UTC")
         fifteen_mins_ago = now_dt - datetime.timedelta(minutes=15)
 
@@ -766,7 +768,7 @@ class TestLog:
             name="prefect.flow_run",
             level=logging.WARNING,
             message="Black flag ahead, captain!",
-            flow_run_id=uuid4(),
+            flow_run_id=flow_run.id,
             timestamp=now_dt,
         )
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -962,10 +962,10 @@ class TestAPILogWorker:
         return APILogWorker.instance()
 
     @pytest.fixture
-    def log_dict(self):
+    def log_dict(self, task_run):
         return LogCreate(
-            flow_run_id=uuid.uuid4(),
-            task_run_id=uuid.uuid4(),
+            flow_run_id=task_run.flow_run_id,
+            task_run_id=task_run.id,
             name="test.logger",
             level=10,
             timestamp=now("UTC"),


### PR DESCRIPTION
This PR adds a foreign key to logs for the flow_run_id such that deleting a flow run will also delete any associated logs.
I've also done the same for task runs although I'm not sure why one would delete a task run but not a flow run however the API does allow it.

This closes #10000

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
