### PR TITLE
Handle dbt kwargs as args

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -38,7 +38,7 @@ from prefect.exceptions import MissingContextError
 from prefect.tasks import MaterializingTask, Task, TaskOptions
 from prefect_dbt.core._tracker import NodeTaskTracker
 from prefect_dbt.core.settings import PrefectDbtSettings
-from prefect_dbt.utilities import format_resource_id
+from prefect_dbt.utilities import format_resource_id, kwargs_to_args
 
 FAILURE_STATUSES = [
     RunStatus.Error,
@@ -660,8 +660,7 @@ class PrefectDbtRunner:
             invoke_kwargs["profiles_dir"] = profiles_dir
 
             res = dbtRunner(callbacks=callbacks).invoke(  # type: ignore[reportUnknownMemberType]
-                args_copy,
-                **invoke_kwargs,
+                kwargs_to_args(invoke_kwargs, args_copy)
             )
 
         if not res.success and res.exception:

--- a/src/integrations/prefect-dbt/prefect_dbt/utilities.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/utilities.py
@@ -71,3 +71,64 @@ def format_resource_id(adapter_type: str, relation_name: str) -> str:
         asset_key = asset_key[:MAX_ASSET_KEY_LENGTH]
 
     return asset_key
+
+
+def kwargs_to_args(kwargs: dict, args: list[str] | None = None) -> list[str]:
+    """
+    Convert a dictionary of kwargs to a list of args in the dbt CLI format.
+    If args are provided, they take priority over kwargs when conflicts exist.
+
+    Args:
+        kwargs: A dictionary of kwargs.
+        args: Optional list of existing args that take priority over kwargs.
+
+    Returns:
+        A list of args.
+    """
+    if args is None:
+        args = []
+
+    kwargs_args = []
+    for key, value in list(kwargs.items()):
+        if value is None:
+            continue
+
+        flag = "--" + key.replace("_", "-")
+
+        if isinstance(value, bool):
+            kwargs_args.append(flag if value else f"--no-{key.replace('_', '-')}")
+
+        elif isinstance(value, (list, tuple)):
+            kwargs_args.append(flag)
+            kwargs_args.extend(str(v) for v in value)
+        else:
+            kwargs_args.extend([flag, str(value)])
+
+        kwargs.pop(key)
+
+    existing_flags = _parse_args_to_flag_groups(args)
+    kwargs_flags = _parse_args_to_flag_groups(kwargs_args)
+
+    result_args = []
+    for flag, values in existing_flags.items():
+        result_args.extend([flag] + values)
+
+    for flag, values in kwargs_flags.items():
+        if flag not in existing_flags:
+            result_args.extend([flag] + values)
+
+    return result_args
+
+
+def _parse_args_to_flag_groups(args_list: list[str]) -> dict[str, list[str]]:
+    groups = {}
+    current_flag = None
+
+    for arg in args_list:
+        if arg.startswith("--"):
+            current_flag = arg
+            groups[current_flag] = []
+        elif current_flag:
+            groups[current_flag].append(arg)
+
+    return groups

--- a/src/integrations/prefect-dbt/prefect_dbt/utilities.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/utilities.py
@@ -4,7 +4,7 @@ Utility functions for prefect-dbt
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import slugify
 
@@ -73,7 +73,7 @@ def format_resource_id(adapter_type: str, relation_name: str) -> str:
     return asset_key
 
 
-def kwargs_to_args(kwargs: dict, args: list[str] | None = None) -> list[str]:
+def kwargs_to_args(kwargs: dict, args: Optional[list[str]] = None) -> list[str]:
     """
     Convert a dictionary of kwargs to a list of args in the dbt CLI format.
     If args are provided, they take priority over kwargs when conflicts exist.

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -518,7 +518,7 @@ class TestPrefectDbtRunnerInvoke:
 
         # Verify log_level was set to "none"
         call_args = mock_dbt_runner_class.return_value.invoke.call_args
-        assert call_args[1]["log_level"] == "none"
+        assert "--log-level", "none" in call_args[0]
 
     def test_invoke_uses_original_log_level_outside_context(
         self, mock_dbt_runner_class, mock_settings_context_manager
@@ -535,7 +535,7 @@ class TestPrefectDbtRunnerInvoke:
 
         # Verify log_level was set to the original value
         call_args = mock_dbt_runner_class.return_value.invoke.call_args
-        assert call_args[1]["log_level"] == str(runner.log_level.value)
+        assert "--log-level", str(runner.log_level.value) in call_args[0]
 
     def test_invoke_handles_dbt_exceptions(
         self, mock_dbt_runner_class, mock_settings_context_manager
@@ -609,7 +609,8 @@ class TestPrefectDbtRunnerInvoke:
         assert result.success is True
         # Verify the CLI flags take precedence (processed after kwargs)
         call_args = mock_dbt_runner_class.return_value.invoke.call_args
-        assert call_args[1]["target_path"] == "/cli/path"
+        assert "--target-path", "/cli/path" in call_args[0]
+        assert "--target-path", "/kwargs/path" not in call_args[0]
 
     def test_invoke_uses_resolve_profiles_yml_context_manager(
         self, mock_dbt_runner_class, mock_settings_context_manager


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

Closes #17555

<!-- Include an overview of the proposed changes here -->
The dbt SDK's `dbtRunner().invoke()` method only accepts global flags as kwargs, so for safety, we'll convert all kwargs to args. Kwargs that are duplicates of args are thrown away.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
