### PR TITLE
clarify that `prefect server services ls` shows configuration, not runtime state

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -719,12 +719,17 @@ def run_manager_process():
 # public, user-facing `prefect server services` commands
 @services_app.command(aliases=["ls"])
 def list_services():
-    """List all available services and their status."""
+    """
+    List all available services and their configuration status.
+
+    This shows which services are configured to be enabled via environment variables.
+    Services will not run if the server was started with --no-services or --workers > 1.
+    """
     from prefect.server.services.base import Service
 
     table = Table(title="Available Services", expand=True)
     table.add_column("Name", no_wrap=True)
-    table.add_column("Enabled?", no_wrap=True)
+    table.add_column("Configured?", no_wrap=True)
     table.add_column("Description", style="cyan", no_wrap=False)
 
     for svc in Service.all_services():
@@ -740,6 +745,11 @@ def list_services():
         table.add_row(name, setting_text, description)
 
     app.console.print(table)
+    app.console.print(
+        "\n[dim]Note: This shows configuration via environment variables. "
+        "Services will not run if the server\n"
+        "      was started with --no-services or --workers > 1.[/dim]"
+    )
 
 
 @services_app.command(aliases=["start"])


### PR DESCRIPTION
## context

when users run `prefect server start --no-services` and then check `prefect server services ls`, the output shows services as "enabled" even though they're not actually running. this is confusing.

the issue is that `services ls` shows which services are **configured** to be enabled via environment variables, not which services are **actually running**.

reported by a user in slack - he was seeing all services listed as enabled even with `--no-services`.

## changes

- column header: "Enabled?" → "Configured?" 
- help text: clarified this shows environment variable configuration
- footer note: explicitly states services won't run with `--no-services` or `--workers > 1`

## before

```
Available Services                               
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┓
┃ Name                   ┃ Enabled?                                           ┃┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇┩
│ CancellationCleanup    │ ✓ PREFECT_SERVER_SERVICES_CANCELLATION_CLEANUP_EN… ││
│ Scheduler              │ ✓ PREFECT_SERVER_SERVICES_SCHEDULER_ENABLED        ││
...
```

## after

```
Available Services                               
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┓
┃ Name                   ┃ Configured?                                        ┃┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇┩
│ CancellationCleanup    │ ✓ PREFECT_SERVER_SERVICES_CANCELLATION_CLEANUP_EN… ││
│ Scheduler              │ ✓ PREFECT_SERVER_SERVICES_SCHEDULER_ENABLED        ││
...

Note: This shows configuration via environment variables. Services will not run 
if the server was started with --no-services or --workers > 1.
```

## related

- #18753 (background services scalability)
- #18820 (pr that fixed --no-services to actually not run services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)