### PR TITLE
[UI v2] Add dashboard filters

### DIFF
--- a/ui-v2/src/components/flow-runs/flow-run-tags-select.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-tags-select.test.tsx
@@ -1,0 +1,183 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { FlowRunTagsSelect } from "./flow-run-tags-select";
+
+// MSW server to mock API endpoints
+const server = setupServer(
+	http.post("/api/flow_runs/paginate", () => {
+		return HttpResponse.json({
+			results: [
+				{ id: "1", tags: ["alpha", "prod"] },
+				{ id: "2", tags: ["beta", "prod"] },
+				{ id: "3", tags: [] },
+			],
+			pages: 1,
+			next: null,
+		});
+	}),
+);
+
+beforeAll(() => {
+	// Ensure the client builds requests against the MSW base URL
+	vi.stubEnv("VITE_API_URL", "/api");
+	// Polyfill scrollIntoView used by cmdk
+	Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+		value: vi.fn(),
+		configurable: true,
+		writable: true,
+	});
+	server.listen();
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function renderWithQueryClient(ui: React.ReactElement) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+	);
+}
+
+describe("FlowRunTagsSelect", () => {
+	it("shows placeholder when no tags selected", () => {
+		renderWithQueryClient(
+			<FlowRunTagsSelect
+				value={[]}
+				onChange={vi.fn()}
+				placeholder="All tags"
+			/>,
+		);
+		// The trigger shows the placeholder text
+		expect(screen.getByText("All tags")).toBeInTheDocument();
+	});
+
+	it("shows selected tags in the trigger", () => {
+		renderWithQueryClient(
+			<FlowRunTagsSelect value={["alpha", "beta"]} onChange={vi.fn()} />,
+		);
+		// Without opening dropdown, tags are visible in trigger
+		expect(screen.getByText("alpha")).toBeInTheDocument();
+		expect(screen.getByText("beta")).toBeInTheDocument();
+	});
+
+	// Suggestion rendering is covered implicitly by other integration tests; core interactions below
+
+	it("adds a freeform tag on Enter", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		renderWithQueryClient(<FlowRunTagsSelect value={[]} onChange={onChange} />);
+
+		const trigger = screen.getByRole("button", { name: /flow run tags/i });
+		await user.click(trigger);
+
+		const combo = screen.getByRole("combobox");
+		await user.type(combo, "newtag");
+		await user.keyboard("{Enter}");
+
+		expect(onChange).toHaveBeenCalledWith(["newtag"]);
+	});
+
+	it("adds a tag when typing a trailing comma", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		renderWithQueryClient(<FlowRunTagsSelect value={[]} onChange={onChange} />);
+
+		const trigger = screen.getByRole("button", { name: /flow run tags/i });
+		await user.click(trigger);
+
+		const input2 = screen.getByRole("combobox");
+		await user.type(input2, "temp,");
+
+		// Comma commits the tag and clears input; we expect onChange invoked
+		await waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith(["temp"]);
+		});
+	});
+
+	it("removes last tag on Backspace when input empty", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		// Start with one selected tag
+		renderWithQueryClient(
+			<FlowRunTagsSelect value={["alpha"]} onChange={onChange} />,
+		);
+
+		const trigger = screen.getByRole("button", { name: /flow run tags/i });
+		await user.click(trigger);
+
+		await user.keyboard("{Backspace}");
+
+		expect(onChange).toHaveBeenCalledWith([]);
+	});
+
+	it("removes a tag via dropdown remove button", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		renderWithQueryClient(
+			<FlowRunTagsSelect value={["alpha", "beta"]} onChange={onChange} />,
+		);
+
+		// Open and remove 'alpha' via dropdown
+		const trigger = screen.getByRole("button", { name: /flow run tags/i });
+		await user.click(trigger);
+		const removeAlpha = await screen.findByRole("button", {
+			name: /remove alpha tag/i,
+		});
+		await user.click(removeAlpha);
+
+		expect(onChange).toHaveBeenCalledWith(["beta"]);
+	});
+
+	it("clears all tags via clear action", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		renderWithQueryClient(
+			<FlowRunTagsSelect value={["alpha", "beta"]} onChange={onChange} />,
+		);
+
+		const trigger = screen.getByRole("button", { name: /flow run tags/i });
+		await user.click(trigger);
+
+		const listbox = await screen.findByRole("listbox");
+		// Clear all item should be visible regardless of suggestions
+		const clearItem = await within(listbox).findByText(/clear all tags/i);
+		await user.click(clearItem);
+
+		expect(onChange).toHaveBeenCalledWith([]);
+	});
+
+	it("does not show 'No tags found' when API returns no tags", async () => {
+		// Return empty results
+		server.use(
+			http.post("/api/flow_runs/paginate", () =>
+				HttpResponse.json({ results: [], pages: 0, next: null }),
+			),
+		);
+
+		const user = userEvent.setup();
+		renderWithQueryClient(<FlowRunTagsSelect value={[]} onChange={vi.fn()} />);
+
+		const trigger = screen.getByRole("button", { name: /flow run tags/i });
+		await user.click(trigger);
+
+		// There is a listbox but no empty message
+		const listbox = await screen.findByRole("listbox");
+		expect(
+			within(listbox).queryByText(/no tags found/i),
+		).not.toBeInTheDocument();
+	});
+});

