### PR TITLE
Allow specifying the key for an existing Kuberentes worker API auth string secret

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
@@ -60,6 +60,16 @@ class KubernetesWorkerSettings(PrefectBaseSettings):
         description="The key of the secret the worker's API key is stored in.",
     )
 
+    api_auth_string_secret_name: Optional[str] = Field(
+        default=None,
+        description="The name of the secret the worker's API auth string is stored in.",
+    )
+
+    api_auth_string_secret_key: Optional[str] = Field(
+        default=None,
+        description="The key of the secret the worker's API auth string is stored in.",
+    )
+
     create_secret_for_api_key: bool = Field(
         default=False,
         description="If `True`, the worker will create a secret in the same namespace as created Kubernetes jobs to store the Prefect API key.",
@@ -67,6 +77,16 @@ class KubernetesWorkerSettings(PrefectBaseSettings):
             AliasPath("create_secret_for_api_key"),
             "prefect_integrations_kubernetes_worker_create_secret_for_api_key",
             "prefect_kubernetes_worker_store_prefect_api_in_secret",
+        ),
+    )
+
+    create_secret_for_api_auth_string: bool = Field(
+        default=False,
+        description="If `True`, the worker will create a secret in the same namespace as created Kubernetes jobs to store the Prefect API auth string.",
+        validation_alias=AliasChoices(
+            AliasPath("create_secret_for_api_auth_string"),
+            "prefect_integrations_kubernetes_worker_create_secret_for_api_auth_string",
+            "prefect_kubernetes_worker_store_prefect_api_auth_string_in_secret",
         ),
     )
 

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -40,6 +40,7 @@ from prefect.futures import PrefectFlowRunFuture
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.settings import (
+    PREFECT_API_AUTH_STRING,
     PREFECT_API_KEY,
     get_current_settings,
     temporary_settings,
@@ -209,12 +210,32 @@ def enable_store_api_key_in_secret(monkeypatch):
 
 
 @pytest.fixture
+def enable_store_api_auth_string_in_secret(monkeypatch):
+    monkeypatch.setenv(
+        "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_CREATE_SECRET_FOR_API_AUTH_STRING",
+        "true",
+    )
+
+
+@pytest.fixture
 def mock_api_key_secret_name_and_key(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(
         "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME", "test-secret"
     )
     monkeypatch.setenv(
         "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY", "value"
+    )
+    return "test-secret", "value"
+
+
+@pytest.fixture
+def mock_api_auth_string_secret_name_and_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_NAME",
+        "test-secret",
+    )
+    monkeypatch.setenv(
+        "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_KEY", "value"
     )
     return "test-secret", "value"
 
@@ -1831,6 +1852,228 @@ class TestKubernetesWorker:
                         "secretKeyRef": {
                             "name": mock_api_key_secret_name,
                             "key": mock_api_key_secret_key,
+                        }
+                    },
+                } in env
+                mock_core_client.return_value.replace_namespaced_secret.assert_not_called()
+
+    async def test_can_store_api_auth_string_in_secret(
+        self,
+        flow_run,
+        mock_core_client,
+        mock_watch,
+        mock_pods_stream_that_returns_completed_pod,
+        mock_batch_client,
+        enable_store_api_auth_string_in_secret,
+    ):
+        mock_watch.return_value.stream = mock.Mock(
+            side_effect=mock_pods_stream_that_returns_completed_pod
+        )
+        mock_core_client.return_value.read_namespaced_secret.side_effect = ApiException(
+            status=404
+        )
+
+        configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
+            KubernetesWorker.get_default_base_job_template(), {"image": "foo"}
+        )
+        with temporary_settings(updates={PREFECT_API_AUTH_STRING: "fake"}):
+            async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+                configuration.prepare_for_flow_run(flow_run=flow_run)
+                await k8s_worker.run(flow_run, configuration)
+                mock_batch_client.return_value.create_namespaced_job.assert_called_once()
+                env = mock_batch_client.return_value.create_namespaced_job.call_args[0][
+                    1
+                ]["spec"]["template"]["spec"]["containers"][0]["env"]
+                assert {
+                    "name": "PREFECT_API_AUTH_STRING",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                            "key": "value",
+                        }
+                    },
+                } in env
+                mock_core_client.return_value.create_namespaced_secret.assert_called_with(
+                    namespace=configuration.namespace,
+                    body=V1Secret(
+                        api_version="v1",
+                        kind="Secret",
+                        metadata=V1ObjectMeta(
+                            name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                            namespace=configuration.namespace,
+                        ),
+                        data={
+                            "value": base64.b64encode("fake".encode("utf-8")).decode(
+                                "utf-8"
+                            )
+                        },
+                    ),
+                )
+
+        # Make sure secret gets deleted
+        assert await mock_core_client.return_value.delete_namespaced_secret(
+            name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+            namespace=configuration.namespace,
+        )
+
+    async def test_store_api_auth_string_in_existing_secret(
+        self,
+        flow_run,
+        mock_core_client,
+        mock_watch,
+        mock_pods_stream_that_returns_running_pod,
+        mock_batch_client,
+        enable_store_api_auth_string_in_secret,
+    ):
+        mock_watch.return_value.stream = mock_pods_stream_that_returns_running_pod
+
+        configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
+            KubernetesWorker.get_default_base_job_template(), {"image": "foo"}
+        )
+        with temporary_settings(updates={PREFECT_API_AUTH_STRING: "fake"}):
+            async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+                mock_core_client.return_value.read_namespaced_secret.return_value = V1Secret(
+                    api_version="v1",
+                    kind="Secret",
+                    metadata=V1ObjectMeta(
+                        name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                        namespace=configuration.namespace,
+                    ),
+                    data={
+                        "value": base64.b64encode("fake".encode("utf-8")).decode(
+                            "utf-8"
+                        )
+                    },
+                )
+
+                configuration.prepare_for_flow_run(flow_run=flow_run)
+                await k8s_worker.run(flow_run, configuration)
+                mock_batch_client.return_value.create_namespaced_job.assert_called_once()
+                env = mock_batch_client.return_value.create_namespaced_job.call_args[0][
+                    1
+                ]["spec"]["template"]["spec"]["containers"][0]["env"]
+                assert {
+                    "name": "PREFECT_API_AUTH_STRING",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                            "key": "value",
+                        }
+                    },
+                } in env
+                mock_core_client.return_value.replace_namespaced_secret.assert_called_with(
+                    name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                    namespace=configuration.namespace,
+                    body=V1Secret(
+                        api_version="v1",
+                        kind="Secret",
+                        metadata=V1ObjectMeta(
+                            name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                            namespace=configuration.namespace,
+                        ),
+                        data={
+                            "value": base64.b64encode("fake".encode("utf-8")).decode(
+                                "utf-8"
+                            )
+                        },
+                    ),
+                )
+
+    async def test_use_existing_auth_string_secret_name(
+        self,
+        flow_run,
+        mock_core_client,
+        mock_watch,
+        mock_pods_stream_that_returns_running_pod,
+        mock_batch_client,
+        mock_api_auth_string_secret_name_and_key: tuple[str, str],
+    ):
+        mock_api_auth_string_secret_name, mock_api_auth_string_secret_key = (
+            mock_api_auth_string_secret_name_and_key
+        )
+        mock_watch.return_value.stream = mock_pods_stream_that_returns_running_pod
+
+        configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
+            KubernetesWorker.get_default_base_job_template(), {"image": "foo"}
+        )
+        with temporary_settings(updates={PREFECT_API_AUTH_STRING: "fake"}):
+            async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+                mock_core_client.return_value.read_namespaced_secret.return_value = V1Secret(
+                    api_version="v1",
+                    kind="Secret",
+                    metadata=V1ObjectMeta(
+                        name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                        namespace=configuration.namespace,
+                    ),
+                    data={
+                        "value": base64.b64encode("fake".encode("utf-8")).decode(
+                            "utf-8"
+                        )
+                    },
+                )
+
+                configuration.prepare_for_flow_run(flow_run=flow_run)
+                await k8s_worker.run(flow_run, configuration)
+                mock_batch_client.return_value.create_namespaced_job.assert_called_once()
+                env = mock_batch_client.return_value.create_namespaced_job.call_args[0][
+                    1
+                ]["spec"]["template"]["spec"]["containers"][0]["env"]
+                assert {
+                    "name": "PREFECT_API_AUTH_STRING",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": mock_api_auth_string_secret_name,
+                            "key": mock_api_auth_string_secret_key,
+                        }
+                    },
+                } in env
+
+    async def test_existing_auth_string_secret_name_takes_precedence(
+        self,
+        flow_run,
+        mock_core_client,
+        mock_watch,
+        mock_pods_stream_that_returns_running_pod,
+        mock_batch_client,
+        mock_api_auth_string_secret_name_and_key: tuple[str, str],
+        enable_store_api_auth_string_in_secret,
+    ):
+        mock_api_auth_string_secret_name, mock_api_auth_string_secret_key = (
+            mock_api_auth_string_secret_name_and_key
+        )
+        mock_watch.return_value.stream = mock_pods_stream_that_returns_running_pod
+
+        configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
+            KubernetesWorker.get_default_base_job_template(), {"image": "foo"}
+        )
+        with temporary_settings(updates={PREFECT_API_AUTH_STRING: "fake"}):
+            async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+                mock_core_client.return_value.read_namespaced_secret.return_value = V1Secret(
+                    api_version="v1",
+                    kind="Secret",
+                    metadata=V1ObjectMeta(
+                        name=f"prefect-{_slugify_name(k8s_worker.name)}-api-auth-string",
+                        namespace=configuration.namespace,
+                    ),
+                    data={
+                        "value": base64.b64encode("fake".encode("utf-8")).decode(
+                            "utf-8"
+                        )
+                    },
+                )
+
+                configuration.prepare_for_flow_run(flow_run=flow_run)
+                await k8s_worker.run(flow_run, configuration)
+                mock_batch_client.return_value.create_namespaced_job.assert_called_once()
+                env = mock_batch_client.return_value.create_namespaced_job.call_args[0][
+                    1
+                ]["spec"]["template"]["spec"]["containers"][0]["env"]
+                assert {
+                    "name": "PREFECT_API_AUTH_STRING",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": mock_api_auth_string_secret_name,
+                            "key": mock_api_auth_string_secret_key,
                         }
                     },
                 } in env


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/PrefectHQ/prefect/pull/17390

Allows the `PREFECT_API_AUTH_STRING` to reference a Kubernetes secret.

Related to https://github.com/PrefectHQ/prefect-helm/issues/442

Related to https://github.com/PrefectHQ/prefect-helm/issues/442

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
