### PR TITLE
Kubernetes: allow opt-out of rescheduling on SIGTERM by setting PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR

### DIFF
--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -2195,6 +2195,40 @@ class TestKubernetesWorker:
                 }.items()
             ]
 
+    async def test_does_not_overwrite_sigterm_behavior_env(
+        self,
+        flow_run,
+        mock_core_client,
+        mock_watch,
+        mock_pods_stream_that_returns_running_pod,
+        mock_batch_client,
+    ):
+        mock_watch.return_value.stream = mock_pods_stream_that_returns_running_pod
+
+        configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
+            KubernetesWorker.get_default_base_job_template(),
+            {"env": {"PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR": "die"}},
+        )
+        configuration.prepare_for_flow_run(flow_run)
+
+        async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+            await k8s_worker.run(flow_run, configuration)
+            mock_batch_client.return_value.create_namespaced_job.assert_called_once()
+
+            manifest = mock_batch_client.return_value.create_namespaced_job.call_args[
+                0
+            ][1]
+            pod = manifest["spec"]["template"]["spec"]
+            env = pod["containers"][0]["env"]
+            assert env == [
+                {"name": key, "value": value}
+                for key, value in {
+                    **configuration._base_environment(),
+                    **configuration._base_flow_run_environment(flow_run),
+                    "PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR": "die",
+                }.items()
+            ]
+
     async def test_uses_custom_env_list_from_base_template(
         self,
         flow_run,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

closes https://github.com/PrefectHQ/prefect/issues/18867.

Gist of the problem is that currently there is no way to opt-out of rescheduling a flow run on SIGTERM. Either:
  - `backoffLimit > 0` in which case the K8s retries the job
  -  `backoffLimit = 0` in which case Prefect forces reschedule behaviour on SIGTERM via setting `PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR=reschedule`

In our case, we have workflows that we want to reschedule with human in the loop when killed due to eviction. That is because processes triggered downstream currently cannot be cancelled and multiple runs of those processes cause all sorts of problems.

The way I've tried to address the problem is by not forcing `PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR=reschedule` when that var is already set in env.

My perspective of Prefect codebase is very limited at this point so I'd appreciate any guidance on this one.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
