### PR TITLE
fix(pydantic schema): replace const with enum for consistent UI behavior

### DIFF
--- a/src/prefect/_internal/pydantic/v2_schema.py
+++ b/src/prefect/_internal/pydantic/v2_schema.py
@@ -31,6 +31,22 @@ def is_v2_type(v: t.Any) -> bool:
     except AttributeError:
         return False
 
+def convert_const_to_enum(schema: dict[str, t.Any]) -> None:
+    """
+    Recursively convert `const` fields to `enum` with a single value
+    to enable dropdown rendering in the UI.
+    """
+    if isinstance(schema, dict):
+        for key, value in list(schema.items()):
+            if key == "const":
+                schema["enum"] = [value]
+                del schema["const"]
+            else:
+                convert_const_to_enum(value)
+    elif isinstance(schema, list):
+        for item in schema:
+            convert_const_to_enum(item)
+
 
 def has_v2_type_as_param(signature: inspect.Signature) -> bool:
     parameters = signature.parameters.values()
@@ -106,5 +122,7 @@ def create_v2_schema(
     # ensure backwards compatibility by copying $defs into definitions
     if "$defs" in schema:
         schema["definitions"] = schema["$defs"]
+
+    convert_const_to_enum(schema)
 
     return schema


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!--This PR fixes an issue where flow parameters defined using `Literal` with a single value (e.g., `Literal["only"]`) do not render as dropdowns in the Prefect deployment UI. 

The issue stems from Pydantic v2 generating a `"const"` in the schema for single-value `Literal`, which the Prefect UI does not treat as a dropdown. This PR adds a recursive post-processing step that converts `"const": "value"` into `"enum": ["value"]`, ensuring consistent UI behavior with multi-value `Literal`.

 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes <https://github.com/PrefectHQ/prefect/issues/18648>"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
closes #18648 

