### PR TITLE
✨ fix(server): update Prefect server docs URL in startup message

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -832,7 +832,7 @@ class SubprocessASGIServer:
             assert self.port is not None, "Port must be provided or available"
             help_message = (
                 f"Starting temporary server on {self.address}\nSee "
-                "https://docs.prefect.io/3.0/manage/self-host#self-host-a-prefect-server "
+                "https://docs.prefect.io/v3/concepts/server#how-to-guides "
                 "for more information on running a dedicated Prefect server."
             )
             subprocess_server_logger.info(help_message)


### PR DESCRIPTION
Change the documentation link in the temporary server startup message to point to the latest Prefect v3 server how-to guides. This ensures users receive accurate and up-to-date information when running a dedicated Prefect server.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

solve #18538