### PR TITLE
Add GCP secret support to `CloudRunWorker` for Prefect API credentials

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
@@ -374,19 +374,19 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         # Create a copy of the environment variables to avoid modifying the original
         env_copy = self.env.copy()
 
-        # Log warnings when plaintext credentials are provided alongside secrets
-        if self.prefect_api_key_secret and "PREFECT_API_KEY" in env_copy:
+        # Log warnings when plaintext credentials are provided without secrets
+        if not self.prefect_api_key_secret and "PREFECT_API_KEY" in env_copy:
             logger.warning(
-                "Both PREFECT_API_KEY environment variable and prefect_api_key_secret are provided. "
-                "The secret will be used and the environment variable will be ignored."
+                "PREFECT_API_KEY environment variable is provided in plaintext without a secret configured. "
+                "Consider using prefect_api_key_secret for better security."
             )
         if (
-            self.prefect_api_auth_string_secret
+            not self.prefect_api_auth_string_secret
             and "PREFECT_API_AUTH_STRING" in env_copy
         ):
             logger.warning(
-                "Both PREFECT_API_AUTH_STRING environment variable and prefect_api_auth_string_secret are provided. "
-                "The secret will be used and the environment variable will be ignored."
+                "PREFECT_API_AUTH_STRING environment variable is provided in plaintext without a secret configured. "
+                "Consider using prefect_api_auth_string_secret for better security."
             )
 
         # Remove Prefect API credentials from environment if secrets are provided

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
@@ -154,6 +154,8 @@ Read more about configuring work pools
     ```
 """
 
+from __future__ import annotations
+
 import re
 import shlex
 import time

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 from unittest.mock import Mock
 

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker.py
@@ -270,7 +270,7 @@ class TestCloudRunWorkerJobConfiguration:
         assert len(caplog.records) == 0
 
     def test_populate_envs_logs_warning_when_plaintext_without_secret(
-        self, cloud_run_worker_job_config, caplog
+        self, cloud_run_worker_job_config, caplog, flow_run
     ):
         """Test that warnings are logged when plaintext credentials are provided without secrets"""
         # Set up environment with plaintext credentials but no secrets
@@ -283,24 +283,24 @@ class TestCloudRunWorkerJobConfiguration:
         cloud_run_worker_job_config.prefect_api_key_secret = None
         cloud_run_worker_job_config.prefect_api_auth_string_secret = None
 
-        with caplog.at_level("WARNING"):
-            cloud_run_worker_job_config._populate_envs()
+        cloud_run_worker_job_config.prepare_for_flow_run(
+            flow_run=flow_run,
+        )
 
-        # Check that warnings were logged for plaintext credentials without secrets
-        assert len(caplog.records) == 2
         assert (
-            "PREFECT_API_KEY environment variable is provided in plaintext without a secret configured"
+            "PREFECT_API_KEY is provided as a plaintext environment variable"
             in caplog.text
         )
         assert (
-            "PREFECT_API_AUTH_STRING environment variable is provided in plaintext without a secret configured"
+            "PREFECT_API_AUTH_STRING is provided as a plaintext environment variable"
             in caplog.text
         )
         assert (
-            "Consider using prefect_api_key_secret for better security" in caplog.text
+            "consider providing it as a secret using 'prefect_api_key_secret' in your base job template"
+            in caplog.text
         )
         assert (
-            "Consider using prefect_api_auth_string_secret for better security"
+            "consider providing it as a secret using 'prefect_api_auth_string_secret' in your base job template"
             in caplog.text
         )
 


### PR DESCRIPTION
## Summary

Adds support for using GCP secrets to provide Prefect API credentials to CloudRunWorker jobs, following the same pattern as the ECS worker implementation.

- Adds `prefect_api_key_secret` and `prefect_api_auth_string_secret` fields
- Modifies `_populate_envs()` to handle secret-based environment variables
- Removes plaintext credentials when secrets are configured
- Includes comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)