### PR TITLE
Add endpoint for acquiring concurrency slots with a lease

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -552,6 +552,7 @@
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/update-concurrency-limit-v2",
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/read-all-concurrency-limits-v2",
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots",
+                          "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots-with-lease",
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-decrement-active-slots"
                         ]
                       },

--- a/docs/v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots-with-lease.mdx
+++ b/docs/v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots-with-lease.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/v2/concurrency_limits/increment-with-lease
+---

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -4491,6 +4491,58 @@
                 }
             }
         },
+        "/api/v2/concurrency_limits/increment-with-lease": {
+            "post": {
+                "tags": [
+                    "Concurrency Limits V2"
+                ],
+                "summary": "Bulk Increment Active Slots With Lease",
+                "operationId": "bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post",
+                "parameters": [
+                    {
+                        "name": "x-prefect-api-version",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "X-Prefect-Api-Version"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConcurrencyLimitWithLeaseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/concurrency_limits/decrement": {
             "post": {
                 "tags": [
@@ -12132,6 +12184,46 @@
                 ],
                 "title": "Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post"
             },
+            "Body_bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post": {
+                "properties": {
+                    "slots": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Slots"
+                    },
+                    "names": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Names",
+                        "min_items": 1
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": [
+                            "concurrency",
+                            "rate_limit"
+                        ],
+                        "title": "Mode",
+                        "default": "concurrency"
+                    },
+                    "lease_duration": {
+                        "type": "number",
+                        "maximum": 86400.0,
+                        "minimum": 60.0,
+                        "title": "Lease Duration",
+                        "description": "The duration of the lease in seconds.",
+                        "default": 300
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "slots",
+                    "names"
+                ],
+                "title": "Body_bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post"
+            },
             "Body_clear_database_admin_database_clear_post": {
                 "properties": {
                     "confirm": {
@@ -14710,6 +14802,28 @@
                 "type": "object",
                 "title": "ConcurrencyLimitV2Update",
                 "description": "Data used by the Prefect REST API to update a v2 concurrency limit."
+            },
+            "ConcurrencyLimitWithLeaseResponse": {
+                "properties": {
+                    "lease_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Lease Id"
+                    },
+                    "limits": {
+                        "items": {
+                            "$ref": "#/components/schemas/MinimalConcurrencyLimitResponse"
+                        },
+                        "type": "array",
+                        "title": "Limits"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "lease_id",
+                    "limits"
+                ],
+                "title": "ConcurrencyLimitWithLeaseResponse"
             },
             "ConcurrencyOptions": {
                 "properties": {

--- a/src/prefect/server/concurrency/lease_storage/memory.py
+++ b/src/prefect/server/concurrency/lease_storage/memory.py
@@ -35,7 +35,7 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         metadata: ConcurrencyLimitLeaseMetadata | None = None,
     ) -> ResourceLease[ConcurrencyLimitLeaseMetadata]:
         lease_id = uuid4()
-        lease = ResourceLease(resource_ids=resource_ids, metadata=metadata)
+        lease = ResourceLease(id=lease_id, resource_ids=resource_ids, metadata=metadata)
         self.leases[lease_id] = lease
         self.expirations[lease_id] = datetime.now(timezone.utc) + ttl
         return lease

--- a/src/prefect/server/utilities/leasing.py
+++ b/src/prefect/server/utilities/leasing.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Generic, Protocol, TypeVar
-from uuid import UUID
+from uuid import UUID, uuid4
 
 T = TypeVar("T")
 
 
 @dataclass
 class ResourceLease(Generic[T]):
-    id: UUID
     resource_ids: list[UUID]
+    id: UUID = field(default_factory=uuid4)
     metadata: T | None = None
 
 

--- a/src/prefect/server/utilities/leasing.py
+++ b/src/prefect/server/utilities/leasing.py
@@ -10,6 +10,7 @@ T = TypeVar("T")
 
 @dataclass
 class ResourceLease(Generic[T]):
+    id: UUID
     resource_ids: list[UUID]
     metadata: T | None = None
 

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -1382,6 +1382,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/concurrency_limits/increment-with-lease": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Bulk Increment Active Slots With Lease */
+        post: operations["bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/concurrency_limits/decrement": {
         parameters: {
             query?: never;
@@ -4025,6 +4042,25 @@ export interface components {
              */
             create_if_missing?: boolean | null;
         };
+        /** Body_bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post */
+        Body_bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post: {
+            /** Slots */
+            slots: number;
+            /** Names */
+            names: string[];
+            /**
+             * Mode
+             * @default concurrency
+             * @enum {string}
+             */
+            mode: "concurrency" | "rate_limit";
+            /**
+             * Lease Duration
+             * @description The duration of the lease in seconds.
+             * @default 300
+             */
+            lease_duration: number;
+        };
         /** Body_clear_database_admin_database_clear_post */
         Body_clear_database_admin_database_clear_post: {
             /**
@@ -5134,6 +5170,16 @@ export interface components {
             denied_slots?: number | null;
             /** Slot Decay Per Second */
             slot_decay_per_second?: number | null;
+        };
+        /** ConcurrencyLimitWithLeaseResponse */
+        ConcurrencyLimitWithLeaseResponse: {
+            /**
+             * Lease Id
+             * Format: uuid
+             */
+            lease_id: string;
+            /** Limits */
+            limits: components["schemas"]["MinimalConcurrencyLimitResponse"][];
         };
         /**
          * ConcurrencyOptions
@@ -12792,6 +12838,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MinimalConcurrencyLimitResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Body_bulk_increment_active_slots_with_lease_v2_concurrency_limits_increment_with_lease_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConcurrencyLimitWithLeaseResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
This PR adds a `/v2/concurrency-limits/increment-with-lease` endpoint that increments the specified concurrency limits and returns a lease ID for a lease valid for the provided duration. A lease renewal endpoint will be added in a subsequent PR.
