### PR TITLE
Fix non-deterministic test flake in PREFECT_EXPERIMENTS_PLUGINS_ALLOW tests

### DIFF
--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -268,7 +268,7 @@ def _to_environment_variable_value(
     value: list[object] | set[object] | tuple[object] | Any,
 ) -> str:
     if isinstance(value, (list, set, tuple)):
-        return ",".join(str(v) for v in value)
+        return ",".join(str(v) for v in sorted(value, key=str))
     if isinstance(value, dict):
         return json.dumps(value)
     return str(value)


### PR DESCRIPTION
## Summary

This PR fixes a test flake in `test_set_via_prefect_toml_file` and `test_set_via_pyproject_toml_file` for the `PREFECT_EXPERIMENTS_PLUGINS_ALLOW` setting.

## Details

<details>
<summary>Click to expand</summary>

### Root Cause

The `PREFECT_EXPERIMENTS_PLUGINS_ALLOW` setting is defined as a `set[str]` type. When converting settings to environment variables, the `_to_environment_variable_value()` function was joining set elements without sorting:

```python
return ",".join(str(v) for v in value)
```

Since Python sets have no guaranteed iteration order, this produced non-deterministic output like `"plugin1,plugin2"` or `"plugin2,plugin1"`, causing random test failures.

### The Fix

Modified `_to_environment_variable_value()` in `src/prefect/settings/base.py` to sort collection values before joining:

```python
return ",".join(str(v) for v in sorted(value, key=str))
```

This ensures deterministic output for all collection types (sets, lists, tuples).

### Testing

- Both previously failing tests now pass consistently
- Ran the tests 5 times each - all passed
- Ran entire `TestSettingValues` class (1412 tests) - all passed

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)