### PR TITLE
Standardize checkbox column spacing across data tables

### DIFF
--- a/ui-v2/src/components/blocks/block-document-data-table/block-document-data-table.tsx
+++ b/ui-v2/src/components/blocks/block-document-data-table/block-document-data-table.tsx
@@ -52,6 +52,7 @@ const createColumns = ({
 		),
 		enableSorting: false,
 		enableHiding: false,
+		maxSize: 20,
 	}),
 	columnHelper.display({
 		id: "block",

--- a/ui-v2/src/components/flows/columns.tsx
+++ b/ui-v2/src/components/flows/columns.tsx
@@ -32,7 +32,7 @@ export const columns: ColumnDef<Flow>[] = [
 		),
 		enableSorting: false,
 		enableHiding: false,
-		maxSize: 10,
+		maxSize: 20,
 	},
 	{
 		accessorKey: "name",


### PR DESCRIPTION
## Summary
- Standardizes checkbox column spacing between flows and blocks tables
- Updates flows table checkbox column `maxSize` from 10 to 20 pixels  
- Adds `maxSize: 20` to blocks table checkbox column for consistency
- Ensures uniform spacing between checkboxes and content across all data tables

## Implementation Details
- **Root cause**: Table component CSS `[&:has([role=checkbox])]:pr-0` automatically removes right padding from checkbox cells
- **Solution**: Work with existing CSS by using consistent column sizing (`maxSize: 20`) rather than fighting specificity with `!important`
- **Files changed**: 
  - `src/components/flows/columns.tsx` - Updated checkbox column maxSize
  - `src/components/blocks/block-document-data-table/block-document-data-table.tsx` - Added maxSize property

🤖 Generated with [Claude Code](https://claude.ai/code)