### PR TITLE
Add LLM-friendly docs section

### DIFF
--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -94,3 +94,13 @@ Prefect 3.0 also unlocked a leap forward in performance, improving the runtime o
 ## Join our community
 
 Join Prefect's vibrant [community of nearly 30,000 engineers](/contribute/index/) to learn with others and share your knowledge!
+
+## LLM-friendly docs
+
+**MCP server access**: Connect to `https://docs.prefect.io/mcp` in Claude Desktop, Cursor, or VS Code for AI-powered documentation search and assistance.
+
+**Plain text formats**:
+- [`llms.txt`](https://docs.prefect.io/llms.txt) - Sitemap of all documentation pages
+- Structured access to all concepts, guides, and examples
+
+**Markdown access**: Use the contextual menu (⋯) on any page to copy as markdown or open directly in your preferred AI tool.

--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -97,10 +97,16 @@ Join Prefect's vibrant [community of nearly 30,000 engineers](/contribute/index/
 
 ## LLM-friendly docs
 
-**MCP server access**: Connect to `https://docs.prefect.io/mcp` in Claude Desktop, Cursor, or VS Code for AI-powered documentation search and assistance.
+### MCP server 
 
-**Plain text formats**:
-- [`llms.txt`](https://docs.prefect.io/llms.txt) - Sitemap of all documentation pages
-- Structured access to all concepts, guides, and examples
+Connect to `https://docs.prefect.io/mcp` in Claude Desktop, Cursor, or VS Code for AI-powered documentation search and assistance.
 
-**Markdown access**: Use the contextual menu (⋯) on any page to copy as markdown or open directly in your preferred AI tool.
+### Plain text formats
+
+The docs are also available in [llms.txt format](https://llmstxt.org/):
+* [llms.txt](https://docs.prefect.io/llms.txt) - A sitemap listing all documentation pages
+* [llms-full.txt](https://docs.prefect.io/llms-full.txt) - The entire documentation in one file (may exceed context windows)
+
+Any page can be accessed as markdown by appending `.md` to the URL. For example, this page becomes `https://docs.prefect.io/v3/get-started.md`.
+
+You can also copy any page as markdown by pressing "Cmd+C" (or "Ctrl+C" on Windows) on your keyboard.


### PR DESCRIPTION
## Summary

Add documentation for using Prefect docs with LLMs and AI tools in the getting started page.

<details>
<summary>Details</summary>

- Adds MCP server connection instructions
- References existing llms.txt sitemap 
- Mentions markdown export via contextual menu
- Uses concise, technical tone similar to other developer tools

</details>

🤖 Generated with [Claude Code](https://claude.ai/code)