### PR TITLE
More robust `write_path` method in `RemoteFileSystem` to handle SMB UNC paths. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,6 @@ dev = [
     "opentelemetry-instrumentation>=0.48b0,<1.0.0",
     "opentelemetry-instrumentation-logging>=0.48b0,<1.0.0",
     "opentelemetry-test-utils>=0.48b0,<1.0.0",
-    "fsspec[smb]"
 ]
 
 perf = ["logfire[fastapi,sqlalchemy]>=3.14.0", "pyinstrument>=5.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ dev = [
     "opentelemetry-instrumentation>=0.48b0,<1.0.0",
     "opentelemetry-instrumentation-logging>=0.48b0,<1.0.0",
     "opentelemetry-test-utils>=0.48b0,<1.0.0",
+    "fsspec[smb]"
 ]
 
 perf = ["logfire[fastapi,sqlalchemy]>=3.14.0", "pyinstrument>=5.0.0"]

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -515,6 +515,9 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
         path = self._resolve_path(path)
         dirpath = path[: path.rindex("/")]
 
+        if self.basepath.startswith("smb://"):
+            dirpath = dirpath.replace(f"smb://{self.settings.get('host', '')}", "")
+
         self.filesystem.makedirs(dirpath, exist_ok=True)
 
         with self.filesystem.open(path, "wb") as file:

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -516,7 +516,8 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
         dirpath = path[: path.rindex("/")]
 
         if self.basepath.startswith("smb://"):
-            dirpath = dirpath.replace(f"smb://{self.settings.get('host', '')}", "")
+            parsed = urllib.parse.urlparse(dirpath)
+            dirpath = parsed.path
 
         self.filesystem.makedirs(dirpath, exist_ok=True)
 

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -488,6 +488,7 @@ class TestRemoteFileSystem:
             await fs.put_directory(to_path=null_value, local_path=local_path)
         assert (local_path / "test").exists()
 
+@pytest.importorskip("fsspec_implementations.smb", reason="requires fsspec[smb]")
 class TestSMB:
     @pytest.fixture
     def smb_block(self):

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -1,17 +1,16 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Generator, Tuple
-import fsspec
+from typing import Tuple
 from unittest.mock import patch
 
 import pytest
 
 import prefect
 from prefect.filesystems import (
+    SMB,
     LocalFileSystem,
     RemoteFileSystem,
-    SMB,
 )
 from prefect.testing.utilities import MagicMock
 from prefect.utilities.filesystem import tmpchdir

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -488,6 +488,7 @@ class TestRemoteFileSystem:
             await fs.put_directory(to_path=null_value, local_path=local_path)
         assert (local_path / "test").exists()
 
+
 @pytest.importorskip("fsspec_implementations.smb", reason="requires fsspec[smb]")
 class TestSMB:
     @pytest.fixture
@@ -502,9 +503,7 @@ class TestSMB:
         )
 
     @patch("fsspec.implementations.smb.smbclient")
-    async def test_write_path_constructs_good_unc_path(
-        self, mock_smbclient, smb_block
-    ):
+    async def test_write_path_constructs_good_unc_path(self, mock_smbclient, smb_block):
         """
         This test reproduces the issue where RemoteFileSystem passes a full URI
         to the underlying fsspec SMBFileSystem, causing a malformed UNC path
@@ -533,5 +532,7 @@ class TestSMB:
         # This is the core of the test. The bug causes the full URI to be passed
         # to fsspec, which then prepends the host again, creating a malformed path.
         # e.g. \\my.smb.server.edu\smb:\\my.smb.server.edu\prefect\storage\test-dir
-        assert unc_path.count(smb_block.smb_host) == 1, "The host name should not be duplicated"
+        assert unc_path.count(smb_block.smb_host) == 1, (
+            "The host name should not be duplicated"
+        )
         assert unc_path == r"\\my.smb.server.edu\prefect\storage\test-dir"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

This PR fixs #10694 and ensures that both `RemoteFileSystem` blocks using SMB protocol and `SMB` blocks works when creating new directories. 

This pull request addresses a bug in SMB path handling in the `write_path` method and adds a targeted test to prevent regressions. The main focus is on ensuring that SMB UNC paths are constructed correctly, avoiding duplication of the host in the path, which previously caused connection errors.

**Bug fix for SMB path handling:**

* Updated `write_path` in `prefect/filesystems.py` to strip the SMB host from the directory path when the base path starts with `smb://`, ensuring that the UNC path passed to `fsspec` is correctly formed and does not duplicate the host.

**Testing improvements:**

* Added a new `TestSMB` class in `tests/test_filesystems.py` with a fixture for creating an SMB block and a test that mocks SMB client interactions. This test verifies that the constructed UNC path contains the host only once and matches the expected format, preventing regressions of the original bug.
* Updated test imports to include `fsspec`, `patch`, and the `SMB` class for mocking and testing SMB functionality.