### PR TITLE
Add starlette status code compatibility layer

### DIFF
--- a/src/prefect/_internal/compatibility/starlette.py
+++ b/src/prefect/_internal/compatibility/starlette.py
@@ -1,0 +1,48 @@
+"""
+Compatibility wrapper for starlette status codes.
+
+Starlette 0.48.0 renamed several status codes per RFC 9110.
+This module provides backwards-compatible access to these codes.
+"""
+
+from starlette import status as _starlette_status
+
+
+class _StatusCompatibility:
+    """
+    Compatibility wrapper that maintains old status code names while using new ones where available.
+
+    Maps these renamed codes from RFC 9110:
+    - HTTP_422_UNPROCESSABLE_ENTITY -> HTTP_422_UNPROCESSABLE_CONTENT
+    - HTTP_413_REQUEST_ENTITY_TOO_LARGE -> HTTP_413_CONTENT_TOO_LARGE
+    - HTTP_414_REQUEST_URI_TOO_LONG -> HTTP_414_URI_TOO_LONG
+    - HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE -> HTTP_416_RANGE_NOT_SATISFIABLE
+    """
+
+    def __getattr__(self, name):
+        mapping = {
+            "HTTP_422_UNPROCESSABLE_ENTITY": "HTTP_422_UNPROCESSABLE_CONTENT",
+            "HTTP_413_REQUEST_ENTITY_TOO_LARGE": "HTTP_413_CONTENT_TOO_LARGE",
+            "HTTP_414_REQUEST_URI_TOO_LONG": "HTTP_414_URI_TOO_LONG",
+            "HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE": "HTTP_416_RANGE_NOT_SATISFIABLE",
+        }
+
+        if name in mapping:
+            new_name = mapping[name]
+            if hasattr(_starlette_status, new_name):
+                return getattr(_starlette_status, new_name)
+            elif hasattr(_starlette_status, name):
+                return getattr(_starlette_status, name)
+            else:
+                fallback_values = {
+                    "HTTP_422_UNPROCESSABLE_ENTITY": 422,
+                    "HTTP_413_REQUEST_ENTITY_TOO_LARGE": 413,
+                    "HTTP_414_REQUEST_URI_TOO_LONG": 414,
+                    "HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE": 416,
+                }
+                return fallback_values[name]
+
+        return getattr(_starlette_status, name)
+
+
+status = _StatusCompatibility()

