### PR TITLE
Hotfix release 0.5.15 for `prefect-aws`

### DIFF
--- a/docs/v3/release-notes/integrations/prefect-aws.mdx
+++ b/docs/v3/release-notes/integrations/prefect-aws.mdx
@@ -2,6 +2,12 @@
 title: prefect-aws
 ---
 
+## 0.5.15
+
+_Released on August 26, 2025_
+
+This release fixes a bug where `prefect-aws` depended on `mypy_boto3_sqs` unnecessarily and caused an error on start up.
+
 ## 0.5.14
 
 _Released on August 26, 2025_

--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -24,7 +24,6 @@ import aiobotocore.session
 import anyio
 from botocore.exceptions import ClientError
 from cachetools import LRUCache
-from mypy_boto3_sqs.type_defs import MessageTypeDef
 from prefect_aws.settings import EcsObserverSettings
 from slugify import slugify
 
@@ -33,6 +32,7 @@ from prefect.events.clients import get_events_client
 from prefect.events.schemas.events import Event, RelatedResource, Resource
 
 if TYPE_CHECKING:
+    from mypy_boto3_sqs.type_defs import MessageTypeDef
     from types_aiobotocore_ecs import ECSClient
 
 
@@ -151,7 +151,7 @@ class SqsSubscriber:
 
     async def stream_messages(
         self,
-    ) -> AsyncGenerator[MessageTypeDef, None]:
+    ) -> AsyncGenerator["MessageTypeDef", None]:
         session = aiobotocore.session.get_session()
         async with session.create_client(
             "sqs", region_name=self.queue_region


### PR DESCRIPTION
`mypy_boto3_sqs` isn't current behind an `if TYPE_CHECKING` guard, which is causing issues with the release that just went out.