### PR TITLE
Configure `kopf` to use its own JSON formatter when Prefect uses JSON logging

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/_logging.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/_logging.py
@@ -1,0 +1,56 @@
+import logging
+from typing import Any, Optional
+
+from pythonjsonlogger.core import RESERVED_ATTRS
+from pythonjsonlogger.json import JsonFormatter
+
+DEFAULT_JSON_REFKEY = "object"
+
+
+class KopfObjectJsonFormatter(JsonFormatter):
+    """
+    Log formatter for kopf objects.
+
+    This formatter will filter unserializable fields from the log record,
+    which the `prefect` JSON formatter is unable to do.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        refkey: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        # Avoid type checking, as the args are not in the parent constructor.
+        reserved_attrs = kwargs.pop("reserved_attrs", RESERVED_ATTRS)
+        reserved_attrs = set(reserved_attrs)
+        reserved_attrs |= {"k8s_skip", "k8s_ref", "settings"}
+        kwargs |= dict(reserved_attrs=reserved_attrs)
+        kwargs.setdefault("timestamp", True)
+        super().__init__(*args, **kwargs)
+        self._refkey: str = refkey or DEFAULT_JSON_REFKEY
+
+    def add_fields(
+        self,
+        log_record: dict[str, object],
+        record: logging.LogRecord,
+        message_dict: dict[str, object],
+    ) -> None:
+        super().add_fields(log_record, record, message_dict)
+
+        if self._refkey and hasattr(record, "k8s_ref"):
+            ref = getattr(record, "k8s_ref")
+            log_record[self._refkey] = ref
+
+        if "severity" not in log_record:
+            log_record["severity"] = (
+                "debug"
+                if record.levelno <= logging.DEBUG
+                else "info"
+                if record.levelno <= logging.INFO
+                else "warn"
+                if record.levelno <= logging.WARNING
+                else "error"
+                if record.levelno <= logging.ERROR
+                else "fatal"
+            )

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "exceptiongroup",
     "pyopenssl>=24.1.0",
     "kopf>=1.37.4",
+    "python-json-logger>=3.3.0",
 ]
 name = "prefect-kubernetes"
 description = "Prefect integrations for interacting with Kubernetes."

--- a/src/integrations/prefect-kubernetes/tests/test_logging.py
+++ b/src/integrations/prefect-kubernetes/tests/test_logging.py
@@ -1,0 +1,224 @@
+import json
+import logging
+from typing import Any
+
+from prefect_kubernetes._logging import KopfObjectJsonFormatter
+
+
+class TestKopfObjectJsonFormatter:
+    """Tests for the KopfObjectJsonFormatter"""
+
+    def test_filters_unserializable_kopf_fields(self):
+        """
+        Test that kopf-specific fields (k8s_skip, k8s_ref, settings) are
+        filtered out from the log record.
+        """
+        formatter = KopfObjectJsonFormatter()
+
+        # Create a log record with kopf-specific fields
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Add kopf-specific attributes that should be filtered
+        record.k8s_skip = True  # type: ignore
+        record.k8s_ref = {"kind": "Pod", "name": "test-pod"}  # type: ignore
+        record.settings = {"some": "settings"}  # type: ignore
+
+        # Format the record
+        formatted = formatter.format(record)
+        log_dict = json.loads(formatted)
+
+        # Verify kopf fields are NOT in the output
+        assert "k8s_skip" not in log_dict, "k8s_skip should be filtered out"
+        assert "settings" not in log_dict, "settings should be filtered out"
+
+    def test_adds_severity_field(self):
+        """Test that the formatter adds a severity field with correct values"""
+        formatter = KopfObjectJsonFormatter()
+
+        # Test different log levels
+        test_cases = [
+            (logging.DEBUG, "debug"),
+            (logging.INFO, "info"),
+            (logging.WARNING, "warn"),
+            (logging.ERROR, "error"),
+            (logging.CRITICAL, "fatal"),
+        ]
+
+        for level, expected_severity in test_cases:
+            record = logging.LogRecord(
+                name="kopf.test",
+                level=level,
+                pathname="test.py",
+                lineno=1,
+                msg=f"Test message at {logging.getLevelName(level)}",
+                args=(),
+                exc_info=None,
+            )
+
+            formatted = formatter.format(record)
+            log_dict = json.loads(formatted)
+
+            assert "severity" in log_dict, (
+                f"severity field should be present for {logging.getLevelName(level)}"
+            )
+            assert log_dict["severity"] == expected_severity, (
+                f"Expected severity '{expected_severity}' for {logging.getLevelName(level)}, "
+                f"got '{log_dict['severity']}'"
+            )
+
+    def test_adds_kubernetes_object_reference(self):
+        """Test that k8s_ref is added to the output under the 'object' key"""
+        formatter = KopfObjectJsonFormatter()
+
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Add k8s_ref attribute
+        k8s_ref: dict[str, Any] = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "name": "test-pod",
+            "uid": "12345",
+            "namespace": "default",
+        }
+        record.k8s_ref = k8s_ref  # type: ignore
+
+        formatted = formatter.format(record)
+        log_dict = json.loads(formatted)
+
+        # Verify the object field contains the k8s_ref
+        assert "object" in log_dict, (
+            "object field should be present when k8s_ref is set"
+        )
+        assert log_dict["object"] == k8s_ref, "object field should contain the k8s_ref"
+
+    def test_custom_refkey(self):
+        """Test that a custom refkey can be used instead of 'object'"""
+        formatter = KopfObjectJsonFormatter(refkey="k8s_resource")
+
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        k8s_ref = {"kind": "Pod", "name": "test-pod"}
+        record.k8s_ref = k8s_ref  # type: ignore
+
+        formatted = formatter.format(record)
+        log_dict = json.loads(formatted)
+
+        # Verify custom refkey is used
+        assert "k8s_resource" in log_dict, "Custom refkey should be present"
+        assert log_dict["k8s_resource"] == k8s_ref
+
+    def test_json_output_is_valid(self):
+        """Test that the formatter produces valid JSON"""
+        formatter = KopfObjectJsonFormatter()
+
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        formatted = formatter.format(record)
+
+        # Should not raise a JSONDecodeError
+        log_dict = json.loads(formatted)
+
+        # Verify expected fields are present
+        assert "message" in log_dict, "message field should be present"
+        assert "severity" in log_dict, "severity field should be present"
+        assert log_dict["message"] == "Test message"
+
+    def test_timestamp_is_included(self):
+        """Test that timestamp is included in the output"""
+        formatter = KopfObjectJsonFormatter()
+
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        formatted = formatter.format(record)
+        log_dict = json.loads(formatted)
+
+        # The formatter should include a timestamp
+        assert "timestamp" in log_dict, "timestamp field should be present"
+
+    def test_log_with_extra_fields(self):
+        """Test that extra fields are included in the output"""
+        formatter = KopfObjectJsonFormatter()
+
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Add extra custom field
+        record.custom_field = "custom_value"  # type: ignore
+
+        formatted = formatter.format(record)
+        log_dict = json.loads(formatted)
+
+        # Custom field should be present
+        assert "custom_field" in log_dict
+        assert log_dict["custom_field"] == "custom_value"
+
+    def test_no_k8s_ref_attribute(self):
+        """Test that formatter works correctly when k8s_ref is not present"""
+        formatter = KopfObjectJsonFormatter()
+
+        record = logging.LogRecord(
+            name="kopf.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Don't set k8s_ref
+        formatted = formatter.format(record)
+        log_dict = json.loads(formatted)
+
+        # Should work fine, just without the object field
+        assert "message" in log_dict
+        assert "severity" in log_dict
+        # object field should not be present if k8s_ref is not set
+        assert "object" not in log_dict or log_dict["object"] is None

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -1,9 +1,12 @@
+import logging
 import uuid
 from contextlib import asynccontextmanager
+from io import StringIO
 from time import sleep
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from prefect_kubernetes._logging import KopfObjectJsonFormatter
 from prefect_kubernetes.observer import (
     _replicate_pod_event,
     start_observer,
@@ -270,3 +273,201 @@ class TestStartAndStopObserver:
         start_observer()
         sleep(1)
         stop_observer()
+
+
+class TestLoggingConfiguration:
+    """Tests for the logging configuration logic in start_observer()"""
+
+    @pytest.mark.usefixtures("mock_events_client", "mock_orchestration_client")
+    def test_json_formatter_configures_kopf_logger(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """
+        Test that when Prefect uses JSON formatting, kopf logger gets its own
+        handler with KopfObjectJsonFormatter and propagation is disabled.
+        """
+        # Stop any existing observer first
+        stop_observer()
+
+        # Set up Prefect to use JSON formatting
+        monkeypatch.setenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER", "json")
+
+        # Import and setup logging fresh to pick up env var
+        from prefect.logging.configuration import PROCESS_LOGGING_CONFIG, setup_logging
+
+        PROCESS_LOGGING_CONFIG.clear()
+        setup_logging(incremental=False)
+
+        # Clear any existing kopf logger configuration
+        kopf_logger = logging.getLogger("kopf")
+        kopf_logger.handlers.clear()
+        kopf_logger.propagate = True
+
+        # Start the observer which should configure kopf logging
+        try:
+            start_observer()
+            sleep(0.5)  # Give it time to configure
+
+            # Verify kopf logger has its own handler
+            assert len(kopf_logger.handlers) > 0, "kopf logger should have a handler"
+
+            # Verify the handler has the correct formatter
+            handler = kopf_logger.handlers[0]
+            assert isinstance(handler.formatter, KopfObjectJsonFormatter), (
+                f"Expected KopfObjectJsonFormatter, got {type(handler.formatter)}"
+            )
+
+            # Verify propagation is disabled
+            assert kopf_logger.propagate is False, (
+                "kopf logger propagation should be disabled"
+            )
+        finally:
+            stop_observer()
+            monkeypatch.delenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER")
+
+    @pytest.mark.usefixtures("mock_events_client", "mock_orchestration_client")
+    def test_standard_formatter_uses_default_behavior(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """
+        Test that when Prefect uses standard formatting (default),
+        kopf logger uses default propagation behavior.
+        """
+        # Stop any existing observer first
+        stop_observer()
+
+        # Use default logging configuration (standard formatter)
+        from prefect.logging.configuration import PROCESS_LOGGING_CONFIG, setup_logging
+
+        PROCESS_LOGGING_CONFIG.clear()
+        setup_logging(incremental=False)
+
+        # Clear any existing kopf logger configuration
+        kopf_logger = logging.getLogger("kopf")
+        kopf_logger.handlers.clear()
+        kopf_logger.propagate = True
+
+        # Start the observer
+        try:
+            start_observer()
+            sleep(0.5)
+
+            # Verify kopf logger doesn't have a dedicated handler added by start_observer
+            # (it should propagate to root logger since we're using standard formatting)
+            assert len(kopf_logger.handlers) == 0, (
+                "kopf logger should not have handlers with standard formatting"
+            )
+
+            # Verify propagation is still enabled (default behavior)
+            assert kopf_logger.propagate is True, (
+                "kopf logger propagation should remain enabled with standard formatting"
+            )
+        finally:
+            stop_observer()
+
+    @pytest.mark.usefixtures("mock_events_client", "mock_orchestration_client")
+    def test_no_duplicate_logs_with_json_formatting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """
+        Test that kopf logs don't appear duplicated when JSON formatting is enabled.
+        """
+        # Stop any existing observer first
+        stop_observer()
+
+        # Set up JSON formatting
+        monkeypatch.setenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER", "json")
+
+        from prefect.logging.configuration import PROCESS_LOGGING_CONFIG, setup_logging
+
+        PROCESS_LOGGING_CONFIG.clear()
+        setup_logging(incremental=False)
+
+        # Clear kopf logger
+        kopf_logger = logging.getLogger("kopf.test")
+        kopf_logger.handlers.clear()
+        kopf_logger.propagate = True
+
+        try:
+            start_observer()
+            sleep(0.5)
+
+            # Create a custom handler to capture logs
+            # (caplog won't work since propagation is disabled)
+            captured_logs: list[logging.LogRecord] = []
+
+            class CaptureHandler(logging.Handler):
+                def emit(self, record: logging.LogRecord):
+                    captured_logs.append(record)
+
+            capture_handler = CaptureHandler()
+            kopf_logger.addHandler(capture_handler)
+
+            # Emit a test message
+            kopf_logger.warning("Test message for duplicate check")
+
+            # Count how many times the message appears
+            matching_records = [
+                r
+                for r in captured_logs
+                if "Test message for duplicate check" in r.message
+            ]
+
+            assert len(matching_records) == 1, (
+                f"Expected 1 log message, got {len(matching_records)}"
+            )
+        finally:
+            stop_observer()
+            monkeypatch.delenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER")
+
+    @pytest.mark.usefixtures("mock_events_client", "mock_orchestration_client")
+    def test_kopf_logs_visible_with_json_formatting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """
+        Test that kopf logs are actually emitted and visible when JSON formatting is enabled.
+        """
+        # Stop any existing observer first
+        stop_observer()
+
+        # Set up JSON formatting
+        monkeypatch.setenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER", "json")
+
+        from prefect.logging.configuration import PROCESS_LOGGING_CONFIG, setup_logging
+
+        PROCESS_LOGGING_CONFIG.clear()
+        setup_logging(incremental=False)
+
+        # Clear kopf logger
+        kopf_logger = logging.getLogger("kopf.test")
+        kopf_logger.handlers.clear()
+        kopf_logger.propagate = True
+
+        try:
+            start_observer()
+            sleep(0.5)
+
+            # Create a string buffer to capture output
+            log_capture = StringIO()
+            test_handler = logging.StreamHandler(log_capture)
+            test_handler.setFormatter(KopfObjectJsonFormatter())
+            kopf_logger.addHandler(test_handler)
+
+            # Emit a test log message
+            kopf_logger.warning("Test message for visibility check")
+
+            # Get the captured output
+            log_output = log_capture.getvalue()
+
+            # Verify the message was emitted
+            assert "Test message for visibility check" in log_output, (
+                "kopf log message should be visible in output"
+            )
+
+            # Verify it's JSON formatted
+            assert '"message"' in log_output or '"msg"' in log_output, (
+                "Log output should be JSON formatted"
+            )
+        finally:
+            stop_observer()
+            monkeypatch.delenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER")


### PR DESCRIPTION
## Summary

When the Prefect console handler is configured to use JSON formatting, `kopf` logs previously encountered serialization errors because Prefect's `JsonFormatter` cannot serialize `kopf`'s internal objects (`ThreadPoolExecutor`, etc.).

This PR detects when JSON formatting is enabled and configures the `kopf` logger to use its own `KopfObjectJsonFormatter` instead, while disabling propagation to prevent duplicates and serialization errors.

## Changes

- **Add `KopfObjectJsonFormatter`**: A custom JSON formatter based on `pythonjsonlogger` that:
  - Filters `kopf`-specific fields (`k8s_skip`, `k8s_ref`, `settings`)
  - Adds `severity` field with standard values
  - Adds kubernetes object references to log output
  - Handles timestamp formatting

- **Modify `start_observer()`**: Detects when Prefect is using JSON formatting and:
  - Creates a dedicated `StreamHandler` for the kopf logger
  - Configures it with `KopfObjectJsonFormatter`
  - Disables propagation to prevent logs from reaching Prefect's handler

Closes https://github.com/PrefectHQ/prefect/issues/19263

🤖 Generated with [Claude Code](https://claude.com/claude-code)