### PR TITLE
Add blurb for Redis auth

### DIFF
--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -114,7 +114,7 @@ export PREFECT_REDIS_MESSAGING_DB="0"
 If your Redis instance requires authentication, you may configure a username and password:
 
 ```bash
-export PREFECT_REDIS_MESSAGING_PASSWORD="marvin"
+export PREFECT_REDIS_MESSAGING_USERNAME="marvin"
 export PREFECT_REDIS_MESSAGING_PASSWORD="dontpanic!"
 ```
 

--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -111,6 +111,19 @@ export PREFECT_REDIS_MESSAGING_PORT="6379"
 export PREFECT_REDIS_MESSAGING_DB="0"
 ```
 
+If your Redis instance requires authentication, you may configure a username and password:
+
+```bash
+export PREFECT_REDIS_MESSAGING_PASSWORD="marvin"
+export PREFECT_REDIS_MESSAGING_PASSWORD="dontpanic!"
+```
+
+For Redis instances that require an encrypted connection, you can enable SSL/TLS:
+
+```bash
+export PREFECT_REDIS_MESSAGING_SSL="true"
+```
+
 Each server instance automatically generates a unique consumer name to prevent message delivery conflicts.
 
 ### Service separation


### PR DESCRIPTION
Add docs for additional ENVs that can be set for Redis authentication and SSL/TLS.

From discussion #18678

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
