### PR TITLE
Add healthcheck support for Prefect server services

### DIFF
--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -89,8 +89,8 @@ class EventPersister(RunInEphemeralServers, Service):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.event_persister
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, health_monitor=None, **kwargs):
+        super().__init__(health_monitor=health_monitor, **kwargs)
         self._started_event: asyncio.Event | None = None
 
     @property

--- a/src/prefect/server/events/services/triggers.py
+++ b/src/prefect/server/events/services/triggers.py
@@ -68,12 +68,15 @@ class ProactiveTriggers(RunInEphemeralServers, LoopService):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.triggers
 
-    def __init__(self, loop_seconds: Optional[float] = None, **kwargs: Any):
+    def __init__(
+        self, loop_seconds: Optional[float] = None, health_monitor=None, **kwargs: Any
+    ):
         super().__init__(
             loop_seconds=(
                 loop_seconds
                 or PREFECT_EVENTS_PROACTIVE_GRANULARITY.value().total_seconds()
             ),
+            health_monitor=health_monitor,
             **kwargs,
         )
 

--- a/src/prefect/server/services/cancellation_cleanup.py
+++ b/src/prefect/server/services/cancellation_cleanup.py
@@ -32,10 +32,13 @@ class CancellationCleanup(LoopService):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.cancellation_cleanup
 
-    def __init__(self, loop_seconds: Optional[float] = None, **kwargs: Any):
+    def __init__(
+        self, loop_seconds: Optional[float] = None, health_monitor=None, **kwargs: Any
+    ):
         super().__init__(
             loop_seconds=loop_seconds
             or PREFECT_API_SERVICES_CANCELLATION_CLEANUP_LOOP_SECONDS.value(),
+            health_monitor=health_monitor,
             **kwargs,
         )
 

--- a/src/prefect/server/services/foreman.py
+++ b/src/prefect/server/services/foreman.py
@@ -47,11 +47,13 @@ class Foreman(LoopService):
         fallback_heartbeat_interval_seconds: Optional[int] = None,
         deployment_last_polled_timeout_seconds: Optional[int] = None,
         work_queue_last_polled_timeout_seconds: Optional[int] = None,
+        health_monitor=None,
         **kwargs: Any,
     ):
         super().__init__(
             loop_seconds=loop_seconds
             or PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS.value(),
+            health_monitor=health_monitor,
             **kwargs,
         )
         self._inactivity_heartbeat_multiple = (

--- a/src/prefect/server/services/healthcheck.py
+++ b/src/prefect/server/services/healthcheck.py
@@ -1,0 +1,114 @@
+"""
+Healthcheck server for Prefect services.
+"""
+
+from datetime import datetime
+from typing import Dict
+
+import uvicorn
+from fastapi import APIRouter, FastAPI, status
+from fastapi.responses import JSONResponse
+
+from prefect.settings import (
+    PREFECT_SERVER_SERVICES_HEALTHCHECK_HOST,
+    PREFECT_SERVER_SERVICES_HEALTHCHECK_PORT,
+)
+from prefect.types._datetime import now
+
+
+class ServicesHealthMonitor:
+    """
+    Monitors the health of running services by tracking their last activity.
+    """
+
+    def __init__(self):
+        self._last_activity: Dict[str, datetime] = {}
+
+    def record_activity(self, service_name: str) -> None:
+        """Record that a service has performed its loop."""
+        self._last_activity[service_name] = now("UTC")
+
+    def is_healthy(self, service_name: str, threshold_seconds: float) -> bool:
+        """
+        Check if a service is healthy based on its last activity.
+
+        Args:
+            service_name: The name of the service to check
+            threshold_seconds: Maximum seconds since last activity before considered unhealthy
+
+        Returns:
+            True if the service has been active within the threshold, False otherwise
+        """
+        last_activity = self._last_activity.get(service_name)
+        if last_activity is None:
+            return False
+
+        time_since_activity = (now("UTC") - last_activity).total_seconds()
+        return time_since_activity <= threshold_seconds
+
+    def get_all_statuses(self, threshold_seconds: float) -> Dict[str, bool]:
+        """Get health status for all tracked services."""
+        return {
+            name: self.is_healthy(name, threshold_seconds)
+            for name in self._last_activity
+        }
+
+
+def build_services_healthcheck_server(
+    health_monitor: ServicesHealthMonitor,
+    log_level: str = "error",
+) -> uvicorn.Server:
+    """
+    Build a healthcheck FastAPI server for services.
+
+    Args:
+        health_monitor: The health monitor tracking service activity
+        log_level: The log level for the uvicorn server
+
+    Returns:
+        A configured uvicorn server
+    """
+    app = FastAPI()
+    router = APIRouter()
+
+    def perform_health_check():
+        # Check if any services have been recorded
+        if not health_monitor._last_activity:
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={"message": "No services have reported activity yet"},
+            )
+
+        # Get status of all services (using 2x loop interval as threshold)
+        statuses = health_monitor.get_all_statuses(threshold_seconds=120)
+
+        # If any service is unhealthy, return 503
+        unhealthy_services = [name for name, healthy in statuses.items() if not healthy]
+        if unhealthy_services:
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "message": "Some services are unhealthy",
+                    "unhealthy_services": unhealthy_services,
+                    "all_statuses": statuses,
+                },
+            )
+
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={
+                "message": "All services are healthy",
+                "statuses": statuses,
+            },
+        )
+
+    router.add_api_route("/health", perform_health_check, methods=["GET"])
+    app.include_router(router)
+
+    config = uvicorn.Config(
+        app=app,
+        host=PREFECT_SERVER_SERVICES_HEALTHCHECK_HOST.value(),
+        port=PREFECT_SERVER_SERVICES_HEALTHCHECK_PORT.value(),
+        log_level=log_level,
+    )
+    return uvicorn.Server(config=config)

