### PR TITLE
Added support for setting flow run name in deployment CLI

### DIFF
--- a/docs/v3/how-to-guides/deployments/run-deployments.mdx
+++ b/docs/v3/how-to-guides/deployments/run-deployments.mdx
@@ -41,15 +41,9 @@ prefect deployment run my-flow/my-deployment --start-in "2 hours"
 prefect deployment run my-flow/my-deployment --watch
 
 # Set custom run name
-Use `--flow-run-name` to set a static or templated name for the flow run.
+Use `--flow-run-name` to set a static name for the flow run.
 
 prefect deployment run my-flow/my-deployment --flow-run-name "custom-run-name"
-
-# Use a templated flow run name based on parameters
-prefect deployment run my-flow/my-deployment \
-  --param customer_id=1234 \
-  --param run_date="2025-07-14" \
-  --flow-run-name "customer-{{customer_id}}-run-{{run_date}}"
 
 # Add tags to the run
 prefect deployment run my-flow/my-deployment --tag production --tag critical

--- a/docs/v3/how-to-guides/deployments/run-deployments.mdx
+++ b/docs/v3/how-to-guides/deployments/run-deployments.mdx
@@ -26,7 +26,7 @@ prefect deployment run my-flow/my-deployment
 
 ### CLI options
 
-Add parameters and customize the run:
+Add parameters and customize the run, including setting a custom flow run name using the new --flow-run-name option:
 
 ```bash
 # Pass parameters
@@ -41,7 +41,15 @@ prefect deployment run my-flow/my-deployment --start-in "2 hours"
 prefect deployment run my-flow/my-deployment --watch
 
 # Set custom run name
-prefect deployment run my-flow/my-deployment --name "custom-run-name"
+Use `--flow-run-name` to set a static or templated name for the flow run.
+
+prefect deployment run my-flow/my-deployment --flow-run-name "custom-run-name"
+
+# Use a templated flow run name based on parameters
+prefect deployment run my-flow/my-deployment \
+  --param customer_id=1234 \
+  --param run_date="2025-07-14" \
+  --flow-run-name "customer-{{customer_id}}-run-{{run_date}}"
 
 # Add tags to the run
 prefect deployment run my-flow/my-deployment --tag production --tag critical

--- a/docs/v3/how-to-guides/deployments/run-deployments.mdx
+++ b/docs/v3/how-to-guides/deployments/run-deployments.mdx
@@ -26,7 +26,7 @@ prefect deployment run my-flow/my-deployment
 
 ### CLI options
 
-Add parameters and customize the run, including setting a custom flow run name using the new --flow-run-name option:
+Add parameters and customize the run:
 
 ```bash
 # Pass parameters

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -5,7 +5,6 @@ Command line interface for working with deployments.
 from __future__ import annotations
 
 import json
-import re
 import sys
 import textwrap
 import warnings
@@ -874,16 +873,6 @@ async def run(
                 f"deployment: {listrepr(unknown_keys, sep=', ')}"
                 f"\n{available_parameters}"
             )
-
-        if flow_run_name and "{{" in flow_run_name:
-            try:
-                fmt_flow_run_name = re.sub(r"{{\s*(\w+)\s*}}", r"{\1}", flow_run_name)
-                flow_run_name = fmt_flow_run_name.format(**parameters)
-
-            except KeyError as e:
-                exit_with_error(f"Missing parameter for flow run name: {e}")
-            except Exception as e:
-                exit_with_error(f"Failed to format flow run name: {e}")
 
         app.console.print(
             f"Creating flow run for deployment '{flow.name}/{deployment.name}'...",

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -5,10 +5,10 @@ Command line interface for working with deployments.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import textwrap
 import warnings
-import re
 from asyncio import iscoroutine
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Optional, TypedDict

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -765,6 +765,9 @@ async def run(
         "--watch-timeout",
         help=("Timeout for --watch."),
     ),
+    flow_run_name: Optional[str] = typer.Option(
+        None, "--flow-run-name", help="Custom name to give the flow run."
+    ),
 ):
     """
     Create a flow run for the given flow and deployment.
@@ -882,6 +885,7 @@ async def run(
                 state=Scheduled(scheduled_time=scheduled_start_time),
                 tags=tags,
                 job_variables=job_vars,
+                name=flow_run_name,
             )
         except PrefectHTTPStatusError as exc:
             detail = exc.response.json().get("detail")

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -19,6 +19,7 @@ import yaml
 from rich.console import Console
 from rich.pretty import Pretty
 from rich.table import Table
+from jinja2 import Template, StrictUndefined, UndefinedError
 
 import prefect.types._datetime
 from prefect.blocks.core import Block
@@ -873,6 +874,12 @@ async def run(
                 f"deployment: {listrepr(unknown_keys, sep=', ')}"
                 f"\n{available_parameters}"
             )
+
+        if flow_run_name and "{{" in flow_run_name:
+            try:
+                flow_run_name = Template(flow_run_name, undefined=StrictUndefined).render(parameters)
+            except UndefinedError as e:
+                exit_with_error(f"Failed to render flow run name: {e}")
 
         app.console.print(
             f"Creating flow run for deployment '{flow.name}/{deployment.name}'...",

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -1164,7 +1164,7 @@ class TestDeploymentRun:
         flow_run = flow_runs[0]
         assert flow_run.parameters == {"name": "foo"}
 
-    async def test_sets_templated_flow_run_name(
+    async def test_sets_static_flow_run_name(
         self,
         deployment: DeploymentResponse,
         deployment_name: str,
@@ -1177,9 +1177,7 @@ class TestDeploymentRun:
                 "run",
                 deployment_name,
                 "--flow-run-name",
-                "hello-{{name}}",
-                "--param",
-                "name=tester",
+                "static-name",
             ],
             expected_code=0,
         )
@@ -1190,21 +1188,7 @@ class TestDeploymentRun:
             )
         )
         assert len(flow_runs) == 1
-        assert flow_runs[0].name == "hello-tester"
-
-    def test_raises_error_on_missing_template_param(self, deployment_name: str):
-        run_sync_in_worker_thread(
-            invoke_and_assert,
-            [
-                "deployment",
-                "run",
-                deployment_name,
-                "--flow-run-name",
-                "hello-{{missing}}",
-            ],
-            expected_code=1,
-            expected_output_contains="Failed to render flow run name: 'missing' is undefined",
-        )
+        assert flow_runs[0].name == "static-name"
 
 
 class TestDeploymentDelete:


### PR DESCRIPTION
### Summary

This PR adds support for specifying a custom name for a flow run using the --flow-run-name flag when running a deployment via the CLI.

### Updates:

- Added --flow-run-name option to set a static flow run name via CLI.
- Validates and passes the static name to the backend during flow run creation.
- Updated CLI command logic and documentation to reflect static name support.
- Added tests to verify correct behavior with static custom names.

Example Usage
```bash
# Static custom name
prefect deployment run my-flow/my-deployment --flow-run-name "custom-run-name"
```

### Testing
The templating logic has been tested with various scenarios, including:

- Verified CLI behavior with and without --flow-run-name
- Ensured flow run names are applied correctly when specified
- Confirmed appropriate fallback and error messaging when flow run name is not provided

Credit: @zzstoatzz

Closes: [#18500]

