### PR TITLE
Revert "Add --flow-run-name option to deployment run CLI with templating support"

### DIFF
--- a/docs/v3/how-to-guides/deployments/run-deployments.mdx
+++ b/docs/v3/how-to-guides/deployments/run-deployments.mdx
@@ -41,13 +41,7 @@ prefect deployment run my-flow/my-deployment --start-in "2 hours"
 prefect deployment run my-flow/my-deployment --watch
 
 # Set custom run name
-prefect deployment run my-flow/my-deployment --flow-run-name "custom-run-name"
-
-# Use templated run name with parameters
-prefect deployment run my-flow/my-deployment \
-  --flow-run-name "etl-{customer}-{date}" \
-  --param customer=acme \
-  --param date=2025-01-14
+prefect deployment run my-flow/my-deployment --name "custom-run-name"
 
 # Add tags to the run
 prefect deployment run my-flow/my-deployment --tag production --tag critical

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -750,14 +750,6 @@ async def run(
         "--tag",
         help=("Tag(s) to be applied to flow run."),
     ),
-    flow_run_name: Optional[str] = typer.Option(
-        None,
-        "--flow-run-name",
-        help=(
-            "A custom name for the flow run. May include template variables in curly braces "
-            "that will be formatted with the flow run parameters, e.g., 'run-{param1}-{param2}'."
-        ),
-    ),
     watch: bool = typer.Option(
         False,
         "--watch",
@@ -879,20 +871,6 @@ async def run(
                 f"\n{available_parameters}"
             )
 
-        # Apply flow run name templating if needed
-        if flow_run_name and "{" in flow_run_name and "}" in flow_run_name:
-            try:
-                flow_run_name = flow_run_name.format(**parameters)
-            except KeyError as e:
-                exit_with_error(
-                    f"Failed to format flow run name template '{flow_run_name}': "
-                    f"Parameter {e} not found. Available parameters: {listrepr(parameters.keys(), sep=', ')}"
-                )
-            except Exception as e:
-                exit_with_error(
-                    f"Failed to format flow run name template '{flow_run_name}': {e}"
-                )
-
         app.console.print(
             f"Creating flow run for deployment '{flow.name}/{deployment.name}'...",
         )
@@ -904,7 +882,6 @@ async def run(
                 state=Scheduled(scheduled_time=scheduled_start_time),
                 tags=tags,
                 job_variables=job_vars,
-                name=flow_run_name,
             )
         except PrefectHTTPStatusError as exc:
             detail = exc.response.json().get("detail")


### PR DESCRIPTION
This PR reverts commit c45c0dde711b295d5a238c02fabf53d4e8f0ad85 which was accidentally pushed directly to main.

## Summary
Reverting the addition of --flow-run-name option to deployment run CLI that was pushed directly to main without PR review.

Original commit added:
- --flow-run-name option to 'prefect deployment run' command
- Support for parameter-based templating
- Documentation updates