### PR TITLE
Allow serving instance methods

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -85,6 +85,6 @@ jobs:
 
       - name: Run pyright check
         run: >-
-          uv run pyright -p pyrightconfig-ci.json
+          uv run pyright -p pyrightconfig-ci.json --level error
 
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -400,7 +400,11 @@ class Runner:
         if TYPE_CHECKING:
             assert inspect.isawaitable(add_deployment_coro)
         deployment_id = await add_deployment_coro
-        self._deployment_flow_map[deployment_id] = flow
+
+        # Only add the flow to the map if it is not loaded from storage
+        # Further work is needed to support directly running flows created using `flow.from_source`
+        if flow._storage is None:
+            self._deployment_flow_map[deployment_id] = flow
         return deployment_id
 
     @sync_compatible

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -403,7 +403,7 @@ class Runner:
 
         # Only add the flow to the map if it is not loaded from storage
         # Further work is needed to support directly running flows created using `flow.from_source`
-        if flow._storage is None:
+        if not getattr(flow, "_storage", None):
             self._deployment_flow_map[deployment_id] = flow
         return deployment_id
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -256,7 +256,7 @@ class Runner:
         )
         self._flow_cache: LRUCache[UUID, "APIFlow"] = LRUCache(maxsize=100)
 
-        ###### EXPERIMENTAL ######
+        # Keep track of added flows so we can run them directly in a subprocess
         self._deployment_flow_map: dict[UUID, "Flow[Any, Any]"] = dict()
 
     @property

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -38,6 +38,7 @@ import asyncio
 import datetime
 import inspect
 import logging
+import multiprocessing.context
 import os
 import shlex
 import shutil
@@ -93,6 +94,7 @@ from prefect.events.clients import EventsClient, get_events_client
 from prefect.events.related import tags_as_related_resources
 from prefect.events.schemas.events import Event, RelatedResource, Resource
 from prefect.exceptions import Abort, ObjectNotFound
+from prefect.flow_engine import run_flow_in_subprocess
 from prefect.flows import Flow, FlowStateHook, load_flow_from_flow_run
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logger
 from prefect.runner._observers import FlowRunCancellingObserver
@@ -254,6 +256,9 @@ class Runner:
         )
         self._flow_cache: LRUCache[UUID, "APIFlow"] = LRUCache(maxsize=100)
 
+        ###### EXPERIMENTAL ######
+        self._deployment_flow_map: dict[UUID, "Flow[Any, Any]"] = dict()
+
     @property
     def _flow_run_process_map_lock(self) -> asyncio.Lock:
         if self.__flow_run_process_map_lock is None:
@@ -394,7 +399,9 @@ class Runner:
         add_deployment_coro = self.add_deployment(deployment)
         if TYPE_CHECKING:
             assert inspect.isawaitable(add_deployment_coro)
-        return await add_deployment_coro
+        deployment_id = await add_deployment_coro
+        self._deployment_flow_map[deployment_id] = flow
+        return deployment_id
 
     @sync_compatible
     async def _add_storage(self, storage: RunnerStorage) -> RunnerStorage:
@@ -574,7 +581,7 @@ class Runner:
         env: dict[str, str | None] | None = None,
         task_status: anyio.abc.TaskStatus[int] = anyio.TASK_STATUS_IGNORED,
         stream_output: bool = True,
