### PR TITLE
Bump minimum `prefect` version in `prefect-redis`

### DIFF
--- a/src/integrations/prefect-redis/pyproject.toml
+++ b/src/integrations/prefect-redis/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["prefect>=3.0.0", "redis>=6.0.0"]
+dependencies = ["prefect>=3.4.9", "redis>=6.0.0"]
 dynamic = ["version"]
 
 [dependency-groups]


### PR DESCRIPTION
Ensures that the `ConcurrencyLeaseStorage` protocol is available in the installed version of `prefect`
