### PR TITLE
Add community integrations section to docs

### DIFF
--- a/docs/integrations/integrations.mdx
+++ b/docs/integrations/integrations.mdx
@@ -5,6 +5,10 @@ description: Prefect integrations are PyPI packages you can install to help you 
 mode: "wide"
 ---
 
+## Official Integrations
+
+These integrations are officially maintained and supported by Prefect:
+
 <CardGroup cols={4}  className="text-center">
 
     <Card title="AWS">
@@ -23,12 +27,6 @@ mode: "wide"
         <a href="/integrations/prefect-bitbucket"> <img src="/images/integrations/bitbucket.png" noZoom alt="prefect-bitbucket"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
-    </Card>
-
-    <Card title="Coiled">
-        <a href="https://docs.coiled.io/user_guide/prefect.html?utm_source=prefect-docs&utm_medium=integrations"> <img src="/images/integrations/coiled.png" noZoom alt="coiled"/>
-        </a>
-        Maintained by <a href="https://www.coiled.io/"> Coiled </a>
     </Card>
 
     <Card title="Dask">
@@ -59,12 +57,6 @@ mode: "wide"
         <a href="/integrations/prefect-email"> <img src="/images/integrations/email.png" noZoom alt="prefect-email"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
-    </Card>
-
-    <Card title="Fivetran">
-        <a href="https://fivetran.github.io/prefect-fivetran/"> <img src="/images/integrations/fivetran.png" noZoom alt="prefect-fivetran"/>
-        </a>
-        Maintained by <a href="https://www.fivetran.com/"> Fivetran </a>
     </Card>
 
     <Card title="GCP">
@@ -119,6 +111,32 @@ mode: "wide"
         <a href="/integrations/prefect-sqlalchemy"> <img src="/images/integrations/sqlalchemy.png" noZoom alt="prefect-sqlalchemy"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
+    </Card>
+
+</CardGroup>
+
+## Community Integrations
+
+These integrations are contributed and maintained by the Prefect community.
+
+<CardGroup cols={4}  className="text-center">
+
+    <Card title="Coiled">
+        <a href="https://docs.coiled.io/user_guide/prefect.html?utm_source=prefect-docs&utm_medium=integrations"> <img src="/images/integrations/coiled.png" noZoom alt="coiled"/>
+        </a>
+        Maintained by <a href="https://www.coiled.io/"> Coiled </a>
+    </Card>
+
+    <Card title="Fivetran">
+        <a href="https://fivetran.github.io/prefect-fivetran/"> <img src="/images/integrations/fivetran.png" noZoom alt="prefect-fivetran"/>
+        </a>
+        Maintained by <a href="https://www.fivetran.com/"> Fivetran </a>
+    </Card>
+
+    <Card title="Vault">
+        <a href="https://github.com/pbchekin/prefect-vault"> <img src="/images/integrations/vault.png" noZoom alt="prefect-vault"/>
+        </a>
+        Maintained by <a href="https://github.com/pbchekin"> @pbchekin </a>
     </Card>
 
 </CardGroup>


### PR DESCRIPTION
closes #19225

this PR adds a community integrations section to the integrations page, separating official Prefect-maintained integrations from community-contributed ones.

<details>
<summary>changes</summary>

- split integrations page into two sections: official and community
- moved Coiled and Fivetran to community section
- added prefect-vault as a community integration

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)