### PR TITLE
fixed styling of certain code blocks and links in docs

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,5 +1,5 @@
 #topbar-cta-button > a > span {
-  background-color: #2D6DF6;
+  background-color: #2d6df6;
   border-radius: 0.25rem;
 }
 
@@ -12,7 +12,7 @@
   letter-spacing: 0.4px;
 }
 
-#topbar-cta-button>a div>span,
+#topbar-cta-button > a div > span,
 #topbar-cta-button > a div > svg {
   color: #fff;
 }
@@ -21,26 +21,28 @@ img {
   filter: none !important;
 }
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap");
 
 /* Base font settings */
 body {
-    font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    font-family: 'Roboto', sans-serif;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Roboto", sans-serif;
 }
 
 /* Other custom styles */
 p {
-    font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
 }
 
-[role="listitem"] *:last-child {
-    border-bottom: none !important;
+[role="listitem"] *:last-child:not(.code-block, .link) {
+  border-bottom: none !important;
 }
-
-
-


### PR DESCRIPTION
Code blocks and links that were last children accidentally had their bottom borders disabled

Before:
![Screenshot 2025-07-31 at 9 03 46 AM](https://github.com/user-attachments/assets/e166d280-1eaf-49e8-85e5-c167e807b551)
![Screenshot 2025-07-31 at 9 01 20 AM](https://github.com/user-attachments/assets/c0c2a136-470a-417e-b718-00ce56394703)

After:
![Screenshot 2025-07-31 at 9 03 26 AM](https://github.com/user-attachments/assets/48285876-ca36-4c49-85da-8aeb94b7403b)
![Screenshot 2025-07-31 at 9 01 31 AM](https://github.com/user-attachments/assets/ccce7b5c-5a85-4a78-81c4-1e452930c726)


### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
