### PR TITLE
chore: atomic consumer group clean up

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -671,11 +671,6 @@ async def _cleanup_empty_consumer_groups_atomically(stream_name: str) -> None:
                 logger.debug(f"Group '{group_name}' changed concurrently: {e}")
             except Exception as e:
                 logger.debug(f"Unable to cleanup group '{group_name}': {e}")
-            finally:
-                try:
-                    await pipe.reset()
-                except Exception:
-                    pass
 
     if deleted_count > 0:
         logger.debug(

--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -636,6 +636,10 @@ async def _cleanup_empty_consumer_groups_atomically(stream_name: str) -> None:
                     )
                     continue
 
+                if not group_name.startswith("ephemeral"):
+                    logger.debug(f"Skipping non-ephemeral empty group '{group_name}'")
+                    continue
+
                 group_info = await pipe.xinfo_groups(stream_name)
 
                 # Check if group has pending messages

--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -629,13 +629,14 @@ async def _cleanup_empty_consumer_groups_atomically(stream_name: str) -> None:
                 await pipe.watch(stream_name)
 
                 consumers = await pipe.xinfo_consumers(stream_name, group_name)
-                group_info = await pipe.xinfo_groups(stream_name)
 
                 if consumers:
                     logger.debug(
                         f"Group '{group_name}' has {len(consumers)} consumers, skipping deletion"
                     )
                     continue
+
+                group_info = await pipe.xinfo_groups(stream_name)
 
                 # Check if group has pending messages
                 current_group = next(
@@ -649,7 +650,7 @@ async def _cleanup_empty_consumer_groups_atomically(stream_name: str) -> None:
                     continue
 
                 # if not pending messages in group, delete it
-                await pipe.multi()
+                pipe.multi()
                 pipe.xgroup_destroy(stream_name, group_name)
                 await pipe.execute()
 

--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -26,6 +26,7 @@ import orjson
 from pydantic import BeforeValidator, Field
 from redis.asyncio import Redis
 from redis.exceptions import ResponseError, WatchError
+
 from typing_extensions import Self
 
 from prefect.logging import get_logger

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -595,7 +595,7 @@ async def test_cleanup_empty_consumer_groups_atomically(redis: Redis):
 
     stream_name = "test-cleanup-stream"
 
-    # Create the stream with a message
+    # Create a stream with a message
     await redis.xadd(stream_name, {"data": "test"})
 
     # Create multiple consumer groups
@@ -611,7 +611,7 @@ async def test_cleanup_empty_consumer_groups_atomically(redis: Redis):
         count=1,
     )
 
-    # Verify that all groups exist
+    # Verify all groups exist
     groups_before = await redis.xinfo_groups(stream_name)
     assert len(groups_before) == 3
     assert {g["name"] for g in groups_before} == {

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -20,7 +20,6 @@ from prefect_redis.messaging import (
 )
 from redis.asyncio import Redis
 
-
 from prefect.server.events import Event
 from prefect.server.events.clients import PrefectServerEventsClient
 from prefect.server.events.messaging import EventPublisher
@@ -615,7 +614,11 @@ async def test_cleanup_empty_consumer_groups_atomically(redis: Redis):
     # Verify that all groups exist
     groups_before = await redis.xinfo_groups(stream_name)
     assert len(groups_before) == 3
-    assert {g["name"] for g in groups_before} == {"active-group", "empty-group-1", "empty-group-2"}
+    assert {g["name"] for g in groups_before} == {
+        "active-group",
+        "empty-group-1",
+        "empty-group-2",
+    }
 
     # Run atomic cleanup
     await _cleanup_empty_consumer_groups_atomically(stream_name)
@@ -656,7 +659,9 @@ async def test_cleanup_keeps_group_with_pending_but_no_consumers(redis: Redis):
     consumers_mid = await redis.xinfo_consumers(stream_name, "orphaned-pending-group")
     assert consumers_mid == []  # no consumers
     groups_mid = await redis.xinfo_groups(stream_name)
-    pending_orphan = next(g for g in groups_mid if g["name"] == "orphaned-pending-group")["pending"]
+    pending_orphan = next(
+        g for g in groups_mid if g["name"] == "orphaned-pending-group"
+    )["pending"]
     assert pending_orphan > 0
 
     # Run atomic cleanup

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -20,6 +20,7 @@ from prefect_redis.messaging import (
 )
 from redis.asyncio import Redis
 
+
 from prefect.server.events import Event
 from prefect.server.events.clients import PrefectServerEventsClient
 from prefect.server.events.messaging import EventPublisher

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -599,13 +599,13 @@ async def test_cleanup_empty_consumer_groups_atomically(redis: Redis):
     await redis.xadd(stream_name, {"data": "test"})
 
     # Create multiple consumer groups
-    await redis.xgroup_create(stream_name, "active-group", id="0")
-    await redis.xgroup_create(stream_name, "empty-group-1", id="0")
-    await redis.xgroup_create(stream_name, "empty-group-2", id="0")
+    await redis.xgroup_create(stream_name, "ephemeral-active-group", id="0")
+    await redis.xgroup_create(stream_name, "ephemeral-empty-group-1", id="0")
+    await redis.xgroup_create(stream_name, "ephemeral-empty-group-2", id="0")
 
     # Add a consumer to the active group (creates a pending entry for the group)
     await redis.xreadgroup(
-        groupname="active-group",
+        groupname="ephemeral-active-group",
         consumername="consumer-1",
         streams={stream_name: ">"},
         count=1,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->
Related to: 
- https://github.com/PrefectHQ/prefect/issues/18654

Make consumer group cleanup for Redis Streams atomic and conservative. Replace the non-atomic cleanup function with an implementation that uses WATCH/MULTI/EXEC on the same pipeline to avoid race conditions. The new logic skips deletion when a group has pending messages, preventing accidental removal of groups that still have work to process.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
