### PR TITLE
fix: use ruff-check instead of legacy ruff alias in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.12
     hooks:
-      - id: ruff
+      - id: ruff-check
         language_version: python3
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format


### PR DESCRIPTION
fixes the ruff (legacy alias) warning in pre-commit by updating to use the modern `ruff-check` hook id.

the legacy `ruff` hook id has been replaced with `ruff-check` for linting and `ruff-format` for formatting in the astral-sh/ruff-pre-commit repository. this change eliminates the warning message while maintaining identical functionality.

```
ruff (legacy alias)......................................................Passed
```

<details>
<summary>details</summary>

- changed `.pre-commit-config.yaml:14` from `id: ruff` to `id: ruff-check`
- verified fix by running `pre-commit run --all-files` successfully
- no functional changes to linting behavior

</details>