-    ) -> anyio.abc.Process | None:
+    ) -> anyio.abc.Process | multiprocessing.context.SpawnProcess | None:
         """
         Executes a single flow run with the given ID.
 
@@ -594,7 +601,9 @@ class Runner:
             self._submitting_flow_run_ids.add(flow_run_id)
             flow_run = await self._client.read_flow_run(flow_run_id)
 
-            process: anyio.abc.Process | Exception = await self._runs_task_group.start(
+            process: (
+                anyio.abc.Process | multiprocessing.context.SpawnProcess | Exception
+            ) = await self._runs_task_group.start(
                 partial(
                     self._submit_run_and_capture_errors,
                     flow_run=flow_run,
@@ -608,13 +617,21 @@ class Runner:
             if isinstance(process, Exception):
                 return
 
+            if process.pid is None:
+                raise RuntimeError("Process has no PID")
+
             task_status.started(process.pid)
 
             if self.heartbeat_seconds is not None:
                 await self._emit_flow_run_heartbeat(flow_run)
 
             # Only add the process to the map if it is still running
-            if process.returncode is None:
+            # The process may be a multiprocessing.context.SpawnProcess, in which case it will have an `exitcode`` attribute
+            # but no `returncode` attribute
+            if (
+                getattr(process, "returncode", None)
+                or getattr(process, "exitcode", None)
+            ) is None:
                 await self._add_flow_run_process_map_entry(
                     flow_run.id, ProcessMapEntry(pid=process.pid, flow_run=flow_run)
                 )
@@ -734,14 +751,14 @@ class Runner:
         self,
         flow_run: "FlowRun",
         task_status: anyio.abc.TaskStatus[
-            anyio.abc.Process
+            anyio.abc.Process | multiprocessing.context.SpawnProcess
         ] = anyio.TASK_STATUS_IGNORED,
         entrypoint: str | None = None,
         command: str | None = None,
         cwd: Path | str | None = None,
         env: dict[str, str | None] | None = None,
         stream_output: bool = True,
-    ) -> anyio.abc.Process:
+    ) -> int | None:
         """
         Runs the given flow run in a subprocess.
 
