### PR TITLE
Add release notes for `prefect-kubernetes==0.6.5`

### DIFF
--- a/docs/v3/release-notes/integrations/prefect-kubernetes.mdx
+++ b/docs/v3/release-notes/integrations/prefect-kubernetes.mdx
@@ -1,0 +1,11 @@
+---
+title: prefect-kubernetes
+---
+
+## 0.6.5
+
+_Released on September 17, 2025_
+
+**Bug Fixes**
+
+- Preserve casing of Kubernetes label values [#18841](https://github.com/PrefectHQ/prefect/pull/18841) by [@raniasev](https://github.com/raniasev)


### PR DESCRIPTION
Planning to cut a release to get a user-contributed fix out