--- a/ui-v2/src/components/flow-runs/flow-run-tags-select.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-tags-select.tsx
@@ -1,0 +1,198 @@
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { buildPaginateFlowRunsQuery } from "@/api/flow-runs";
+import {
+	Combobox,
+	ComboboxCommandEmtpy,
+	ComboboxCommandGroup,
+	ComboboxCommandInput,
+	ComboboxCommandItem,
+	ComboboxCommandList,
+	ComboboxContent,
+	ComboboxTrigger,
+} from "@/components/ui/combobox";
+import { Icon } from "@/components/ui/icons";
+import { TagBadgeGroup } from "@/components/ui/tag-badge-group";
+
+type FlowRunTagsSelectProps = {
+	value?: string[];
+	onChange?: (tags: string[]) => void;
+	placeholder?: string;
+	id?: string;
+};
+
+export function FlowRunTagsSelect({
+	value = [],
+	onChange,
+	placeholder = "All tags",
+	id,
+}: FlowRunTagsSelectProps) {
+	const [search, setSearch] = useState("");
+
+	// Fetch a recent page of flow runs to derive tag suggestions
+	const { data } = useQuery(
+		buildPaginateFlowRunsQuery({
+			page: 1,
+			limit: 100,
+			sort: "START_TIME_DESC",
+		}),
+	);
+
+	const suggestions = useMemo(() => {
+		const all = new Set<string>();
+		(data?.results ?? []).forEach((fr) => {
+			(fr.tags ?? []).forEach((t) => all.add(t));
+		});
+		return Array.from(all).sort((a, b) => a.localeCompare(b));
+	}, [data?.results]);
+
+	// Computed suggestions are built inline below; keep ranking helpers here if needed later
+
+	const toggleTag = (tag: string) => {
+		const exists = value.includes(tag);
+		const next = exists ? value.filter((t) => t !== tag) : [...value, tag];
+		onChange?.(next);
+	};
+
+	const addFreeformTag = useCallback(
+		(tag: string) => {
+			if (!tag) return;
+			if (value.includes(tag)) return;
+			onChange?.([...value, tag]);
+		},
+		[onChange, value],
+	);
+
+	// Add on trailing comma for quick entry (matches common tags UX)
+	useEffect(() => {
+		const trimmed = search.trim();
+		if (trimmed.endsWith(",")) {
+			const tag = trimmed.replace(/,+$/, "").trim();
+			if (tag) {
+				addFreeformTag(tag);
+			}
+			setSearch("");
+		}
+	}, [search, addFreeformTag]);
+
+	const triggerLabel = (
+		<span className="text-muted-foreground">
+			{value.length ? "Edit tags" : placeholder}
+		</span>
+	);
+
+	return (
+		<div className="w-full">
+			<Combobox>
+				<ComboboxTrigger
+					aria-label="Flow run tags"
+					id={id}
+					selected={value.length === 0}
+				>
+					{value.length > 0 ? (
+						<div className="flex items-center gap-1 overflow-hidden">
+							<TagBadgeGroup
+								tags={value}
+								variant="secondary"
+								maxTagsDisplayed={3}
+							/>
+						</div>
+					) : (
+						triggerLabel
+					)}
+				</ComboboxTrigger>
+				<ComboboxContent>
+					<ComboboxCommandInput
+						value={search}
+						onValueChange={setSearch}
+						placeholder="Search or enter new tag"
+						onKeyDown={(e) => {
+							const query = search.trim();
+							if (e.key === "Enter" && query) {
+								e.preventDefault();
+								addFreeformTag(query);
+								setSearch("");
+							} else if (e.key === "Backspace" && !search && value.length > 0) {
+								onChange?.(value.slice(0, -1));
+							}
+						}}
+					/>
+					<ComboboxCommandList>
+						{suggestions.length > 0 ? (
+							<ComboboxCommandEmtpy>No tags found</ComboboxCommandEmtpy>
+						) : null}
+						<ComboboxCommandGroup>
+							{/* Selected tags with inline remove */}
+							{value.length > 0 && (
+								<div>
+									{value.map((tag) => (
+										<ComboboxCommandItem
+											key={`selected-${tag}`}
+											value={`selected-${tag}`}
+											onSelect={() => toggleTag(tag)}
+											closeOnSelect={false}
+										>
+											<button
+												type="button"
+												aria-label={`Remove ${tag} tag`}
+												className="text-muted-foreground hover:text-foreground"
+												onClick={(ev) => {
+													ev.preventDefault();
+													ev.stopPropagation();
+													onChange?.(value.filter((t) => t !== tag));
+												}}
+											>
+												<Icon id="X" className="size-3" />
+											</button>
+											<span>{tag}</span>
+										</ComboboxCommandItem>
+									))}
+									<ComboboxCommandItem
+										value="__clear__"
+										onSelect={() => onChange?.([])}
+										closeOnSelect={false}
+									>
+										Clear all tags
+									</ComboboxCommandItem>
+								</div>
+							)}
+
+							{/* Add freeform */}
+							{search.trim() && !value.includes(search.trim()) && (
+								<ComboboxCommandItem
+									value={`__add__:${search.trim()}`}
+									onSelect={() => addFreeformTag(search.trim())}
+									closeOnSelect={false}
+								>
+									Add &quot;{search.trim()}&quot;
+								</ComboboxCommandItem>
+							)}
+
+							{/* Suggestions (exclude already selected) */}
+							{suggestions
+								.filter((t) => !value.includes(t))
+								.filter((t) => {
+									const q = search.trim().toLowerCase();
+									if (!q) return true;
+									return t.toLowerCase().includes(q);
+								})
+								.map((tag) => (
+									<ComboboxCommandItem
+										key={tag}
+										value={tag}
+										selected={value.includes(tag)}
+										onSelect={() => toggleTag(tag)}
+										closeOnSelect={false}
+									>
+										{tag}
+									</ComboboxCommandItem>
+								))}
+						</ComboboxCommandGroup>
+					</ComboboxCommandList>
+				</ComboboxContent>
+			</Combobox>
+		</div>
+	);
+}
+
+FlowRunTagsSelect.displayName = "FlowRunTagsSelect";

