### PR TITLE
refactor(deploy): make deploy CLI model-first (typed DeploymentConfig)

### DIFF
--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -342,10 +342,8 @@ async def _run_single_deploy(
 
     deployment._parameter_openapi_schema = dd["parameter_openapi_schema"]
 
-    if deploy_config.get("enforce_parameter_schema") is not None:
-        deployment.enforce_parameter_schema = deploy_config.get(
-            "enforce_parameter_schema"
-        )
+    if dd.get("enforce_parameter_schema") is not None:
+        deployment.enforce_parameter_schema = dd.get("enforce_parameter_schema")
 
     apply_coro = deployment.apply(schedules=dd.get("schedules"))
     if TYPE_CHECKING:

--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -389,7 +389,13 @@ async def _run_single_deploy(
             ),
             console=app.console,
         ):
-            deploy_config_before_templating.update({"schedules": schedules})
+            deploy_config_before_templating.update(
+                {
+                    "schedules": schedules,
+                    # Ensure key exists for _format_deployment_for_saving_to_prefect_file
+                    "parameter_openapi_schema": parameter_openapi_schema,
+                }
+            )
             _save_deployment_to_prefect_file(
                 deploy_config_before_templating,
                 build_steps=build_steps or None,

--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -41,6 +41,7 @@ from ._actions import (
 from ._config import (
     _apply_cli_options_to_deploy_config,
     _handle_deprecated_schedule_fields,
+    _merge_with_default_deploy_config,
 )
 from ._models import DeploymentConfig
 from ._schedules import _construct_schedules
@@ -317,6 +318,9 @@ async def _run_single_deploy(
             )
         }
         dd["concurrency_limit"] = get_from_dict(dd, "concurrency_limit.limit")
+
+    # Ensure legacy defaults are present for downstream objects (e.g., parameters {})
+    dd = _merge_with_default_deploy_config(dd)
 
     pull_steps = apply_values(pull_steps, step_outputs, remove_notset=False)
 


### PR DESCRIPTION
Summary
- Loader now returns `DeploymentConfig` models instead of dicts
- CLI applies flags directly onto models for strong typing
- Core deploy path resolves/normalizes on the model, then dumps to dicts only when building `RunnerDeployment`
- Keeps behavior for defaults, templating, actions; fixes legacy `schedule: {}` promotion

Details
- `_load_deploy_configs_and_actions`: returns `list[DeploymentConfig]` + actions dict
- Selection helpers (`_parse_name_from_pattern`, `_filter_matching_deploy_config`, `_handle_pick_deploy_*`) accept models and convert to dicts for prompt/display and downstream execution
- `_apply_cli_options_to_deploy_config`: takes/returns `DeploymentConfig`; merges params, variables and work-pool fields; accepts dict `concurrency_limit` and validates into `ConcurrencyLimitSpec`
- `_handle_deprecated_schedule_fields`: typed to `DeploymentConfig`; only promotes `schedule` to `schedules` if non-empty when dict (avoids `schedule: {}` errors)
- `_run_single_deploy`: dict -> model -> resolve blocks/vars/env -> apply options -> template -> dump JSON for `RunnerDeployment` construction

Why
- Strengthens typing across deploy CLI, reducing key typos and easing refactors
- Minimizes blast radius by retaining dicts at integration boundaries

Testing
- Reproduced and fixed `TestProjectDeploy::test_project_deploy` locally
- Can run full CLI deploy suite if desired

Follow-ups
- Consider migrating remaining deploy helpers to model-first or adding mypy coverage for deploy package.
