### PR TITLE
Document PostgreSQL 14.9+ requirement

### DIFF
--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -10,7 +10,7 @@ Running multiple Prefect server instances enables high availability and distribu
 
 Multi-server deployments require:
 
-- PostgreSQL database (SQLite does not support multi-server synchronization)
+- PostgreSQL database version 14.9 or higher (SQLite does not support multi-server synchronization)
 - Redis for event messaging
 - Load balancer for API traffic distribution
 
@@ -96,7 +96,7 @@ export PREFECT_API_DATABASE_CONNECTION_URL="postgresql+asyncpg://user:password@h
 ```
 
 <Warning>
-PostgreSQL is required for multi-server deployments. SQLite does not support the features needed for state synchronization across multiple servers.
+PostgreSQL version 14.9 or higher is required for multi-server deployments. SQLite does not support the features needed for state synchronization across multiple servers.
 </Warning>
 
 ### Redis setup

--- a/docs/v3/concepts/server.mdx
+++ b/docs/v3/concepts/server.mdx
@@ -32,7 +32,7 @@ The Prefect database persists data to track the state of your flow runs and rela
 Prefect supports the following databases:
 
 - **SQLite** (default): Recommended for lightweight, single-server deployments. SQLite requires essentially no setup.
-- **PostgreSQL**: Best for production use, high availability, and multi-server deployments. Requires additional setup. Prefect uses the [`pg_trgm`](https://www.postgresql.org/docs/current/pgtrgm.html) extension, so it must be installed and enabled.
+- **PostgreSQL**: Best for production use, high availability, and multi-server deployments. Requires PostgreSQL 14.9 or higher. Prefect uses the [`pg_trgm`](https://www.postgresql.org/docs/current/pgtrgm.html) extension, so it must be installed and enabled.
 
 ## Database migrations
 


### PR DESCRIPTION
Documents PostgreSQL 14.9+ requirement in self-hosted deployment docs.

🤖 Generated with [Claude Code](https://claude.ai/code)