### PR TITLE
Add CLI command to emit events

### DIFF
--- a/docs/v3/api-ref/python/prefect-cli-events.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Functions
 
-### `stream` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L30" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `stream` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L31" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 stream(format: StreamFormat = typer.Option(StreamFormat.json, '--format', help='Output format (json or text)'), output_file: str = typer.Option(None, '--output-file', help='File to write events to'), account: bool = typer.Option(False, '--account', help='Stream events for entire account, including audit logs'), run_once: bool = typer.Option(False, '--run-once', help='Stream only one event'))
@@ -19,19 +19,19 @@ as it is received. By default, events are printed as JSON, but can be
 printed as text by passing `--format text`.
 
 
-### `handle_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L65" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `handle_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L66" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 handle_event(event: Event, format: StreamFormat, output_file: str) -> None
 ```
 
-### `handle_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L79" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `handle_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L80" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 handle_error(exc: Exception) -> None
 ```
 
-### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L91" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L92" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 emit(event: str = typer.Argument(help='The name of the event'), resource: str = typer.Option(None, '--resource', '-r', help="Resource specification as 'key=value' or JSON. Can be used multiple times."), resource_id: str = typer.Option(None, '--resource-id', help='The resource ID (shorthand for --resource prefect.resource.id=<id>)'), related: Optional[str] = typer.Option(None, '--related', help='Related resources as JSON string'), payload: Optional[str] = typer.Option(None, '--payload', '-p', help='Event payload as JSON string'))
@@ -54,4 +54,4 @@ prefect event emit customer.subscribed --resource '{"prefect.resource.id": "cust
 
 ## Classes
 
-### `StreamFormat` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `StreamFormat` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L25" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>

--- a/docs/v3/api-ref/python/prefect-cli-events.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-events.mdx
@@ -7,7 +7,7 @@ sidebarTitle: events
 
 ## Functions
 
-### `stream` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `stream` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L30" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 stream(format: StreamFormat = typer.Option(StreamFormat.json, '--format', help='Output format (json or text)'), output_file: str = typer.Option(None, '--output-file', help='File to write events to'), account: bool = typer.Option(False, '--account', help='Stream events for entire account, including audit logs'), run_once: bool = typer.Option(False, '--run-once', help='Stream only one event'))
@@ -19,18 +19,39 @@ as it is received. By default, events are printed as JSON, but can be
 printed as text by passing `--format text`.
 
 
-### `handle_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L63" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `handle_event` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L65" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 handle_event(event: Event, format: StreamFormat, output_file: str) -> None
 ```
 
-### `handle_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `handle_error` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L79" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 handle_error(exc: Exception) -> None
 ```
 
+### `emit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L91" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+emit(event: str = typer.Argument(help='The name of the event'), resource: str = typer.Option(None, '--resource', '-r', help="Resource specification as 'key=value' or JSON. Can be used multiple times."), resource_id: str = typer.Option(None, '--resource-id', help='The resource ID (shorthand for --resource prefect.resource.id=<id>)'), related: Optional[str] = typer.Option(None, '--related', help='Related resources as JSON string'), payload: Optional[str] = typer.Option(None, '--payload', '-p', help='Event payload as JSON string'))
+```
+
+
+Emit a single event to Prefect.
+
+**Examples:**
+
+# Simple event with resource ID
+prefect event emit user.logged_in --resource-id user-123
+
+# Event with payload
+prefect event emit order.shipped --resource-id order-456 --payload '{"tracking": "ABC123"}'
+
+# Event with full resource specification
+prefect event emit customer.subscribed --resource '{"prefect.resource.id": "customer-789", "prefect.resource.name": "ACME Corp"}'
+
+
 ## Classes
 
-### `StreamFormat` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L22" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `StreamFormat` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/events.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -248,3 +248,75 @@ async def test_emit_event_invalid_json_payload():
             "Payload must be valid JSON",
         ],
     )
+
+
+async def test_emit_event_key_value_syntax():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "events",
+            "emit",
+            "database.migrated",
+            "--resource",
+            "prefect.resource.id=db-prod-01",
+        ],
+        expected_code=0,
+        expected_output_contains=[
+            "Successfully emitted event 'database.migrated'",
+        ],
+    )
+
+
+async def test_emit_event_resource_not_dict():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "events",
+            "emit",
+            "test.event",
+            "--resource",
+            '["not", "a", "dict"]',
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            "Resource must be a JSON object, not an array or string",
+        ],
+    )
+
+
+async def test_emit_event_payload_not_dict():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "events",
+            "emit",
+            "test.event",
+            "--resource-id",
+            "test-123",
+            "--payload",
+            '"just a string"',
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            "Payload must be a JSON object",
+        ],
+    )
+
+
+async def test_emit_event_related_single_object():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "events",
+            "emit",
+            "item.purchased",
+            "--resource-id",
+            "item-789",
+            "--related",
+            '{"prefect.resource.id": "user-456", "prefect.resource.role": "buyer"}',
+        ],
+        expected_code=0,
+        expected_output_contains=[
+            "Successfully emitted event 'item.purchased'",
+        ],
+    )


### PR DESCRIPTION
## Summary
- Adds a new `emit` command to the event CLI for emitting events directly from the command line
- Enables event emission from GitHub Actions and other CI/CD systems
- Supports resource specifications, payloads, and related resources

## Details
This PR adds a new command `prefect event emit` that uses the existing `emit_event` utility function to send events to Prefect. This is particularly useful for:
- Triggering deployments from GitHub Actions
- Integrating with external systems that need to notify Prefect of events
- Testing and debugging event-driven workflows

### Usage Examples
```bash
# Simple event with resource ID
prefect event emit user.logged_in --resource-id user-123

# Event with payload
prefect event emit order.shipped --resource-id order-456 --payload '{"tracking": "ABC123"}'

# Event with full resource specification
prefect event emit customer.subscribed --resource '{"prefect.resource.id": "customer-789", "prefect.resource.name": "ACME Corp"}'
```

## Test Plan
- [x] Added unit tests for the new CLI command
- [x] Tested with various event types and payloads
- [x] Verified error handling for invalid inputs
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.ai/code)