### PR TITLE
docs: clarify `build_docker_image` accepts all docker sdk kwargs

### DIFF
--- a/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
+++ b/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
@@ -171,6 +171,29 @@ In the build step example above, you relied on the `prefect-docker` package; in 
 additional required packages are auto-installed for you.
 </Note>
 
+<Tip>
+**Passing Docker build arguments**
+
+The `build_docker_image` step accepts any keyword arguments supported by the Docker Python SDK's [`build` method](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.build). This allows you to customize the Docker build process beyond the explicitly documented parameters.
+
+Common examples:
+
+```yaml
+build:
+  - prefect_docker.deployments.steps.build_docker_image:
+      image_name: my-repo/my-image
+      tag: my-tag
+      dockerfile: auto
+      nocache: true           # Disable Docker layer caching (--no-cache)
+      pull: true              # Always pull the latest base image
+      platform: linux/amd64   # Specify target platform
+      buildargs:              # Pass build-time variables
+        MY_ARG: value
+```
+
+Note: `ignore_cache` is a separate parameter that controls **Prefect's step-level caching** (whether to reuse the entire build step result across `prefect deploy --all` runs), not Docker's layer caching.
+</Tip>
+
 **Pass output to downstream steps**
 
 Each deployment action can be composed of multiple steps. For example, to build a Docker image tagged with the


### PR DESCRIPTION
closes #19193

this PR adds documentation clarifying that `build_docker_image` accepts all docker python sdk `build()` kwargs via `**build_kwargs`, addressing confusion between `ignore_cache` (prefect step caching) and `nocache` (docker layer caching).

<details>
<summary>background</summary>

user confusion from slack:
- user asked how to disable docker layer caching
- marvin suggested `ignore_cache=True` (incorrect - this only controls prefect step caching)
- correct answer is `nocache=True` (passed through to docker sdk)

the `build_docker_image` docstring mentions `**build_kwargs` briefly with a link to docker-py docs, but this wasn't obvious to users. adding a tip with concrete examples should prevent this confusion.

</details>

## changes

- added a `<Tip>` block after the existing note about prefect integrations in `docs/v3/how-to-guides/deployments/prefect-yaml.mdx`
- shows common examples: `nocache`, `pull`, `platform`, `buildargs`
- explicitly clarifies the `ignore_cache` vs `nocache` distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)