--- a/ui-v2/src/components/ui/combobox/combobox.tsx
+++ b/ui-v2/src/components/ui/combobox/combobox.tsx
@@ -1,4 +1,4 @@
-import { createContext, use, useState } from "react";
+import { createContext, type KeyboardEventHandler, use, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Command,
@@ -81,10 +81,12 @@ const ComboboxCommandInput = ({
 	value,
 	onValueChange,
 	placeholder,
+	onKeyDown,
 }: {
 	value?: string;
 	onValueChange?: (value: string) => void;
 	placeholder?: string;
+	onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 }) => {
 	return (
 		<CommandInput
@@ -92,6 +94,7 @@ const ComboboxCommandInput = ({
 			onValueChange={onValueChange}
 			placeholder={placeholder}
 			className="h-9"
+			onKeyDown={onKeyDown}
 		/>
 	);
 };

--- a/ui-v2/src/routes/dashboard.tsx
+++ b/ui-v2/src/routes/dashboard.tsx
@@ -1,4 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { useCallback, useEffect, useMemo } from "react";
+import { z } from "zod";
+import { FlowRunTagsSelect } from "@/components/flow-runs/flow-run-tags-select";
 import {
 	Breadcrumb,
 	BreadcrumbItem,
@@ -6,21 +10,243 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+	type DateRangeSelectAroundUnit,
+	type DateRangeSelectValue,
+	RichDateRangeSelector,
+} from "@/components/ui/date-range-select";
+import { Label } from "@/components/ui/label";
+import {
 	LayoutWell,
 	LayoutWellContent,
 	LayoutWellHeader,
 } from "@/components/ui/layout-well";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+
+// Search params for dashboard filters (flat structure)
+const searchParams = z.object({
+	hideSubflows: z.boolean().optional().catch(false),
+	tags: z.array(z.string()).optional().catch(undefined),
+	// Derived normalized range for downstream queries
+	from: z.string().datetime().optional().catch(undefined),
+	to: z.string().datetime().optional().catch(undefined),
+	// Rich selector flat params
+	rangeType: z.enum(["span", "range", "around", "period"]).optional(),
+	seconds: z.number().optional(), // for span
+	start: z.string().datetime().optional(), // for range
+	end: z.string().datetime().optional(),
+	aroundDate: z.string().datetime().optional(), // for around
+	aroundQuantity: z.number().optional(),
+	aroundUnit: z.enum(["second", "minute", "hour", "day"]).optional(),
+	period: z.enum(["Today"]).optional(),
+});
 
 export const Route = createFileRoute("/dashboard")({
+	validateSearch: zodValidator(searchParams),
 	component: RouteComponent,
 });
 
+function omitKeys<T extends object, K extends readonly (keyof T)[]>(
+	obj: T,
+	keys: K,
+): Omit<T, K[number]> {
+	const clone: Record<string, unknown> = {
+		...(obj as Record<string, unknown>),
+	};
+	for (const k of keys as readonly string[]) {
+		delete clone[k];
+	}
+	return clone as Omit<T, K[number]>;
+}
+
 export function RouteComponent() {
+	type DashboardSearch = z.infer<typeof searchParams>;
+	const search = Route.useSearch();
+	const navigate = Route.useNavigate();
+
+	// Derive UI states with sensible defaults
+	const hideSubflows = search.hideSubflows ?? false;
+	const tags = search.tags ?? [];
+	const dateRangeValue = useMemo<DateRangeSelectValue>(() => {
+		switch (search.rangeType) {
+			case "span": {
+				const seconds = search.seconds ?? -86400; // default 24h
+				return { type: "span", seconds };
+			}
+			case "range": {
+				if (search.start && search.end) {
+					return {
+						type: "range",
+						startDate: new Date(search.start),
+						endDate: new Date(search.end),
+					};
+				}
+				return { type: "span", seconds: -86400 };
+			}
+			case "around": {
+				if (search.aroundDate && search.aroundQuantity && search.aroundUnit) {
+					return {
+						type: "around",
+						date: new Date(search.aroundDate),
+						quantity: search.aroundQuantity,
+						unit: search.aroundUnit as DateRangeSelectAroundUnit,
+					};
+				}
+				return { type: "span", seconds: -86400 };
+			}
+			case "period": {
+				return { type: "period", period: search.period ?? "Today" };
+			}
+			default:
+				return { type: "span", seconds: -86400 };
+		}
+	}, [
+		search.rangeType,
+		search.seconds,
+		search.start,
+		search.end,
+		search.aroundDate,
+		search.aroundQuantity,
+		search.aroundUnit,
+		search.period,
+	]);
+
+	const onToggleHideSubflows = useCallback(
+		(checked: boolean) => {
+			void navigate({
+				to: ".",
+				search: (prev) => ({ ...prev, hideSubflows: checked }),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	const onTagsChange = useCallback(
+		(nextTags: string[]) => {
+			void navigate({
+				to: ".",
+				search: (prev) => ({
+					...prev,
+					tags: nextTags.length ? nextTags : undefined,
+				}),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	const onDateRangeChange = useCallback(
+		(next: DateRangeSelectValue) => {
+			void navigate({
+				to: ".",
+				search: (prev: DashboardSearch) => {
+					if (!next) {
+						return omitKeys(prev, [
+							"rangeType",
+							"seconds",
+							"start",
+							"end",
+							"aroundDate",
+							"aroundQuantity",
+							"aroundUnit",
+							"period",
+							"from",
+							"to",
+						] as const);
+					}
+
+					// Compute normalized from/to for convenience
+					let fromIso: string | undefined;
+					let toIso: string | undefined;
+					switch (next.type) {
+						case "span": {
+							const now = new Date();
+							const then = new Date(now.getTime() + next.seconds * 1000);
+							const [a, b] = [now, then].sort(
+								(x, y) => x.getTime() - y.getTime(),
+							);
+							fromIso = a.toISOString();
+							toIso = b.toISOString();
+							return {
+								...prev,
+								rangeType: "span",
+								seconds: next.seconds,
+								from: fromIso,
+								to: toIso,
+							};
+						}
+						case "range": {
+							fromIso = next.startDate.toISOString();
+							toIso = next.endDate.toISOString();
+							return {
+								...prev,
+								rangeType: "range",
+								start: fromIso,
+								end: toIso,
+								from: fromIso,
+								to: toIso,
+							};
+						}
+						case "around": {
+							const center = next.date;
+							const multiplier = {
+								second: 1,
+								minute: 60,
+								hour: 3600,
+								day: 86400,
+							}[next.unit];
+							const spanSeconds = next.quantity * multiplier;
+							const from = new Date(center.getTime() - spanSeconds * 1000);
+							const to = new Date(center.getTime() + spanSeconds * 1000);
+							fromIso = from.toISOString();
+							toIso = to.toISOString();
+							return {
+								...prev,
+								rangeType: "around",
+								aroundDate: center.toISOString(),
+								aroundQuantity: next.quantity,
+								aroundUnit: next.unit,
+								from: fromIso,
+								to: toIso,
+							};
+						}
+						case "period": {
+							// Only Today supported; normalize to today's start/end
+							const now = new Date();
+							const start = new Date(now);
+							start.setHours(0, 0, 0, 0);
+							const end = new Date(now);
+							end.setHours(23, 59, 59, 999);
+							fromIso = start.toISOString();
+							toIso = end.toISOString();
+							return {
+								...prev,
+								rangeType: "period",
+								period: next.period,
+								from: fromIso,
+								to: toIso,
+							};
+						}
+					}
+				},
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	// Initialize default date range to last 24 hours if unset
+	useEffect(() => {
+		if (!search.rangeType && !search.from && !search.to) {
+			// default to a span of last 24 hours
+			onDateRangeChange({ type: "span", seconds: -86400 });
+		}
+	}, [search.rangeType, search.from, search.to, onDateRangeChange]);
+
 	return (
 		<LayoutWell>
 			<LayoutWellContent>
-				<LayoutWellHeader>
+				<LayoutWellHeader className="pb-4 md:pb-6">
 					<div className="flex flex-col space-y-4 md:space-y-0 md:flex-row md:items-center md:justify-between">
 						<div>
 							<Breadcrumb>
@@ -32,11 +258,30 @@ export function RouteComponent() {
 							</Breadcrumb>
 						</div>
 						<div className="flex flex-col w-full max-w-full gap-2 md:w-auto md:inline-flex md:flex-row items-center">
-							{/* Placeholder for future filter controls */}
-							<div className="hidden md:flex items-center gap-2">
-								<Skeleton className="h-9 w-32" /> {/* Hide subflows toggle */}
-								<Skeleton className="h-9 w-40" /> {/* Tags filter */}
-								<Skeleton className="h-9 w-48" /> {/* Date range selector */}
+							{/* Filters */}
+							<div className="flex items-center gap-2 w-full md:w-auto">
+								<div className="pr-2 w-full md:w-auto flex items-center gap-2">
+									<Switch
+										id="hide-subflows"
+										checked={hideSubflows}
+										onCheckedChange={onToggleHideSubflows}
+									/>
+									<Label htmlFor="hide-subflows">Hide subflows</Label>
+								</div>
+								<div className="min-w-0 w-60">
+									<FlowRunTagsSelect
+										value={tags}
+										onChange={onTagsChange}
+										placeholder="All tags"
+									/>
+								</div>
+								<div className="min-w-0">
+									<RichDateRangeSelector
+										value={dateRangeValue}
+										onValueChange={onDateRangeChange}
+										placeholder="Select a time span"
+									/>
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Summary
- Migrates dashboard filters to React

Technical details
- Dashboard search params are validated with zod and kept flat:
  - `rangeType`, `seconds`, `start`, `end`, `aroundDate`, `aroundQuantity`, `aroundUnit`, `period`
  - Normalized `from`/`to` always present for downstream queries.
- URL cleanup uses a typed `omitKeys` to avoid any-casts.
- Default date window set to last 24 hours on first load.
- Tag suggestions are sourced from `/flow_runs/paginate` (recent page) via react-query.

Related to #15512 
