### PR TITLE
Fix race condition in ProactiveTriggers service

### DIFF
--- a/src/prefect/server/events/triggers.py
+++ b/src/prefect/server/events/triggers.py
@@ -1209,7 +1209,7 @@ async def proactive_evaluation(
 
 
 async def evaluate_proactive_triggers() -> None:
-    for trigger in triggers.values():
+    for trigger in list(triggers.values()):
         if trigger.posture != Posture.Proactive:
             continue
 


### PR DESCRIPTION
Wrap triggers.values() with list() in evaluate_proactive_triggers() to prevent 'RuntimeError: dictionary changed size during iteration' when the triggers dictionary is modified concurrently by the automation change listener.

Fixes #18871

Generated with [Claude Code](https://claude.ai/code)