### PR TITLE
Improve deployment validation error messages

### DIFF
--- a/src/prefect/cli/deploy/_models.py
+++ b/src/prefect/cli/deploy/_models.py
@@ -107,7 +107,7 @@ class RawScheduleConfig(BaseModel):
     Exactly one of cron, interval, or rrule must be provided.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     # One-of schedule selectors
     cron: Optional[str] = None
@@ -132,5 +132,5 @@ class RawScheduleConfig(BaseModel):
 
 
 ScheduleItem = Union[
-    RawScheduleConfig, DeploymentScheduleCreate, SCHEDULE_TYPES, Dict[str, Any]
+    RawScheduleConfig, DeploymentScheduleCreate, SCHEDULE_TYPES, Dict[None, None]
 ]

--- a/src/prefect/cli/deploy/_models.py
+++ b/src/prefect/cli/deploy/_models.py
@@ -117,7 +117,7 @@ class RawScheduleConfig(BaseModel):
     # Common extras
     timezone: Optional[str] = None
     anchor_date: Optional[str] = None
-    active: Optional[bool] = None
+    active: Optional[Union[bool, str]] = None  # Allow string for template values
     parameters: Dict[str, Any] = Field(default_factory=dict)
     slug: Optional[str] = None
 

--- a/tests/cli/deploy/test_format_validation_error.py
+++ b/tests/cli/deploy/test_format_validation_error.py
@@ -1,0 +1,164 @@
+"""Tests for the _format_validation_error function."""
+
+import pytest
+from pydantic import ValidationError
+
+from prefect.cli.deploy._config import _format_validation_error
+from prefect.cli.deploy._models import PrefectYamlModel
+
+
+def test_format_validation_error_with_invalid_schedule():
+    """Test error formatting when schedule field is invalid."""
+    raw_data = {
+        "deployments": [
+            {
+                "name": "my-deployment",
+                "entrypoint": "flow.py:my_flow",
+                "schedule": "not a dict",  # Should be a dict
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PrefectYamlModel.model_validate(raw_data)
+
+    result = _format_validation_error(exc_info.value, raw_data)
+
+    assert "Invalid fields in deployments:" in result
+    assert "my-deployment: schedule" in result
+    assert "https://docs.prefect.io/v3/concepts/deployments#deployment-schema" in result
+
+
+def test_format_validation_error_with_multiple_invalid_fields():
+    """Test error formatting with multiple invalid fields in one deployment."""
+    raw_data = {
+        "deployments": [
+            {
+                "name": "test-deploy",
+                "entrypoint": 123,  # Should be string
+                "schedule": False,  # Should be dict
+                "tags": {},  # Should be list or string
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PrefectYamlModel.model_validate(raw_data)
+
+    result = _format_validation_error(exc_info.value, raw_data)
+
+    assert "Invalid fields in deployments:" in result
+    assert "test-deploy:" in result
+    # Fields should be sorted alphabetically
+    assert "entrypoint, schedule, tags" in result or (
+        "entrypoint" in result and "schedule" in result and "tags" in result
+    )
+
+
+def test_format_validation_error_with_multiple_deployments():
+    """Test error formatting with errors in multiple deployments."""
+    raw_data = {
+        "deployments": [
+            {
+                "name": "first-deployment",
+                "entrypoint": "flow.py:my_flow",
+                "schedule": [],  # Invalid
+            },
+            {
+                "name": "second-deployment",
+                "entrypoint": "flow.py:my_flow",
+                "concurrency_limit": "not a number",  # Invalid
+            },
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PrefectYamlModel.model_validate(raw_data)
+
+    result = _format_validation_error(exc_info.value, raw_data)
+
+    assert "Invalid fields in deployments:" in result
+    assert "first-deployment: schedule" in result
+    assert "second-deployment: concurrency_limit" in result
+
+
+def test_format_validation_error_with_unnamed_deployment():
+    """Test error formatting when deployment has no name."""
+    raw_data = {
+        "deployments": [
+            {
+                "entrypoint": "flow.py:my_flow",
+                "tags": 123,  # Invalid
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PrefectYamlModel.model_validate(raw_data)
+
+    result = _format_validation_error(exc_info.value, raw_data)
+
+    assert "Invalid fields in deployments:" in result
+    assert "#0: tags" in result  # Should use index when no name
+
+
+def test_format_validation_error_with_invalid_tags_type():
+    """Test error formatting for invalid tags type."""
+    raw_data = {
+        "deployments": [
+            {
+                "name": "my-deployment",
+                "entrypoint": "flow.py:my_flow",
+                "tags": 123,  # Should be list or string
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PrefectYamlModel.model_validate(raw_data)
+
+    result = _format_validation_error(exc_info.value, raw_data)
+
+    assert "Invalid fields in deployments:" in result
+    assert "my-deployment: tags" in result
+
+
+def test_format_validation_error_with_invalid_dict_keys():
+    """Test error formatting when dict has wrong keys."""
+    raw_data = {
+        "deployments": [
+            {
+                "name": "bad-schedule",
+                "entrypoint": "flow.py:my_flow",
+                "schedule": {"foo": "0 4 * * *"},  # Invalid key
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PrefectYamlModel.model_validate(raw_data)
+
+    result = _format_validation_error(exc_info.value, raw_data)
+
+    assert "Invalid fields in deployments:" in result
+    # Should still identify schedule as the problem field
+    assert "bad-schedule:" in result
+    assert "schedule" in result or "foo" in result
+
+
+def test_format_validation_error_empty_raw_data():
+    """Test error formatting with minimal data."""
+    raw_data = {}
+
+    # This should validate fine (empty is valid)
+    model = PrefectYamlModel.model_validate(raw_data)
+    assert model.deployments == []
+
+
+def test_format_validation_error_no_deployment_errors():
+    """Test when there are no deployment-specific errors."""
+    raw_data = {"invalid_top_level_field": "value", "deployments": []}
+
+    # Extra fields are ignored, so this should validate fine
+    model = PrefectYamlModel.model_validate(raw_data)
+    assert model.deployments == []


### PR DESCRIPTION
## Summary
This PR significantly improves the error messages shown when `prefect.yaml` contains invalid deployment configurations.

Closes https://github.com/PrefectHQ/prefect/issues/19007

## Before
invaliduld see validation errors if th,eir deployment config was invalide, but they'd only see one error and it wouldn't be clear which deployment config the error was coming from.

## After
Users now see clear, concise error messages:
```
Invalid fields in deployments:

  • my-deployment: schedule

For valid deployment fields and examples, go to:
https://docs.prefect.io/v3/concepts/deployments#deployment-schema
```

## Examples
This `prefect.yaml` file:
```yaml
deployments:
  - name: deployment-name-1
    schedule: []
    parameters: {}
    entrypoint: flow.py:my_flow
    work_pool: 
      name:  olympic
  - name: deployment-name-2
    schedule: "0 4 * * *"
    parameters: {}
    entrypoint: flow.py:my_flow
    work_pool: 
      name: olympic
```
shows the following errors when `prefect deploy` is run:
```
Invalid fields in deployments:

  • deployment-name-1: schedule
  • deployment-name-2: schedule
```


🤖 Generated with [Claude Code](https://claude.ai/code)