### PR TITLE
docs: add health check configuration for .serve() deployments

### DIFF
--- a/docs/v3/how-to-guides/deployment_infra/serve-flows-docker.mdx
+++ b/docs/v3/how-to-guides/deployment_infra/serve-flows-docker.mdx
@@ -175,6 +175,137 @@ You should see logs from your newly served process, with the link to your deploy
 docker stop <CONTAINER-ID>
 ```
 
+## Health checks for production deployments
+
+When deploying to production environments like Google Cloud Run, AWS ECS, or Kubernetes, you may need to configure health checks to ensure your container is running properly. The `.serve()` method supports an optional webserver that exposes a health endpoint.
+
+### Enabling the health check webserver
+
+You can enable the health check webserver in two ways:
+
+1. **Pass `webserver=True` to `.serve()`:**
+
+```python
+if __name__ == "__main__":
+    retrieve_github_stars.serve(
+        parameters={
+            "repos": ["python/cpython", "prefectHQ/prefect"],
+        },
+        webserver=True  # Enable health check webserver
+    )
+```
+
+2. **Set the environment variable:**
+
+```bash
+PREFECT_RUNNER_SERVER_ENABLE=true
+```
+
+When enabled, the webserver exposes a health endpoint at `http://localhost:8080/health` by default.
+
+### Configuring the health check port
+
+You can customize the host and port using environment variables:
+
+```bash
+PREFECT_RUNNER_SERVER_HOST=0.0.0.0  # Allow external connections
+PREFECT_RUNNER_SERVER_PORT=8080      # Port for health checks
+```
+
+### Docker with health checks
+
+Add a health check to your Dockerfile:
+
+```dockerfile
+# ... your existing Dockerfile content ...
+
+# Health check configuration
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
+
+# Set the command to run your application with webserver enabled
+CMD ["python", "serve_retrieve_github_stars.py"]
+```
+
+Or if you prefer to use environment variables:
+
+```dockerfile
+# ... your existing Dockerfile content ...
+
+# Enable the health check webserver
+ENV PREFECT_RUNNER_SERVER_ENABLE=true
+ENV PREFECT_RUNNER_SERVER_HOST=0.0.0.0
+ENV PREFECT_RUNNER_SERVER_PORT=8080
+
+# Health check configuration
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
+
+CMD ["python", "serve_retrieve_github_stars.py"]
+```
+
+### Platform-specific configurations
+
+<Tabs>
+<Tab title="Google Cloud Run">
+Cloud Run requires containers to listen on a port. Configure your container to expose the health check port:
+
+```yaml
+# In your Cloud Run configuration
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30
+```
+
+Make sure to set the container port to 8080 in Cloud Run settings.
+</Tab>
+
+<Tab title="AWS ECS/Fargate">
+Configure health checks in your task definition:
+
+```json
+{
+  "healthCheck": {
+    "command": ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"],
+    "interval": 30,
+    "timeout": 10,
+    "retries": 3,
+    "startPeriod": 60
+  }
+}
+```
+</Tab>
+
+<Tab title="Kubernetes">
+Add liveness and readiness probes to your deployment:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 5
+```
+</Tab>
+</Tabs>
+
+The health endpoint returns:
+- **200 OK** with `{"message": "OK"}` when the runner is healthy and polling for work
+- **503 Service Unavailable** when the runner hasn't polled recently (indicating it may be unresponsive)
+
 ## Next steps
 
 Congratulations! You have packaged and served a flow on a long-lived Docker container.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for configuring health checks when deploying flows with `.serve()` to production environments.

## Context

When deploying Prefect flows using `.serve()` to container platforms like Google Cloud Run, AWS ECS, or Kubernetes, these platforms often require health check endpoints to monitor container health and perform automatic restarts when needed. The `.serve()` method includes built-in support for a health check webserver, but this wasn't well documented.

## Changes

Added a new section "Health checks for production deployments" to the Docker deployment guide that covers:

- How to enable the health check webserver (via `webserver=True` parameter or `PREFECT_RUNNER_SERVER_ENABLE` environment variable)
- Configuration options for customizing the host and port
- Docker-specific HEALTHCHECK configuration examples
- Platform-specific configurations for:
  - Google Cloud Run
  - AWS ECS/Fargate  
  - Kubernetes
- Documentation of the health endpoint responses (200 OK when healthy, 503 when unresponsive)

## Related

This documentation helps users who encounter issues deploying to platforms that require health endpoints, particularly Cloud Run which won't promote a revision without a listening port.

🤖 Generated with [Claude Code](https://claude.ai/code)