### PR TITLE
Bump apprise minimum version to 1.9.5 for new Power Automate URLs

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -73,7 +73,7 @@ Documentation = "https://docs.prefect.io"
 Source = "https://github.com/PrefectHQ/prefect"
 Tracker = "https://github.com/PrefectHQ/prefect/issues"
 [project.optional-dependencies]
-notifications = ["apprise>=1.1.0, <2.0.0"]
+notifications = ["apprise>=1.9.5, <2.0.0"]
 
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # Server dependencies
     "aiosqlite>=0.17.0,<1.0.0",
     "alembic>=1.7.5,<2.0.0",
-    "apprise>=1.1.0,<2.0.0",
+    "apprise>=1.9.5,<2.0.0",
     "asyncpg>=0.23,<1.0.0",
     "click>=8.0,<9",
     "cryptography>=36.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "apprise"
-version = "1.9.4"
+version = "1.9.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -226,10 +226,11 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-oauthlib" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/f9/bda66afaf393f6914f4d6c035964936cadd98ee1fef44e4e77cba3b5828c/apprise-1.9.4.tar.gz", hash = "sha256:483122aee19a89a7b075ecd48ef11ae37d79744f7aeb450bcf985a9a6c28c988", size = 1855012, upload-time = "2025-08-02T18:13:28.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/16/e39338b8310af9466fab6f4482b542e24cb1fcbb7e36bf00c089c4e015e7/apprise-1.9.5.tar.gz", hash = "sha256:8f3be318bb429c2017470e33928a2e313cbf7600fc74b8184782a37060db366a", size = 1877134, upload-time = "2025-09-30T15:57:28.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/fa/7875ad63088b2d7dea538ffe60fba85786c228c7349d258891c54d0416a0/apprise-1.9.4-py3-none-any.whl", hash = "sha256:17dca8ad0a5b2063f6bae707979a51ca2cb374fcc66b0dd5c05a9d286dd40069", size = 1402630, upload-time = "2025-08-02T18:13:26.263Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/318762320d966e528dfb9e6be5953fe7df2952156f15ba857cbccafb630c/apprise-1.9.5-py3-none-any.whl", hash = "sha256:1873a8a1b8cf9e44fcbefe0486ed260b590652aea12427f545b37c8566142961", size = 1421011, upload-time = "2025-09-30T15:57:26.268Z" },
 ]
 
 [[package]]
@@ -3954,7 +3955,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.17.0,<1.0.0" },
     { name = "alembic", specifier = ">=1.7.5,<2.0.0" },
     { name = "anyio", specifier = ">=4.4.0,<5.0.0" },
-    { name = "apprise", specifier = ">=1.1.0,<2.0.0" },
+    { name = "apprise", specifier = ">=1.9.5,<2.0.0" },
     { name = "asgi-lifespan", specifier = ">=1.0,<3.0" },
     { name = "asyncpg", specifier = ">=0.23,<1.0.0" },
     { name = "cachetools", specifier = ">=5.3,<7.0" },


### PR DESCRIPTION
closes #19114

This PR bumps the minimum apprise version from 1.1.0 to 1.9.5 to ensure support for the new Microsoft Power Automate webhook URL format.

## Background

Microsoft changed the Power Automate webhook URL format in August 2025 from:
- Old: `logic.azure.com`
- New: `environment.api.powerplatform.com`

The old format will be deprecated on **November 30, 2025**.

## Changes

- Updated `pyproject.toml`: `apprise>=1.9.5,<2.0.0`
- Updated `client/pyproject.toml`: `apprise>=1.9.5, <2.0.0`
- Updated `uv.lock` accordingly

## References

- Upstream apprise issue: https://github.com/caronc/apprise/issues/1405
- Upstream apprise fix: https://github.com/caronc/apprise/pull/1407 (merged Sept 2025, released in v1.9.5)
- Previous Prefect PR: #14771 (added initial Power Automate support)
- Related issue: #14575

🤖 Generated with [Claude Code](https://claude.com/claude-code)