### PR TITLE
Avoid transitioning flow run to crashed when user code has already finished successfully

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -731,9 +731,16 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     # Do not capture generator exits as crashes
                     raise
                 except BaseException as exc:
-                    # BaseExceptions are caught and handled as crashes
-                    self.handle_crash(exc)
-                    raise
+                    # We don't want to crash a flow run if the user code finished executing
+                    if self.flow_run.state and not self.flow_run.state.is_final():
+                        # BaseExceptions are caught and handled as crashes
+                        self.handle_crash(exc)
+                        raise
+                    else:
+                        self.logger.debug(
+                            "BaseException was raised after user code finished executing",
+                            exc_info=exc,
+                        )
                 finally:
                     # If debugging, use the more complete `repr` than the usual `str` description
                     display_state = (
@@ -1305,9 +1312,16 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     # Do not capture generator exits as crashes
                     raise
                 except BaseException as exc:
-                    # BaseExceptions are caught and handled as crashes
-                    await self.handle_crash(exc)
-                    raise
+                    # We don't want to crash a flow run if the user code finished executing
+                    if self.flow_run.state and not self.flow_run.state.is_final():
+                        # BaseExceptions are caught and handled as crashes
+                        await self.handle_crash(exc)
+                        raise
+                    else:
+                        self.logger.debug(
+                            "BaseException was raised after user code finished executing",
+                            exc_info=exc,
+                        )
                 finally:
                     # If debugging, use the more complete `repr` than the usual `str` description
                     display_state = (

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -1000,6 +1000,139 @@ class TestFlowCrashDetection:
         with pytest.raises(CrashedRun, match="Execution was aborted"):
             await flow_run.state.result()
 
+    async def test_base_exception_after_user_code_finishes_does_not_crash_sync(
+        self, prefect_client, monkeypatch, caplog
+    ):
+        """
+        Test that a BaseException raised after user code finishes executing
+        does not crash the flow run (sync flow).
+        """
+
+        @flow
+        def my_flow():
+            return 42
+
+        # Mock the flow run engine to raise a BaseException after handle_success
+        original_handle_success = FlowRunEngine.handle_success
+
+        def handle_success_with_exception(self, result):
+            original_handle_success(self, result)
+            # At this point the flow run state is final (Completed)
+            raise BaseException("Post-execution error")
+
+        monkeypatch.setattr(
+            FlowRunEngine, "handle_success", handle_success_with_exception
+        )
+
+        # The flow should complete successfully and return the result
+        result = my_flow()
+        assert result == 42
+
+        flow_runs = await prefect_client.read_flow_runs()
+        assert len(flow_runs) == 1
+        flow_run = flow_runs[0]
+        # The flow run should be completed, not crashed
+        assert flow_run.state.is_completed()
+        assert not flow_run.state.is_crashed()
+        # Verify the debug log message was recorded
+        assert (
+            "BaseException was raised after user code finished executing" in caplog.text
+        )
+
+    async def test_base_exception_after_user_code_finishes_does_not_crash_async(
+        self, prefect_client, monkeypatch, caplog
+    ):
+        """
+        Test that a BaseException raised after user code finishes executing
+        does not crash the flow run (async flow).
+        """
+
+        @flow
+        async def my_flow():
+            return 42
+
+        # Mock the flow run engine to raise a BaseException after handle_success
+        original_handle_success = AsyncFlowRunEngine.handle_success
+
+        async def handle_success_with_exception(self, result):
+            await original_handle_success(self, result)
+            # At this point the flow run state is final (Completed)
+            raise BaseException("Post-execution error")
+
+        monkeypatch.setattr(
+            AsyncFlowRunEngine, "handle_success", handle_success_with_exception
+        )
+
+        # The flow should complete successfully and return the result
+        result = await my_flow()
+        assert result == 42
+
+        flow_runs = await prefect_client.read_flow_runs()
+        assert len(flow_runs) == 1
+        flow_run = flow_runs[0]
+        # The flow run should be completed, not crashed
+        assert flow_run.state.is_completed()
+        assert not flow_run.state.is_crashed()
+        # Verify the debug log message was recorded
+        assert (
+            "BaseException was raised after user code finished executing" in caplog.text
+        )
+
+    async def test_base_exception_before_user_code_finishes_crashes_sync(
+        self, prefect_client, monkeypatch
+    ):
+        """
+        Test that a BaseException raised before user code finishes executing
+        still crashes the flow run (sync flow).
+        """
+
+        @flow
+        def my_flow():
+            return 42
+
+        # Mock the flow run engine to raise a BaseException during begin_run
+        monkeypatch.setattr(
+            FlowRunEngine,
+            "begin_run",
+            MagicMock(side_effect=BaseException("Pre-execution error")),
+        )
+
+        with pytest.raises(BaseException, match="Pre-execution error"):
+            my_flow()
+
+        flow_runs = await prefect_client.read_flow_runs()
+        assert len(flow_runs) == 1
+        flow_run = flow_runs[0]
+        # The flow run should be crashed
+        assert flow_run.state.is_crashed()
+
+    async def test_base_exception_before_user_code_finishes_crashes_async(
+        self, prefect_client, monkeypatch
+    ):
+        """
+        Test that a BaseException raised before user code finishes executing
+        still crashes the flow run (async flow).
+        """
+
+        @flow
+        async def my_flow():
+            return 42
+
+        # Mock the flow run engine to raise a BaseException during begin_run
+        async def begin_run_with_exception(self):
+            raise BaseException("Pre-execution error")
+
+        monkeypatch.setattr(AsyncFlowRunEngine, "begin_run", begin_run_with_exception)
+
+        with pytest.raises(BaseException, match="Pre-execution error"):
+            await my_flow()
+
+        flow_runs = await prefect_client.read_flow_runs()
+        assert len(flow_runs) == 1
+        flow_run = flow_runs[0]
+        # The flow run should be crashed
+        assert flow_run.state.is_crashed()
+
 
 class TestPauseFlowRun:
     async def test_tasks_cannot_be_paused(self):


### PR DESCRIPTION
Closes #18942 

Because the lease renewal loop is stopped after a flow run is transitioned to `COMPLETED`, it's possible that a deployment concurrency lease is gone for the final lease renewal. This will cancel execution and cause the flow run to be transitioned to `CRASHED`.

We don't want to crash flow runs when the user code has already run successfully, so this PR checks to see if the flow run is in a final state and doesn't transition to crashed if it is already in a final state.