### PR TITLE
Add setting to customize which causal ordering implementation to use

### DIFF
--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1605,6 +1605,18 @@ Which cache implementation to use for the events system. Should point to a modul
 **Supported environment variables**:
 `PREFECT_SERVER_EVENTS_MESSAGING_CACHE`, `PREFECT_MESSAGING_CACHE`
 
+### `causal_ordering`
+Which causal ordering implementation to use for the events system. Should point to a module that exports a CausalOrdering class.
+
+**Type**: `string`
+
+**Default**: `prefect.server.events.ordering.memory`
+
+**TOML dotted key path**: `server.events.causal_ordering`
+
+**Supported environment variables**:
+`PREFECT_SERVER_EVENTS_CAUSAL_ORDERING`
+
 ### `maximum_event_name_length`
 The maximum length of an event name.
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1444,6 +1444,15 @@
                     "title": "Messaging Cache",
                     "type": "string"
                 },
+                "causal_ordering": {
+                    "default": "prefect.server.events.ordering.memory",
+                    "description": "Which causal ordering implementation to use for the events system. Should point to a module that exports a CausalOrdering class.",
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_EVENTS_CAUSAL_ORDERING"
+                    ],
+                    "title": "Causal Ordering",
+                    "type": "string"
+                },
                 "maximum_event_name_length": {
                     "default": 1024,
                     "description": "The maximum length of an event name.",

--- a/src/prefect/server/events/ordering/__init__.py
+++ b/src/prefect/server/events/ordering/__init__.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Protocol,
     Union,
+    runtime_checkable,
 )
 from uuid import UUID
 from prefect.logging import get_logger
@@ -35,6 +36,11 @@ SEEN_EXPIRATION = max(PRECEDING_EVENT_LOOKBACK, PROCESSED_EVENT_LOOKBACK)
 
 # How deep we'll allow the recursion to go when processing events
 MAX_DEPTH_OF_PRECEDING_EVENT = 20
+
+
+@runtime_checkable
+class CausalOrderingModule(Protocol):
+    CausalOrdering: type["CausalOrdering"]
 
 
 class EventArrivedEarly(Exception):
@@ -93,7 +99,7 @@ def get_task_run_recorder_causal_ordering() -> CausalOrdering:
     import_path = get_current_settings().server.events.causal_ordering
     causal_ordering_module = importlib.import_module(import_path)
 
-    if not isinstance(causal_ordering_module, CausalOrdering):
+    if not isinstance(causal_ordering_module, CausalOrderingModule):
         raise ValueError(
             f"Module at {import_path} does not export a CausalOrdering class. Please check your server.events.causal_ordering setting."
         )

--- a/src/prefect/settings/models/server/events.py
+++ b/src/prefect/settings/models/server/events.py
@@ -140,6 +140,11 @@ class ServerEventsSettings(PrefectBaseSettings):
         ),
     )
 
+    causal_ordering: str = Field(
+        default="prefect.server.events.ordering.memory",
+        description="Which causal ordering implementation to use for the events system. Should point to a module that exports a CausalOrdering class.",
+    )
+
     maximum_event_name_length: int = Field(
         default=1024,
         gt=0,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -351,6 +351,9 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS": {"test_value": 10},
     "PREFECT_SERVER_EPHEMERAL_ENABLED": {"test_value": True},
     "PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS": {"test_value": 10},
+    "PREFECT_SERVER_EVENTS_CAUSAL_ORDERING": {
+        "test_value": "prefect.server.events.ordering.memory"
+    },
     "PREFECT_SERVER_EVENTS_EXPIRED_BUCKET_BUFFER": {
         "test_value": timedelta(seconds=60)
     },


### PR DESCRIPTION
These changes will allow users to configure their server to use the a Redis causal ordering implementation for HA setups.
