### PR TITLE
Add --flow-run-name option to deployment run CLI

### DIFF
--- a/docs/v3/how-to-guides/deployments/run-deployments.mdx
+++ b/docs/v3/how-to-guides/deployments/run-deployments.mdx
@@ -41,7 +41,13 @@ prefect deployment run my-flow/my-deployment --start-in "2 hours"
 prefect deployment run my-flow/my-deployment --watch
 
 # Set custom run name
-prefect deployment run my-flow/my-deployment --name "custom-run-name"
+prefect deployment run my-flow/my-deployment --flow-run-name "custom-run-name"
+
+# Use templated run name with parameters
+prefect deployment run my-flow/my-deployment \
+  --flow-run-name "etl-{customer}-{date}" \
+  --param customer=acme \
+  --param date=2025-01-14
 
 # Add tags to the run
 prefect deployment run my-flow/my-deployment --tag production --tag critical

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -750,6 +750,14 @@ async def run(
         "--tag",
         help=("Tag(s) to be applied to flow run."),
     ),
+    flow_run_name: Optional[str] = typer.Option(
+        None,
+        "--flow-run-name",
+        help=(
+            "A custom name for the flow run. May include template variables in curly braces "
+            "that will be formatted with the flow run parameters, e.g., 'run-{param1}-{param2}'."
+        ),
+    ),
     watch: bool = typer.Option(
         False,
         "--watch",
@@ -871,6 +879,24 @@ async def run(
                 f"\n{available_parameters}"
             )
 
+        # Apply flow run name templating if needed
+        if flow_run_name and "{" in flow_run_name and "}" in flow_run_name:
+            # Merge deployment default parameters with CLI parameters
+            # CLI parameters take precedence over defaults
+            template_parameters = {**deployment.parameters, **parameters}
+
+            try:
+                flow_run_name = flow_run_name.format(**template_parameters)
+            except KeyError as e:
+                exit_with_error(
+                    f"Failed to format flow run name template '{flow_run_name}': "
+                    f"Parameter {e} not found. Available parameters: {listrepr(template_parameters.keys(), sep=', ')}"
+                )
+            except Exception as e:
+                exit_with_error(
+                    f"Failed to format flow run name template '{flow_run_name}': {e}"
+                )
+
         app.console.print(
             f"Creating flow run for deployment '{flow.name}/{deployment.name}'...",
         )
@@ -882,6 +908,7 @@ async def run(
                 state=Scheduled(scheduled_time=scheduled_start_time),
                 tags=tags,
                 job_variables=job_vars,
+                name=flow_run_name,
             )
         except PrefectHTTPStatusError as exc:
             detail = exc.response.json().get("detail")


### PR DESCRIPTION
closes #18500

## Summary

This PR adds the ability to set custom flow run names when triggering deployments via the CLI, including support for parameter-based templating that matches the SDK's behavior.

## Changes

- Add `--flow-run-name` option to `prefect deployment run` command
- Support templating with Python string formatting (e.g., `run-{customer}-{date}`)
- Template variables are replaced with deployment parameters before creating the flow run
- Clear error messages when template parameters are missing
- Updated documentation with examples

## Examples

```bash
# Static custom name
prefect deployment run my-flow/my-deployment --flow-run-name "production-run-001"

# Templated name with parameters
prefect deployment run etl/daily --flow-run-name "etl-{customer}-{date}" -p customer=acme -p date=2025-01-14

# Complex template
prefect deployment run pipeline/batch --flow-run-name "{env}/{date}/batch-{job_id}" -p env=prod -p date=2025-01-14 -p job_id=12345
```

## Testing

The templating logic has been tested with various scenarios including:
- Static names (no templating)
- Simple templates with all parameters provided
- Templates using a subset of available parameters
- Error handling for missing parameters
- Special characters in parameters and templates

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>