### PR TITLE
use canonical websocket_connect import in proxy test script

### DIFF
--- a/scripts/proxy-test/client.py
+++ b/scripts/proxy-test/client.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 
-from prefect.events.clients import websocket_connect
+from prefect._internal.websockets import websocket_connect
 
 PROXY_URL = "http://localhost:3128"
 WS_SERVER_URL = "ws://server:8000/ws"


### PR DESCRIPTION
follow-up to #19159 which consolidated websocket utilities.

## issue

the proxy test script at `scripts/proxy-test/client.py` was importing `websocket_connect` from `prefect.events.clients`:

```python
from prefect.events.clients import websocket_connect
```

this only worked because `events.clients` happened to import and re-export it from `prefect._internal.websockets`. this is a circumstantial re-export, not an intentional public api.

## changes

update the import to use the canonical location:

```python
from prefect._internal.websockets import websocket_connect
```

## related

- #19159 (consolidated websocket utilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)