### PR TITLE
Fix MinIOCredentials hashing with nested config dictionaries

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/credentials.py
+++ b/src/integrations/prefect-aws/prefect_aws/credentials.py
@@ -235,7 +235,7 @@ class MinIOCredentials(CredentialsBlock):
                 hash(self.minio_root_user),
                 hash(self.minio_root_password),
                 hash(self.region_name),
-                hash(frozenset(self.aws_client_parameters.model_dump().items())),
+                hash(self.aws_client_parameters),
             )
         )
 


### PR DESCRIPTION
Closes #18748

## Summary
This PR fixes a TypeError that occurs when MinIOCredentials is used with botocore config options that contain nested dictionaries.

## The Issue
When users configure MinIOCredentials with nested botocore config options (e.g., `{"request_checksum_calculation": "when_required"}`), the credentials object fails to hash properly with:
```
TypeError: unhashable type: 'dict'
```

This prevents the credentials from being used because the `@lru_cache` decorator on `_get_client_cached()` requires all arguments to be hashable.

## Root Cause
`MinIOCredentials.__hash__()` was using:
```python
hash(frozenset(self.aws_client_parameters.model_dump().items()))
```

This approach fails when `model_dump()` returns nested dictionaries because `frozenset()` requires all items to be hashable, but dictionaries are not.

## The Fix
Aligned `MinIOCredentials` with `AwsCredentials` by using:
```python
hash(self.aws_client_parameters)
```

This delegates to `AwsClientParameters.__hash__()`, which properly handles nested structures using the `hash_collection()` utility.

## Why This Approach?
- **Consistency**: Both `AwsCredentials` and `MinIOCredentials` use the same caching mechanism (`_get_client_cached`), so they should use the same hashing approach
- **Proven**: `AwsCredentials` already successfully uses this pattern with nested parameters
- **Simpler**: Removes unnecessary complexity and potential for errors

## Test Plan
Added regression test `test_minio_credentials_nested_client_parameters_are_hashable` that:
1. Creates MinIOCredentials with nested config parameters
2. Verifies the object can be hashed
3. Confirms caching works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)