### PR TITLE
Update bundle creation to exclude dependencies installed from a local file path

### DIFF
--- a/src/prefect/_experimental/bundles/__init__.py
+++ b/src/prefect/_experimental/bundles/__init__.py
@@ -101,11 +101,24 @@ def create_bundle_for_flow_run(
         .strip()
     )
 
-    # Remove dependencies installed from a local file path because we won't be able to install them in the execution environment
-    # The user will be responsible for making sure they are available in the execution environment
-    dependencies = "\n".join(
-        [line for line in dependencies.split("\n") if "file://" not in line]
-    )
+    # Remove dependencies installed from a local file path because we won't be able
+    # to install them in the execution environment. The user will be responsible for
+    # making sure they are available in the execution environment
+    filtered_dependencies: list[str] = []
+    file_dependencies: list[str] = []
+    for line in dependencies.split("\n"):
+        if "file://" in line:
+            file_dependencies.append(line)
+        else:
+            filtered_dependencies.append(line)
+    dependencies = "\n".join(filtered_dependencies)
+    if file_dependencies:
+        logger.warning(
+            "The following dependencies were installed from a local file path and will not be "
+            "automatically installed in the execution environment: %s. If these dependencies "
+            "are not available in the execution environment, your flow run may fail.",
+            "\n".join(file_dependencies),
+        )
 
     return {
         "function": _serialize_bundle_object(flow),


### PR DESCRIPTION
This PR updates bundle creation to exclude dependencies that were installed from a local wheel or code. These can't be installed in the execution environment, so we'll exclude them and warn that the user needs to ensure that the dependencies are available in the execution environment.