### PR TITLE
docs: fix profiles_path rendering in settings ref

### DIFF
--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -18,7 +18,7 @@ The path to the Prefect home directory. Defaults to ~/.prefect
 `PREFECT_HOME`
 
 ### `profiles_path`
-The path to a profiles configuration file. Supports $PREFECT_HOME templating. Defaults to $PREFECT_HOME/profiles.toml.
+The path to a profiles configuration file. Supports \$PREFECT_HOME templating. Defaults to $PREFECT_HOME/profiles.toml.
 
 **Type**: `string`
 


### PR DESCRIPTION
TIL mintlify reads anything between `$ .. $` as [inline math](https://mintlify.com/docs/text#inline-math), which caused the `profiles_path` description to render as LaTeX. Here's a quick fix for it!

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
