### PR TITLE
Adds ability to automatically setup SQS queue and EventBridge rule for `ECSWorker`

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -76,7 +76,7 @@ class AsyncEcsEventHandler(Protocol):
     ) -> None: ...
 
 
-H = TypeVar("H", bound=EcsEventHandler | AsyncEcsEventHandler)
+H = TypeVar("H", bound=Union[EcsEventHandler, AsyncEcsEventHandler])
 
 
 class EventHandlerFilters(TypedDict):

--- a/src/integrations/prefect-aws/prefect_aws/settings.py
+++ b/src/integrations/prefect-aws/prefect_aws/settings.py
@@ -31,6 +31,11 @@ class EcsObserverSettings(PrefectBaseSettings):
         description="Whether to enable the ECS observer.",
     )
 
+    automatic_setup: bool = Field(
+        default=False,
+        description="Whether to automatically set up the SQS queue and EventBridge rule if they don't exist.",
+    )
+
     sqs: EcsObserverSqsSettings = Field(
         description="Settings for controlling ECS observer SQS behavior.",
         default_factory=EcsObserverSqsSettings,

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -296,11 +296,24 @@ class TestEcsObserver:
         return reader
 
     @pytest.fixture
-    def observer(self, settings, mock_sqs_subscriber, mock_tags_reader):
+    def mock_infrastructure_manager(self):
+        manager = AsyncMock()
+        manager.check_sqs_queue_exists.return_value = True
+        return manager
+
+    @pytest.fixture
+    def observer(
+        self,
+        settings,
+        mock_sqs_subscriber,
+        mock_tags_reader,
+        mock_infrastructure_manager,
+    ):
         return EcsObserver(
             settings=settings,
             sqs_subscriber=mock_sqs_subscriber,
             ecs_tags_reader=mock_tags_reader,
+            infrastructure_manager=mock_infrastructure_manager,
         )
 
     def test_init_with_defaults(self):


### PR DESCRIPTION
### Summary

Adds automatic SQS queue and EventBridge rule setup for the ECS observer to streamline infrastructure provisioning.

### Changes

 - New `ObserverInfrastructureManager` class to manage AWS infrastructure setup of SQS and EventBridge
 - ECS observer can now automatically create the required AWS infrastructure when `automatic_setup` is enabled (defaults to `False` for now)
 - Graceful fallback when infrastructure doesn't exist, but automatic setup is disabled

### Configuration

Enable automatic setup via environment variable:
```bash
export PREFECT_INTEGRATIONS_AWS_ECS_OBSERVER_AUTOMATIC_SETUP=true
```

When enabled, the observer will automatically create:
 - SQS queue with appropriate permissions for EventBridge
 - EventBridge rule targeting ECS task state changes
 - IAM policies for cross-service communication

  When disabled, the observer logs helpful guidance for manual setup if the infrastructure is missing.

Related to https://github.com/PrefectHQ/prefect/issues/18508