--- a/src/prefect/server/services/late_runs.py
+++ b/src/prefect/server/services/late_runs.py
@@ -44,10 +44,13 @@ class MarkLateRuns(LoopService):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.late_runs
 
-    def __init__(self, loop_seconds: float | None = None, **kwargs: Any):
+    def __init__(
+        self, loop_seconds: float | None = None, health_monitor=None, **kwargs: Any
+    ):
         super().__init__(
             loop_seconds=loop_seconds
             or PREFECT_API_SERVICES_LATE_RUNS_LOOP_SECONDS.value(),
+            health_monitor=health_monitor,
             **kwargs,
         )
 

--- a/src/prefect/server/services/pause_expirations.py
+++ b/src/prefect/server/services/pause_expirations.py
@@ -29,10 +29,13 @@ class FailExpiredPauses(LoopService):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.pause_expirations
 
-    def __init__(self, loop_seconds: Optional[float] = None, **kwargs: Any):
+    def __init__(
+        self, loop_seconds: Optional[float] = None, health_monitor=None, **kwargs: Any
+    ):
         super().__init__(
             loop_seconds=loop_seconds
             or PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_LOOP_SECONDS.value(),
+            health_monitor=health_monitor,
             **kwargs,
         )
 

--- a/src/prefect/server/services/repossessor.py
+++ b/src/prefect/server/services/repossessor.py
@@ -16,9 +16,11 @@ class Repossessor(LoopService):
     Handles the reconciliation of expired leases; no tow truck dependency.
     """
 
-    def __init__(self):
+    def __init__(self, health_monitor=None, **kwargs):
         super().__init__(
             loop_seconds=get_current_settings().server.services.repossessor.loop_seconds,
+            health_monitor=health_monitor,
+            **kwargs,
         )
         self.concurrency_lease_storage: ConcurrencyLeaseStorage = (
             get_concurrency_lease_storage()

--- a/src/prefect/server/services/scheduler.py
+++ b/src/prefect/server/services/scheduler.py
@@ -48,13 +48,16 @@ class Scheduler(LoopService):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.scheduler
 
-    def __init__(self, loop_seconds: float | None = None, **kwargs: Any):
+    def __init__(
+        self, loop_seconds: float | None = None, health_monitor=None, **kwargs: Any
+    ):
         super().__init__(
             loop_seconds=(
                 loop_seconds
                 or self.loop_seconds
                 or PREFECT_API_SERVICES_SCHEDULER_LOOP_SECONDS.value()
             ),
+            health_monitor=health_monitor,
             **kwargs,
         )
         self.deployment_batch_size: int = (
@@ -322,12 +325,15 @@ class RecentDeploymentsScheduler(Scheduler):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.scheduler
 
-    def __init__(self, loop_seconds: float | None = None, **kwargs: Any):
+    def __init__(
+        self, loop_seconds: float | None = None, health_monitor=None, **kwargs: Any
+    ):
         super().__init__(
             loop_seconds=(
                 loop_seconds
                 or get_current_settings().server.services.scheduler.recent_deployments_loop_seconds
             ),
+            health_monitor=health_monitor,
             **kwargs,
         )
 

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -250,8 +250,8 @@ class TaskRunRecorder(RunInEphemeralServers, Service):
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.task_run_recorder
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, health_monitor=None, **kwargs):
+        super().__init__(health_monitor=health_monitor, **kwargs)
         self._started_event: Optional[asyncio.Event] = None
 
     @property

--- a/src/prefect/server/services/telemetry.py
+++ b/src/prefect/server/services/telemetry.py
@@ -47,8 +47,12 @@ class Telemetry(RunInEphemeralServers, RunInWebservers, LoopService):
     def enabled(cls) -> bool:
         return get_current_settings().server.analytics_enabled
 
-    def __init__(self, loop_seconds: Optional[int] = None, **kwargs: Any):
-        super().__init__(loop_seconds=loop_seconds, **kwargs)
+    def __init__(
+        self, loop_seconds: Optional[int] = None, health_monitor=None, **kwargs: Any
+    ):
+        super().__init__(
+            loop_seconds=loop_seconds, health_monitor=health_monitor, **kwargs
+        )
         self.telemetry_environment: str = os.environ.get(
             "PREFECT_API_TELEMETRY_ENVIRONMENT", "production"
         )

--- a/src/prefect/settings/models/server/services.py
+++ b/src/prefect/settings/models/server/services.py
@@ -495,6 +495,26 @@ class ServerServicesTriggersSettings(ServicesBaseSetting):
     )
 
 
+class ServerServicesHealthcheckSettings(PrefectBaseSettings):
+    """
+    Settings for controlling the services healthcheck server
+    """
+
+    model_config: ClassVar[SettingsConfigDict] = build_settings_config(
+        ("server", "services", "healthcheck")
+    )
+
+    host: str = Field(
+        default="0.0.0.0",
+        description="The host address the services healthcheck server should bind to.",
+    )
+
+    port: int = Field(
+        default=8081,
+        description="The port the services healthcheck server should bind to.",
+    )
+
+
 class ServerServicesSettings(PrefectBaseSettings):
     """
     Settings for controlling server services