@@ -753,6 +770,16 @@ class Runner:
             task_status: anyio task status used to send a message to the caller
                 than the flow run process has started.
         """
+        # If we have an instance of the flow for this deployment, run it directly in a subprocess
+        if flow_run.deployment_id is not None:
+            flow = self._deployment_flow_map.get(flow_run.deployment_id)
+            if flow:
+                process = run_flow_in_subprocess(flow, flow_run=flow_run)
+                task_status.started(process)
+                await anyio.to_thread.run_sync(process.join)
+                return process.exitcode
+
+        # Otherwise, we'll need to run a `python -m prefect.engine` command to load and run the flow
         if command is None:
             runner_command = [get_sys_executable(), "-m", "prefect.engine"]
         else:
@@ -818,52 +845,7 @@ class Runner:
             **kwargs,
         )
 
-        if process.returncode is None:
-            raise RuntimeError("Process exited with None return code")
-
-        if process.returncode:
-            help_message = None
-            level = logging.ERROR
-            if process.returncode == -9:
-                level = logging.INFO
-                help_message = (
-                    "This indicates that the process exited due to a SIGKILL signal. "
-                    "Typically, this is either caused by manual cancellation or "
-                    "high memory usage causing the operating system to "
-                    "terminate the process."
-                )
-            if process.returncode == -15:
-                level = logging.INFO
-                help_message = (
-                    "This indicates that the process exited due to a SIGTERM signal. "
-                    "Typically, this is caused by manual cancellation."
-                )
-            elif process.returncode == 247:
-                help_message = (
-                    "This indicates that the process was terminated due to high "
-                    "memory usage."
-                )
-            elif (
-                sys.platform == "win32" and process.returncode == STATUS_CONTROL_C_EXIT
-            ):
-                level = logging.INFO
-                help_message = (
-                    "Process was terminated due to a Ctrl+C or Ctrl+Break signal. "
-                    "Typically, this is caused by manual cancellation."
-                )
-
-            flow_run_logger.log(
-                level,
-                f"Process for flow run {flow_run.name!r} exited with status code:"
-                f" {process.returncode}"
-                + (f"; {help_message}" if help_message else ""),
-            )
-        else:
-            flow_run_logger.info(
-                f"Process for flow run {flow_run.name!r} exited cleanly."
-            )
-
-        return process
+        return process.returncode
 
     async def _kill_process(
         self,
@@ -1299,7 +1281,9 @@ class Runner:
     async def _submit_run_and_capture_errors(
         self,
         flow_run: "FlowRun",
-        task_status: anyio.abc.TaskStatus[anyio.abc.Process | Exception],
+        task_status: anyio.abc.TaskStatus[
+            anyio.abc.Process | multiprocessing.context.SpawnProcess | Exception
+        ],
         entrypoint: str | None = None,
         command: str | None = None,
         cwd: Path | str | None = None,
@@ -1309,7 +1293,7 @@ class Runner:
         run_logger = self._get_flow_run_logger(flow_run)
 
         try:
-            process = await self._run_process(
+            exit_code = await self._run_process(
                 flow_run=flow_run,
                 task_status=task_status,
                 entrypoint=entrypoint,
@@ -1318,7 +1302,45 @@ class Runner:
                 env=env,
                 stream_output=stream_output,
             )
-            status_code = process.returncode
+            flow_run_logger = self._get_flow_run_logger(flow_run)
+            if exit_code:
+                help_message = None
+                level = logging.ERROR
+                if exit_code == -9:
+                    level = logging.INFO
+                    help_message = (
+                        "This indicates that the process exited due to a SIGKILL signal. "
+                        "Typically, this is either caused by manual cancellation or "
+                        "high memory usage causing the operating system to "
+                        "terminate the process."
+                    )
+                if exit_code == -15:
+                    level = logging.INFO
+                    help_message = (
+                        "This indicates that the process exited due to a SIGTERM signal. "
+                        "Typically, this is caused by manual cancellation."
+                    )
+                elif exit_code == 247:
+                    help_message = (
+                        "This indicates that the process was terminated due to high "
+                        "memory usage."
+                    )
+                elif sys.platform == "win32" and exit_code == STATUS_CONTROL_C_EXIT:
+                    level = logging.INFO
+                    help_message = (
+                        "Process was terminated due to a Ctrl+C or Ctrl+Break signal. "
+                        "Typically, this is caused by manual cancellation."
+                    )
+
+                flow_run_logger.log(
+                    level,
+                    f"Process for flow run {flow_run.name!r} exited with status code:"
+                    f" {exit_code}" + (f"; {help_message}" if help_message else ""),
+                )
+            else:
+                flow_run_logger.info(
+                    f"Process for flow run {flow_run.name!r} exited cleanly."
+                )
         except Exception as exc:
             if not task_status._future.done():  # type: ignore
                 # This flow run was being submitted and did not start successfully
@@ -1341,10 +1363,10 @@ class Runner:
 
             await self._remove_flow_run_process_map_entry(flow_run.id)
 
-        if status_code != 0 and not self._rescheduling:
+        if exit_code != 0 and not self._rescheduling:
             await self._propose_crashed_state(
                 flow_run,
-                f"Flow run process exited with non-zero status code {status_code}.",
+                f"Flow run process exited with non-zero status code {exit_code}.",
             )
 
         api_flow_run = await self._client.read_flow_run(flow_run_id=flow_run.id)
@@ -1352,7 +1374,7 @@ class Runner:
         if terminal_state and terminal_state.is_crashed():
             await self._run_on_crashed_hooks(flow_run=flow_run, state=terminal_state)
 
-        return status_code
+        return exit_code
 
     async def _propose_pending_state(self, flow_run: "FlowRun") -> bool:
         run_logger = self._get_flow_run_logger(flow_run)
@@ -1459,6 +1481,10 @@ class Runner:
                     flow = extract_flow_from_bundle(
                         self._flow_run_bundle_map[flow_run.id]
                     )
+                elif flow_run.deployment_id and self._deployment_flow_map.get(
+                    flow_run.deployment_id
+                ):
+                    flow = self._deployment_flow_map[flow_run.deployment_id]
                 else:
                     run_logger.info("Loading flow to check for on_cancellation hooks")
                     flow = await load_flow_from_flow_run(
@@ -1488,6 +1514,10 @@ class Runner:
                     flow = extract_flow_from_bundle(
                         self._flow_run_bundle_map[flow_run.id]
                     )
+                elif flow_run.deployment_id and self._deployment_flow_map.get(
+                    flow_run.deployment_id
+                ):
+                    flow = self._deployment_flow_map[flow_run.deployment_id]
                 else:
                     run_logger.info("Loading flow to check for on_crashed hooks")
                     flow = await load_flow_from_flow_run(

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -427,8 +427,8 @@ def generate_parameter_schema(
             param, position=position, docstrings=docstrings, aliases=aliases
         )
 
-        if name == "cls":
-            continue  # Exclude 'cls' as it's implicitly passed to @classmethod and not a real flow parameter
+        if name in ("cls", "self"):
+            continue  # Exclude 'cls'/'self' as they're implicitly passed and not real flow parameters
 
         # Generate a Pydantic model at each step so we can check if this parameter
         # type supports schema generation

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -17,6 +17,7 @@ checkout out the [Prefect docs](https://docs.prefect.io/v3/concepts/work-pools/)
 from __future__ import annotations
 
 import contextlib
+import multiprocessing.context
 import os
 import tempfile
 import threading
@@ -246,9 +247,11 @@ class ProcessWorker(
                 task_status=task_status,
             )
 
-        status_code = getattr(process, "returncode", None) or getattr(
-            process, "exitcode", None
-        )
+        status_code = None
+        if isinstance(process, multiprocessing.context.SpawnProcess):
+            status_code = process.exitcode
+        elif isinstance(process, anyio.abc.Process):
+            status_code = process.returncode
 
         if process is None or status_code is None:
             raise RuntimeError("Failed to start flow run process.")

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -17,7 +17,6 @@ checkout out the [Prefect docs](https://docs.prefect.io/v3/concepts/work-pools/)
 from __future__ import annotations
 
 import contextlib
-import multiprocessing.context
 import os
 import tempfile
 import threading
@@ -247,11 +246,11 @@ class ProcessWorker(
                 task_status=task_status,
             )
 
-        status_code = None
-        if isinstance(process, multiprocessing.context.SpawnProcess):
-            status_code = process.exitcode
-        elif isinstance(process, anyio.abc.Process):
-            status_code = process.returncode
+        status_code = (
+            getattr(process, "returncode", None)
+            if getattr(process, "returncode", None) is not None
+            else getattr(process, "exitcode", None)
+        )
 
         if process is None or status_code is None:
             raise RuntimeError("Failed to start flow run process.")

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -246,12 +246,14 @@ class ProcessWorker(
                 task_status=task_status,
             )
 
-        if process is None or process.returncode is None:
+        status_code = getattr(process, "returncode", None) or getattr(
+            process, "exitcode", None
+        )
+
+        if process is None or status_code is None:
             raise RuntimeError("Failed to start flow run process.")
 
-        return ProcessWorkerResult(
-            status_code=process.returncode, identifier=str(process.pid)
-        )
+        return ProcessWorkerResult(status_code=status_code, identifier=str(process.pid))
 
     async def _submit_adhoc_run(
         self,


### PR DESCRIPTION
This PR updates the `Runner` class to maintain a dictionary of flow instances for deployments that have been registered with the `Runner`. This enables flows like the following to be successfully served and run:
```python
import time

from prefect import flow


class MyClass:
    def __init__(self):
        self.sleep_time = 60

    @flow(log_prints=True)
    def my_method(self, override_sleep_time: int | None = None):
        sleep_time = override_sleep_time or self.sleep_time
        print(f"Sleeping for {sleep_time} seconds")
        time.sleep(sleep_time)
        print("Done sleeping")


if __name__ == "__main__":
    my_class = MyClass()
    my_class.my_method.serve(name="served-from-instance")
```