### PR TITLE
Update task engine to use GCLs to limit task concurrency

### DIFF
--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
         GlobalConcurrencyLimitCreate,
         GlobalConcurrencyLimitUpdate,
     )
-    from prefect.client.schemas.objects import ConcurrencyLimit
+    from prefect.client.schemas.objects import ConcurrencyLeaseHolder, ConcurrencyLimit
     from prefect.client.schemas.responses import GlobalConcurrencyLimitResponse
 
 
@@ -269,7 +269,7 @@ class ConcurrencyLimitClient(BaseClient):
         slots: int,
         mode: Literal["concurrency", "rate_limit"],
         lease_duration: float,
-        holder: dict[str, Any] | None = None,
+        holder: "ConcurrencyLeaseHolder | None" = None,
     ) -> "Response":
         """
         Increment concurrency slots for the specified limits with a lease.
@@ -288,7 +288,7 @@ class ConcurrencyLimitClient(BaseClient):
             "lease_duration": lease_duration,
         }
         if holder is not None:
-            body["holder"] = holder
+            body["holder"] = holder.model_dump(mode="json")
 
         return self.request(
             "POST",
@@ -721,7 +721,7 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
         slots: int,
         mode: Literal["concurrency", "rate_limit"],
         lease_duration: float,
-        holder: dict[str, Any] | None = None,
+        holder: "ConcurrencyLeaseHolder | None" = None,
     ) -> "Response":
         """
         Increment concurrency slots for the specified limits with a lease.
@@ -740,7 +740,7 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
             "lease_duration": lease_duration,
         }
         if holder is not None:
-            body["holder"] = holder
+            body["holder"] = holder.model_dump(mode="json")
 
         return await self.request(
             "POST",

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -166,6 +166,15 @@ class ConcurrencyLimitConfig(PrefectBaseModel):
     collision_strategy: ConcurrencyLimitStrategy = ConcurrencyLimitStrategy.ENQUEUE
 
 
+class ConcurrencyLeaseHolder(PrefectBaseModel):
+    """Model for validating concurrency lease holder information."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    type: Literal["flow_run", "task_run", "deployment"]
+    id: UUID
+
+
 class StateDetails(PrefectBaseModel):
     flow_run_id: Optional[UUID] = None
     task_run_id: Optional[UUID] = None

--- a/src/prefect/concurrency/_asyncio.py
+++ b/src/prefect/concurrency/_asyncio.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 from uuid import UUID
 
 import httpx
@@ -15,6 +15,9 @@ from prefect.logging.loggers import get_run_logger
 from prefect.utilities.timeout import timeout_async
 
 from .services import ConcurrencySlotAcquisitionService
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.objects import ConcurrencyLeaseHolder
 
 
 class ConcurrencySlotAcquisitionError(Exception):
@@ -76,6 +79,7 @@ async def aacquire_concurrency_slots_with_lease(
     max_retries: Optional[int] = None,
     lease_duration: float = 300,
     strict: bool = False,
+    holder: "Optional[ConcurrencyLeaseHolder]" = None,
 ) -> ConcurrencyLimitWithLeaseResponse:
     try:
         # Use a run logger if available
@@ -93,6 +97,7 @@ async def aacquire_concurrency_slots_with_lease(
                             slots=slots,
                             mode=mode,
                             lease_duration=lease_duration,
+                            holder=holder,
                         )
                         retval = ConcurrencyLimitWithLeaseResponse.model_validate(
                             response.json()

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import anyio
 
@@ -21,6 +21,9 @@ from ._events import (
 )
 from .context import ConcurrencyContext
 
+if TYPE_CHECKING:
+    from prefect.client.schemas.objects import ConcurrencyLeaseHolder
+
 
 @asynccontextmanager
 async def concurrency(
@@ -30,6 +33,7 @@ async def concurrency(
     max_retries: Optional[int] = None,
     lease_duration: float = 300,
     strict: bool = False,
+    holder: "Optional[ConcurrencyLeaseHolder]" = None,
 ) -> AsyncGenerator[None, None]:
     """A
     context manager that acquires and releases concurrency slots from the
@@ -44,6 +48,8 @@ async def concurrency(
         lease_duration: The duration of the lease for the acquired slots in seconds.
         strict: A boolean specifying whether to raise an error if the concurrency limit does not exist.
             Defaults to `False`.
+        holder: A dictionary containing information about the holder of the concurrency slots.
+            Typically includes 'type' and 'id' keys.
 
     Raises:
         TimeoutError: If the slots are not acquired within the given timeout.
@@ -75,6 +81,7 @@ async def concurrency(
         max_retries=max_retries,
         lease_duration=lease_duration,
         strict=strict,
+        holder=holder,
     )
     emitted_events = emit_concurrency_acquisition_events(response.limits, occupy)
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -819,7 +819,14 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 if self.task_run.tags:
                     # Map tags to V2 global limit names
                     v2_limit_names = [f"tag:{tag}" for tag in self.task_run.tags]
-                    concurrency_ctx = concurrency(v2_limit_names, occupy=1)
+                    from prefect.client.schemas.objects import ConcurrencyLeaseHolder
+
+                    holder = ConcurrencyLeaseHolder(
+                        type="task_run", id=self.task_run.id
+                    )
+                    concurrency_ctx = concurrency(
+                        v2_limit_names, occupy=1, holder=holder
+                    )
                 else:
                     concurrency_ctx = nullcontext()
 
@@ -1416,7 +1423,14 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 if self.task_run.tags:
                     # Map tags to V2 global limit names
                     v2_limit_names = [f"tag:{tag}" for tag in self.task_run.tags]
-                    concurrency_ctx = aconcurrency(v2_limit_names, occupy=1)
+                    from prefect.client.schemas.objects import ConcurrencyLeaseHolder
+
+                    holder = ConcurrencyLeaseHolder(
+                        type="task_run", id=self.task_run.id
+                    )
+                    concurrency_ctx = aconcurrency(
+                        v2_limit_names, occupy=1, holder=holder
+                    )
                 else:
                     # Use a no-op context manager when there are no tags
                     @asynccontextmanager

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -49,6 +49,7 @@ async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV
                 max_retries=None,
                 lease_duration=300,
                 strict=False,
+                holder=None,
             )
 
             lease_id = release_spy.call_args[1]["lease_id"]

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -46,6 +46,7 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
                 max_retries=None,
                 lease_duration=300,
                 strict=False,
+                holder=None,
             )
 
             lease_id = release_spy.call_args[0][0]

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -2626,8 +2626,14 @@ class TestTaskConcurrencyLimits:
 
             await bar()
 
-            # Check that aconcurrency was called with the correct V2 limit names
-            mock_aconcurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
+            # Check that aconcurrency was called with the correct V2 limit names and holder
+            mock_aconcurrency.assert_called_once()
+            args, kwargs = mock_aconcurrency.call_args
+            assert args == (["tag:limit-tag"],)
+            assert kwargs["occupy"] == 1
+            assert kwargs["holder"] is not None
+            assert kwargs["holder"].type == "task_run"
+            assert kwargs["holder"].id == task_run_id
 
     def test_tag_concurrency_sync(self):
         task_run_id = None
@@ -2645,8 +2651,14 @@ class TestTaskConcurrencyLimits:
 
             bar()
 
