### PR TITLE
fix: add errors.404.redirect setting to fix /latest path 404s

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "redirect": true,
+  "errors": {
+    "404": {
+      "redirect": true
+    }
+  },
   "api": {
     "playground": {
       "display": "simple"


### PR DESCRIPTION
## Problem
Our docs were returning 404s for all  paths due to recent changes to Mintlify's 404 behavior that no longer automatically redirects.

## Solution  
Per Mintlify support, adding `redirect: true` in the `errors.404` configuration restores the redirect behavior for the /latest path.

Note: The `errors` section didn't exist in our docs.json so this creates it with the necessary 404 redirect configuration.

## Reference
- Mintlify docs: https://www.mintlify.com/docs/settings#param-redirect
- Previous (incorrect) PR that put it at top level: #18945