### PR TITLE
Enable metrics server on workers

### DIFF
--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -175,7 +175,7 @@ def start_client_metrics_server() -> None:
 
 
 def stop_client_metrics_server() -> None:
-    """Start the process-wide Prometheus metrics server for client metrics, if it has
+    """Stop the process-wide Prometheus metrics server for client metrics, if it has
     previously been started"""
     global _metrics_server
     if _metrics_server:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -78,7 +78,11 @@ from prefect.tasks import Task
 from prefect.types import KeyValueLabels
 from prefect.utilities.dispatch import get_registry_for_type, register_base_type
 from prefect.utilities.engine import propose_state
-from prefect.utilities.services import critical_service_loop
+from prefect.utilities.services import (
+    critical_service_loop,
+    start_client_metrics_server,
+    stop_client_metrics_server,
+)
 from prefect.utilities.slugify import slugify
 from prefect.utilities.templating import (
     apply_values,
@@ -657,6 +661,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
                     self._started_event = await self._emit_worker_started_event()
 
+                    start_client_metrics_server()
+
                     if with_healthcheck:
                         from prefect.workers.server import build_healthcheck_server
 
@@ -674,6 +680,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                         healthcheck_thread.start()
                     printer(f"Worker {worker.name!r} started!")
         finally:
+            stop_client_metrics_server()
+
             if healthcheck_server and healthcheck_thread:
                 self._logger.debug("Stopping healthcheck server...")
                 healthcheck_server.should_exit = True

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -34,7 +34,11 @@ from prefect.runner.runner import Runner
 from prefect.settings import PREFECT_WORKER_QUERY_SECONDS
 from prefect.states import Pending
 from prefect.utilities.processutils import get_sys_executable
-from prefect.utilities.services import critical_service_loop
+from prefect.utilities.services import (
+    critical_service_loop,
+    start_client_metrics_server,
+    stop_client_metrics_server,
+)
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,
@@ -180,6 +184,8 @@ class ProcessWorker(
 
                     self._started_event = await self._emit_worker_started_event()
 
+                    start_client_metrics_server()
+
                     if with_healthcheck:
                         from prefect.workers.server import build_healthcheck_server
 
@@ -197,6 +203,8 @@ class ProcessWorker(
                         healthcheck_thread.start()
                     printer(f"Worker {worker.name!r} started!")
         finally:
+            stop_client_metrics_server()
+
             if healthcheck_server and healthcheck_thread:
                 self._logger.debug("Stopping healthcheck server...")
                 healthcheck_server.should_exit = True


### PR DESCRIPTION
Starts the metrics server (assuming `PREFECT_CLIENT_ENABLE_METRICS=True`) on workers.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
