### PR TITLE
Fix date-dependent test flake in WorkPoolDetails

### DIFF
--- a/ui-v2/src/components/work-pools/work-pool-details/work-pool-details.test.tsx
+++ b/ui-v2/src/components/work-pools/work-pool-details/work-pool-details.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { buildApiUrl } from "@tests/utils/handlers";
+import { subYears } from "date-fns";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -8,14 +9,17 @@ import type { WorkPool } from "@/api/work-pools";
 import { createFakeWorkPoolWorker } from "@/mocks";
 import { WorkPoolDetails } from "./work-pool-details";
 
+// Create a date that's exactly 1.5 years ago to ensure it formats as "over 1 year ago"
+const overOneYearAgo = subYears(new Date(), 1.5).toISOString();
+
 const mockWorkers = [
 	createFakeWorkPoolWorker({
 		name: "worker-1",
-		last_heartbeat_time: "2024-01-15T14:30:00Z",
+		last_heartbeat_time: overOneYearAgo,
 	}),
 	createFakeWorkPoolWorker({
 		name: "worker-2",
-		last_heartbeat_time: "2024-01-15T14:00:00Z",
+		last_heartbeat_time: overOneYearAgo,
 	}),
 ];
 
@@ -26,8 +30,8 @@ const mockWorkPool: WorkPool = {
 	type: "docker",
 	status: "READY",
 	concurrency_limit: 10,
-	created: "2024-01-15T10:00:00Z",
-	updated: "2024-01-15T12:00:00Z",
+	created: overOneYearAgo,
+	updated: overOneYearAgo,
 	is_paused: false,
 	base_job_template: {
 		job_configuration: {


### PR DESCRIPTION
## Summary

fixes test flake in the ui-v2 work pool details test that was caused by date-dependent mock data

## Details

<details>
<summary>Test Failure Context</summary>

The test was using static mock dates from January 2024. As time passed, these dates eventually became almost 2 years old, causing date-fns's `formatDistanceToNow` to change the format from "over 1 year ago" to other values, breaking the test assertion.

</details>

<details>
<summary>Fix Approach</summary>

Instead of using static dates, the fix generates mock dates dynamically using date-fns's `subYears` to create dates that are exactly 1.5 years ago:

```ts
const overOneYearAgo = subYears(new Date(), 1.5).toISOString();
```

This ensures dates will consistently format as "over 1 year ago" regardless of when the test runs, while keeping the original test assertion intact.

</details>

Related: https://github.com/PrefectHQ/prefect/actions/runs/18570005120/job/52941134124

🤖 Generated with [Claude Code](https://claude.com/claude-code)