### PR TITLE
Support custom capacity provider

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -822,6 +822,8 @@ class ECSWorker(BaseWorker):
                         + ", ".join(placeholders)
                     )
 
+        # Note: _prepare_task_definition (called later) mutates the task definition so
+        # validation needs to account for the mutation logic
         self._validate_task_definition(task_definition, configuration)
 
         if flow_run.deployment_id:
@@ -1045,28 +1047,6 @@ class ECSWorker(BaseWorker):
 
         Raises `ValueError` on incompatibility. Returns `None` on success.
         """
-        launch_type = configuration.task_run_request.get(
-            "launchType", ECS_DEFAULT_LAUNCH_TYPE
-        )
-        if (
-            launch_type != "EC2"
-            and "FARGATE" not in task_definition["requiresCompatibilities"]
-        ):
-            raise ValueError(
-                "Task definition does not have 'FARGATE' in 'requiresCompatibilities'"
-                f" and cannot be used with launch type {launch_type!r}"
-            )
-
-        if launch_type == "FARGATE" or launch_type == "FARGATE_SPOT":
-            # Only the 'awsvpc' network mode is supported when using FARGATE
-            network_mode = task_definition.get("networkMode")
-            if network_mode != "awsvpc":
-                raise ValueError(
-                    f"Found network mode {network_mode!r} which is not compatible with "
-                    f"launch type {launch_type!r}. Use either the 'EC2' launch "
-                    "type or the 'awsvpc' network mode."
-                )
-
         if configuration.configure_cloudwatch_logs and not task_definition.get(
             "executionRoleArn"
         ):
@@ -1075,6 +1055,44 @@ class ECSWorker(BaseWorker):
                 "`configure_cloudwatch_logs` or `stream_logs` but no execution role "
                 "was found on the task definition."
             )
+
+        launch_type = configuration.task_run_request.get("launchType")
+        capacity_provider_strategy = configuration.task_run_request.get(
+            "capacityProviderStrategy"
+        )
+
+        # Users may submit a job with a custom capacity provider strategy which requires
+        # launch type to be empty.
+        if not launch_type and not capacity_provider_strategy:
+            launch_type = ECS_DEFAULT_LAUNCH_TYPE
+
+        # Fargate spot requires a launch type and a capacity provider strategy
+        # otherwise we're valid with a capacity provider strategy alone
+        if capacity_provider_strategy and launch_type != "FARGATE_SPOT":
+            return
+
+        # Default launch type in compatibilities to maintain functionality with
+        # _prepare_task_definition which sets requiresCompatibilties to FARGATE
+        # which is the default launch type.
+        if launch_type != "EC2" and "FARGATE" not in task_definition.get(
+            "requiresCompatibilities", [ECS_DEFAULT_LAUNCH_TYPE]
+        ):
+            raise ValueError(
+                "Task definition does not have 'FARGATE' in 'requiresCompatibilities'"
+                f" and cannot be used with launch type {launch_type!r}"
+            )
+
+        if launch_type == "FARGATE" or launch_type == "FARGATE_SPOT":
+            # Only the 'awsvpc' network mode is supported when using FARGATE
+            # Default to 'awsvpc' if not provided to maintain functionality with
+            # _prepare_task_definition which sets network mode to 'awsvpc' if not provided.
+            network_mode = task_definition.get("networkMode", "awsvpc")
+            if network_mode != "awsvpc":
+                raise ValueError(
+                    f"Found network mode {network_mode!r} which is not compatible with "
+                    f"launch type {launch_type!r}. Use either the 'EC2' launch "
+                    "type or the 'awsvpc' network mode."
+                )
 
     def _register_task_definition(
         self,
@@ -1455,9 +1473,7 @@ class ECSWorker(BaseWorker):
         cpu = task_definition.get("cpu") or ECS_DEFAULT_CPU
         memory = task_definition.get("memory") or ECS_DEFAULT_MEMORY
 
-        launch_type = configuration.task_run_request.get(
-            "launchType", ECS_DEFAULT_LAUNCH_TYPE
-        )
+        launch_type = configuration.task_run_request.get("launchType")
 
         if launch_type == "FARGATE" or launch_type == "FARGATE_SPOT":
             # Task level memory and cpu are required when using fargate
@@ -1475,14 +1491,10 @@ class ECSWorker(BaseWorker):
             # However, we will not enforce that here if the user has set it
             task_definition.setdefault("networkMode", "awsvpc")
 
-        elif launch_type == "EC2":
-            # Container level memory and cpu are required when using ec2
-            container.setdefault("cpu", cpu)
-            container.setdefault("memory", memory)
-
-            # Ensure set values are cast to integers
-            container["cpu"] = int(container["cpu"])
-            container["memory"] = int(container["memory"])
+        else:
+            # Container level memory and cpu are required when using non-FARGATE launch types
+            container.setdefault("cpu", int(cpu))
+            container.setdefault("memory", int(memory))
 
         # Ensure set values are cast to strings
         if task_definition.get("cpu"):

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -2292,6 +2292,46 @@ async def test_user_defined_capacity_provider_strategy(
 
 
 @pytest.mark.usefixtures("ecs_mocks")
+async def test_user_defined_capacity_provider_strategy_with_launch_type(
+    aws_credentials: AwsCredentials, flow_run: FlowRun, caplog
+):
+    configuration = await construct_configuration(
+        aws_credentials=aws_credentials,
+        launch_type="EC2",
+        capacity_provider_strategy=[
+            {
+                "weight": 1,
+                "base": 0,
+                "capacityProvider": "user-defined-capacity-provider",
+            }
+        ],
+    )
+
+    async with ECSWorker(work_pool_name="test") as worker:
+        # Capture the task run call because moto does not track 'capacityProviderStrategy'
+        original_run_task = worker._create_task_run
+        mock_run_task = MagicMock(side_effect=original_run_task)
+        worker._create_task_run = mock_run_task
+
+        result = await run_then_stop_task(worker, configuration, flow_run)
+
+    assert result.status_code == 0
+
+    # Assert the warning was emitted and that launchType was removed
+    assert (
+        "Found capacityProviderStrategy. Removing launchType from task run request."
+        in caplog.text
+    )
+
+    # launchType should be omitted and capacity provider strategy should be present
+    run_kwargs = mock_run_task.call_args[0][1]
+    assert "launchType" not in run_kwargs
+    assert run_kwargs.get("capacityProviderStrategy") == [
+        {"weight": 1, "base": 0, "capacityProvider": "user-defined-capacity-provider"}
+    ]
+
+
+@pytest.mark.usefixtures("ecs_mocks")
 async def test_user_defined_environment_variables_in_task_run_request_template(
     aws_credentials: AwsCredentials, flow_run: FlowRun
 ):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

- Add custom capacity provider support: `ECSWorker` now accepts user-defined `capacityProviderStrategy` in the `task_run_request`.
- `launchType` now defaults only when neither `launchType` nor `capacityProviderStrategy` are provided. Special case: `FARGATE_SPOT` still requires both.
- Validation updates: Move the CloudWatch logs `executionRoleArn` check up so we can return early.
- Tests: Add coverage for capacity provider strategy with a provided launchType (verifies the warning and removal of launchType from the run request).

Relates to #13030 but needs support from Prefect employees to update the push worker.

Local test result successfully placing a task in a cluster with no active container instances in which the task is `PROVISIONING`:

<img width="2492" height="1376" alt="image" src="https://github.com/user-attachments/assets/68cbfd3f-c9f2-44cf-b4e1-693929336dfc" />

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.