### PR TITLE
Add `no-commit-to-branch` hook to prevent accidental commits to main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,11 @@ default_install_hook_types:
   - pre-push
 
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.5
     hooks:


### PR DESCRIPTION
I accidentally commit to `main` every once in a while, so this adds some guardrails via `pre-commit`.