### PR TITLE
improve CLI import performance

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -29,7 +29,6 @@ from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.cloud import prompt_select_from_list
 from prefect.cli.root import app, is_interactive
 from prefect.logging import get_logger
-from prefect.server.services.base import Service
 from prefect.settings import (
     PREFECT_API_SERVICES_LATE_RUNS_ENABLED,
     PREFECT_API_SERVICES_SCHEDULER_ENABLED,
@@ -702,6 +701,8 @@ def run_manager_process():
 
     We do everything in sync so that the child won't exit until the user kills it.
     """
+    from prefect.server.services.base import Service
+
     if not Service.enabled_services():
         logger.error("No services are enabled! Exiting manager.")
         sys.exit(1)
@@ -719,6 +720,8 @@ def run_manager_process():
 @services_app.command(aliases=["ls"])
 def list_services():
     """List all available services and their status."""
+    from prefect.server.services.base import Service
+
     table = Table(title="Available Services", expand=True)
     table.add_column("Name", no_wrap=True)
     table.add_column("Enabled?", no_wrap=True)
@@ -746,6 +749,8 @@ def start_services(
     ),
 ):
     """Start all enabled Prefect services in one process."""
+    from prefect.server.services.base import Service
+
     SERVICES_PID_FILE.parent.mkdir(parents=True, exist_ok=True)
 
     if SERVICES_PID_FILE.exists():


### PR DESCRIPTION
## Summary

Improves CLI startup time by ~30-45% through lazy imports. Import time for `prefect.cli` drops from ~1.6s to ~0.9s.

## Background

The Prefect CLI was slow to start (1.3-1.6s for simple commands like `prefect --help`). This was identified as a potential blocker for consolidating the `prefect-cloud` CLI into `prefect` proper, as discussed in [this Slack thread](https://prefecthq.slack.com/archives/C01P81D026N/p1738363679259479).

## Methodology

Built an empirical benchmarking harness (`repros/cli_benchmark.py`) to measure:
1. Import times for key modules using `subprocess` to spawn fresh Python processes
2. CLI command execution times
3. Detailed profiling with `python -X importtime` and `pyinstrument`

The profiling revealed two main bottlenecks:
1. **dateparser** (~250-300ms): Imported at module level in `deprecated.py`, triggering regex compilation during CLI initialization
2. **server modules** (~300-400ms): `prefect.server.__init__.py` eagerly imports all database models, triggered when any CLI module imports from `prefect.server`

## Changes

### 1. Lazy dateparser import
- Moved `import dateparser` from module-level to inside `_coerce_datetime()`
- Moved deprecation message generation from decorator application time to decorator invocation time
- This means dateparser is only loaded when a deprecated function with string dates is actually called, not when the decorator is applied

**Files changed:**
- `src/prefect/_internal/compatibility/deprecated.py`

### 2. Lazy server imports
- Moved `from prefect.server.services.base import Service` from module-level to inside CLI command functions
- Only the `prefect server services` commands need `Service`, not every CLI invocation

**Files changed:**
- `src/prefect/cli/server.py`

## Performance Impact

Empirically tested by running the benchmark script on both `main` and this branch:

### main branch
```
prefect --help         1.376s (min: 1.314s, max: 1.479s)
prefect version        1.381s (min: 1.374s, max: 1.386s)
prefect config view    1.364s (min: 1.339s, max: 1.402s)
import prefect.cli     1.617s (min: 1.346s, max: 1.782s)
```

### cli-perf-improvements branch
```
prefect --help         1.022s (min: 0.825s, max: 1.336s)
prefect version        1.375s (min: 1.331s, max: 1.412s)
prefect config view    0.939s (min: 0.851s, max: 1.026s)
import prefect.cli     0.887s (min: 0.826s, max: 0.922s)
```

### Improvements
- `import prefect.cli`: **1.617s → 0.887s** (45% faster, -730ms)
- `prefect --help`: **1.376s → 1.022s** (26% faster, -354ms)
- `prefect config view`: **1.364s → 0.939s** (31% faster, -425ms)

## Why Draft?

There are likely more quick wins available. Initial profiling suggests:
- Pydantic settings eager loading (~270ms) - may be unavoidable
- Events/automations schemas (~210ms) - could potentially be lazy-loaded
- Other module-level imports that could be deferred

We wanted to get this initial improvement out for review while exploring additional optimizations.