### PR TITLE
Fix work pool env vars being overwritten by variable defaults

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -180,10 +180,15 @@ class BaseJobConfiguration(BaseModel):
             variables_schema.get("properties", {})
         )
 
-        # copy variable defaults for `env` to base config before they're replaced by
+        # merge variable defaults for `env` into base config before they're replaced by
         # deployment overrides
         if variables.get("env"):
-            base_config["env"] = variables.get("env")
+            if isinstance(base_config.get("env"), dict):
+                # Merge: preserve env vars from job_configuration
+                base_config["env"] = base_config["env"] | variables.get("env")
+            else:
+                # Replace template with defaults
+                base_config["env"] = variables.get("env")
 
         variables.update(values)
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1976,6 +1976,82 @@ async def test_env_merge_logic_is_deep(
         assert config.env[key] == value
 
 
+async def test_work_pool_env_from_job_configuration_merges_with_variable_defaults(
+    prefect_client, session, flow, work_pool
+):
+    """
+    Test for issue #19256: Work pool env vars should merge from both job_configuration
+    and variable defaults, then merge with deployment env vars.
+
+    When a work pool has env vars in BOTH job_configuration.env AND
+    variables.properties.env.default, they should all be merged together along with
+    deployment env vars.
+    """
+    # Configure work pool with env vars in BOTH places
+    base_job_template = {
+        "job_configuration": {
+            "env": {
+                "WORK_POOL_BASE_VAR": "from-job-config",  # Should NOT be lost
+            }
+        },
+        "variables": {
+            "properties": {
+                "env": {
+                    "type": "object",
+                    "default": {"WORK_POOL_DEFAULT_VAR": "from-variable-defaults"},
+                }
+            }
+        },
+    }
+
+    await models.workers.update_work_pool(
+        session=session,
+        work_pool_id=work_pool.id,
+        work_pool=ServerWorkPoolUpdate(
+            base_job_template=base_job_template,
+            description="test",
+            is_paused=False,
+            concurrency_limit=None,
+        ),
+    )
+    await session.commit()
+
+    # Create deployment with its own env vars
+    deployment = await models.deployments.create_deployment(
+        session=session,
+        deployment=Deployment(
+            name="env-testing-merge",
+            tags=["test"],
+            flow_id=flow.id,
+            path="./subdir",
+            entrypoint="/file.py:flow",
+            parameter_openapi_schema={"type": "object", "properties": {}},
+            job_variables={"env": {"DEPLOYMENT_VAR": "from-deployment"}},
+            work_queue_id=work_pool.default_queue_id,
+        ),
+    )
+    await session.commit()
+
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        deployment.id,
+        state=Pending(),
+    )
+
+    async with WorkerTestImpl(
+        name="test",
+        work_pool_name=work_pool.name,
+    ) as worker:
+        await worker.sync_with_backend()
+        config = await worker._get_configuration(
+            flow_run, schemas.responses.DeploymentResponse.model_validate(deployment)
+        )
+
+    # All env vars should be present: job_configuration + variable defaults + deployment
+    assert config.env["WORK_POOL_BASE_VAR"] == "from-job-config"
+    assert config.env["WORK_POOL_DEFAULT_VAR"] == "from-variable-defaults"
+    assert config.env["DEPLOYMENT_VAR"] == "from-deployment"
+
+
 class TestBaseWorkerHeartbeat:
     async def test_worker_heartbeat_sends_integrations(
         self, work_pool, hosted_api_server


### PR DESCRIPTION
closes #19256

This PR fixes work pool environment variables from `job_configuration` being overwritten (not merged) when variable defaults exist, which caused work pool env vars to be lost when deployments had their own env vars.

<details>
<summary>Details</summary>

## Problem
When a work pool had environment variables in both:
1. `job_configuration.env` (base env vars)
2. `variables.properties.env.default` (variable defaults)

The env vars from `job_configuration` were being **overwritten** instead of **merged** with the variable defaults. This caused work pool env vars to disappear when deployments also provided env vars.

## Root Cause
In `BaseJobConfiguration.from_template_and_values()` at line 186:
```python
if variables.get("env"):
    base_config["env"] = variables.get("env")  # ❌ overwrites!
```

## The Fix
Changed to merge instead of replace:
```python
if variables.get("env"):
    if isinstance(base_config.get("env"), dict):
        # Merge: preserve env vars from job_configuration
        base_config["env"] = base_config["env"] | variables.get("env")
    else:
        # Replace template with defaults
        base_config["env"] = variables.get("env")
```

Now env vars from all sources are properly merged:
- Work pool `job_configuration.env` (base)
- Work pool `variables.properties.env.default` (defaults)
- Deployment `job_variables.env` (overrides)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)