### PR TITLE
update typer minimum to 0.16.0 for click 8.2+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pytz>=2021.1,<2026",
     "readchar>=4.0.0,<5.0.0",
     "sqlalchemy[asyncio]>=2.0,<3.0.0",
-    "typer>=0.12.0,!=0.12.2,<0.20.0",
+    "typer>=0.16.0,<0.20.0",
     # Client dependencies
     # If you modify this list, make the same modification in client/pyproject.toml
     "anyio>=4.4.0,<5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -4055,7 +4055,7 @@ requires-dist = [
     { name = "sniffio", specifier = ">=1.3.0,<2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0,<3.0.0" },
     { name = "toml", specifier = ">=0.10.0" },
-    { name = "typer", specifier = ">=0.12.0,!=0.12.2,<0.20.0" },
+    { name = "typer", specifier = ">=0.16.0,<0.20.0" },
     { name = "typing-extensions", specifier = ">=4.10.0,<5.0.0" },
     { name = "uv", specifier = ">=0.6.0" },
     { name = "uvicorn", specifier = ">=0.14.0,!=0.29.0" },


### PR DESCRIPTION
closes #19259

this PR updates the typer minimum from `>=0.12.0` to `>=0.16.0` to prevent dependency solvers from picking incompatible combinations with click 8.2+.

<details>
<summary>details</summary>

## background

while fixing the conda-forge feedstock for prefect 3.4.24, we discovered that the conda solver was picking typer 0.12.5 (the minimum allowed by our constraint), which fails with click 8.3.0:

```
TypeError: Secondary flag is not valid for non-boolean flag.
```

our Docker builds work fine because uv.lock pins to exactly typer 0.16.0.

## testing

tested with fresh environments and prefect 3.4.24:
- typer 0.12.5 + click 8.3.0: ✗ fails with TypeError
- typer 0.15.0 + click 8.3.0: ✗ fails (different error)
- typer 0.16.0 + click 8.3.0: ✓ works

## changes

- updated typer constraint from `>=0.12.0,!=0.12.2,<0.20.0` to `>=0.16.0,<0.20.0`
- removed `!=0.12.2` exclusion (now redundant)
- updated uv.lock

</details>

related conda-forge feedstock PR: https://github.com/conda-forge/prefect-feedstock/pull/410