### PR TITLE
improve automation actions documentation with type identifiers

### DIFF
--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -46,17 +46,23 @@ notification for someone to take manual remediation steps. Or you could set both
 
 Actions specify what your automation does when its trigger criteria are met. Current action types include:
 
-- Cancel a flow run
-- Pause or resume a schedule
-- Run a deployment
-- Pause or resume a deployment schedule
-- Pause or resume a work pool
-- Pause or resume a work queue
-- Pause or resume an automation
-- Send a [notification](#sending-notifications-with-automations)
-- Call a webhook
-- Suspend a flow run
-- Change the state of a flow run
+| Action | Type |
+| ------ | ---- |
+| Cancel a flow run | `cancel-flow-run` |
+| Change the state of a flow run | `change-flow-run-state` |
+| Suspend a flow run | `suspend-flow-run` |
+| Resume a flow run | `resume-flow-run` |
+| Run a deployment | `run-deployment` |
+| Pause a deployment schedule | `pause-deployment` |
+| Resume a deployment schedule | `resume-deployment` |
+| Pause a work pool | `pause-work-pool` |
+| Resume a work pool | `resume-work-pool` |
+| Pause a work queue | `pause-work-queue` |
+| Resume a work queue | `resume-work-queue` |
+| Pause an automation | `pause-automation` |
+| Resume an automation | `resume-automation` |
+| Send a [notification](#sending-notifications-with-automations) | `send-notification` |
+| Call a webhook | `call-webhook` |
 
 ![Configuring an action for an automation in Prefect Cloud.](/v3/img/ui/automations-action.png)
 


### PR DESCRIPTION
## summary

this pr updates the automation actions documentation to use a table format that includes both the human-readable action description and the actual type identifier (slug) that users need when defining automations in yaml or json.

## changes

- converted the bulleted list of automation actions to a table with two columns:
  - **action**: human-readable description 
  - **type**: the actual identifier used in automation definitions (e.g., `cancel-flow-run`, `run-deployment`)
- organized actions by category (flow runs, deployments, work pools, work queues, automations, notifications/webhooks)
- verified all type identifiers match the actual implementations in `src/prefect/server/events/actions.py`

## why

when users define automations programmatically via yaml or json, they need to know the exact type identifiers to use. the previous documentation only showed human-readable descriptions, making it difficult to know what values to use in automation definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)