### PR TITLE
Rename `server.concurrency.initial_lease_timeout` to `server.concurrency.initial_deployment_lease_duration`

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -593,7 +593,7 @@ class SecureFlowConcurrencySlots(FlowRunOrchestrationRule):
                     slots=1,
                 ),
                 ttl=datetime.timedelta(
-                    seconds=settings.server.concurrency.initial_lease_timeout
+                    seconds=settings.server.concurrency.initial_deployment_lease_duration
                 ),
             )
             proposed_state.state_details.deployment_concurrency_lease_id = lease.id

--- a/src/prefect/settings/models/server/concurrency.py
+++ b/src/prefect/settings/models/server/concurrency.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from pydantic import AliasChoices, AliasPath, Field
+from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
@@ -16,13 +16,9 @@ class ServerConcurrencySettings(PrefectBaseSettings):
         description="The module to use for storing concurrency limit leases.",
     )
 
-    initial_lease_timeout: float = Field(
+    initial_deployment_lease_duration: float = Field(
         default=300.0,
         ge=30.0,  # Minimum 30 seconds
         le=3600.0,  # Maximum 1 hour
-        description="Initial timeout for concurrency lease acquisition in seconds.",
-        validation_alias=AliasChoices(
-            AliasPath("initial_lease_timeout"),
-            "prefect_server_concurrency_initial_lease_timeout",
-        ),
+        description="Initial duration for deployment concurrency lease in seconds.",
     )

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -60,7 +60,7 @@ from prefect.server.schemas.responses import SetStateStatus
 from prefect.server.schemas.states import StateType
 from prefect.settings import (
     PREFECT_DEPLOYMENT_CONCURRENCY_SLOT_WAIT_SECONDS,
-    PREFECT_SERVER_CONCURRENCY_INITIAL_LEASE_TIMEOUT,
+    PREFECT_SERVER_CONCURRENCY_INITIAL_DEPLOYMENT_LEASE_DURATION,
     temporary_settings,
 )
 from prefect.testing.utilities import AsyncMock
@@ -4560,7 +4560,7 @@ class TestFlowConcurrencyLimits:
         lease_ids = await lease_storage.read_active_lease_ids()
         assert len(lease_ids) == 1
 
-    async def test_configurable_initial_lease_timeout(
+    async def test_configurable_initial_lease_duration(
         self,
         session,
         initialize_orchestration,
@@ -4575,7 +4575,9 @@ class TestFlowConcurrencyLimits:
 
         # Use temporary_settings to set custom initial lease timeout
         with temporary_settings(
-            updates={PREFECT_SERVER_CONCURRENCY_INITIAL_LEASE_TIMEOUT: 123.0}
+            updates={
+                PREFECT_SERVER_CONCURRENCY_INITIAL_DEPLOYMENT_LEASE_DURATION: 123.0
+            }
         ):
             ctx = await initialize_orchestration(
                 session, "flow", *pending_transition, deployment_id=deployment.id

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -313,7 +313,9 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE": {
         "test_value": "prefect.server.concurrency.lease_storage.filesystem"
     },
-    "PREFECT_SERVER_CONCURRENCY_INITIAL_LEASE_TIMEOUT": {"test_value": 120.0},
+    "PREFECT_SERVER_CONCURRENCY_INITIAL_DEPLOYMENT_LEASE_DURATION": {
+        "test_value": 120.0
+    },
     "PREFECT_SERVER_CORS_ALLOWED_HEADERS": {"test_value": "foo", "legacy": True},
     "PREFECT_SERVER_CORS_ALLOWED_METHODS": {"test_value": "foo", "legacy": True},
     "PREFECT_SERVER_CORS_ALLOWED_ORIGINS": {"test_value": "foo", "legacy": True},


### PR DESCRIPTION
This changes the name of an unreleased setting to more closely match the language used in other parts of the system.
