### PR TITLE
Omit compiled dbt code when it exceeds max asset description length

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -30,6 +30,7 @@ from google.protobuf.json_format import MessageToDict
 from prefect import get_client, get_run_logger
 from prefect._internal.uuid7 import uuid7
 from prefect.assets import Asset, AssetProperties
+from prefect.assets.core import MAX_ASSET_DESCRIPTION_LENGTH
 from prefect.cache_policies import NO_CACHE
 from prefect.client.orchestration import PrefectClient
 from prefect.context import AssetContext, hydrated_context, serialize_context
@@ -254,7 +255,16 @@ class PrefectDbtRunner:
         if os.path.exists(compiled_code_path):
             with open(compiled_code_path, "r") as f:
                 code_content = f.read()
-                return f"\n ### Compiled code\n```sql\n{code_content.strip()}\n```"
+                description = (
+                    f"\n ### Compiled code\n```sql\n{code_content.strip()}\n```"
+                )
+                if len(description) > MAX_ASSET_DESCRIPTION_LENGTH:
+                    description = (
+                        "\n ### Compiled code\n"
+                        "Compiled code code was omitted because it exceeded the "
+                        f"maximum asset description length of {MAX_ASSET_DESCRIPTION_LENGTH} characters."
+                    )
+                return description
         return ""
 
     def _create_asset_from_node(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
After https://github.com/PrefectHQ/prefect/pull/18541, we want to enforce this by skipping collection of compiled model code instead of failing on a validation error in the dbt integration.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
