### PR TITLE
Track concurrency limit lease creation time and use it to calculate occupancy seconds

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -4622,7 +4622,10 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post"
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "The ID of the lease corresponding to the concurrency limits to decrement.",
+                                "title": "Lease Id"
                             }
                         }
                     }
@@ -12240,33 +12243,6 @@
                     "names"
                 ],
                 "title": "Body_bulk_decrement_active_slots_v2_concurrency_limits_decrement_post"
-            },
-            "Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post": {
-                "properties": {
-                    "lease_id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Lease Id",
-                        "description": "The ID of the lease corresponding to the concurrency limits to decrement."
-                    },
-                    "occupancy_seconds": {
-                        "anyOf": [
-                            {
-                                "type": "number",
-                                "exclusiveMinimum": 0.0
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Occupancy Seconds"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "lease_id"
-                ],
-                "title": "Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post"
             },
             "Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post": {
                 "properties": {

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -4622,10 +4622,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "string",
-                                "format": "uuid",
-                                "description": "The ID of the lease corresponding to the concurrency limits to decrement.",
-                                "title": "Lease Id"
+                                "$ref": "#/components/schemas/Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post"
                             }
                         }
                     }
@@ -12243,6 +12240,21 @@
                     "names"
                 ],
                 "title": "Body_bulk_decrement_active_slots_v2_concurrency_limits_decrement_post"
+            },
+            "Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post": {
+                "properties": {
+                    "lease_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Lease Id",
+                        "description": "The ID of the lease corresponding to the concurrency limits to decrement."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "lease_id"
+                ],
+                "title": "Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post"
             },
             "Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post": {
                 "properties": {

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Literal, Optional, Union
 from uuid import UUID
 
@@ -370,13 +370,14 @@ async def bulk_decrement_active_slots_with_lease(
         ...,
         description="The ID of the lease corresponding to the concurrency limits to decrement.",
     ),
-    occupancy_seconds: Optional[float] = Body(None, gt=0.0),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> None:
     lease_storage = get_concurrency_lease_storage()
     lease = await lease_storage.read_lease(lease_id)
     if not lease:
         return
+
+    occupancy_seconds = (datetime.now(timezone.utc) - lease.created_at).total_seconds()
 
     async with db.session_context(begin_transaction=True) as session:
         await models.concurrency_limits_v2.bulk_decrement_active_slots(

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -369,6 +369,7 @@ async def bulk_decrement_active_slots_with_lease(
     lease_id: UUID = Body(
         ...,
         description="The ID of the lease corresponding to the concurrency limits to decrement.",
+        embed=True,
     ),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> None:

--- a/src/prefect/server/utilities/leasing.py
+++ b/src/prefect/server/utilities/leasing.py
@@ -12,6 +12,7 @@ T = TypeVar("T")
 class ResourceLease(Generic[T]):
     resource_ids: list[UUID]
     expiration: datetime
+    created_at: datetime = field(default_factory=datetime.now)
     id: UUID = field(default_factory=uuid4)
     metadata: T | None = None
 

--- a/src/prefect/server/utilities/leasing.py
+++ b/src/prefect/server/utilities/leasing.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from functools import partial
 from typing import Generic, Protocol, TypeVar
 from uuid import UUID, uuid4
 
@@ -12,7 +13,7 @@ T = TypeVar("T")
 class ResourceLease(Generic[T]):
     resource_ids: list[UUID]
     expiration: datetime
-    created_at: datetime = field(default_factory=datetime.now)
+    created_at: datetime = field(default_factory=partial(datetime.now, timezone.utc))
     id: UUID = field(default_factory=uuid4)
     metadata: T | None = None
 

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -737,7 +737,7 @@ async def test_decrement_concurrency_limit_with_lease(
         "/v2/concurrency_limits/decrement-with-lease",
         json={"lease_id": lease_id},
     )
-    assert response.status_code == 204
+    assert response.status_code == 204, response.text
 
     lease = await get_concurrency_lease_storage().read_lease(lease_id)
     assert not lease

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -4058,6 +4058,15 @@ export interface components {
              */
             create_if_missing?: boolean;
         };
+        /** Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post */
+        Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post: {
+            /**
+             * Lease Id
+             * Format: uuid
+             * @description The ID of the lease corresponding to the concurrency limits to decrement.
+             */
+            lease_id: string;
+        };
         /** Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post */
         Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post: {
             /** Slots */
@@ -12975,7 +12984,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": string;
+                "application/json": components["schemas"]["Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post"];
             };
         };
         responses: {

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -4058,17 +4058,6 @@ export interface components {
              */
             create_if_missing?: boolean;
         };
-        /** Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post */
-        Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post: {
-            /**
-             * Lease Id
-             * Format: uuid
-             * @description The ID of the lease corresponding to the concurrency limits to decrement.
-             */
-            lease_id: string;
-            /** Occupancy Seconds */
-            occupancy_seconds?: number | null;
-        };
         /** Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post */
         Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post: {
             /** Slots */
@@ -12986,7 +12975,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["Body_bulk_decrement_active_slots_with_lease_v2_concurrency_limits_decrement_with_lease_post"];
+                "application/json": string;
             };
         };
         responses: {


### PR DESCRIPTION
This PR updates the concurrency limit lease implementation to track when leases are created, and use that timestamp to populate `occupancy_seconds` when decrementing concurrency limit slots. With this change, clients will not need to provide `occupancy_seconds` when decrementing concurrency limit slots via a lease.

Related to https://github.com/PrefectHQ/prefect/issues/17415