### PR TITLE
Refactor git credential formatting to fix leaky abstraction

### DIFF
--- a/src/integrations/prefect-bitbucket/tests/test_credentials.py
+++ b/src/integrations/prefect-bitbucket/tests/test_credentials.py
@@ -60,26 +60,26 @@ def test_bitbucket_username_with_email_passes():
 
 
 def test_format_git_credentials_cloud():
-    """Test that BitBucket Cloud credentials get x-token-auth: prefix."""
+    """Test that BitBucket Cloud credentials get x-token-auth: prefix and are embedded in URL."""
     credentials = BitBucketCredentials(token="my-token")
     result = credentials.format_git_credentials("https://bitbucket.org/org/repo.git")
-    assert result == "x-token-auth:my-token"
+    assert result == "https://x-token-auth:my-token@bitbucket.org/org/repo.git"
 
 
 def test_format_git_credentials_cloud_already_prefixed():
-    """Test that already-prefixed tokens are used as-is."""
+    """Test that already-prefixed tokens are used as-is in URL."""
     credentials = BitBucketCredentials(token="x-token-auth:my-token")
     result = credentials.format_git_credentials("https://bitbucket.org/org/repo.git")
-    assert result == "x-token-auth:my-token"
+    assert result == "https://x-token-auth:my-token@bitbucket.org/org/repo.git"
 
 
 def test_format_git_credentials_server():
-    """Test that BitBucket Server credentials use username:token format."""
+    """Test that BitBucket Server credentials use username:token format in URL."""
     credentials = BitBucketCredentials(token="my-token", username="myuser")
     result = credentials.format_git_credentials(
         "https://bitbucketserver.com/scm/project/repo.git"
     )
-    assert result == "myuser:my-token"
+    assert result == "https://myuser:my-token@bitbucketserver.com/scm/project/repo.git"
 
 
 def test_format_git_credentials_server_no_username_raises():

--- a/src/integrations/prefect-github/tests/test_credentials.py
+++ b/src/integrations/prefect-github/tests/test_credentials.py
@@ -12,10 +12,10 @@ def test_github_credentials_get_client(token):
 
 
 def test_format_git_credentials():
-    """Test that GitHub credentials return plain token format."""
+    """Test that GitHub credentials return URL with token embedded."""
     credentials = GitHubCredentials(token="my-github-token")
     result = credentials.format_git_credentials("https://github.com/org/repo.git")
-    assert result == "my-github-token"
+    assert result == "https://my-github-token@github.com/org/repo.git"
 
 
 def test_format_git_credentials_no_token_raises():

--- a/src/integrations/prefect-gitlab/tests/test_credentials.py
+++ b/src/integrations/prefect-gitlab/tests/test_credentials.py
@@ -19,24 +19,24 @@ def test_gitlab_credentials_get_client(monkeypatch):
 
 
 def test_format_git_credentials_personal_access_token():
-    """Test that personal access tokens get oauth2: prefix."""
+    """Test that personal access tokens get oauth2: prefix and are embedded in URL."""
     credentials = GitLabCredentials(token="my-personal-token")
     result = credentials.format_git_credentials("https://gitlab.com/org/repo.git")
-    assert result == "oauth2:my-personal-token"
+    assert result == "https://oauth2:my-personal-token@gitlab.com/org/repo.git"
 
 
 def test_format_git_credentials_deploy_token():
-    """Test that deploy tokens (username:token format) are used as-is."""
+    """Test that deploy tokens (username:token format) are used as-is in URL."""
     credentials = GitLabCredentials(token="deploy-user:deploy-token-value")
     result = credentials.format_git_credentials("https://gitlab.com/org/repo.git")
-    assert result == "deploy-user:deploy-token-value"
+    assert result == "https://deploy-user:deploy-token-value@gitlab.com/org/repo.git"
 
 
 def test_format_git_credentials_already_prefixed():
-    """Test that already-prefixed tokens don't get double-prefixed."""
+    """Test that already-prefixed tokens don't get double-prefixed in URL."""
     credentials = GitLabCredentials(token="oauth2:my-token")
     result = credentials.format_git_credentials("https://gitlab.com/org/repo.git")
-    assert result == "oauth2:my-token"
+    assert result == "https://oauth2:my-token@gitlab.com/org/repo.git"
 
 
 def test_format_git_credentials_no_token_raises():


### PR DESCRIPTION
## Summary

Addresses a leaky abstraction where core `GitRepository` contains provider-specific credential formatting logic for GitLab, GitHub, and BitBucket. This refactor moves the formatting logic to the respective integration libraries using a protocol-based approach.

<details>
<summary>Background</summary>

After merging #19227 (GitLab credentials fix), a comment highlighted the core issue:

> i agree, i think the formatting should happen in the respective libraries

The problem: `GitRepository` in core Prefect has hardcoded logic for each git provider's authentication format quirks (oauth2: for GitLab, x-token-auth: for BitBucket, etc.). This violates separation of concerns and makes adding new providers require changes to core.
</details>

## Changes

### Core (`src/prefect/runner/storage.py`)
- Added `_GitCredentialsFormatter` protocol (private) with `@runtime_checkable`
- Updated `_format_token_from_credentials()` to check protocol first, then fall back to legacy logic
- Legacy logic preserved for backward compatibility with blocks that don't implement the protocol

### Integrations
Each integration now implements `format_git_credentials()` method:

- **prefect-gitlab**: Handles PAT (oauth2: prefix) vs deploy tokens (username:token)
- **prefect-github**: Plain token format (no prefix)
- **prefect-bitbucket**: Cloud (x-token-auth:) vs Server (username:token)

### Tests
- Core: Updated `MockGitLabCredentials` + 2 protocol detection tests
- Integration tests: 11 new tests across all three libraries

## Design

Uses `@runtime_checkable` Protocol pattern already established in Prefect (e.g., `RunnerStorage`):
- Protocol is private (`_GitCredentialsFormatter`) - not part of public API
- Protocol implementation is opt-in via duck typing (no inheritance required)
- Blocks implementing protocol use new path
- Blocks without protocol use legacy path (backward compatible)
- No breaking changes to existing deployments

## Test Results

All tests pass:
- ✅ 95 storage tests
- ✅ 5 gitlab tests
- ✅ 4 github tests
- ✅ 16 bitbucket tests

## Benefits

1. **Separation of Concerns**: Integrations own their auth logic
2. **Extensibility**: New git providers just implement the protocol
3. **Maintainability**: Changes localized to integration packages
4. **No Breaking Changes**: Fully backward compatible

Related: #10832, #16836