### PR TITLE
Update rate limit and metadata retention docs

### DIFF
--- a/docs/v3/concepts/rate-limits.mdx
+++ b/docs/v3/concepts/rate-limits.mdx
@@ -1,44 +1,49 @@
 ---
 title: Rate limits and data retention
-description: Prefect Cloud API rate limits.
+keywords: [rate limits, data retention, prefect cloud, api rate limits]
 ---
-<span class="badge cloud"></span>
 
-Prefect Cloud has controls in place to ensure stability.
-
-## API Rate Limits
+## API rate limits
 
 <Note>
-**Prefect Cloud rate limits are subject to change**
+**Rate limits are subject to change.**
 
-**API rate limits are subject to change.**
 Contact Prefect support at [help@prefect.io](mailto:help@prefect.io) with questions about rate limits.
 </Note>
 
-Prefect Cloud's API rate limits restrict the number of requests that a single client can make to certain endpoints in a given time period. 
-The `flow_runs`, `task_runs`, and `flows` endpoints and their subroutes are limited to:
+Prefect Cloud applies rate limits to API endpoints to ensure system stability. When limits are exceeded, endpoints return a `429` response with a `Retry-After` header.
 
-- 400 requests per minute for Free accounts
-- 2,000 requests per minute for Pro accounts
+### Request limits by plan
 
-These endpoints return a `429` response with an appropriate `Retry-After` header if this limit is triggered. See [ClientSettings](/v3/develop/settings-ref#clientsettings) for more information on how retries are handled client-side and how to modify the default behavior.
+The `flow_runs`, `task_runs`, and `flows` endpoints and their subroutes:
 
-The `logs` endpoint is limited to:
+- **Hobby**: 250 requests per minute
+- **Starter**: 500 requests per minute
+- **Team**: 1,000 requests per minute
+- **Pro**: 2,000 requests per minute
+- **Enterprise**: Custom limits
 
-- 700 logs per minute for Free accounts
-- 10,000 logs per minute for Pro accounts
+The `logs` endpoint:
 
-The endpoint returns a `429` response if this limit is triggered.
+- **Hobby**: 500 logs per minute
+- **Starter**: 1,600 logs per minute
+- **Team**: 2,000 logs per minute
+- **Pro**: 10,000 logs per minute
+- **Enterprise**: Custom limits
 
-## Metadata retention period
+The Prefect SDK automatically retries rate-limited requests up to 5 times, using the delay specified in the `Retry-After` header. You can customize this behavior through [client settings](/v3/develop/settings-ref#clientsettings).
 
-Flow run, task run, and artifact metadata is retained according to your Prefect Cloud account's retention period.
-The retention period applies to all workspaces that belong to the account.
+## Metadata retention
 
-The retention period is the number of days that metadata is available after it is created. 
-For flow and task runs, it is calculated from the time the run reaches a 
-[terminal state](/v3/develop/manage-states/#state-types). 
-Subflow runs are retained independently from their parent flow runs. They are removed based on 
-the time each subflow run reaches a terminal state.
+Prefect Cloud retains flow run, task run, and artifact metadata for a limited time based on your plan. This applies to all workspaces in your account.
 
-If you have needs that require a custom retention period, [contact Prefect's sales team](https://www.prefect.io/pricing).
+### Retention periods by plan
+
+- **Hobby and Starter**: 7 days
+- **Team**: 14 days  
+- **Pro**: 30 days
+- **Enterprise**: Custom retention periods
+
+Metadata is retained from creation until the specified period expires. For flow and task runs, retention is calculated from when the run reaches a [terminal state](/v3/develop/manage-states/#state-types). Subflow runs are retained independently from their parent flows.
+
+For custom retention periods, [contact Prefect's sales team](https://www.prefect.io/pricing).


### PR DESCRIPTION
These changes update the rate limits and metadata retention docs to reflect the tiers added since these docs were last updated. I also removed redundant information and improved to overall flow.
