### PR TITLE
Fix duplicate env vars from work pools in Kubernetes jobs

### DIFF
--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -2340,6 +2340,46 @@ class TestKubernetesWorker:
             env_names = {variable["name"] for variable in env}
             assert "PREFECT_TEST_MODE" not in env_names
 
+    async def test_env_vars_from_work_pool_not_duplicated(
+        self,
+        flow_run,
+        mock_core_client,
+        mock_watch,
+        mock_pods_stream_that_returns_running_pod,
+        mock_batch_client,
+    ):
+        """Test that environment variables set in work pool are not duplicated.
+
+        Regression test for https://github.com/PrefectHQ/prefect/issues/19167
+        """
+        mock_watch.return_value.stream = mock_pods_stream_that_returns_running_pod
+
+        # Create configuration with env vars set as work pool variables
+        # (this is what happens when you set env vars in the work pool UI)
+        configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
+            KubernetesWorker.get_default_base_job_template(),
+            {"env": [{"name": "TEST_VALUE", "value": "1"}]},
+        )
+        configuration.prepare_for_flow_run(flow_run)
+
+        async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+            await k8s_worker.run(flow_run, configuration)
+            mock_batch_client.return_value.create_namespaced_job.assert_called_once()
+
+            manifest = mock_batch_client.return_value.create_namespaced_job.call_args[
+                0
+            ][1]
+            pod = manifest["spec"]["template"]["spec"]
+            env = pod["containers"][0]["env"]
+
+            # Count how many times TEST_VALUE appears
+            test_value_entries = [e for e in env if e.get("name") == "TEST_VALUE"]
+            assert len(test_value_entries) == 1, (
+                f"Expected TEST_VALUE to appear once, but it appeared "
+                f"{len(test_value_entries)} times: {test_value_entries}"
+            )
+            assert test_value_entries[0]["value"] == "1"
+
     @pytest.mark.parametrize(
         "given,expected",
         [


### PR DESCRIPTION
closes #19167

this PR fixes an issue where environment variables set in kubernetes work pools were being duplicated in the final job manifest.

<details>
<summary>details</summary>

## problem

when environment variables are set in a kubernetes work pool, they appear twice in the created job manifest. this happens because `_populate_env_in_manifest()` in the kubernetes worker doesn't distinguish between:
- env vars that came from template rendering (which are duplicates of work pool vars)
- env vars that were manually hard-coded in the template (which should be preserved)

the method would prepend all vars from `self.env` and then append all vars from `template_env`, causing duplicates when both contained the same variables.

## solution

modified `_populate_env_in_manifest()` to:
1. get the names of all env vars in `transformed_env` (vars to add)
2. filter out any env vars from `template_env` that have matching names
3. only keep user-hardcoded vars from the template that don't conflict

this preserves the original behavior of allowing users to hard-code env vars in their templates while preventing duplicates from work pool variables.

## testing

- added regression test `test_env_vars_from_work_pool_not_duplicated`
- verified existing test `test_uses_custom_env_list_from_base_template` still passes
- all 81 tests in `test_worker.py` pass

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)