### PR TITLE
Fix docstrings and regenerate SDK docs

### DIFF
--- a/docs/v3/api-ref/python/prefect-blocks-abstract.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-abstract.mdx
@@ -42,7 +42,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -246,7 +246,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -317,8 +317,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -458,7 +458,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -649,7 +649,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -720,8 +720,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -921,7 +921,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1112,7 +1112,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1183,8 +1183,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -1338,7 +1338,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1614,7 +1614,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1685,8 +1685,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -1821,7 +1821,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -2064,7 +2064,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -2135,8 +2135,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -2322,7 +2322,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -2513,7 +2513,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -2584,8 +2584,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.

--- a/docs/v3/api-ref/python/prefect-blocks-core.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-core.mdx
@@ -92,7 +92,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -283,7 +283,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -354,8 +354,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.

--- a/docs/v3/api-ref/python/prefect-blocks-system.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-system.mdx
@@ -38,7 +38,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -229,7 +229,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -300,8 +300,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -420,7 +420,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -611,7 +611,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -682,8 +682,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -802,7 +802,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -993,7 +993,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1064,8 +1064,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -1185,7 +1185,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1382,7 +1382,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1453,8 +1453,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.

--- a/docs/v3/api-ref/python/prefect-blocks-webhook.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-webhook.mdx
@@ -38,7 +38,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -247,7 +247,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -318,8 +318,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.

