### PR TITLE
fix: respect serialization_alias when generating dbt configs

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/configs/base.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/configs/base.py
@@ -56,7 +56,10 @@ class DbtConfigs(Block, abc.ABC):
                 field_value = getattr(model, field_name, None)
                 # override the name with alias so dbt parser can recognize the keyword;
                 # e.g. schema_ -> schema, returns the original name if no alias is set
-                if field.alias:
+                # prioritize serialization_alias since we're generating output
+                if field.serialization_alias:
+                    field_name = field.serialization_alias
+                elif field.alias:
                     field_name = field.alias
             else:
                 field_value = field


### PR DESCRIPTION
closes #19069

this pr fixes an issue where the `schema` field from a `SnowflakeConnector` was not being included in generated dbt profiles.yml output.

## root cause

the `_populate_configs_json` method in `prefect_dbt/cli/configs/base.py` only checked `field.alias` when determining the output field name, but `SnowflakeConnector.schema_` uses `serialization_alias="schema"` (not `alias`).

this caused the field to be skipped during the filtering/renaming process in `snowflake.py`, resulting in missing schema in the dbt profile.

## fix

updated the field name resolution to check `serialization_alias` first (since we're generating serialized output), then fall back to `alias`.

```python
if field.serialization_alias:
    field_name = field.serialization_alias
elif field.alias:
    field_name = field.alias
```

## testing

added regression test `test_snowflake_target_configs_schema_from_connector_in_profile` that reproduces the exact scenario from the issue and verifies the fix.

all 24 config tests pass ✅