### PR TITLE
Fix event filter empty label value arrays to return no results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,5 +68,6 @@ prefect config view            # Inspect configuration
 
 - GitHub issues are used for tracking issues (use the `gh` cli)
 - Pre-commit hooks required (never use `--no-verify`)
+- There are some slower pre-push hooks that may modify files on `git push`; when that happens, run `git commit --amend` to bring those into the prior commit (never use `--amend` in any other situation unless asked)
 - Dependencies: updates to client-side deps in `@pyproject.toml` require parallel changes ing `@client/pyproject.toml`
 - AGENTS.md always symlinked to CLAUDE.md

--- a/docs/v3/api-ref/python/prefect-server-events-filters.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-filters.mdx
@@ -257,11 +257,11 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-### `EventRelatedFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L387" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EventRelatedFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L392" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 **Methods:**
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L405" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L410" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
@@ -291,11 +291,11 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-### `EventAnyResourceFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L486" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EventAnyResourceFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L496" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 **Methods:**
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L523" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L533" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
@@ -316,7 +316,7 @@ Would the given filter exclude this event?
 get_filters(self) -> list['EventDataFilter']
 ```
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L501" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L511" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
@@ -331,11 +331,11 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-### `EventIDFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L591" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EventIDFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L606" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 **Methods:**
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L604" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L619" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
@@ -356,7 +356,7 @@ Would the given filter exclude this event?
 get_filters(self) -> list['EventDataFilter']
 ```
 
-#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L596" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `includes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L611" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 includes(self, event: Event) -> bool
@@ -371,7 +371,7 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-### `EventOrder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L615" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EventOrder` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L630" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 **Methods:**
 
@@ -384,11 +384,11 @@ auto() -> str
 Exposes `enum.auto()` to avoid requiring a second import to use `AutoEnum`
 
 
-### `EventFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L620" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EventFilter` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L635" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 **Methods:**
 
-#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L653" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `build_where_clauses` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L668" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 build_where_clauses(self, db: PrefectDBInterface) -> Sequence['ColumnExpressionArgument[bool]']
@@ -418,7 +418,7 @@ includes(self, event: Event) -> bool
 Does the given event match the criteria of this filter?
 
 
-#### `logical_limit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L670" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `logical_limit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/events/filters.py#L685" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 logical_limit(self) -> int

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -359,6 +359,11 @@ class EventResourceFilter(EventDataFilter):
 
             if labels:
                 for _, (label, values) in enumerate(labels.items()):
+                    # Empty label value arrays should match nothing
+                    if not values:
+                        label_filters.append(sa.false())
+                        continue
+
                     label_ops = LabelOperations(values)
 
                     label_column = db.EventResource.resource[label].astext
@@ -451,6 +456,11 @@ class EventRelatedFilter(EventDataFilter):
 
             if labels:
                 for _, (label, values) in enumerate(labels.items()):
+                    # Empty label value arrays should match nothing
+                    if not values:
+                        label_filters.append(sa.false())
+                        continue
+
                     label_ops = LabelOperations(values)
 
                     label_column = db.EventResource.resource[label].astext
@@ -563,6 +573,11 @@ class EventAnyResourceFilter(EventDataFilter):
 
             if labels:
                 for _, (label, values) in enumerate(labels.items()):
+                    # Empty label value arrays should match nothing
+                    if not values:
+                        label_filters.append(sa.false())
+                        continue
+
                     label_ops = LabelOperations(values)
 
                     label_column = db.EventResource.resource[label].astext

--- a/tests/events/server/test_events_queries.py
+++ b/tests/events/server/test_events_queries.py
@@ -1502,3 +1502,59 @@ async def test_event_dates_always_have_timezones(
 async def test_corrupted_page_tokens_are_treated_as_noops(busted_token: str):
     with pytest.raises(ValueError):
         from_page_token(busted_token)
+
+
+async def test_resource_filter_empty_label_values(
+    events_query_session: AsyncSession,
+    full_occurred_range: EventOccurredFilter,
+) -> None:
+    """Test that resource labels with empty values array return no results."""
+
+    filter = EventFilter(
+        occurred=full_occurred_range,
+        resource=EventResourceFilter(labels={"hello": []}),  # Empty values = no matches
+    )
+
+    events, count, _ = await query_events(session=events_query_session, filter=filter)
+
+    # Empty label values should match nothing
+    assert count == 0
+    assert events == []
+
+
+async def test_related_filter_empty_label_values(
+    events_query_session: AsyncSession,
+    full_occurred_range: EventOccurredFilter,
+) -> None:
+    """Test that related resource labels with empty values array return no results."""
+
+    filter = EventFilter(
+        occurred=full_occurred_range,
+        related=EventRelatedFilter(labels={"hello": []}),  # Empty values = no matches
+    )
+
+    events, count, _ = await query_events(session=events_query_session, filter=filter)
+
+    # Empty label values should match nothing
+    assert count == 0
+    assert events == []
+
+
+async def test_any_resource_filter_empty_label_values(
+    events_query_session: AsyncSession,
+    full_occurred_range: EventOccurredFilter,
+) -> None:
+    """Test that any resource labels with empty values array return no results."""
+
+    filter = EventFilter(
+        occurred=full_occurred_range,
+        any_resource=EventAnyResourceFilter(
+            labels={"hello": []}
+        ),  # Empty values = no matches
+    )
+
+    events, count, _ = await query_events(session=events_query_session, filter=filter)
+
+    # Empty label values should match nothing
+    assert count == 0
+    assert events == []


### PR DESCRIPTION
When event filters had labels with empty value arrays (like `{"hello": []}`), the PostgreSQL/SQLAlchemy query generation was not handling them correctly, allowing all events to match instead of returning no results.

This adds guard conditions to inject `sa.false()` when label value arrays are empty, ensuring they consistently return no results across all event filter types (EventResourceFilter, EventRelatedFilter, EventAnyResourceFilter).

The fix aligns with expected behavior where empty label value arrays mean "match nothing" and closes a gap discovered in Prefect Cloud to keep OSS behavior consistent.

## Changes

- Added empty label value array checks in `EventResourceFilter.build_where_clauses`
- Added empty label value array checks in `EventRelatedFilter.build_where_clauses`  
- Added empty label value array checks in `EventAnyResourceFilter.build_where_clauses`
- Added tests to verify empty label arrays return no results for all filter types

🤖 Generated with [Claude Code](https://claude.ai/code)