### PR TITLE
Add pre-commit instruction to Claude GitHub workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
 
             IMPORTANT: Before committing any code changes, you MUST run `pre-commit run --all-files` to ensure all formatting, linting, and type checking passes. This prevents the Static Analysis workflow from failing.
 
-            The pre-commit hooks will automatically format code with ruff and check types with mypy. If the hooks modify any files, add them with `git add .` and commit again.
+            The pre-commit hooks will automatically format code with ruff and check types with pyright. If the hooks modify any files, add them with `git add .` and commit again.
 
             Never use `git commit --no-verify` or `git commit --amend` under any circumstances.
 


### PR DESCRIPTION
## Summary
This PR adds a custom prompt to the Claude GitHub workflow that ensures pre-commit hooks are run before any code changes are committed.

## Details
<details>
<summary>Changes made</summary>

- Added a custom `prompt` configuration to the Claude Code action in `.github/workflows/claude.yml`
- The prompt instructs Claude to always run `pre-commit run --all-files` before committing
- Prevents Static Analysis workflow failures by ensuring formatting, linting, and type checking pass
- Explicitly forbids using `--no-verify` or `--amend` flags

</details>

🤖 Generated with [Claude Code](https://claude.ai/code)