### PR TITLE
Add PREFECT_API_AUTH_STRING to ENV_SECRETS for ACI worker

### DIFF
--- a/src/integrations/prefect-azure/prefect_azure/workers/container_instance.py
+++ b/src/integrations/prefect-azure/prefect_azure/workers/container_instance.py
@@ -117,7 +117,7 @@ ACI_DEFAULT_GPU = 0.0
 DEFAULT_CONTAINER_ENTRYPOINT = "/opt/prefect/entrypoint.sh"
 # environment variables that ACI should treat as secure variables so they
 # won't appear in logs
-ENV_SECRETS = ["PREFECT_API_KEY"]
+ENV_SECRETS = ["PREFECT_API_KEY", "PREFECT_API_AUTH_STRING"]
 
 # The maximum time to wait for container group deletion before giving up and
 # moving on. Deletion is usually quick, so exceeding this timeout means something


### PR DESCRIPTION
Ensures PREFECT_API_AUTH_STRING is treated as secure variable in Azure Container Instances, preventing it from appearing in logs.