### PR TITLE
Fixes async locking error by generating unique holder for each transaction

### DIFF
--- a/src/prefect/locking/memory.py
+++ b/src/prefect/locking/memory.py
@@ -33,6 +33,7 @@ class MemoryLockManager(LockManager):
     """
 
     _instance = None
+    _initialized = False
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         if cls._instance is None:
@@ -40,8 +41,11 @@ class MemoryLockManager(LockManager):
         return cls._instance
 
     def __init__(self):
+        if self.__class__._initialized:
+            return
         self._locks_dict_lock = threading.Lock()
         self._locks: dict[str, _LockInfo] = {}
+        self.__class__._initialized = True
 
     def _expire_lock(self, key: str):
         """

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -776,6 +776,7 @@ class ResultStore(BaseModel):
             and self.is_locked(base_key)
             and not self.is_lock_holder(base_key, holder)
         ):
+            breakpoint()
             raise RuntimeError(
                 f"Cannot write to result record with key {base_key} because it is locked by "
                 f"another holder."

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -776,7 +776,6 @@ class ResultStore(BaseModel):
             and self.is_locked(base_key)
             and not self.is_lock_holder(base_key, holder)
         ):
-            breakpoint()
             raise RuntimeError(
                 f"Cannot write to result record with key {base_key} because it is locked by "
                 f"another holder."


### PR DESCRIPTION
These changes fix an error where running nested transactions across asyncio tasks caused an error when releasing a transactions lock. The default holder string contains the ID of the current task, so mixing tasks would result in mismatched holders on lock acquisition and release.

The fix is to generate a unique holder for each transaction, which is used to acquire and release the lock, and held for the duration of the transaction.

Closes https://github.com/PrefectHQ/prefect/issues/18600
