### PR TITLE
Fix: Pin distributed!=2024.10.0 to avoid AttributeError with DaskTaskRunner

### DIFF
--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -9,7 +9,9 @@ dependencies = [
   # don't allow versions from 2023.3.2 to 2023.5 (inclusive) due to issue with
   # get_client starting in 2023.3.2 (fixed in 2023.6.0)
   # https://github.com/dask/distributed/issues/7763
-  "distributed>=2022.5.0,!=2023.3.2,!=2023.3.2.1,!=2023.4.*,!=2023.5.*",
+  # don't allow version 2024.10.0 due to AttributeError with DaskTaskRunner and .map()
+  # https://github.com/PrefectHQ/prefect/issues/18994
+  "distributed>=2022.5.0,!=2023.3.2,!=2023.3.2.1,!=2023.4.*,!=2023.5.*,!=2024.10.0",
 ]
 dynamic = ["version"]
 description = "Prefect integrations with the Dask execution framework."
@@ -39,7 +41,7 @@ dev = [
   # Dask and its distributed scheduler follow the same release schedule and version,
   # so here we apply the same restrictions as for the distributed package up above in
   # project.dependencies
-  "dask[dataframe]>=2022.5.0,!=2023.3.2,!=2023.3.2.1,!=2023.4.*,!=2023.5.*",
+  "dask[dataframe]>=2022.5.0,!=2023.3.2,!=2023.3.2.1,!=2023.4.*,!=2023.5.*,!=2024.10.0",
   "interrogate",
   "mkdocs-gen-files",
   "mkdocs-material",


### PR DESCRIPTION
closes #18998

This PR adds a version exclusion for `distributed==2024.10.0` in prefect-dask dependencies to prevent an AttributeError that occurs when using DaskTaskRunner with `task.map()` followed by `task.submit(futures)`.

## Problem
When using `distributed==2024.10.0` with `DaskTaskRunner`, passing futures from `.map()` directly to `.submit()` fails with:
```
AttributeError: 'NoneType' object has no attribute 'type'
```

The issue occurs when Dask futures are accessed in certain contexts (like logging with f-strings), where the internal `_state` attribute is `None`.

## Solution
- Pin `distributed!=2024.10.0` in prefect-dask dependencies
- The issue is fixed in `distributed>=2024.11.1`

## Testing
Confirmed that:
- ❌ `distributed==2024.10.0` reproduces the error
- ✅ `distributed==2024.11.1` and later versions work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)