-            # Check that concurrency was called with the correct V2 limit names
-            mock_concurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
+            # Check that concurrency was called with the correct V2 limit names and holder
+            mock_concurrency.assert_called_once()
+            args, kwargs = mock_concurrency.call_args
+            assert args == (["tag:limit-tag"],)
+            assert kwargs["occupy"] == 1
+            assert kwargs["holder"] is not None
+            assert kwargs["holder"].type == "task_run"
+            assert kwargs["holder"].id == task_run_id
 
     async def test_tag_concurrency_is_taken_prior_to_running_state(
         self, events_pipeline, prefect_client
@@ -2765,8 +2777,14 @@ class TestTaskConcurrencyLimits:
             with tags("limit-tag"):
                 bar()
 
-            # Check that concurrency was called with the correct V2 limit names
-            mock_concurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
+            # Check that concurrency was called with the correct V2 limit names and holder
+            mock_concurrency.assert_called_once()
+            args, kwargs = mock_concurrency.call_args
+            assert args == (["tag:limit-tag"],)
+            assert kwargs["occupy"] == 1
+            assert kwargs["holder"] is not None
+            assert kwargs["holder"].type == "task_run"
+            assert kwargs["holder"].id == task_run_id
 
     async def test_tag_concurrency_with_tags_context(self):
         task_run_id = None
@@ -2787,8 +2805,14 @@ class TestTaskConcurrencyLimits:
             with tags("limit-tag"):
                 await bar()
 
-            # Check that aconcurrency was called with the correct V2 limit names
-            mock_aconcurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
+            # Check that aconcurrency was called with the correct V2 limit names and holder
+            mock_aconcurrency.assert_called_once()
+            args, kwargs = mock_aconcurrency.call_args
+            assert args == (["tag:limit-tag"],)
+            assert kwargs["occupy"] == 1
+            assert kwargs["holder"] is not None
+            assert kwargs["holder"].type == "task_run"
+            assert kwargs["holder"].id == task_run_id
 
     async def test_no_tags_no_concurrency(self):
         @task
@@ -2830,8 +2854,14 @@ class TestTaskConcurrencyLimits:
 
             await bar()
 
-            # Check that aconcurrency was called with the correct V2 limit names
-            mock_aconcurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
+            # Check that aconcurrency was called with the correct V2 limit names and holder
+            mock_aconcurrency.assert_called_once()
+            args, kwargs = mock_aconcurrency.call_args
+            assert args == (["tag:limit-tag"],)
+            assert kwargs["occupy"] == 1
+            assert kwargs["holder"] is not None
+            assert kwargs["holder"].type == "task_run"
+            assert kwargs["holder"].id == task_run_id
 
             # V2 global concurrency limits are different from V1 limits
             # We don't expect V1 limits to be created

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -19,10 +19,6 @@ from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.objects import StateType
 from prefect.concurrency.asyncio import concurrency as aconcurrency
 from prefect.concurrency.sync import concurrency
-from prefect.concurrency.v1._asyncio import (
-    acquire_concurrency_slots,
-    release_concurrency_slots,
-)
 from prefect.context import (
     EngineContext,
     FlowRunContext,
@@ -2621,24 +2617,17 @@ class TestTaskConcurrencyLimits:
             task_run_id = TaskRunContext.get().task_run.id
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1.asyncio.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
-            with mock.patch(
-                "prefect.concurrency.v1.asyncio.release_concurrency_slots",
-                wraps=release_concurrency_slots,
-            ) as release_spy:
-                await bar()
+        with mock.patch("prefect.task_engine.aconcurrency") as mock_aconcurrency:
+            # Set up the mock to act as an async context manager
+            mock_aconcurrency.return_value.__aenter__ = mock.AsyncMock(
+                return_value=None
+            )
+            mock_aconcurrency.return_value.__aexit__ = mock.AsyncMock(return_value=None)
 
-                acquire_spy.assert_called_once_with(
-                    ["limit-tag"], task_run_id=task_run_id, timeout_seconds=None
-                )
+            await bar()
 
-                names, _task_run_id, occupy_seconds = release_spy.call_args[0]
-                assert names == ["limit-tag"]
-                assert _task_run_id == task_run_id
-                assert occupy_seconds > 0
+            # Check that aconcurrency was called with the correct V2 limit names
+            mock_aconcurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
 
     def test_tag_concurrency_sync(self):
         task_run_id = None
@@ -2649,27 +2638,15 @@ class TestTaskConcurrencyLimits:
             task_run_id = TaskRunContext.get().task_run.id
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1.sync.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
-            with mock.patch(
-                "prefect.concurrency.v1.sync.release_concurrency_slots",
-                wraps=release_concurrency_slots,
-            ) as release_spy:
-                bar()
+        with mock.patch("prefect.task_engine.concurrency") as mock_concurrency:
+            # Set up the mock to act as a context manager
+            mock_concurrency.return_value.__enter__ = mock.Mock(return_value=None)
+            mock_concurrency.return_value.__exit__ = mock.Mock(return_value=None)
 
-                acquire_spy.assert_called_once_with(
-                    ["limit-tag"],
-                    task_run_id=task_run_id,
-                    timeout_seconds=None,
-                    _sync=True,
-                )
+            bar()
 
-                names, _task_run_id, occupy_seconds = release_spy.call_args[0]
-                assert names == ["limit-tag"]
-                assert _task_run_id == task_run_id
-                assert occupy_seconds > 0
+            # Check that concurrency was called with the correct V2 limit names
+            mock_concurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
 
     async def test_tag_concurrency_is_taken_prior_to_running_state(
         self, events_pipeline, prefect_client
@@ -2698,9 +2675,9 @@ class TestTaskConcurrencyLimits:
                     task_run_id = task_run_context.task_run.id
             raise BaseException("stop concurrency")  # Simulate acquisition failure
 
-        # Mock the sync concurrency function called by SyncTaskRunEngine.call_task_fn
+        # Mock the V2 concurrency function at the task_engine level
         with mock.patch(
-            "prefect.concurrency.v1.sync.acquire_concurrency_slots",
+            "prefect.task_engine.concurrency",
             side_effect=side_effect,
         ):
             # The task call itself should raise because the mocked function raises
@@ -2748,9 +2725,9 @@ class TestTaskConcurrencyLimits:
                     task_run_id = task_run_context.task_run.id
             raise BaseException("stop concurrency")  # Simulate acquisition failure
 
-        # Mock the async concurrency function called by AsyncTaskRunEngine.start
+        # Mock the V2 async concurrency function at the task_engine level
         with mock.patch(
-            "prefect.concurrency.v1.asyncio.acquire_concurrency_slots",
+            "prefect.task_engine.aconcurrency",
             side_effect=side_effect,
         ):
             # The task call itself should raise because the mocked function raises
@@ -2780,28 +2757,16 @@ class TestTaskConcurrencyLimits:
             task_run_id = TaskRunContext.get().task_run.id
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1.sync.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
-            with mock.patch(
-                "prefect.concurrency.v1.sync.release_concurrency_slots",
-                wraps=release_concurrency_slots,
-            ) as release_spy:
-                with tags("limit-tag"):
-                    bar()
+        with mock.patch("prefect.task_engine.concurrency") as mock_concurrency:
+            # Set up the mock to act as a context manager
+            mock_concurrency.return_value.__enter__ = mock.Mock(return_value=None)
+            mock_concurrency.return_value.__exit__ = mock.Mock(return_value=None)
 
-                acquire_spy.assert_called_once_with(
-                    ["limit-tag"],
-                    task_run_id=task_run_id,
-                    timeout_seconds=None,
-                    _sync=True,
-                )
+            with tags("limit-tag"):
+                bar()
 
-                names, _task_run_id, occupy_seconds = release_spy.call_args[0]
-                assert names == ["limit-tag"]
-                assert _task_run_id == task_run_id
-                assert occupy_seconds > 0
+            # Check that concurrency was called with the correct V2 limit names
+            mock_concurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
 
     async def test_tag_concurrency_with_tags_context(self):
         task_run_id = None
@@ -2812,61 +2777,40 @@ class TestTaskConcurrencyLimits:
             task_run_id = TaskRunContext.get().task_run.id
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1.asyncio.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
-            with mock.patch(
-                "prefect.concurrency.v1.asyncio.release_concurrency_slots",
-                wraps=release_concurrency_slots,
-            ) as release_spy:
-                with tags("limit-tag"):
-                    await bar()
+        with mock.patch("prefect.task_engine.aconcurrency") as mock_aconcurrency:
+            # Set up the mock to act as an async context manager
+            mock_aconcurrency.return_value.__aenter__ = mock.AsyncMock(
+                return_value=None
+            )
+            mock_aconcurrency.return_value.__aexit__ = mock.AsyncMock(return_value=None)
 
-                acquire_spy.assert_called_once_with(
-                    ["limit-tag"], task_run_id=task_run_id, timeout_seconds=None
-                )
+            with tags("limit-tag"):
+                await bar()
 
-                names, _task_run_id, occupy_seconds = release_spy.call_args[0]
-                assert names == ["limit-tag"]
-                assert _task_run_id == task_run_id
-                assert occupy_seconds > 0
+            # Check that aconcurrency was called with the correct V2 limit names
+            mock_aconcurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
 
     async def test_no_tags_no_concurrency(self):
         @task
         async def bar():
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1._asyncio.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
-            with mock.patch(
-                "prefect.concurrency.v1._asyncio.release_concurrency_slots",
-                wraps=release_concurrency_slots,
-            ) as release_spy:
-                await bar()
+        with mock.patch("prefect.task_engine.aconcurrency") as mock_aconcurrency:
+            await bar()
 
-                assert acquire_spy.call_count == 0
-                assert release_spy.call_count == 0
+            # Should not be called when there are no tags
+            mock_aconcurrency.assert_not_called()
 
     def test_no_tags_no_concurrency_sync(self):
         @task
         def bar():
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1.sync.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
-            with mock.patch(
-                "prefect.concurrency.v1.sync.release_concurrency_slots",
-                wraps=release_concurrency_slots,
-            ) as release_spy:
-                bar()
+        with mock.patch("prefect.task_engine.concurrency") as mock_concurrency:
+            bar()
 
-                assert acquire_spy.call_count == 0
-                assert release_spy.call_count == 0
+            # Should not be called when there are no tags
+            mock_concurrency.assert_not_called()
 
     async def test_tag_concurrency_does_not_create_limits(self, prefect_client):
         task_run_id = None
@@ -2877,16 +2821,20 @@ class TestTaskConcurrencyLimits:
             task_run_id = TaskRunContext.get().task_run.id
             return 42
 
-        with mock.patch(
-            "prefect.concurrency.v1.asyncio.acquire_concurrency_slots",
-            wraps=acquire_concurrency_slots,
-        ) as acquire_spy:
+        with mock.patch("prefect.task_engine.aconcurrency") as mock_aconcurrency:
+            # Set up the mock to act as an async context manager
+            mock_aconcurrency.return_value.__aenter__ = mock.AsyncMock(
+                return_value=None
+            )
+            mock_aconcurrency.return_value.__aexit__ = mock.AsyncMock(return_value=None)
+
             await bar()
 
-            acquire_spy.assert_called_once_with(
-                ["limit-tag"], task_run_id=task_run_id, timeout_seconds=None
-            )
+            # Check that aconcurrency was called with the correct V2 limit names
+            mock_aconcurrency.assert_called_once_with(["tag:limit-tag"], occupy=1)
 
+            # V2 global concurrency limits are different from V1 limits
+            # We don't expect V1 limits to be created
             limits = await prefect_client.read_concurrency_limits(10, 0)
             assert len(limits) == 0
 


### PR DESCRIPTION
This PR updates the task engine to use the GCL versions of the `concurrency` context managers. Note that this will require a server upgrade that migrates all tag-based concurrency limits to GCLs, along with a client upgrade. 

Using GCLs for tag-based concurrency will allow this method of concurrency limiting to use leasing, which will eliminate zombie slots for tag-based concurrency limits.

Related to #17415 