### PR TITLE
fix: add redirect setting to docs.json to fix /latest path 404s

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
+  "redirect": true,
   "api": {
     "playground": {
       "display": "simple"


### PR DESCRIPTION
Fixes the 404 issue on docs.prefect.io/latest paths.

## Problem
Our docs were returning 404s for all  paths due to recent changes to Mintlify's 404 behavior that no longer automatically redirects.

## Solution
Per Mintlify support, adding `redirect: true` to docs.json restores the redirect behavior for the /latest path.

## Reference
- Mintlify docs: https://www.mintlify.com/docs/settings#param-redirect