### PR TITLE
Bugfix clientcustomheaders pydanticvalidation

### DIFF
--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -1,8 +1,7 @@
-from typing import ClassVar, Dict
 import json
+from typing import ClassVar, Dict
 
-from pydantic import AliasChoices, AliasPath, Field
-from pydantic import field_validator
+from pydantic import AliasChoices, AliasPath, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 
 from prefect.settings.base import (

--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -1,6 +1,8 @@
 from typing import ClassVar, Dict
+import json
 
 from pydantic import AliasChoices, AliasPath, Field
+from pydantic import field_validator
 from pydantic_settings import SettingsConfigDict
 
 from prefect.settings.base import (
@@ -102,3 +104,9 @@ class ClientSettings(PrefectBaseSettings):
         default_factory=ClientMetricsSettings,
         description="Settings for controlling metrics reporting from the client",
     )
+
+    @field_validator("custom_headers", mode="before")
+    def validate_custom_headers(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2547,6 +2547,13 @@ class TestClientCustomHeadersSetting:
         expected = {"X-Json-Header": "json-value", "Api-Key": "secret123"}
         assert settings.client.custom_headers == expected
 
+    def test_setting_via_cli(self):
+        """Test setting custom headers via the CLI. Ensures string->dict validation works."""
+        from prefect.settings import update_current_profile
+
+        update_current_profile({"PREFECT_CLIENT_CUSTOM_HEADERS": '{"X-Test-Header": "test-value", "Authorization": "Bearer token123"}'})
+
+    #     settings = get_current_settings()
     def test_invalid_json_string_raises_error(self, monkeypatch: pytest.MonkeyPatch):
         """Test that invalid JSON raises appropriate error."""
         monkeypatch.setenv("PREFECT_CLIENT_CUSTOM_HEADERS", "not-valid-json")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2551,7 +2551,11 @@ class TestClientCustomHeadersSetting:
         """Test setting custom headers via the CLI. Ensures string->dict validation works."""
         from prefect.settings import update_current_profile
 
-        update_current_profile({"PREFECT_CLIENT_CUSTOM_HEADERS": '{"X-Test-Header": "test-value", "Authorization": "Bearer token123"}'})
+        update_current_profile(
+            {
+                "PREFECT_CLIENT_CUSTOM_HEADERS": '{"X-Test-Header": "test-value", "Authorization": "Bearer token123"}'
+            }
+        )
 
     #     settings = get_current_settings()
     def test_invalid_json_string_raises_error(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2557,7 +2557,6 @@ class TestClientCustomHeadersSetting:
             }
         )
 
-    #     settings = get_current_settings()
     def test_invalid_json_string_raises_error(self, monkeypatch: pytest.MonkeyPatch):
         """Test that invalid JSON raises appropriate error."""
         monkeypatch.setenv("PREFECT_CLIENT_CUSTOM_HEADERS", "not-valid-json")


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/18611

# Change Overview
1. Add a `field_validator` to `Client.custom_headers` client settings model to ensure that strings are parsed into dicts. This allows setting header dicts via the CLI tool and toml config files.
2. Add a test to ensure the CLI tool mechanism successfully sets headers.


### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