@@ -543,4 +563,8 @@ class ServerServicesSettings(PrefectBaseSettings):
     triggers: ServerServicesTriggersSettings = Field(
         default_factory=ServerServicesTriggersSettings,
         description="Settings for controlling the triggers service",
+    )
+    healthcheck: ServerServicesHealthcheckSettings = Field(
+        default_factory=ServerServicesHealthcheckSettings,
+        description="Settings for controlling the services healthcheck server",
     )


### PR DESCRIPTION
Closes #18997

## Summary
This PR adds healthcheck support for Prefect server background services, enabling proper health monitoring in containerized environments.

## Changes
- Added `--with-healthcheck` flag to `prefect server services start` command
- Created `ServicesHealthMonitor` class to track service activity 
- Added healthcheck server that runs on port 8081 by default (configurable)
- Updated all services to support optional health monitoring
- Added new settings `PREFECT_SERVER_SERVICES_HEALTHCHECK_HOST` and `PREFECT_SERVER_SERVICES_HEALTHCHECK_PORT`

## How it works
When services are started with `--with-healthcheck`, a lightweight HTTP server starts on port 8081 that exposes a `/health` endpoint. Each service reports its activity after completing its loop, and the healthcheck endpoint returns:
- **200 OK** when all services are healthy
- **503 Service Unavailable** when services are unhealthy or not reporting

## Usage

### Command line
```bash
# Start services with healthcheck
prefect server services start --with-healthcheck

# Or in background
prefect server services start --with-healthcheck --background
```

### Docker Compose
```yaml
services:
  prefect-background:
    image: prefecthq/prefect:3-latest
    command: prefect server services start --with-healthcheck
    healthcheck:
      test: ["CMD", "python", "-c", "import urllib.request as u; u.urlopen('http://localhost:8081/health', timeout=1)"]
      interval: 30s
      timeout: 10s
      retries: 3
      start_period: 60s
```

## Test Plan
- [x] Started services with `--with-healthcheck` flag
- [x] Verified healthcheck endpoint returns proper status
- [x] Tested both foreground and background modes
- [x] Verified all services report their health status

🤖 Generated with [Claude Code](https://claude.ai/code)