### PR TITLE
remove log level set in kubernetes observer

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -39,8 +39,6 @@ _last_event_cache: TTLCache[str, Event] = TTLCache(
     maxsize=1000, ttl=60 * 5
 )  # 5 minutes
 
-logging.getLogger("kopf.objects").setLevel(logging.INFO)
-
 settings = KubernetesSettings()
 
 events_client: EventsClient | None = None


### PR DESCRIPTION
allows configuration of logging level per [typical `logging.yaml`](https://docs.python.org/3/library/logging.config.html)