### PR TITLE
Add concurrency lease renewal endpoint

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -553,7 +553,8 @@
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/read-all-concurrency-limits-v2",
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots",
                           "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots-with-lease",
-                          "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-decrement-active-slots"
+                          "v3/api-ref/rest-api/server/concurrency-limits-v2/bulk-decrement-active-slots",
+                          "v3/api-ref/rest-api/server/concurrency-limits-v2/renew-concurrency-lease"
                         ]
                       },
                       {

--- a/docs/v3/api-ref/rest-api/server/concurrency-limits-v2/renew-concurrency-lease.mdx
+++ b/docs/v3/api-ref/rest-api/server/concurrency-limits-v2/renew-concurrency-lease.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/v2/concurrency_limits/leases/{lease_id}/renew
+---

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -4599,6 +4599,62 @@
                 }
             }
         },
+        "/api/v2/concurrency_limits/leases/{lease_id}/renew": {
+            "post": {
+                "tags": [
+                    "Concurrency Limits V2"
+                ],
+                "summary": "Renew Concurrency Lease",
+                "operationId": "renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post",
+                "parameters": [
+                    {
+                        "name": "lease_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The ID of the lease to renew",
+                            "title": "Lease Id"
+                        },
+                        "description": "The ID of the lease to renew"
+                    },
+                    {
+                        "name": "x-prefect-api-version",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "X-Prefect-Api-Version"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/block_types/": {
             "post": {
                 "tags": [
@@ -14077,6 +14133,20 @@
                 },
                 "type": "object",
                 "title": "Body_read_workers_work_pools__work_pool_name__workers_filter_post"
+            },
+            "Body_renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post": {
+                "properties": {
+                    "lease_duration": {
+                        "type": "number",
+                        "maximum": 86400.0,
+                        "minimum": 60.0,
+                        "title": "Lease Duration",
+                        "description": "The duration of the lease in seconds.",
+                        "default": 300
+                    }
+                },
+                "type": "object",
+                "title": "Body_renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post"
             },
             "Body_reset_concurrency_limit_by_tag_concurrency_limits_tag__tag__reset_post": {
                 "properties": {

--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1243,6 +1243,20 @@ The default limit applied to queries that can return multiple objects, such as `
 `PREFECT_SERVER_API_CORS_ALLOWED_HEADERS`, `PREFECT_SERVER_CORS_ALLOWED_HEADERS`
 
 ---
+## ServerConcurrencySettings
+### `lease_storage`
+The module to use for storing concurrency limit leases.
+
+**Type**: `string`
+
+**Default**: `prefect.server.concurrency.lease_storage.memory`
+
+**TOML dotted key path**: `server.concurrency.lease_storage`
+
+**Supported environment variables**:
+`PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE`
+
+---
 ## ServerDatabaseSettings
 Settings for controlling server database behavior
 ### `sqlalchemy`
@@ -2320,6 +2334,13 @@ The maximum number of scheduled runs to create for a deployment.
 **Type**: [ServerAPISettings](#serverapisettings)
 
 **TOML dotted key path**: `server.api`
+
+### `concurrency`
+Settings for controlling server-side concurrency limit handling
+
+**Type**: [ServerConcurrencySettings](#serverconcurrencysettings)
+
+**TOML dotted key path**: `server.concurrency`
 
 ### `database`
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1064,6 +1064,21 @@
             "title": "ServerAPISettings",
             "type": "object"
         },
+        "ServerConcurrencySettings": {
+            "properties": {
+                "lease_storage": {
+                    "default": "prefect.server.concurrency.lease_storage.memory",
+                    "description": "The module to use for storing concurrency limit leases.",
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE"
+                    ],
+                    "title": "Lease Storage",
+                    "type": "string"
+                }
+            },
+            "title": "ServerConcurrencySettings",
+            "type": "object"
+        },
         "ServerDatabaseSettings": {
             "description": "Settings for controlling server database behavior",
             "properties": {
@@ -2033,6 +2048,11 @@
                 },
                 "api": {
                     "$ref": "#/$defs/ServerAPISettings",
+                    "supported_environment_variables": []
+                },
+                "concurrency": {
+                    "$ref": "#/$defs/ServerConcurrencySettings",
+                    "description": "Settings for controlling server-side concurrency limit handling",
                     "supported_environment_variables": []
                 },
                 "database": {

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -10,6 +10,7 @@ import prefect.server.schemas as schemas
 from prefect.server.api.dependencies import LimitBody
 from prefect.server.concurrency.lease_storage import (
     ConcurrencyLimitLeaseMetadata,
+    get_concurrency_lease_storage,
 )
 from prefect.server.concurrency.lease_storage.memory import ConcurrencyLeaseStorage
 from prefect.server.database import PrefectDBInterface, provide_database_interface
@@ -305,7 +306,7 @@ async def bulk_increment_active_slots_with_lease(
         )
 
     if acquired:
-        lease_storage = ConcurrencyLeaseStorage()
+        lease_storage = get_concurrency_lease_storage()
         lease = await lease_storage.create_lease(
             resource_ids=[limit.id for limit in acquired_limits],
             ttl=timedelta(seconds=lease_duration),
@@ -362,3 +363,27 @@ async def bulk_decrement_active_slots(
         )
         for limit in limits
     ]
+
+
+@router.post("/leases/{lease_id}/renew", status_code=status.HTTP_204_NO_CONTENT)
+async def renew_concurrency_lease(
+    lease_id: UUID = Path(..., description="The ID of the lease to renew"),
+    lease_duration: float = Body(
+        300,  # 5 minutes
+        ge=60,  # 1 minute
+        le=60 * 60 * 24,  # 1 day
+        description="The duration of the lease in seconds.",
+        embed=True,
+    ),
+    lease_storage: ConcurrencyLeaseStorage = Depends(get_concurrency_lease_storage),
+):
+    lease = await lease_storage.read_lease(lease_id)
+    if not lease:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Lease not found"
+        )
+
+    await lease_storage.renew_lease(
+        lease_id=lease_id,
+        ttl=timedelta(seconds=lease_duration),
+    )

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -12,7 +12,6 @@ from prefect.server.concurrency.lease_storage import (
     ConcurrencyLimitLeaseMetadata,
     get_concurrency_lease_storage,
 )
-from prefect.server.concurrency.lease_storage.memory import ConcurrencyLeaseStorage
 from prefect.server.database import PrefectDBInterface, provide_database_interface
 from prefect.server.schemas import actions
 from prefect.server.utilities.schemas import PrefectBaseModel
@@ -375,8 +374,8 @@ async def renew_concurrency_lease(
         description="The duration of the lease in seconds.",
         embed=True,
     ),
-    lease_storage: ConcurrencyLeaseStorage = Depends(get_concurrency_lease_storage),
-):
+) -> None:
+    lease_storage = get_concurrency_lease_storage()
     lease = await lease_storage.read_lease(lease_id)
     if not lease:
         raise HTTPException(

--- a/src/prefect/server/concurrency/lease_storage/__init__.py
+++ b/src/prefect/server/concurrency/lease_storage/__init__.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
+import importlib
+from typing import Protocol, runtime_checkable
 from uuid import UUID
 
 from prefect.server.utilities.leasing import LeaseStorage, ResourceLease
+from prefect.settings.context import get_current_settings
+
+
+@runtime_checkable
+class ConcurrencyLeaseStorageModule(Protocol):
+    ConcurrencyLeaseStorage: type[ConcurrencyLeaseStorage]
 
 
 @dataclass
@@ -29,3 +37,19 @@ class ConcurrencyLeaseStorage(LeaseStorage[ConcurrencyLimitLeaseMetadata]):
     async def release_lease(self, lease_id: UUID) -> None: ...
 
     async def read_expired_lease_ids(self, limit: int = 100) -> list[UUID]: ...
+
+
+def get_concurrency_lease_storage() -> ConcurrencyLeaseStorage:
+    """
+    Returns a ConcurrencyLeaseStorage instance based on the configured lease storage module.
+
+    Will raise a ValueError if the configured module does not pass a type check.
+    """
+    concurrency_lease_storage_module = importlib.import_module(
+        get_current_settings().server.concurrency.lease_storage
+    )
+    if not isinstance(concurrency_lease_storage_module, ConcurrencyLeaseStorageModule):
+        raise ValueError(
+            f"The module {get_current_settings().server.concurrency.lease_storage} does not contain a ConcurrencyLeaseStorage class"
+        )
+    return concurrency_lease_storage_module.ConcurrencyLeaseStorage()

--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import UUID
+
+from prefect.server.concurrency.lease_storage import (
+    ConcurrencyLeaseStorage as _ConcurrencyLeaseStorage,
+)
+from prefect.server.concurrency.lease_storage import (
+    ConcurrencyLimitLeaseMetadata,
+)
+from prefect.server.utilities.leasing import ResourceLease
+from prefect.settings.context import get_current_settings
+
+
+class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
+    """
+    A file-based concurrency lease storage implementation that stores leases on disk.
+    """
+
+    def __init__(self, storage_path: Path | None = None):
+        prefect_home = get_current_settings().home
+        self.storage_path = Path(storage_path or prefect_home / "concurrency_leases")
+
+    def _ensure_storage_path(self) -> None:
+        """Ensure the storage path exists, creating it if necessary."""
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+
+    def _lease_file_path(self, lease_id: UUID) -> Path:
+        return self.storage_path / f"{lease_id}.json"
+
+    def _serialize_lease(
+        self, lease: ResourceLease[ConcurrencyLimitLeaseMetadata], expiration: datetime
+    ) -> dict:
+        return {
+            "resource_ids": [str(rid) for rid in lease.resource_ids],
+            "metadata": {"slots": lease.metadata.slots} if lease.metadata else None,
+            "expiration": expiration.isoformat(),
+        }
+
+    def _deserialize_lease(
+        self, data: dict
+    ) -> ResourceLease[ConcurrencyLimitLeaseMetadata]:
+        resource_ids = [UUID(rid) for rid in data["resource_ids"]]
+        metadata = (
+            ConcurrencyLimitLeaseMetadata(slots=data["metadata"]["slots"])
+            if data["metadata"]
+            else None
+        )
+        expiration = datetime.fromisoformat(data["expiration"])
+        lease = ResourceLease(
+            resource_ids=resource_ids, metadata=metadata, expiration=expiration
+        )
+        return lease
+
+    async def create_lease(
+        self,
+        resource_ids: list[UUID],
+        ttl: timedelta,
+        metadata: ConcurrencyLimitLeaseMetadata | None = None,
+    ) -> ResourceLease[ConcurrencyLimitLeaseMetadata]:
+        expiration = datetime.now(timezone.utc) + ttl
+        lease = ResourceLease(
+            resource_ids=resource_ids, metadata=metadata, expiration=expiration
+        )
+
+        self._ensure_storage_path()
+        lease_file = self._lease_file_path(lease.id)
+        lease_data = self._serialize_lease(lease, expiration)
+
+        with open(lease_file, "w") as f:
+            json.dump(lease_data, f)
+
+        return lease
+
+    async def read_lease(
+        self, lease_id: UUID
+    ) -> ResourceLease[ConcurrencyLimitLeaseMetadata] | None:
+        lease_file = self._lease_file_path(lease_id)
+
+        if not lease_file.exists():
+            return None
+
+        try:
+            with open(lease_file, "r") as f:
+                lease_data = json.load(f)
+
+            lease = self._deserialize_lease(lease_data)
+
+            # Check if lease is expired
+            if lease.expiration < datetime.now(timezone.utc):
+                # Clean up expired lease
+                lease_file.unlink(missing_ok=True)
+                return None
+
+            return lease
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # Clean up corrupted lease file
+            lease_file.unlink(missing_ok=True)
+            return None
+
+    async def renew_lease(self, lease_id: UUID, ttl: timedelta) -> None:
+        lease_file = self._lease_file_path(lease_id)
+
+        if not lease_file.exists():
+            return
+
+        try:
+            with open(lease_file, "r") as f:
+                lease_data = json.load(f)
+
+            # Update expiration time
+            new_expiration = datetime.now(timezone.utc) + ttl
+            lease_data["expiration"] = new_expiration.isoformat()
+
+            self._ensure_storage_path()
+            with open(lease_file, "w") as f:
+                json.dump(lease_data, f)
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # Clean up corrupted lease file
+            lease_file.unlink(missing_ok=True)
+
+    async def release_lease(self, lease_id: UUID) -> None:
+        lease_file = self._lease_file_path(lease_id)
+        lease_file.unlink(missing_ok=True)
+
+    async def read_expired_lease_ids(self, limit: int = 100) -> list[UUID]:
+        expired_leases = []
+        now = datetime.now(timezone.utc)
+
+        for lease_file in self.storage_path.glob("*.json"):
+            if len(expired_leases) >= limit:
+                break
+
+            try:
+                lease_id = UUID(lease_file.stem)
+
+                with open(lease_file, "r") as f:
+                    lease_data = json.load(f)
+
+                expiration = datetime.fromisoformat(lease_data["expiration"])
+
+                if expiration < now:
+                    expired_leases.append(lease_id)
+            except (json.JSONDecodeError, KeyError, ValueError):
+                # Clean up corrupted lease file
+                lease_file.unlink(missing_ok=True)
+
+        return expired_leases

--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -22,7 +22,9 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
 
     def __init__(self, storage_path: Path | None = None):
         prefect_home = get_current_settings().home
-        self.storage_path = Path(storage_path or prefect_home / "concurrency_leases")
+        self.storage_path: Path = Path(
+            storage_path or prefect_home / "concurrency_leases"
+        )
 
     def _ensure_storage_path(self) -> None:
         """Ensure the storage path exists, creating it if necessary."""

--- a/src/prefect/server/concurrency/lease_storage/memory.py
+++ b/src/prefect/server/concurrency/lease_storage/memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from prefect.server.concurrency.lease_storage import (
     ConcurrencyLeaseStorage as _ConcurrencyLeaseStorage,
@@ -34,10 +34,12 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         ttl: timedelta,
         metadata: ConcurrencyLimitLeaseMetadata | None = None,
     ) -> ResourceLease[ConcurrencyLimitLeaseMetadata]:
-        lease_id = uuid4()
-        lease = ResourceLease(id=lease_id, resource_ids=resource_ids, metadata=metadata)
-        self.leases[lease_id] = lease
-        self.expirations[lease_id] = datetime.now(timezone.utc) + ttl
+        expiration = datetime.now(timezone.utc) + ttl
+        lease = ResourceLease(
+            resource_ids=resource_ids, metadata=metadata, expiration=expiration
+        )
+        self.leases[lease.id] = lease
+        self.expirations[lease.id] = expiration
         return lease
 
     async def read_lease(

--- a/src/prefect/server/services/repossessor.py
+++ b/src/prefect/server/services/repossessor.py
@@ -1,6 +1,6 @@
-from prefect.server.concurrency.lease_storage import ConcurrencyLeaseStorage
-from prefect.server.concurrency.lease_storage.memory import (
-    ConcurrencyLeaseStorage as MemoryConcurrencyLeaseStorage,
+from prefect.server.concurrency.lease_storage import (
+    ConcurrencyLeaseStorage,
+    get_concurrency_lease_storage,
 )
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.models.concurrency_limits_v2 import bulk_decrement_active_slots
@@ -17,7 +17,7 @@ class Repossessor(LoopService):
     def __init__(self):
         super().__init__()
         self.concurrency_lease_storage: ConcurrencyLeaseStorage = (
-            MemoryConcurrencyLeaseStorage()
+            get_concurrency_lease_storage()
         )
 
     @classmethod

--- a/src/prefect/server/utilities/leasing.py
+++ b/src/prefect/server/utilities/leasing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Generic, Protocol, TypeVar
 from uuid import UUID, uuid4
 
@@ -11,6 +11,7 @@ T = TypeVar("T")
 @dataclass
 class ResourceLease(Generic[T]):
     resource_ids: list[UUID]
+    expiration: datetime
     id: UUID = field(default_factory=uuid4)
     metadata: T | None = None
 

--- a/src/prefect/settings/models/server/concurrency.py
+++ b/src/prefect/settings/models/server/concurrency.py
@@ -1,0 +1,17 @@
+from typing import ClassVar
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings, build_settings_config
+
+
+class ServerConcurrencySettings(PrefectBaseSettings):
+    model_config: ClassVar[SettingsConfigDict] = build_settings_config(
+        ("server", "concurrency")
+    )
+
+    lease_storage: str = Field(
+        default="prefect.server.concurrency.lease_storage.memory",
+        description="The module to use for storing concurrency limit leases.",
+    )

--- a/src/prefect/settings/models/server/root.py
+++ b/src/prefect/settings/models/server/root.py
@@ -7,6 +7,7 @@ from pydantic import AliasChoices, AliasPath, Field
 from pydantic_settings import SettingsConfigDict
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
+from prefect.settings.models.server.concurrency import ServerConcurrencySettings
 from prefect.types import LogLevel
 
 from .._defaults import default_memo_store_path
@@ -110,6 +111,10 @@ class ServerSettings(PrefectBaseSettings):
     api: ServerAPISettings = Field(
         default_factory=ServerAPISettings,
         description="Settings for controlling API server behavior",
+    )
+    concurrency: ServerConcurrencySettings = Field(
+        default_factory=ServerConcurrencySettings,
+        description="Settings for controlling server-side concurrency limit handling",
     )
     database: ServerDatabaseSettings = Field(
         default_factory=ServerDatabaseSettings,

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -1,0 +1,344 @@
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from prefect.server.concurrency.lease_storage import ConcurrencyLimitLeaseMetadata
+from prefect.server.concurrency.lease_storage.filesystem import (
+    ConcurrencyLeaseStorage,
+)
+from prefect.server.utilities.leasing import ResourceLease
+
+
+class TestFilesystemConcurrencyLeaseStorage:
+    @pytest.fixture
+    def temp_dir(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield Path(temp_dir)
+
+    @pytest.fixture
+    def storage(self, temp_dir: Path) -> ConcurrencyLeaseStorage:
+        return ConcurrencyLeaseStorage(storage_path=temp_dir)
+
+    @pytest.fixture
+    def sample_resource_ids(self) -> list[UUID]:
+        return [uuid4(), uuid4()]
+
+    @pytest.fixture
+    def sample_metadata(self) -> ConcurrencyLimitLeaseMetadata:
+        return ConcurrencyLimitLeaseMetadata(slots=5)
+
+    async def test_create_lease_without_metadata(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        ttl = timedelta(minutes=5)
+        lease = await storage.create_lease(sample_resource_ids, ttl)
+
+        assert lease.resource_ids == sample_resource_ids
+        assert lease.metadata is None
+
+        # Verify file was created
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 1
+
+    async def test_create_lease_with_metadata(
+        self,
+        storage: ConcurrencyLeaseStorage,
+        sample_resource_ids: list[UUID],
+        sample_metadata: ConcurrencyLimitLeaseMetadata,
+    ):
+        ttl = timedelta(minutes=5)
+        lease = await storage.create_lease(sample_resource_ids, ttl, sample_metadata)
+
+        assert lease.resource_ids == sample_resource_ids
+        assert lease.metadata == sample_metadata
+
+        # Verify file was created with correct data
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 1
+
+        with open(lease_files[0], "r") as f:
+            data = json.load(f)
+
+        assert data["metadata"]["slots"] == 5
+        assert len(data["resource_ids"]) == 2
+
+    async def test_read_lease_existing(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Get the lease ID from the file
+        lease_files = list(storage.storage_path.glob("*.json"))
+        lease_id = UUID(lease_files[0].stem)
+
+        read_lease = await storage.read_lease(lease_id)
+
+        assert read_lease is not None
+        assert read_lease.resource_ids == sample_resource_ids
+        assert read_lease.metadata is None
+
+    async def test_read_lease_non_existing(self, storage: ConcurrencyLeaseStorage):
+        non_existing_id = uuid4()
+        lease = await storage.read_lease(non_existing_id)
+        assert lease is None
+
+    async def test_read_lease_expired(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        # Create an expired lease
+        expired_ttl = timedelta(seconds=-1)
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+
+        # Get the lease ID from the file
+        lease_files = list(storage.storage_path.glob("*.json"))
+        lease_id = UUID(lease_files[0].stem)
+
+        # Reading should return None and clean up the file
+        read_lease = await storage.read_lease(lease_id)
+        assert read_lease is None
+
+        # File should be cleaned up
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 0
+
+    async def test_read_lease_corrupted_file(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        # Create a valid lease first
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Get the lease ID and corrupt the file
+        lease_files = list(storage.storage_path.glob("*.json"))
+        lease_id = UUID(lease_files[0].stem)
+
+        with open(lease_files[0], "w") as f:
+            f.write("invalid json content")
+
+        # Reading should return None and clean up the corrupted file
+        read_lease = await storage.read_lease(lease_id)
+        assert read_lease is None
+
+        # File should be cleaned up
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 0
+
+    async def test_renew_lease(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Get the lease ID and original expiration
+        lease_files = list(storage.storage_path.glob("*.json"))
+        lease_id = UUID(lease_files[0].stem)
+
+        with open(lease_files[0], "r") as f:
+            original_data = json.load(f)
+        original_expiration = datetime.fromisoformat(original_data["expiration"])
+
+        # Renew the lease
+        new_ttl = timedelta(minutes=10)
+        await storage.renew_lease(lease_id, new_ttl)
+
+        # Check that expiration was updated
+        with open(lease_files[0], "r") as f:
+            updated_data = json.load(f)
+        new_expiration = datetime.fromisoformat(updated_data["expiration"])
+
+        assert new_expiration > original_expiration
+
+    async def test_renew_lease_non_existing(self, storage: ConcurrencyLeaseStorage):
+        non_existing_id = uuid4()
+        # Should not raise an exception
+        await storage.renew_lease(non_existing_id, timedelta(minutes=5))
+
+    async def test_renew_lease_corrupted_file(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        # Create a valid lease first
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Get the lease ID and corrupt the file
+        lease_files = list(storage.storage_path.glob("*.json"))
+        lease_id = UUID(lease_files[0].stem)
+
+        with open(lease_files[0], "w") as f:
+            f.write("invalid json content")
+
+        # Renewing should clean up the corrupted file
+        await storage.renew_lease(lease_id, timedelta(minutes=10))
+
+        # File should be cleaned up
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 0
+
+    async def test_release_lease(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Verify file exists
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 1
+        lease_id = UUID(lease_files[0].stem)
+
+        # Release the lease
+        await storage.release_lease(lease_id)
+
+        # File should be deleted
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 0
+
+    async def test_release_lease_non_existing(self, storage: ConcurrencyLeaseStorage):
+        non_existing_id = uuid4()
+        # Should not raise an exception
+        await storage.release_lease(non_existing_id)
+
+    async def test_read_expired_lease_ids_no_expired(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        expired_ids = await storage.read_expired_lease_ids()
+        assert expired_ids == []
+
+    async def test_read_expired_lease_ids_with_expired(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        expired_ttl = timedelta(seconds=-1)
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+
+        expired_ids = await storage.read_expired_lease_ids()
+        assert len(expired_ids) == 1
+
+        # Verify the lease ID is correct
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 1
+        expected_lease_id = UUID(lease_files[0].stem)
+        assert expired_ids[0] == expected_lease_id
+
+    async def test_read_expired_lease_ids_with_limit(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        expired_ttl = timedelta(seconds=-1)
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+
+        expired_ids = await storage.read_expired_lease_ids(limit=2)
+        assert len(expired_ids) == 2
+
+    async def test_read_expired_lease_ids_mixed_expiration(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        expired_ttl = timedelta(seconds=-1)
+        valid_ttl = timedelta(minutes=5)
+
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+        await storage.create_lease(sample_resource_ids, valid_ttl)
+        await storage.create_lease(sample_resource_ids, expired_ttl)
+
+        expired_ids = await storage.read_expired_lease_ids()
+        assert len(expired_ids) == 2
+
+    async def test_read_expired_lease_ids_corrupted_files(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        # Create a valid lease and a corrupted file
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Create a corrupted file
+        corrupted_file = storage.storage_path / f"{uuid4()}.json"
+        with open(corrupted_file, "w") as f:
+            f.write("invalid json content")
+
+        # Should clean up corrupted file and return no expired leases
+        expired_ids = await storage.read_expired_lease_ids()
+        assert expired_ids == []
+
+        # Corrupted file should be cleaned up
+        assert not corrupted_file.exists()
+
+    async def test_serialize_deserialize_lease(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        metadata = ConcurrencyLimitLeaseMetadata(slots=10)
+        lease = ResourceLease(resource_ids=sample_resource_ids, metadata=metadata)
+        expiration = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+        # Serialize
+        serialized = storage._serialize_lease(lease, expiration)
+
+        # Deserialize
+        deserialized_lease, deserialized_expiration = storage._deserialize_lease(
+            serialized
+        )
+
+        assert deserialized_lease.resource_ids == sample_resource_ids
+        assert deserialized_lease.metadata is not None
+        assert deserialized_lease.metadata.slots == 10
+        assert deserialized_expiration == expiration
+
+    async def test_serialize_lease_without_metadata(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        lease = ResourceLease(resource_ids=sample_resource_ids, metadata=None)
+        expiration = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+        # Serialize
+        serialized = storage._serialize_lease(lease, expiration)
+
+        # Deserialize
+        deserialized_lease, deserialized_expiration = storage._deserialize_lease(
+            serialized
+        )
+
+        assert deserialized_lease.resource_ids == sample_resource_ids
+        assert deserialized_lease.metadata is None
+        assert deserialized_expiration == expiration
+
+    async def test_storage_path_creation(self, temp_dir: Path):
+        # Test that storage path is created only when needed
+        storage_path = temp_dir / "nested" / "path"
+        assert not storage_path.exists()
+
+        # Creating the storage instance should not create the directory
+        storage = ConcurrencyLeaseStorage(storage_path=storage_path)
+        assert not storage_path.exists()
+
+        # Creating a lease should create the directory
+        sample_resource_ids = [uuid4(), uuid4()]
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+        assert storage_path.exists()
+        assert storage_path.is_dir()
+
+    async def test_multiple_leases_persistence(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        # Create multiple leases
+        ttl = timedelta(minutes=5)
+        await storage.create_lease(sample_resource_ids, ttl)
+        await storage.create_lease(sample_resource_ids, ttl)
+        await storage.create_lease(sample_resource_ids, ttl)
+
+        # Verify all files exist
+        lease_files = list(storage.storage_path.glob("*.json"))
+        assert len(lease_files) == 3
+
+        # Verify we can read all leases
+        lease_ids = [UUID(f.stem) for f in lease_files]
+        for lease_id in lease_ids:
+            read_lease = await storage.read_lease(lease_id)
+            assert read_lease is not None
+            assert read_lease.resource_ids == sample_resource_ids

--- a/tests/server/concurrency/test_memory_lease_storage.py
+++ b/tests/server/concurrency/test_memory_lease_storage.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -17,7 +17,11 @@ class TestMemoryConcurrencyLeaseStorage:
         assert instance1 is instance2
 
         instance1.leases = {
-            uuid4(): ResourceLease(resource_ids=[uuid4()], metadata=None)
+            uuid4(): ResourceLease(
+                resource_ids=[uuid4()],
+                metadata=None,
+                expiration=datetime.now(timezone.utc),
+            )
         }
         assert instance1.leases == instance2.leases
 

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -37,12 +37,12 @@ def use_filesystem_lease_storage():
 
 
 @pytest.fixture()
-def app(use_filesystem_lease_storage) -> Generator[FastAPI, Any, None]:
+def app(use_filesystem_lease_storage: None) -> Generator[FastAPI, Any, None]:
     yield create_app(ephemeral=True)
 
 
 @pytest.fixture
-async def client(app) -> AsyncGenerator[AsyncClient, Any]:
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, Any]:
     async with httpx.AsyncClient(
         transport=ASGITransport(app=app), base_url="https://test/api"
     ) as async_client:
@@ -112,7 +112,7 @@ async def locked_concurrency_limit_with_decay(
 @pytest.fixture
 async def expiring_concurrency_lease(
     concurrency_limit: ConcurrencyLimitV2,
-    use_filesystem_lease_storage,
+    use_filesystem_lease_storage: None,
 ) -> ResourceLease[ConcurrencyLimitLeaseMetadata]:
     return await get_concurrency_lease_storage().create_lease(
         resource_ids=[concurrency_limit.id],
@@ -666,12 +666,12 @@ async def test_decrement_concurrency_limit_slots_gt_zero_422(client: AsyncClient
     assert response.status_code == 422
 
 
+@pytest.mark.usefixtures("ignore_prefect_deprecation_warnings")
 async def test_decrement_concurrency_limit(
     locked_concurrency_limit: ConcurrencyLimitV2,
     concurrency_limit: ConcurrencyLimitV2,
     client: AsyncClient,
     session: AsyncSession,
-    ignore_prefect_deprecation_warnings,
 ):
     assert concurrency_limit.active_slots == 0
     response = await client.post(

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -1,3 +1,4 @@
+import shutil
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, AsyncGenerator, Generator
@@ -14,6 +15,7 @@ from prefect.server.concurrency.lease_storage import (
     ConcurrencyLimitLeaseMetadata,
     get_concurrency_lease_storage,
 )
+from prefect.server.concurrency.lease_storage.filesystem import ConcurrencyLeaseStorage
 from prefect.server.database import PrefectDBInterface
 from prefect.server.models.concurrency_limits_v2 import (
     bulk_update_denied_slots,
@@ -33,6 +35,7 @@ def use_filesystem_lease_storage():
             PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE: "prefect.server.concurrency.lease_storage.filesystem"
         }
     ):
+        shutil.rmtree(ConcurrencyLeaseStorage().storage_path, ignore_errors=True)
         yield
 
 

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -1,14 +1,18 @@
 import uuid
-from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timedelta, timezone
+from typing import Any, AsyncGenerator, Generator
 
+import httpx
 import pytest
-from httpx import AsyncClient
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.client import schemas as client_schemas
+from prefect.server.api.server import create_app
 from prefect.server.concurrency.lease_storage import (
     ConcurrencyLimitLeaseMetadata,
+    get_concurrency_lease_storage,
 )
 from prefect.server.database import PrefectDBInterface
 from prefect.server.models.concurrency_limits_v2 import (
@@ -18,6 +22,31 @@ from prefect.server.models.concurrency_limits_v2 import (
 )
 from prefect.server.schemas.core import ConcurrencyLimitV2
 from prefect.server.utilities.leasing import ResourceLease
+from prefect.settings import PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
+from prefect.settings.context import temporary_settings
+
+
+@pytest.fixture
+def use_filesystem_lease_storage():
+    with temporary_settings(
+        {
+            PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE: "prefect.server.concurrency.lease_storage.filesystem"
+        }
+    ):
+        yield
+
+
+@pytest.fixture()
+def app(use_filesystem_lease_storage) -> Generator[FastAPI, Any, None]:
+    yield create_app(ephemeral=True)
+
+
+@pytest.fixture
+async def client(app) -> AsyncGenerator[AsyncClient, Any]:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test/api"
+    ) as async_client:
+        yield async_client
 
 
 @pytest.fixture
@@ -78,6 +107,18 @@ async def locked_concurrency_limit_with_decay(
     await session.commit()
 
     return ConcurrencyLimitV2.model_validate(concurrency_limit)
+
+
+@pytest.fixture
+async def expiring_concurrency_lease(
+    concurrency_limit: ConcurrencyLimitV2,
+    use_filesystem_lease_storage,
+) -> ResourceLease[ConcurrencyLimitLeaseMetadata]:
+    return await get_concurrency_lease_storage().create_lease(
+        resource_ids=[concurrency_limit.id],
+        metadata=ConcurrencyLimitLeaseMetadata(slots=1),
+        ttl=timedelta(seconds=0.1),
+    )
 
 
 async def test_create_concurrency_limit(client: AsyncClient):
@@ -269,25 +310,11 @@ async def test_increment_concurrency_limit_simple(
     assert refreshed_limit.active_slots == 1
 
 
+@pytest.mark.usefixtures("use_filesystem_lease_storage")
 async def test_increment_concurrency_limit_with_lease_simple(
     client: AsyncClient,
     concurrency_limit: ConcurrencyLimitV2,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    mock_lease_storage = MagicMock()
-    monkeypatch.setattr(
-        "prefect.server.api.concurrency_limits_v2.ConcurrencyLeaseStorage",
-        mock_lease_storage,
-    )
-    lease_id = uuid.uuid4()
-    mock_lease_storage().create_lease = AsyncMock(
-        return_value=ResourceLease(
-            id=lease_id,
-            resource_ids=[concurrency_limit.id],
-            metadata=ConcurrencyLimitLeaseMetadata(slots=1),
-        )
-    )
-
     assert concurrency_limit.active_slots == 0
     response = await client.post(
         "/v2/concurrency_limits/increment-with-lease",
@@ -301,34 +328,19 @@ async def test_increment_concurrency_limit_with_lease_simple(
     assert [limit["id"] for limit in response.json()["limits"]] == [
         str(concurrency_limit.id)
     ]
-    assert str(lease_id) == response.json()["lease_id"]
-    mock_lease_storage().create_lease.assert_called_once_with(
-        resource_ids=[concurrency_limit.id],
-        ttl=timedelta(seconds=300),
-        metadata=ConcurrencyLimitLeaseMetadata(slots=1),
-    )
+    lease_storage = get_concurrency_lease_storage()
+    lease = await lease_storage.read_lease(uuid.UUID(response.json()["lease_id"]))
+    assert lease
+    assert lease.resource_ids == [concurrency_limit.id]
+    assert lease.metadata == ConcurrencyLimitLeaseMetadata(slots=1)
 
 
 async def test_increment_concurrency_limit_with_lease_ttl(
     client: AsyncClient,
     concurrency_limit: ConcurrencyLimitV2,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    mock_lease_storage = MagicMock()
-    monkeypatch.setattr(
-        "prefect.server.api.concurrency_limits_v2.ConcurrencyLeaseStorage",
-        mock_lease_storage,
-    )
-    lease_id = uuid.uuid4()
-    mock_lease_storage().create_lease = AsyncMock(
-        return_value=ResourceLease(
-            id=lease_id,
-            resource_ids=[concurrency_limit.id],
-            metadata=ConcurrencyLimitLeaseMetadata(slots=1),
-        )
-    )
-
     assert concurrency_limit.active_slots == 0
+    now = datetime.now(timezone.utc)
     response = await client.post(
         "/v2/concurrency_limits/increment-with-lease",
         json={
@@ -342,11 +354,13 @@ async def test_increment_concurrency_limit_with_lease_ttl(
     assert [limit["id"] for limit in response.json()["limits"]] == [
         str(concurrency_limit.id)
     ]
-    assert str(lease_id) == response.json()["lease_id"]
-    mock_lease_storage().create_lease.assert_called_once_with(
-        resource_ids=[concurrency_limit.id],
-        ttl=timedelta(seconds=60),
-        metadata=ConcurrencyLimitLeaseMetadata(slots=1),
+    lease_storage = get_concurrency_lease_storage()
+    lease = await lease_storage.read_lease(uuid.UUID(response.json()["lease_id"]))
+    assert lease
+    assert lease.resource_ids == [concurrency_limit.id]
+    assert lease.metadata == ConcurrencyLimitLeaseMetadata(slots=1)
+    assert (
+        now + timedelta(seconds=60) <= lease.expiration <= now + timedelta(seconds=62)
     )
 
 
@@ -688,3 +702,35 @@ async def test_decrement_concurrency_limit(
     )
     assert refreshed_limit
     assert refreshed_limit.active_slots == refreshed_limit.limit - 1
+
+
+async def test_renew_concurrency_lease(
+    expiring_concurrency_lease: ResourceLease[ConcurrencyLimitLeaseMetadata],
+    client: AsyncClient,
+):
+    lease_storage = get_concurrency_lease_storage()
+    expired_lease_ids = await lease_storage.read_expired_lease_ids()
+    now = datetime.now(timezone.utc)
+    assert not expired_lease_ids
+
+    response = await client.post(
+        f"/v2/concurrency_limits/leases/{expiring_concurrency_lease.id}/renew",
+        json={"lease_duration": 600},
+    )
+    assert response.status_code == 204, response.text
+
+    lease = await lease_storage.read_lease(expiring_concurrency_lease.id)
+    assert lease
+    assert (
+        now + timedelta(seconds=600) <= lease.expiration <= now + timedelta(seconds=602)
+    )
+
+
+async def test_renew_concurrency_lease_not_found(
+    client: AsyncClient,
+):
+    response = await client.post(
+        f"/v2/concurrency_limits/leases/{uuid.uuid4()}/renew",
+        json={"lease_duration": 600},
+    )
+    assert response.status_code == 404, response.text

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -120,7 +120,7 @@ async def expiring_concurrency_lease(
     return await get_concurrency_lease_storage().create_lease(
         resource_ids=[concurrency_limit.id],
         metadata=ConcurrencyLimitLeaseMetadata(slots=1),
-        ttl=timedelta(seconds=0.1),
+        ttl=timedelta(seconds=5),
     )
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -303,6 +303,9 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_API_HOST": {"test_value": "host"},
     "PREFECT_SERVER_API_KEEPALIVE_TIMEOUT": {"test_value": 10},
     "PREFECT_SERVER_API_PORT": {"test_value": 4200},
+    "PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE": {
+        "test_value": "prefect.server.concurrency.lease_storage.filesystem"
+    },
     "PREFECT_SERVER_CORS_ALLOWED_HEADERS": {"test_value": "foo", "legacy": True},
     "PREFECT_SERVER_CORS_ALLOWED_METHODS": {"test_value": "foo", "legacy": True},
     "PREFECT_SERVER_CORS_ALLOWED_ORIGINS": {"test_value": "foo", "legacy": True},

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -1416,6 +1416,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/concurrency_limits/leases/{lease_id}/renew": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Renew Concurrency Lease */
+        post: operations["renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/block_types/": {
         parameters: {
             query?: never;
@@ -4778,6 +4795,15 @@ export interface components {
              * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
+        };
+        /** Body_renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post */
+        Body_renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post: {
+            /**
+             * Lease Duration
+             * @description The duration of the lease in seconds.
+             * @default 300
+             */
+            lease_duration: number;
         };
         /** Body_reset_concurrency_limit_by_tag_concurrency_limits_tag__tag__reset_post */
         Body_reset_concurrency_limit_by_tag_concurrency_limits_tag__tag__reset_post: {
@@ -12909,6 +12935,42 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["MinimalConcurrencyLimitResponse"][];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path: {
+                /** @description The ID of the lease to renew */
+                lease_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["Body_renew_concurrency_lease_v2_concurrency_limits_leases__lease_id__renew_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
This PR adds a `/v2/concurrency-limits/renew` endpoint to enable the exertion of concurrency limit leases to prevent the repossessor service from freeing slots in the associated concurrency limits.

This PR also adds a filesystem-based `ConcurrencyLeaseStorage` implementation to aid in testing, along with the settings mechanics to enable switching between different `ConcurrencyLeaseStorage` implementations.

Related to https://github.com/PrefectHQ/prefect/issues/17415
