### PR TITLE
Fix Docker healthcheck documentation to use Python instead of curl

### DIFF
--- a/docs/v3/advanced/worker-healthchecks.mdx
+++ b/docs/v3/advanced/worker-healthchecks.mdx
@@ -64,7 +64,7 @@ Use Docker's built-in health check functionality by including these lines in you
 ```dockerfile
 # Health check configuration
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD python -c "import urllib.request as u; u.urlopen('http://localhost:8080/health', timeout=1)"
 
 # Start worker with healthcheck
 CMD ["prefect", "worker", "start", "--pool", "my-pool", "--with-healthcheck"]
@@ -100,7 +100,7 @@ services:
     image: my-prefect-worker:latest
     command: ["prefect", "worker", "start", "--pool", "my-pool", "--with-healthcheck"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "python", "-c", "import urllib.request as u; u.urlopen('http://localhost:8080/health', timeout=1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/v3/how-to-guides/deployment_infra/serve-flows-docker.mdx
+++ b/docs/v3/how-to-guides/deployment_infra/serve-flows-docker.mdx
@@ -221,7 +221,7 @@ Add a health check to your Dockerfile:
 
 # Health check configuration
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD python -c "import urllib.request as u; u.urlopen('http://localhost:8080/health', timeout=1)"
 
 # Set the command to run your application with webserver enabled
 CMD ["python", "serve_retrieve_github_stars.py"]
@@ -239,7 +239,7 @@ ENV PREFECT_RUNNER_SERVER_PORT=8080
 
 # Health check configuration
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD python -c "import urllib.request as u; u.urlopen('http://localhost:8080/health', timeout=1)"
 
 CMD ["python", "serve_retrieve_github_stars.py"]
 ```
@@ -269,7 +269,7 @@ Configure health checks in your task definition:
 ```json
 {
   "healthCheck": {
-    "command": ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"],
+    "command": ["CMD-SHELL", "python -c \"import urllib.request as u; u.urlopen('http://localhost:8080/health', timeout=1)\""],
     "interval": 30,
     "timeout": 10,
     "retries": 3,


### PR DESCRIPTION
## Summary

Closes #18800

Updates Docker healthcheck documentation to use Python's `urllib.request` instead of `curl`, since the Prefect Docker images don't include `curl`.

## Problem

Our documentation shows healthcheck examples using `curl`:
```dockerfile
CMD curl -f http://localhost:8080/health || exit 1
```

However, the base Prefect Docker images don't include `curl`, causing these healthchecks to fail with "curl: not found".

## Solution

Replace all `curl` healthcheck commands with Python one-liners using `urllib.request`, which is always available in our Docker images:
```dockerfile
CMD python -c "import urllib.request as u; u.urlopen('http://localhost:8080/health', timeout=1)"
```

## Testing

Verified that:
- `curl` is not available in `prefecthq/prefect:latest` image
- `wget` is also not available
- Python with `urllib.request` is available and works correctly
- The Python healthcheck command returns proper exit codes (0 for success, non-zero for failure)

🤖 Generated with [Claude Code](https://claude.ai/code)