### PR TITLE
avoid key collision in tests

### DIFF
--- a/tests/results/test_result_fetch.py
+++ b/tests/results/test_result_fetch.py
@@ -16,11 +16,17 @@ async def test_async_result_warnings_are_not_raised_by_engine():
             raise ValueError()
         return 1
 
-    @task(persist_result=True, cache_key_fn=lambda *_: "test")
+    @task(
+        persist_result=True,
+        cache_key_fn=lambda *_: "test_async_result_warnings_are_not_raised_by_engine",
+    )
     def foo():
         return 1
 
-    @task(persist_result=True, cache_key_fn=lambda *_: "test")
+    @task(
+        persist_result=True,
+        cache_key_fn=lambda *_: "test_async_result_warnings_are_not_raised_by_engine",
+    )
     def bar():
         return 2
 


### PR DESCRIPTION
sometimes we get a flake where we get this
```
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```

[here](https://github.com/prefecthq/prefect/blob/avoid-key-potential-key-collision/tests/results/test_result_fetch.py#L65)

I don't know exactly where it's coming from, but I suspect that test corresponds to a different cached value somewhere else, and that's how we end up with that error