--- a/docs/v3/api-ref/python/prefect-cli-artifact.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-artifact.mdx
@@ -26,40 +26,43 @@ inspect(key: str, limit: int = typer.Option(10, '--limit', help='The maximum num
 
 View details about an artifact.
 
-    Arguments:
-        key: the key of the artifact to inspect
+**Args:**
+- `key`: the key of the artifact to inspect
 
-    Examples:
-        $ prefect artifact inspect "my-artifact"
-       [
-        {
-            'id': 'ba1d67be-0bd7-452e-8110-247fe5e6d8cc',
-            'created': '2023-03-21T21:40:09.895910+00:00',
-            'updated': '2023-03-21T21:40:09.895910+00:00',
-            'key': 'my-artifact',
-            'type': 'markdown',
-            'description': None,
-            'data': 'my markdown',
-            'metadata_': None,
-            'flow_run_id': '8dc54b6f-6e24-4586-a05c-e98c6490cb98',
-            'task_run_id': None
-        },
-        {
-            'id': '57f235b5-2576-45a5-bd93-c829c2900966',
-            'created': '2023-03-27T23:16:15.536434+00:00',
-            'updated': '2023-03-27T23:16:15.536434+00:00',
-            'key': 'my-artifact',
-            'type': 'markdown',
-            'description': 'my-artifact-description',
-            'data': 'my markdown',
-            'metadata_': None,
-            'flow_run_id': 'ffa91051-f249-48c1-ae0f-4754fcb7eb29',
-            'task_run_id': None
-        }
+**Examples:**
+
+`$ prefect artifact inspect "my-artifact"`
+```json
+[
+  {
+    'id': 'ba1d67be-0bd7-452e-8110-247fe5e6d8cc',
+    'created': '2023-03-21T21:40:09.895910+00:00',
+    'updated': '2023-03-21T21:40:09.895910+00:00',
+    'key': 'my-artifact',
+    'type': 'markdown',
+    'description': None,
+    'data': 'my markdown',
+    'metadata_': None,
+    'flow_run_id': '8dc54b6f-6e24-4586-a05c-e98c6490cb98',
+    'task_run_id': None
+  },
+  {
+    'id': '57f235b5-2576-45a5-bd93-c829c2900966',
+    'created': '2023-03-27T23:16:15.536434+00:00',
+    'updated': '2023-03-27T23:16:15.536434+00:00',
+    'key': 'my-artifact',
+    'type': 'markdown',
+    'description': 'my-artifact-description',
+    'data': 'my markdown',
+    'metadata_': None,
+    'flow_run_id': 'ffa91051-f249-48c1-ae0f-4754fcb7eb29',
+    'task_run_id': None
+  }
 ]
+```
 
 
-### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/artifact.py#L166" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/artifact.py#L168" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete(key: Optional[str] = typer.Argument(None, help='The key of the artifact to delete.'), artifact_id: Optional[UUID] = typer.Option(None, '--id', help='The ID of the artifact to delete.'))
@@ -73,5 +76,5 @@ Delete an artifact.
 
 **Examples:**
 
-$ prefect artifact delete "my-artifact"
+`$ prefect artifact delete "my-artifact"`
 

--- a/docs/v3/api-ref/python/prefect-cli-deployment.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-deployment.mdx
@@ -56,46 +56,8 @@ inspect(name: str, output: Optional[str] = typer.Option(None, '--output', '-o', 
 
 View details about a deployment.
 
-
-Example:
-    
-    $ prefect deployment inspect "hello-world/my-deployment"
-    $ prefect deployment inspect "hello-world/my-deployment" --output json
-    {
-        'id': '610df9c3-0fb4-4856-b330-67f588d20201',
-        'created': '2022-08-01T18:36:25.192102+00:00',
-        'updated': '2022-08-01T18:36:25.188166+00:00',
-        'name': 'my-deployment',
-        'description': None,
-        'flow_id': 'b57b0aa2-ef3a-479e-be49-381fb0483b4e',
-        'schedules': None,
-        'parameters': {'name': 'Marvin'},
-        'tags': ['test'],
-        'parameter_openapi_schema': {
-            'title': 'Parameters',
-            'type': 'object',
-            'properties': {
-                'name': {
-                    'title': 'name',
-                    'type': 'string'
-                }
-            },
-            'required': ['name']
-        },
-        'storage_document_id': '63ef008f-1e5d-4e07-a0d4-4535731adb32',
-        'infrastructure_document_id': '6702c598-7094-42c8-9785-338d2ec3a028',
-        'infrastructure': {
-            'type': 'process',
-            'env': {},
-            'labels': {},
-            'name': None,
-            'command': ['python', '-m', 'prefect.engine'],
-            'stream_output': True
-        }
-    }
 
-
-### `create_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L307" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L306" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_schedule(name: str, interval: Optional[float] = typer.Option(None, '--interval', help='An interval to schedule on, specified in seconds', min=0.0001), interval_anchor: Optional[str] = typer.Option(None, '--anchor-date', help='The anchor date for an interval schedule'), rrule_string: Optional[str] = typer.Option(None, '--rrule', help='Deployment schedule rrule string'), cron_string: Optional[str] = typer.Option(None, '--cron', help='Deployment schedule cron string'), cron_day_or: bool = typer.Option(True, '--day_or', help='Control how croniter handles `day` and `day_of_week` entries'), timezone: Optional[str] = typer.Option(None, '--timezone', help="Deployment schedule timezone string e.g. 'America/New_York'"), active: bool = typer.Option(True, '--active', help='Whether the schedule is active. Defaults to True.'), replace: Optional[bool] = typer.Option(False, '--replace', help="Replace the deployment's current schedule(s) with this new schedule."), assume_yes: Optional[bool] = typer.Option(False, '--accept-yes', '-y', help='Accept the confirmation prompt without prompting'))
@@ -105,7 +67,7 @@ create_schedule(name: str, interval: Optional[float] = typer.Option(None, '--int
 Create a schedule for a given deployment.
 
 
-### `delete_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L466" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L465" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_schedule(deployment_name: str, schedule_id: UUID, assume_yes: bool = typer.Option(False, '--accept-yes', '-y', help='Accept the confirmation prompt without prompting'))
@@ -115,7 +77,7 @@ delete_schedule(deployment_name: str, schedule_id: UUID, assume_yes: bool = type
 Delete a deployment schedule.
 
 
-### `pause_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L506" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `pause_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L505" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 pause_schedule(deployment_name: str, schedule_id: UUID)
@@ -125,7 +87,7 @@ pause_schedule(deployment_name: str, schedule_id: UUID)
 Pause a deployment schedule.
 
 
-### `resume_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L537" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `resume_schedule` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L536" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 resume_schedule(deployment_name: str, schedule_id: UUID)
@@ -135,7 +97,7 @@ resume_schedule(deployment_name: str, schedule_id: UUID)
 Resume a deployment schedule.
 
 
-### `list_schedules` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L566" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `list_schedules` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L565" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 list_schedules(deployment_name: str)
@@ -145,7 +107,7 @@ list_schedules(deployment_name: str)
 View all schedules for a deployment.
 
 
-### `clear_schedules` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L609" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `clear_schedules` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L608" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 clear_schedules(deployment_name: str, assume_yes: bool = typer.Option(False, '--accept-yes', '-y', help='Accept the confirmation prompt without prompting'))
@@ -155,7 +117,7 @@ clear_schedules(deployment_name: str, assume_yes: bool = typer.Option(False, '--
 Clear all schedules for a deployment.
 
 
-### `ls` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L646" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `ls` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L645" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 ls(flow_name: Optional[list[str]] = None, by_created: bool = False)
@@ -165,7 +127,7 @@ ls(flow_name: Optional[list[str]] = None, by_created: bool = False)
 View all deployments or deployments for specific flows.
 
 
-### `run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L695" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L694" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 run(name: Optional[str] = typer.Argument(None, help="A deployed flow's name: <FLOW_NAME>/<DEPLOYMENT_NAME>"), deployment_id: Optional[str] = typer.Option(None, '--id', help='A deployment id to search for if no name is given'), job_variables: list[str] = typer.Option(None, '-jv', '--job-variable', help='A key, value pair (key=value) specifying a flow run job variable. The value will be interpreted as JSON. May be passed multiple times to specify multiple job variable values.'), params: list[str] = typer.Option(None, '-p', '--param', help='A key, value pair (key=value) specifying a flow parameter. The value will be interpreted as JSON. May be passed multiple times to specify multiple parameter values.'), multiparams: Optional[str] = typer.Option(None, '--params', help="A mapping of parameters to values. To use a stdin, pass '-'. Any parameters passed with `--param` will take precedence over these values."), start_in: Optional[str] = typer.Option(None, '--start-in', help="A human-readable string specifying a time interval to wait before starting the flow run. E.g. 'in 5 minutes', 'in 1 hour', 'in 2 days'."), start_at: Optional[str] = typer.Option(None, '--start-at', help="A human-readable string specifying a time to start the flow run. E.g. 'at 5:30pm', 'at 2022-08-01 17:30', 'at 2022-08-01 17:30:00'."), tags: list[str] = typer.Option(None, '--tag', help='Tag(s) to be applied to flow run.'), watch: bool = typer.Option(False, '--watch', help='Whether to poll the flow run until a terminal state is reached.'), watch_interval: Optional[int] = typer.Option(None, '--watch-interval', help='How often to poll the flow run for state changes (in seconds).'), watch_timeout: Optional[int] = typer.Option(None, '--watch-timeout', help='Timeout for --watch.'), flow_run_name: Optional[str] = typer.Option(None, '--flow-run-name', help='Custom name to give the flow run.'))
@@ -179,7 +141,7 @@ The flow run will not execute until a worker starts.
 To watch the flow run until it reaches a terminal state, use the `--watch` flag.
 
 
-### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L949" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/deployment.py#L948" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete(name: Optional[str] = typer.Argument(None, help="A deployed flow's name: <FLOW_NAME>/<DEPLOYMENT_NAME>"), deployment_id: Optional[UUID] = typer.Option(None, '--id', help='A deployment id to search for if no name is given'), _all: bool = typer.Option(False, '--all', help='Delete all deployments'))
@@ -188,11 +150,10 @@ delete(name: Optional[str] = typer.Argument(None, help="A deployed flow's name: 
 
 Delete a deployment.
 
-
-Examples:
-    
-    $ prefect deployment delete test_flow/test_deployment
-    $ prefect deployment delete --id dfd3e220-a130-4149-9af6-8d487e02fea6
+**Examples:**
+
+`$ prefect deployment delete test_flow/test_deployment`
+`$ prefect deployment delete --id dfd3e220-a130-4149-9af6-8d487e02fea6`
 
 
 ## Classes

--- a/docs/v3/api-ref/python/prefect-events-cli-automations.mdx
+++ b/docs/v3/api-ref/python/prefect-events-cli-automations.mdx
@@ -49,14 +49,14 @@ Arguments:
 
 Examples:
 
-    $ prefect automation inspect "my-automation"
+    `$ prefect automation inspect "my-automation"`
 
-    $ prefect automation inspect --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    `$ prefect automation inspect --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
 
-    $ prefect automation inspect "my-automation" --yaml
+    `$ prefect automation inspect "my-automation" --yaml`
 
-    $ prefect automation inspect "my-automation" --output json
-    $ prefect automation inspect "my-automation" --output yaml
+    `$ prefect automation inspect "my-automation" --output json`
+    `$ prefect automation inspect "my-automation" --output yaml`
 
 
 ### `resume` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/cli/automations.py#L191" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
@@ -76,9 +76,9 @@ Arguments:
 
 Examples:
 
-        $ prefect automation resume "my-automation"
+        `$ prefect automation resume "my-automation"`
 
-        $ prefect automation resume --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        `$ prefect automation resume --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
 
 
 ### `pause` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/cli/automations.py#L246" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
@@ -98,9 +98,9 @@ Arguments:
 
 Examples:
 
-    $ prefect automation pause "my-automation"
+    `$ prefect automation pause "my-automation"`
 
-    $ prefect automation pause --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    `$ prefect automation pause --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
 
 
 ### `delete` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/cli/automations.py#L301" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
@@ -118,8 +118,8 @@ Delete an automation.
 
 **Examples:**
 
-$ prefect automation delete "my-automation"
-$ prefect automation delete --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+`$ prefect automation delete "my-automation"`
+`$ prefect automation delete --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
 
 
 ### `create` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/events/cli/automations.py#L353" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
@@ -133,8 +133,8 @@ Create one or more automations from a file or JSON string.
 
 **Examples:**
 
-$ prefect automation create --from-file automation.yaml
-$ prefect automation create -f automation.json
-$ prefect automation create --from-json '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
-$ prefect automation create -j '[{"name": "auto1", ...}, {"name": "auto2", ...}]'
+`$ prefect automation create --from-file automation.yaml`
+`$ prefect automation create -f automation.json`
+`$ prefect automation create --from-json '{"name": "my-automation", "trigger": {...}, "actions": [...]}'`
+`$ prefect automation create -j '[{"name": "auto1", ...}, {"name": "auto2", ...}]'`
 

--- a/docs/v3/api-ref/python/prefect-filesystems.mdx
+++ b/docs/v3/api-ref/python/prefect-filesystems.mdx
@@ -34,7 +34,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -225,7 +225,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -296,8 +296,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -418,7 +418,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -609,7 +609,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -680,8 +680,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -808,7 +808,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1005,7 +1005,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1076,8 +1076,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.
@@ -1192,7 +1192,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1389,7 +1389,7 @@ and saved to a new block document before the block can be used as expected.
 
 **Args:**
 - `name`: The name or slug of the block document. A block document slug is a
-string with the format &lt;block_type_slug&gt;/&lt;block_document_name&gt;
+string with the format `<block_type_slug>/<block_document_name>`
 - `validate`: If False, the block document will be loaded without Pydantic
 validating the block schema. This is useful if the block schema has
 changed client-side since the block document referred to by `name` was saved.
@@ -1460,8 +1460,8 @@ the current class with the data stored in the block document.
 
 Provided reference can be a block document ID, or a reference data in dictionary format.
 Supported dictionary reference formats are:
-- {"block_document_id": &lt;block_document_id&gt;}
-- {"block_document_slug": &lt;block_document_slug&gt;}
+- `{"block_document_id": <block_document_id>}`
+- `{"block_document_slug": <block_document_slug>}`
 
 If a block document for a given block type is saved with a different schema
 than the current class calling `load`, a warning will be raised.

--- a/docs/v3/api-ref/python/prefect-utilities-templating.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-templating.mdx
@@ -122,16 +122,16 @@ For a block document with the structure:
 examples of value resolution are as follows:
 
 1. Accessing a nested dictionary:
-   Format: prefect.blocks.&lt;block_type_slug&gt;.&lt;block_document_name&gt;.value.key
-   Example: Returns {"nested-key": "nested-value"}
+   Format: `prefect.blocks.<block_type_slug>.<block_document_name>.value.key`
+   Example: Returns `{"nested-key": "nested-value"}`
 
 2. Accessing a specific nested value:
-   Format: prefect.blocks.&lt;block_type_slug&gt;.&lt;block_document_name&gt;.value.key.nested-key
-   Example: Returns "nested-value"
+   Format: `prefect.blocks.<block_type_slug>.<block_document_name>.value.key.nested-key`
+   Example: Returns `"nested-value"`
 
 3. Accessing a list element's key-value:
-   Format: prefect.blocks.&lt;block_type_slug&gt;.&lt;block_document_name&gt;.value.list\[0].list-key
-   Example: Returns "list-value"
+   Format: `prefect.blocks.<block_type_slug>.<block_document_name>.value.list[0].list-key`
+   Example: Returns `"list-value"`
 
 Default Resolution for System Blocks:
 -------------------------------------

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -1013,7 +1013,7 @@ class Block(BaseModel, ABC):
 
         Args:
             name: The name or slug of the block document. A block document slug is a
-                string with the format <block_type_slug>/<block_document_name>
+                string with the format `<block_type_slug>/<block_document_name>`
             validate: If False, the block document will be loaded without Pydantic
                 validating the block schema. This is useful if the block schema has
                 changed client-side since the block document referred to by `name` was saved.
@@ -1102,7 +1102,7 @@ class Block(BaseModel, ABC):
 
         Args:
             name: The name or slug of the block document. A block document slug is a
-                string with the format <block_type_slug>/<block_document_name>
+                string with the format `<block_type_slug>/<block_document_name>`
             validate: If False, the block document will be loaded without Pydantic
                 validating the block schema. This is useful if the block schema has
                 changed client-side since the block document referred to by `name` was saved.
@@ -1190,8 +1190,8 @@ class Block(BaseModel, ABC):
 
         Provided reference can be a block document ID, or a reference data in dictionary format.
         Supported dictionary reference formats are:
-        - {"block_document_id": <block_document_id>}
-        - {"block_document_slug": <block_document_slug>}
+        - `{"block_document_id": <block_document_id>}`
+        - `{"block_document_slug": <block_document_slug>}`
 
         If a block document for a given block type is saved with a different schema
         than the current class calling `load`, a warning will be raised.

--- a/src/prefect/cli/artifact.py
+++ b/src/prefect/cli/artifact.py
@@ -105,39 +105,41 @@ async def inspect(
     ),
 ):
     """
-        View details about an artifact.
+    View details about an artifact.
 
-        Arguments:
-            key: the key of the artifact to inspect
+    Arguments:
+        key: the key of the artifact to inspect
 
-        Examples:
-            $ prefect artifact inspect "my-artifact"
-           [
-            {
-                'id': 'ba1d67be-0bd7-452e-8110-247fe5e6d8cc',
-                'created': '2023-03-21T21:40:09.895910+00:00',
-                'updated': '2023-03-21T21:40:09.895910+00:00',
-                'key': 'my-artifact',
-                'type': 'markdown',
-                'description': None,
-                'data': 'my markdown',
-                'metadata_': None,
-                'flow_run_id': '8dc54b6f-6e24-4586-a05c-e98c6490cb98',
-                'task_run_id': None
-            },
-            {
-                'id': '57f235b5-2576-45a5-bd93-c829c2900966',
-                'created': '2023-03-27T23:16:15.536434+00:00',
-                'updated': '2023-03-27T23:16:15.536434+00:00',
-                'key': 'my-artifact',
-                'type': 'markdown',
-                'description': 'my-artifact-description',
-                'data': 'my markdown',
-                'metadata_': None,
-                'flow_run_id': 'ffa91051-f249-48c1-ae0f-4754fcb7eb29',
-                'task_run_id': None
-            }
-    ]
+    Examples:
+        `$ prefect artifact inspect "my-artifact"`
+        ```json
+        [
+          {
+            'id': 'ba1d67be-0bd7-452e-8110-247fe5e6d8cc',
+            'created': '2023-03-21T21:40:09.895910+00:00',
+            'updated': '2023-03-21T21:40:09.895910+00:00',
+            'key': 'my-artifact',
+            'type': 'markdown',
+            'description': None,
+            'data': 'my markdown',
+            'metadata_': None,
+            'flow_run_id': '8dc54b6f-6e24-4586-a05c-e98c6490cb98',
+            'task_run_id': None
+          },
+          {
+            'id': '57f235b5-2576-45a5-bd93-c829c2900966',
+            'created': '2023-03-27T23:16:15.536434+00:00',
+            'updated': '2023-03-27T23:16:15.536434+00:00',
+            'key': 'my-artifact',
+            'type': 'markdown',
+            'description': 'my-artifact-description',
+            'data': 'my markdown',
+            'metadata_': None,
+            'flow_run_id': 'ffa91051-f249-48c1-ae0f-4754fcb7eb29',
+            'task_run_id': None
+          }
+        ]
+        ```
     """
     if output and output.lower() != "json":
         exit_with_error("Only 'json' output format is supported.")
@@ -178,7 +180,7 @@ async def delete(
         key: the key of the artifact to delete
 
     Examples:
-        $ prefect artifact delete "my-artifact"
+        `$ prefect artifact delete "my-artifact"`
     """
     if key and artifact_id:
         exit_with_error("Please provide either a key or an artifact_id but not both.")

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -228,11 +228,10 @@ async def inspect(
     """
     View details about a deployment.
 
-    \b
     Example:
-        \b
-        $ prefect deployment inspect "hello-world/my-deployment"
-        $ prefect deployment inspect "hello-world/my-deployment" --output json
+        `$ prefect deployment inspect "hello-world/my-deployment"`
+        `$ prefect deployment inspect "hello-world/my-deployment" --output json`
+        ```json
         {
             'id': '610df9c3-0fb4-4856-b330-67f588d20201',
             'created': '2022-08-01T18:36:25.192102+00:00',
@@ -265,7 +264,7 @@ async def inspect(
                 'stream_output': True
             }
         }
-
+        ```
     """
     if output and output.lower() != "json":
         exit_with_error("Only 'json' output format is supported.")
@@ -958,11 +957,9 @@ async def delete(
     """
     Delete a deployment.
 
-    \b
     Examples:
-        \b
-        $ prefect deployment delete test_flow/test_deployment
-        $ prefect deployment delete --id dfd3e220-a130-4149-9af6-8d487e02fea6
+        `$ prefect deployment delete test_flow/test_deployment`
+        `$ prefect deployment delete --id dfd3e220-a130-4149-9af6-8d487e02fea6`
     """
     async with get_client() as client:
         if _all:

--- a/src/prefect/events/cli/automations.py
+++ b/src/prefect/events/cli/automations.py
@@ -130,14 +130,14 @@ async def inspect(
 
     Examples:
 
-        $ prefect automation inspect "my-automation"
+        `$ prefect automation inspect "my-automation"`
 
-        $ prefect automation inspect --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        `$ prefect automation inspect --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
 
-        $ prefect automation inspect "my-automation" --yaml
+        `$ prefect automation inspect "my-automation" --yaml`
 
-        $ prefect automation inspect "my-automation" --output json
-        $ prefect automation inspect "my-automation" --output yaml
+        `$ prefect automation inspect "my-automation" --output json`
+        `$ prefect automation inspect "my-automation" --output yaml`
     """
     if output and output.lower() not in ["json", "yaml"]:
         exit_with_error("Only 'json' and 'yaml' output formats are supported.")
@@ -203,9 +203,9 @@ async def resume(
 
     Examples:
 
-            $ prefect automation resume "my-automation"
+            `$ prefect automation resume "my-automation"`
 
-            $ prefect automation resume --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+            `$ prefect automation resume --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
     """
     if not id and not name:
         exit_with_error("Please provide either a name or an id.")
@@ -258,9 +258,9 @@ async def pause(
 
     Examples:
 
-        $ prefect automation pause "my-automation"
+        `$ prefect automation pause "my-automation"`
 
-        $ prefect automation pause --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        `$ prefect automation pause --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
     """
     if not id and not name:
         exit_with_error("Please provide either a name or an id.")
@@ -309,8 +309,8 @@ async def delete(
         id: the id of the automation to delete
 
     Examples:
-        $ prefect automation delete "my-automation"
-        $ prefect automation delete --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        `$ prefect automation delete "my-automation"`
+        `$ prefect automation delete --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`
     """
 
     async with get_client() as client:
@@ -367,10 +367,10 @@ async def create(
     """Create one or more automations from a file or JSON string.
 
     Examples:
-        $ prefect automation create --from-file automation.yaml
-        $ prefect automation create -f automation.json
-        $ prefect automation create --from-json '{"name": "my-automation", "trigger": {...}, "actions": [...]}'
-        $ prefect automation create -j '[{"name": "auto1", ...}, {"name": "auto2", ...}]'
+        `$ prefect automation create --from-file automation.yaml`
+        `$ prefect automation create -f automation.json`
+        `$ prefect automation create --from-json '{"name": "my-automation", "trigger": {...}, "actions": [...]}'`
+        `$ prefect automation create -j '[{"name": "auto1", ...}, {"name": "auto2", ...}]'`
     """
     if from_file and from_json:
         exit_with_error("Please provide either --from-file or --from-json, not both.")

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -280,16 +280,16 @@ async def resolve_block_document_references(
     examples of value resolution are as follows:
 
     1. Accessing a nested dictionary:
-       Format: prefect.blocks.<block_type_slug>.<block_document_name>.value.key
-       Example: Returns {"nested-key": "nested-value"}
+       Format: `prefect.blocks.<block_type_slug>.<block_document_name>.value.key`
+       Example: Returns `{"nested-key": "nested-value"}`
 
     2. Accessing a specific nested value:
-       Format: prefect.blocks.<block_type_slug>.<block_document_name>.value.key.nested-key
-       Example: Returns "nested-value"
+       Format: `prefect.blocks.<block_type_slug>.<block_document_name>.value.key.nested-key`
+       Example: Returns `"nested-value"`
 
     3. Accessing a list element's key-value:
-       Format: prefect.blocks.<block_type_slug>.<block_document_name>.value.list[0].list-key
-       Example: Returns "list-value"
+       Format: `prefect.blocks.<block_type_slug>.<block_document_name>.value.list[0].list-key`
+       Example: Returns `"list-value"`
 
     Default Resolution for System Blocks:
     -------------------------------------


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Puts `$` and `<>/<>` and `<>.<>` instances in code blocks. After making these changes, I can run `mintlify dev` locally and host the docs without any parsing errors. We may want to consider adding some checks for this so new docstrings don't break our docs.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
