### PR TITLE
keep DeploymentCreate.parameter_openapi_schema Optional for Cloud compat

### DIFF
--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -235,7 +235,7 @@ class DeploymentCreate(ActionBaseModel):
             "Whether or not the deployment should enforce the parameter schema."
         ),
     )
-    parameter_openapi_schema: ParameterSchema = Field(
+    parameter_openapi_schema: Optional[ParameterSchema] = Field(
         default_factory=lambda: {"type": "object", "properties": {}}
     )
     parameters: dict[str, Any] = Field(

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -179,7 +179,7 @@ class DeploymentCreate(ActionBaseModel):
             "Whether or not the deployment should enforce the parameter schema."
         ),
     )
-    parameter_openapi_schema: ParameterSchema = Field(
+    parameter_openapi_schema: Optional[ParameterSchema] = Field(
         default_factory=lambda: {"type": "object", "properties": {}},
         description="The parameter schema of the flow, including defaults.",
         json_schema_extra={"additionalProperties": True},

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5494,7 +5494,9 @@ export interface components {
              */
             parameter_openapi_schema?: {
                 [key: string]: unknown;
-            };
+            } | {
+                [key: string]: unknown;
+            } | null;
             /**
              * Parameters
              * @description Parameters for flow runs scheduled by the deployment.


### PR DESCRIPTION
## summary

this PR keeps `DeploymentCreate.parameter_openapi_schema` as `Optional[ParameterSchema]` to maintain compatibility with Prefect Cloud, which may send null values.

this is a follow-up to #19072 which made the field non-Optional, breaking the OpenAPI schema compatibility with Cloud.

## problem

after #19072, the OpenAPI schema changed to make `parameter_openapi_schema` non-nullable in the create schema. this breaks compatibility with Prefect Cloud which may send null values.

## solution

changed both client and server `DeploymentCreate.parameter_openapi_schema` back to `Optional[ParameterSchema]`.

the normalization behavior is preserved:
- `None` input: stays `None` (Cloud compat - won't break Cloud requests)
- `{}` input: normalized to `{"type": "object", "properties": {}}` by BeforeValidator
- omitted: gets default `{"type": "object", "properties": {}}` from default_factory
- client code: converts `None` to `{}` before passing to schema, so users still get valid schemas

## testing

- unit tests pass
- reproduction script works
- UI builds successfully
- pyright passes (1 pre-existing error unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)