### PR TITLE
chore(cicd): Update Dockerhub token for `prefect-aws` image builds

### DIFF
--- a/.github/workflows/prefect-aws-docker-images.yaml
+++ b/.github/workflows/prefect-aws-docker-images.yaml
@@ -26,7 +26,6 @@ jobs:
   build-and-push:
     name: Build and push prefect-aws Docker images
     runs-on: ubuntu-latest
-    environment: prod
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Relates to PLA-2154

Depends on https://github.com/PrefectHQ/platform/pull/9295