### PR TITLE
Fix completed flows being marked as Crashed on lease renewal failure

### DIFF
--- a/src/prefect/concurrency/_leases.py
+++ b/src/prefect/concurrency/_leases.py
@@ -1,8 +1,11 @@
 import asyncio
 import concurrent.futures
+from collections.abc import Callable
 from contextlib import asynccontextmanager, contextmanager
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator, Generator, Optional
 from uuid import UUID
+
+from httpx import HTTPStatusError
 
 from prefect._internal.concurrency.api import create_call
 from prefect._internal.concurrency.cancellation import (
@@ -17,6 +20,7 @@ from prefect.logging.loggers import get_logger, get_run_logger
 async def _lease_renewal_loop(
     lease_id: UUID,
     lease_duration: float,
+    should_raise_on_missing_lease: Optional[Callable[[], bool]] = None,
 ) -> None:
     """
     Maintain a concurrency lease by renewing it after the given interval.
@@ -24,12 +28,37 @@ async def _lease_renewal_loop(
     Args:
         lease_id: The ID of the lease to maintain.
         lease_duration: The duration of the lease in seconds.
+        should_raise_on_missing_lease: Optional callable that returns whether to raise
+            an exception if lease renewal fails with a 404. If None or returns True,
+            the exception will be raised. If returns False, the loop exits gracefully.
     """
     async with get_client() as client:
         while True:
-            await client.renew_concurrency_lease(
-                lease_id=lease_id, lease_duration=lease_duration
-            )
+            try:
+                await client.renew_concurrency_lease(
+                    lease_id=lease_id, lease_duration=lease_duration
+                )
+            except HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    # Lease not found - check if we should raise
+                    if (
+                        should_raise_on_missing_lease is None
+                        or should_raise_on_missing_lease()
+                    ):
+                        # Lease was revoked unexpectedly, raise the error
+                        raise
+                    else:
+                        # Lease cleanup is expected (e.g., flow run completed), exit gracefully
+                        logger = get_logger("concurrency.leases")
+                        logger.debug(
+                            f"Lease {lease_id} not found during renewal. "
+                            "This is expected when the flow run has completed."
+                        )
+                        return
+                else:
+                    # Re-raise all other HTTP errors
+                    raise
+
             await asyncio.sleep(  # Renew the lease 3/4 of the way through the lease duration
                 lease_duration * 0.75
             )
@@ -40,6 +69,7 @@ def maintain_concurrency_lease(
     lease_id: UUID,
     lease_duration: float,
     raise_on_lease_renewal_failure: bool = False,
+    should_raise_on_missing_lease: Optional[Callable[[], bool]] = None,
 ) -> Generator[None, None, None]:
     """
     Maintain a concurrency lease for the given lease ID.
@@ -48,6 +78,9 @@ def maintain_concurrency_lease(
         lease_id: The ID of the lease to maintain.
         lease_duration: The duration of the lease in seconds.
         raise_on_lease_renewal_failure: A boolean specifying whether to raise an error if the lease renewal fails.
+        should_raise_on_missing_lease: Optional callable that returns whether to raise
+            an exception if lease renewal fails with a 404. If None or returns True,
+            the exception will be raised. If returns False, the loop exits gracefully.
     """
     # Start a loop to renew the lease on the global event loop to avoid blocking the main thread
     global_loop = get_global_loop()
@@ -55,6 +88,7 @@ def maintain_concurrency_lease(
         _lease_renewal_loop,
         lease_id,
         lease_duration,
+        should_raise_on_missing_lease,
     )
     global_loop.submit(lease_renewal_call)
 
@@ -94,6 +128,7 @@ async def amaintain_concurrency_lease(
     lease_id: UUID,
     lease_duration: float,
     raise_on_lease_renewal_failure: bool = False,
+    should_raise_on_missing_lease: Optional[Callable[[], bool]] = None,
 ) -> AsyncGenerator[None, None]:
     """
     Maintain a concurrency lease for the given lease ID.
@@ -102,9 +137,12 @@ async def amaintain_concurrency_lease(
         lease_id: The ID of the lease to maintain.
         lease_duration: The duration of the lease in seconds.
         raise_on_lease_renewal_failure: A boolean specifying whether to raise an error if the lease renewal fails.
+        should_raise_on_missing_lease: Optional callable that returns whether to raise
+            an exception if lease renewal fails with a 404. If None or returns True,
+            the exception will be raised. If returns False, the loop exits gracefully.
     """
     lease_renewal_task = asyncio.create_task(
-        _lease_renewal_loop(lease_id, lease_duration)
+        _lease_renewal_loop(lease_id, lease_duration, should_raise_on_missing_lease)
     )
     with AsyncCancelScope() as cancel_scope:
 

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -631,7 +631,10 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             if lease_id := self.state.state_details.deployment_concurrency_lease_id:
                 stack.enter_context(
                     maintain_concurrency_lease(
-                        lease_id, 300, raise_on_lease_renewal_failure=True
+                        lease_id,
+                        300,
+                        raise_on_lease_renewal_failure=True,
+                        should_raise_on_missing_lease=lambda: not self.flow_run.state.is_final(),
                     )
                 )
 
@@ -1201,7 +1204,10 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             if lease_id := self.state.state_details.deployment_concurrency_lease_id:
                 await stack.enter_async_context(
                     amaintain_concurrency_lease(
-                        lease_id, 300, raise_on_lease_renewal_failure=True
+                        lease_id,
+                        300,
+                        raise_on_lease_renewal_failure=True,
+                        should_raise_on_missing_lease=lambda: not self.flow_run.state.is_final(),
                     )
                 )
 


### PR DESCRIPTION
Closes #18942

This PR fixes a race condition where completed flow runs with deployment concurrency were incorrectly marked as Crashed when the server cleaned up their lease before the background renewal loop stopped.

<details>
<summary>Changes</summary>

- Added conditional 404 handling in lease renewal loop
- Only raise on missing lease if flow is still running  
- Exit gracefully if flow has completed (expected cleanup)

</details>