### PR TITLE
Skip validating generated CloudFormation templates

### DIFF
--- a/.github/workflows/integration-package-release.yaml
+++ b/.github/workflows/integration-package-release.yaml
@@ -67,7 +67,6 @@ jobs:
         if: ${{ steps.package_name.outputs.PACKAGE_NAME }} == 'prefect-aws'
         run: |
           just generate-cfn
-          just validate-cfn
         working-directory: src/integrations/prefect-aws/infra
 
       - name: Build a binary wheel and a source tarball


### PR DESCRIPTION
Will fix https://github.com/PrefectHQ/prefect/actions/runs/17250943676/job/48952780475. You need AWS credentials to validate a CloudFormation template.