### PR TITLE
Add display of late runs in the work pool work queues table

### DIFF
--- a/ui-v2/src/components/work-pools/work-pool-queues-table/components/queue-name-with-late-indicator.tsx
+++ b/ui-v2/src/components/work-pools/work-pool-queues-table/components/queue-name-with-late-indicator.tsx
@@ -1,4 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { buildCountFlowRunsQuery } from "@/api/flow-runs";
 import type { WorkPoolQueue } from "@/api/work-pool-queues";
 import { LateFlowRunsIndicator } from "@/components/flow-runs/late-flow-runs-indicator";
 
@@ -9,10 +11,28 @@ type QueueNameWithLateIndicatorProps = {
 export const QueueNameWithLateIndicator = ({
 	queue,
 }: QueueNameWithLateIndicatorProps) => {
-	// TODO: Implement proper late flow runs detection when API supports it
-	// For now, using a mock count to demonstrate the feature
-	const lateRunsCount =
-		queue.name === "default" ? 0 : Math.floor(Math.random() * 3);
+	const { data: lateRunsCount = 0 } = useQuery(
+		buildCountFlowRunsQuery(
+			{
+				work_pools: {
+					operator: "and_",
+					name: { any_: [queue.work_pool_name || ""] },
+				},
+				work_pool_queues: {
+					operator: "and_",
+					name: { any_: [queue.name] },
+				},
+				flow_runs: {
+					operator: "and_",
+					state: {
+						operator: "and_",
+						name: { any_: ["Late"] },
+					},
+				},
+			},
+			30000,
+		),
+	);
 
 	return (
 		<div className="flex items-center space-x-2">

--- a/ui-v2/src/routes/work-pools/work-pool.$workPoolName.tsx
+++ b/ui-v2/src/routes/work-pools/work-pool.$workPoolName.tsx
@@ -9,7 +9,10 @@ import { zodValidator } from "@tanstack/zod-adapter";
 import { Suspense, useCallback, useMemo, useState } from "react";
 import { z } from "zod";
 import { buildPaginateDeploymentsQuery } from "@/api/deployments";
-import { buildFilterFlowRunsQuery } from "@/api/flow-runs";
+import {
+	buildCountFlowRunsQuery,
+	buildFilterFlowRunsQuery,
+} from "@/api/flow-runs";
 import { buildGetFlowRunsTaskRunsCountQuery } from "@/api/task-runs";
 import { buildListWorkPoolQueuesQuery } from "@/api/work-pool-queues";
 import { buildGetWorkPoolQuery } from "@/api/work-pools";
@@ -57,6 +60,38 @@ export const Route = createFileRoute("/work-pools/work-pool/$workPoolName")({
 		void queryClient.prefetchQuery(
 			buildListWorkPoolWorkersQuery(params.workPoolName),
 		);
+
+		// Prefetch late runs count for each queue (non-blocking)
+		void queryClient
+			.ensureQueryData(buildListWorkPoolQueuesQuery(params.workPoolName))
+			.then((queues) =>
+				Promise.all(
+					queues.map((queue) =>
+						queryClient.prefetchQuery(
+							buildCountFlowRunsQuery(
+								{
+									work_pools: {
+										operator: "and_",
+										name: { any_: [params.workPoolName] },
+									},
+									work_pool_queues: {
+										operator: "and_",
+										name: { any_: [queue.name] },
+									},
+									flow_runs: {
+										operator: "and_",
+										state: {
+											operator: "and_",
+											name: { any_: ["Late"] },
+										},
+									},
+								},
+								30000,
+							),
+						),
+					),
+				),
+			);
 
 		// Prefetch filtered data for runs and deployments
 		void queryClient


### PR DESCRIPTION
## Summary
This PR implements the display of real late run counts in the work pool work queues table, replacing the previous mock data with actual API calls.

## Changes
- Updated `QueueNameWithLateIndicator` component to fetch real late run counts using the `buildCountFlowRunsQuery` API
- Added prefetching of late run counts in the work pool route loader for improved performance
- Filters late runs by work pool name, queue name, and flow runs with state name "Late"

## Implementation Details
The component now queries the API every 30 seconds to get updated late run counts for each queue. The route loader prefetches this data when the work pool page loads to ensure fast initial rendering.

Related to #15512

🤖 Generated with [Claude Code](https://claude.ai/code)