### PR TITLE
Add support for day_or parameter in cron schedule configurations

### DIFF
--- a/src/prefect/cli/deploy/_models.py
+++ b/src/prefect/cli/deploy/_models.py
@@ -121,6 +121,9 @@ class RawScheduleConfig(BaseModel):
     parameters: Dict[str, Any] = Field(default_factory=dict)
     slug: Optional[str] = None
 
+    # Cron-specific
+    day_or: Optional[Union[bool, str]] = None  # Allow string for template values
+
     @model_validator(mode="after")
     def _one_of_schedule(self):
         provided = [v is not None for v in (self.cron, self.interval, self.rrule)]

--- a/src/prefect/cli/deploy/_schedules.py
+++ b/src/prefect/cli/deploy/_schedules.py
@@ -46,7 +46,8 @@ def _schedule_config_to_deployment_schedule(
     slug = schedule_config.get("slug")
 
     if cron := schedule_config.get("cron"):
-        cron_kwargs = {"cron": cron, "timezone": timezone}
+        day_or = schedule_config.get("day_or")
+        cron_kwargs = {"cron": cron, "timezone": timezone, "day_or": day_or}
         schedule = CronSchedule(
             **{k: v for k, v in cron_kwargs.items() if v is not None}
         )

--- a/tests/cli/deploy/test_schedule_config.py
+++ b/tests/cli/deploy/test_schedule_config.py
@@ -1,0 +1,38 @@
+"""Tests for schedule configuration in deployment YAML."""
+
+from prefect.cli.deploy._models import RawScheduleConfig
+from prefect.cli.deploy._schedules import _schedule_config_to_deployment_schedule
+from prefect.client.schemas.schedules import CronSchedule
+
+
+def test_cron_schedule_with_day_or_and_active():
+    """Test that cron schedule with both day_or and active fields validates.
+
+    Regression test for issue #19117 where using day_or and active together
+    would fail with "Extra inputs are not permitted" error.
+    """
+    # Test RawScheduleConfig model accepts both fields
+    schedule = RawScheduleConfig(
+        cron="0 3 * * *",
+        timezone="UTC",
+        active=False,
+        day_or=True,
+    )
+    assert schedule.cron == "0 3 * * *"
+    assert schedule.active is False
+    assert schedule.day_or is True
+
+    # Test that conversion to CronSchedule passes day_or through
+    schedule_config = {
+        "cron": "0 3 * * *",
+        "timezone": "UTC",
+        "active": False,
+        "day_or": True,
+    }
+
+    result = _schedule_config_to_deployment_schedule(schedule_config)
+
+    assert result["active"] is False
+    schedule = result["schedule"]
+    assert isinstance(schedule, CronSchedule)
+    assert schedule.day_or is True


### PR DESCRIPTION
closes #19117

This PR adds support for the `day_or` parameter in cron schedule configurations defined in `prefect.yaml` deployment files.

## Problem
When both `day_or` and `active` were defined in a deployment's cron schedule, the deployment would fail with a validation error saying the schedules field was invalid. The `day_or` field works individually, but couldn't be used together with other schedule parameters like `active`.

## Root Cause
The `RawScheduleConfig` model in `src/prefect/cli/deploy/_models.py` had `extra="forbid"` but was missing the `day_or` field, even though the underlying `CronSchedule` class supports it. This caused any schedule config with `day_or` to be rejected as an invalid extra field.

<details>
<summary>Technical Details</summary>

The `CronSchedule` class has supported the `day_or` parameter since it was added (see `src/prefect/client/schemas/schedules.py:129-134`):

```python
day_or: bool = Field(
    default=True,
    description=(
        "Control croniter behavior for handling day and day_of_week entries."
    ),
)
```

However, the YAML validation layer (`RawScheduleConfig`) didn't expose this field, causing validation to fail when users tried to use it in their `prefect.yaml` files.

</details>

## Changes
1. **Added `day_or` field to `RawScheduleConfig` model** (`src/prefect/cli/deploy/_models.py`)
   - Added as `Optional[Union[bool, str]]` to allow both boolean values and template strings
   
2. **Updated schedule conversion** (`src/prefect/cli/deploy/_schedules.py`)
   - Extract `day_or` from schedule config and pass it to `CronSchedule` constructor

3. **Added regression test** (`tests/cli/deploy/test_schedule_config.py`)
   - Tests that `day_or` and `active` can be used together

## Example Usage
Users can now use `day_or` in their `prefect.yaml`:

```yaml
deployments:
  - name: my-deployment
    entrypoint: flow.py:my_flow
    schedules:
      - cron: 0 0 13 * 5
        timezone: UTC
        active: true
        day_or: false  # Run on 13th of month AND Friday (not OR)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>