--- a/src/prefect/_internal/compatibility/starlette.py
+++ b/src/prefect/_internal/compatibility/starlette.py
@@ -19,7 +19,7 @@ class _StatusCompatibility:
     - HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE -> HTTP_416_RANGE_NOT_SATISFIABLE
     """
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> int:
         mapping = {
             "HTTP_422_UNPROCESSABLE_ENTITY": "HTTP_422_UNPROCESSABLE_CONTENT",
             "HTTP_413_REQUEST_ENTITY_TOO_LARGE": "HTTP_413_CONTENT_TOO_LARGE",

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -14,10 +14,10 @@ import anyio
 import httpx
 from asgi_lifespan import LifespanManager
 from httpx import HTTPStatusError, Request, Response
-from starlette import status
 from typing_extensions import Self
 
 import prefect
+from prefect._internal.compatibility.starlette import status
 from prefect.client import constants
 from prefect.client.schemas.objects import CsrfToken
 from prefect.exceptions import PrefectHTTPStatusError

--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -1,10 +1,11 @@
 from typing import Optional, Sequence
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, status
+from fastapi import Body, Depends, HTTPException, Path
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 
+from prefect._internal.compatibility.starlette import status
 from prefect.server.api.dependencies import LimitBody
 from prefect.server.api.validation import (
     validate_job_variables_for_run_deployment_action,

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -2,11 +2,12 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Literal, Optional, Union
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, status
+from fastapi import Body, Depends, HTTPException, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.starlette import status
 from prefect.server.api.dependencies import LimitBody
 from prefect.server.concurrency.lease_storage import (
     ConcurrencyLimitLeaseMetadata,

--- a/src/prefect/server/api/csrf_token.py
+++ b/src/prefect/server/api/csrf_token.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
 
-from fastapi import Depends, Query, status
+from fastapi import Depends, Query
 from starlette.exceptions import HTTPException
 
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server import models, schemas
 from prefect.server.database import PrefectDBInterface, provide_database_interface

--- a/src/prefect/server/api/dependencies.py
+++ b/src/prefect/server/api/dependencies.py
@@ -10,10 +10,11 @@ from base64 import b64decode
 from typing import Annotated, Any, Optional
 from uuid import UUID
 
-from fastapi import Body, Depends, Header, HTTPException, status
+from fastapi import Body, Depends, Header, HTTPException
 from packaging.version import Version
 from starlette.requests import Request
 
+from prefect._internal.compatibility.starlette import status
 from prefect.server import schemas
 from prefect.settings import PREFECT_API_DEFAULT_LIMIT
 

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -8,12 +8,13 @@ from uuid import UUID
 
 import jsonschema.exceptions
 import sqlalchemy as sa
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from fastapi import Body, Depends, HTTPException, Path, Response
 from starlette.background import BackgroundTasks
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.starlette import status
 from prefect.server.api.validation import (
     validate_job_variables_for_deployment,
     validate_job_variables_for_deployment_flow_run,

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -1,7 +1,7 @@
 import base64
 from typing import TYPE_CHECKING, List, Optional
 
-from fastapi import Response, WebSocket, status
+from fastapi import Response, WebSocket
 from fastapi.exceptions import HTTPException
 from fastapi.param_functions import Depends, Path
 from fastapi.params import Body, Query
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from starlette.status import WS_1002_PROTOCOL_ERROR
 
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server.api.dependencies import is_ephemeral_request
 from prefect.server.database import PrefectDBInterface, provide_database_interface

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -18,7 +18,6 @@ from fastapi import (
     Path,
     Query,
     Response,
-    status,
 )
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import ORJSONResponse, PlainTextResponse, StreamingResponse
@@ -27,6 +26,7 @@ from sqlalchemy.exc import IntegrityError
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server.api.run_history import run_history
 from prefect.server.api.validation import validate_job_variables_for_deployment_flow_run

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -30,7 +30,7 @@ import httpx
 import sqlalchemy as sa
 import sqlalchemy.exc
 import sqlalchemy.orm.exc
-from fastapi import Depends, FastAPI, Request, Response, status
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -44,6 +44,7 @@ from typing_extensions import Self
 import prefect
 import prefect.server.api as api
 import prefect.settings
+from prefect._internal.compatibility.starlette import status
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.logging import get_logger
 from prefect.server.api.dependencies import EnforceMinimumAPIVersion

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -15,7 +15,6 @@ from fastapi import (
     Path,
     Response,
     WebSocket,
-    status,
 )
 from fastapi.responses import ORJSONResponse
 from starlette.websockets import WebSocketDisconnect
@@ -23,6 +22,7 @@ from starlette.websockets import WebSocketDisconnect
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server.api.run_history import run_history
 from prefect.server.database import PrefectDBInterface, provide_database_interface

--- a/src/prefect/server/api/ui/schemas.py
+++ b/src/prefect/server/api/ui/schemas.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Any
 
-from fastapi import Body, Depends, HTTPException, status
+from fastapi import Body, Depends, HTTPException
 
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server.database import PrefectDBInterface, provide_database_interface
 from prefect.server.schemas.responses import SchemaValuesValidationResponse

--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -3,10 +3,11 @@ from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import Depends, HTTPException, Path, status
+from fastapi import Depends, HTTPException, Path
 from pydantic import Field, model_serializer
 
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server import models
 from prefect.server.database import PrefectDBInterface, provide_database_interface

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -39,10 +39,11 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from uuid import UUID
 
 import pydantic
-from fastapi import HTTPException, status
+from fastapi import HTTPException
 from sqlalchemy.exc import DBAPIError, NoInspectionAvailable
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect._internal.compatibility.starlette import status
 from prefect.logging import get_logger
 from prefect.server import models, schemas
 from prefect.server.database.orm_models import Deployment as BaseDeployment

--- a/tests/cli/cloud/test_ip_allowlist.py
+++ b/tests/cli/cloud/test_ip_allowlist.py
@@ -4,9 +4,9 @@ from typing import Optional
 
 import httpx
 import pytest
-from starlette import status
 from tests.cli.cloud.test_cloud import gen_test_workspace
 
+from prefect._internal.compatibility.starlette import status
 from prefect.client.schemas.objects import IPAllowlist, IPAllowlistEntry
 from prefect.context import use_profile
 from prefect.settings import (

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -6,11 +6,11 @@ from unittest import mock
 import httpx
 import pytest
 from httpx import AsyncClient, Request, Response
-from starlette import status
 
 import prefect
 import prefect.client
 import prefect.client.constants
+from prefect._internal.compatibility.starlette import status
 from prefect.client.base import (
     PrefectHttpxAsyncClient,
     PrefectResponse,

--- a/tests/server/api/test_pagination.py
+++ b/tests/server/api/test_pagination.py
@@ -1,7 +1,8 @@
 import pytest
-from fastapi import Body, FastAPI, status
+from fastapi import Body, FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from prefect._internal.compatibility.starlette import status
 from prefect.server.api.dependencies import LimitBody
 
 

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -11,9 +11,9 @@ import httpx
 import pytest
 import sqlalchemy as sa
 import toml
-from fastapi import status
 from httpx import ASGITransport, AsyncClient
 
+from prefect._internal.compatibility.starlette import status
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import get_client
 from prefect.flows import flow

--- a/tests/server/orchestration/api/test_block_documents.py
+++ b/tests/server/orchestration/api/test_block_documents.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 
 import pytest
 from pydantic import SecretBytes, SecretStr
-from starlette import status
 
+from prefect._internal.compatibility.starlette import status
 from prefect.blocks.core import Block
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import BlockDocumentCreate, BlockDocumentUpdate

--- a/tests/server/orchestration/api/test_block_types.py
+++ b/tests/server/orchestration/api/test_block_types.py
@@ -4,9 +4,9 @@ from typing import List
 from uuid import uuid4
 
 import pytest
-from starlette import status
 
 import prefect
+from prefect._internal.compatibility.starlette import status
 from prefect.blocks.core import Block
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import BlockTypeCreate, BlockTypeUpdate

--- a/tests/server/orchestration/api/test_flow_runs.py
+++ b/tests/server/orchestration/api/test_flow_runs.py
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette import status
 
+from prefect._internal.compatibility.starlette import status
 from prefect.client.schemas import actions as client_actions
 from prefect.input import RunInput, keyset_from_paused_state
 from prefect.server import models, schemas

--- a/tests/server/orchestration/api/test_task_runs.py
+++ b/tests/server/orchestration/api/test_task_runs.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette import status
 
+from prefect._internal.compatibility.starlette import status
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.objects import Flow, State
 from prefect.server import models, schemas

--- a/tests/server/orchestration/api/test_work_queues.py
+++ b/tests/server/orchestration/api/test_work_queues.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette import status
 
+from prefect._internal.compatibility.starlette import status
 from prefect.server import models, schemas
 from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.schemas.actions import WorkQueueCreate, WorkQueueUpdate

--- a/tests/server/orchestration/api/test_workers.py
+++ b/tests/server/orchestration/api/test_workers.py
@@ -5,10 +5,10 @@ from typing import List
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette import status
 
 import prefect
 import prefect.server
+from prefect._internal.compatibility.starlette import status
 from prefect.client.schemas.actions import WorkPoolCreate
 from prefect.client.schemas.objects import WorkPool, WorkQueue
 from prefect.server import models, schemas


### PR DESCRIPTION
## Summary

This PR adds a compatibility wrapper for starlette status codes to handle the breaking changes introduced in starlette 0.48.0, which renamed several HTTP status codes per RFC 9110.

Instead of bumping the minimum starlette version requirement to 0.48.0, we're creating a compatibility layer that allows us to support both old and new versions.

## Changes

- Created `src/prefect/_internal/compatibility/starlette.py` with a `status` object that:
  - Maps old status code names to new ones automatically
  - Falls back gracefully for older starlette versions  
  - Prevents deprecation warnings
  
- Updated all imports throughout the codebase to use our compatibility layer instead of importing directly from starlette/fastapi

The main renamed codes handled are:
- `HTTP_422_UNPROCESSABLE_ENTITY` -> `HTTP_422_UNPROCESSABLE_CONTENT`
- `HTTP_413_REQUEST_ENTITY_TOO_LARGE` -> `HTTP_413_CONTENT_TOO_LARGE`
- `HTTP_414_REQUEST_URI_TOO_LONG` -> `HTTP_414_URI_TOO_LONG`
- `HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE` -> `HTTP_416_RANGE_NOT_SATISFIABLE`

This allows us to support both old and new starlette versions without raising the minimum version requirement.

## Testing

- Existing tests pass with the compatibility layer
- Manually tested that the wrapper correctly returns status codes for both old and new starlette versions