### PR TITLE
fix gitlab credentials for self-hosted instances and deploy tokens

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -184,7 +184,11 @@ class GitRepository:
             elif isinstance(v, SecretStr):
                 credentials[k] = v.get_secret_value()
 
-        return _format_token_from_credentials(urlparse(self._url).netloc, credentials)
+        # Pass the original Block (if it is one) so we can detect its type
+        block = self._credentials if isinstance(self._credentials, Block) else None
+        return _format_token_from_credentials(
+            urlparse(self._url).netloc, credentials, block
+        )
 
     def _add_credentials_to_url(self, url: str) -> str:
         """Add credentials to given url if possible."""
@@ -814,10 +818,17 @@ def create_storage_from_source(
 
 
 def _format_token_from_credentials(
-    netloc: str, credentials: dict[str, Any] | GitCredentials
+    netloc: str,
+    credentials: dict[str, Any] | GitCredentials,
+    block: Block | None = None,
 ) -> str:
     """
     Formats the credentials block for the git provider.
+
+    Args:
+        netloc: The network location (hostname) of the git repository
+        credentials: Dictionary containing credential information
+        block: Optional Block object to determine credential type
 
     BitBucket supports the following syntax:
         git clone "https://x-token-auth:{token}@bitbucket.org/yourRepoOwnerHere/RepoNameHere"
@@ -841,6 +852,26 @@ def _format_token_from_credentials(
 
     if username:
         return f"{username}:{user_provided_token}"
+
+    # Check if this is a GitLab credentials block by inspecting the block type
+    # This handles self-hosted GitLab instances that don't have "gitlab" in the hostname
+    if block is not None:
+        block_type_slug = getattr(block, "get_block_type_slug", lambda: None)()
+        if block_type_slug == "gitlab-credentials":
+            # If token already contains ":", it's likely a deploy token in username:token format
+            # Deploy tokens should not have oauth2: prefix (GitLab 16.3.4+ rejects them)
+            # See: https://github.com/PrefectHQ/prefect/issues/10832
+            if ":" in user_provided_token and not user_provided_token.startswith(
+                "oauth2:"
+            ):
+                return user_provided_token
+
+            # For personal access tokens, add oauth2: prefix
+            return (
+                f"oauth2:{user_provided_token}"
+                if not user_provided_token.startswith("oauth2:")
+                else user_provided_token
+            )
 
     if "bitbucketserver" in netloc:
         # If they pass a BitBucketCredentials block and we don't have both a username and at


### PR DESCRIPTION
closes #16836
closes #10832

## summary

this PR fixes two related issues with GitLab credential formatting in `GitRepository`:

1. **self-hosted gitlab support**: GitLabCredentials blocks now work with self-hosted GitLab instances that don't have "gitlab" in the hostname (e.g., `git.company.com`, `code.company.com`)
2. **deploy token support**: deploy tokens in `username:token` format are no longer incorrectly prefixed with `oauth2:`, which was causing authentication failures in GitLab 16.3.4+

## technical approach

the fix changes from URL pattern matching to block type detection:

- uses `get_block_type_slug()` to identify GitLabCredentials blocks
- for GitLabCredentials blocks:
  - deploy tokens (containing `:`) are used as-is without `oauth2:` prefix
  - personal access tokens get `oauth2:` prefix added
  - works regardless of hostname pattern

## changes

<details>
<summary>src/prefect/runner/storage.py</summary>

- modified `_formatted_credentials` property to pass Block object to formatting function
- updated `_format_token_from_credentials` to accept optional `block` parameter
- added block type detection logic for gitlab-credentials
- added deploy token detection (checks for `:` in token)
</details>

<details>
<summary>tests/runner/test_storage.py</summary>

added three comprehensive regression tests:
- `test_git_clone_with_gitlab_credentials_block_self_hosted` - verifies self-hosted GitLab works (issue #16836)
- `test_git_clone_with_gitlab_credentials_block_deploy_token` - verifies deploy tokens aren't prefixed (issue #10832)
- `test_git_clone_with_gitlab_credentials_block_already_prefixed` - verifies no double-prefixing
</details>

## test results

all 93 tests in `tests/runner/test_storage.py` pass, including the three new regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)