### PR TITLE
create db vacuum service to periodically delete old prefect resources

### DIFF
--- a/src/prefect/server/database/sql/postgres/delete-old-artifacts.sql.jinja
+++ b/src/prefect/server/database/sql/postgres/delete-old-artifacts.sql.jinja
@@ -1,0 +1,22 @@
+-- Deletes artifacts in batch that have no associated flow runs with them - meaning their associated flow runs have been deleted.
+--
+-- The query attempts to make this deletion efficient by:
+-- - utilizing a FOR UPDATE SKIP LOCKED for concurrent worker safety
+-- - DELETE...USING for efficient JOIN (faster than WHERE IN)
+--
+-- Parameters:
+--   :limit  - Maximum number of artifacts to delete
+
+WITH doomed_artifacts AS (
+    SELECT artifact.id as id
+    FROM artifact
+    LEFT OUTER JOIN flow_run ON artifact.flow_run_id = flow_run.id
+    WHERE flow_run.id IS NULL
+    ORDER BY artifact.flow_run_id, artifact.created ASC
+    LIMIT :limit
+    FOR UPDATE SKIP LOCKED
+)
+DELETE FROM artifact
+USING doomed_artifacts
+WHERE artifact.id = doomed_artifacts.id
+RETURNING COUNT(*)

--- a/src/prefect/server/database/sql/postgres/delete-old-flow-runs.sql.jinja
+++ b/src/prefect/server/database/sql/postgres/delete-old-flow-runs.sql.jinja
@@ -1,0 +1,42 @@
+-- Deletes old flow runs before the cutoff date.
+--
+-- Because flow runs cascade delete child task runs, the idea is to limit the amount of tasks deleted by this query.
+-- If the query limited the amount of flow runs deleted, this could potentially delete an unbounded amount of task runs.
+-- Therefore, the query joins flow runs to their children tasks, sorts by the flow run id, and takes children task runs
+-- up to the limit, and only then takes the distinct flow run ids for deletion. For example, a limit of 1000 may only
+-- delete 500 flow runs if there are 2 children task runs per flow run, but it will delete 1000 task runs for a total
+-- of 1500 records.
+--
+-- Features:
+-- - CTE with FOR UPDATE SKIP LOCKED for concurrent worker safety
+-- - DELETE...USING for efficient JOIN (faster than WHERE IN)
+-- - Returns deleted flow run count and cascade deleted task run count
+--
+-- Parameters:
+--   :before - Delete flow runs before this timestamp
+--   :limit - Maximum number of flow runs to delete in this batch
+
+WITH doomed_flow_runs AS (
+    SELECT flow_run.id AS flow_run_id, task_run.id AS task_run_id
+    FROM flow_run
+    LEFT JOIN task_run ON task_run.flow_run_id = flow_run.id
+    WHERE flow_run.created < :before AND flow_run.parent_task_run_id IS NULL
+    ORDER BY flow_run.id
+    FOR UPDATE SKIP LOCKED LIMIT :limit
+), flow_run_ids AS (
+    SELECT DISTINCT flow_run_id AS id
+    FROM doomed_flow_runs
+), doomed_task_runs AS (
+    SELECT id
+    FROM task_run
+    USING flow_run_ids AS flow_run
+    WHERE task_run.flow_run_id = flow_run.id
+), deleted_flow_runs AS (
+    DELETE FROM flow_run
+    USING flow_run_ids AS doomed_flow_run
+    WHERE flow_run.id = doomed_flow_run.id
+    RETURNING flow_run.id
+)
+SELECT
+    (COUNT(*) FROM deleted_flow_runs) AS flow_run_count,
+    (COUNT(*) FROM doomed_task_runs) AS task_run_count

--- a/src/prefect/server/database/sql/postgres/delete-old-logs.sql.jinja
+++ b/src/prefect/server/database/sql/postgres/delete-old-logs.sql.jinja
@@ -1,0 +1,22 @@
+-- Deletes logs in batch that have no associated flow runs with them - meaning their associated flow runs have been deleted.
+--
+-- The query attempts to make this deletion efficient by:
+-- - utilizing a FOR UPDATE SKIP LOCKED for concurrent worker safety
+-- - DELETE...USING for efficient JOIN (faster than WHERE IN)
+--
+-- Parameters:
+--   :limit  - Maximum number of logs to delete
+
+WITH doomed_logs AS (
+    SELECT logs.id as id
+    FROM logs
+    LEFT OUTER JOIN flow_run ON logs.flow_run_id = flow_run.id
+    WHERE flow_run.id IS NULL
+    LIMIT :limit
+    ORDER BY logs.flow_run_id, created ASC
+    FOR UPDATE SKIP LOCKED
+),
+DELETE FROM logs
+USING doomed_logs
+WHERE logs.id = doomed_logs.id
+RETURNING COUNT(*)

--- a/src/prefect/server/database/sql/sqlite/delete-old-artifacts.sql.jinja
+++ b/src/prefect/server/database/sql/sqlite/delete-old-artifacts.sql.jinja
@@ -1,0 +1,21 @@
+-- Deletes artifacts in batch that have no associated flow runs with them - meaning their associated flow runs have been deleted.
+--
+-- SQLite version - has some limitations compared to PostgreSQL:
+-- - No DELETE...USING (uses WHERE IN with subquery instead)
+-- - No FOR UPDATE SKIP LOCKED (not needed for SQLite's locking model)
+-- - RETURNING is supported in SQLite 3.35+
+--
+-- Parameters:
+--   :limit  - Maximum number of artifacts to delete
+
+WITH doomed_artifacts AS (
+    SELECT artifact.id as id
+    FROM artifact
+    LEFT OUTER JOIN flow_run ON artifact.flow_run_id = flow_run.id
+    WHERE flow_run.id IS NULL
+    ORDER BY artifact.flow_run_id, artifact.created ASC
+    LIMIT :limit
+)
+DELETE FROM artifact
+WHERE id IN (SELECT id FROM doomed_artifacts)
+RETURNING (SELECT COUNT(*) FROM doomed_artifacts)

--- a/src/prefect/server/database/sql/sqlite/delete-old-flow-runs.sql.jinja
+++ b/src/prefect/server/database/sql/sqlite/delete-old-flow-runs.sql.jinja
@@ -1,0 +1,41 @@
+-- Deletes old flow runs before the cutoff date (SQLite version)
+--
+-- Because flow runs cascade delete child task runs, the idea is to limit the amount of tasks deleted by this query.
+-- If the query limited the amount of flow runs deleted, this could potentially delete an unbounded amount of task runs.
+-- Therefore, the query joins flow runs to their children tasks, sorts by the flow run id, and takes children task runs
+-- up to the limit, and only then takes the distinct flow run ids for deletion. For example, a limit of 1000 may only
+-- delete 500 flow runs if there are 2 children task runs per flow run, but it will delete 1000 task runs for a total
+-- of 1500 records.
+--
+-- SQLite limitations:
+-- - No DELETE...USING (use WHERE IN with subquery instead)
+-- - No FOR UPDATE SKIP LOCKED (not needed for SQLite's locking model)
+-- - RETURNING is supported in SQLite 3.35+
+-- - Returns deleted flow run count and cascade deleted task run count
+--
+-- Parameters:
+--   :before - Delete flow runs before this timestamp
+--   :limit - Maximum number of flow runs to delete in this batch
+
+WITH doomed_flow_runs AS (
+    SELECT flow_run.id AS flow_run_id, task_run.id AS task_run_id
+    FROM flow_run
+    LEFT JOIN task_run ON task_run.flow_run_id = flow_run.id
+    WHERE flow_run.created < :before AND flow_run.parent_task_run_id IS NULL
+    ORDER BY flow_run.id
+    LIMIT :limit
+), flow_run_ids AS (
+    SELECT DISTINCT flow_run_id AS id
+    FROM doomed_flow_runs
+), doomed_task_runs AS (
+    SELECT task_run.id
+    FROM task_run
+    WHERE task_run.flow_run_id IN (SELECT id FROM flow_run_ids)
+), counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM flow_run_ids) AS flow_run_count,
+        (SELECT COUNT(*) FROM doomed_task_runs) AS task_run_count
+)
+DELETE FROM flow_run
+WHERE id IN (SELECT id FROM flow_run_ids)
+RETURNING (SELECT flow_run_count FROM counts) AS flow_run_count, (SELECT task_run_count FROM counts) AS task_run_count

--- a/src/prefect/server/database/sql/sqlite/delete-old-logs.sql.jinja
+++ b/src/prefect/server/database/sql/sqlite/delete-old-logs.sql.jinja
@@ -1,0 +1,21 @@
+-- Deletes logs in batch that have no associated flow runs with them - meaning their associated flow runs have been deleted.
+--
+-- SQLite version - has some limitations compared to PostgreSQL:
+-- - No DELETE...USING (uses WHERE IN with subquery instead)
+-- - No FOR UPDATE SKIP LOCKED (not needed for SQLite's locking model)
+-- - RETURNING is supported in SQLite 3.35+
+--
+-- Parameters:
+--   :limit  - Maximum number of logs to delete
+
+WITH doomed_logs AS (
+    SELECT log.id as id
+    FROM log
+    LEFT OUTER JOIN flow_run ON log.flow_run_id = flow_run.id
+    WHERE flow_run.id IS NULL
+    ORDER BY log.flow_run_id, log.created ASC
+    LIMIT :limit
+)
+DELETE FROM log
+WHERE id IN (SELECT id FROM doomed_logs)
+RETURNING (SELECT COUNT(*) FROM doomed_logs)

--- a/src/prefect/server/services/__init__.py
+++ b/src/prefect/server/services/__init__.py
@@ -1,4 +1,5 @@
 import prefect.server.services.cancellation_cleanup
+import prefect.server.services.db_vacuum
 import prefect.server.services.foreman
 import prefect.server.services.late_runs
 import prefect.server.services.pause_expirations

--- a/src/prefect/server/services/base.py
+++ b/src/prefect/server/services/base.py
@@ -39,6 +39,7 @@ def _known_service_modules() -> list[ModuleType]:
     from prefect.server.logs import stream as logs_stream
     from prefect.server.services import (
         cancellation_cleanup,
+        db_vacuum,
         foreman,
         late_runs,
         pause_expirations,
@@ -51,6 +52,7 @@ def _known_service_modules() -> list[ModuleType]:
     return [
         # Orchestration services
         cancellation_cleanup,
+        db_vacuum,
         foreman,
         late_runs,
         pause_expirations,

--- a/src/prefect/server/services/db_vacuum.py
+++ b/src/prefect/server/services/db_vacuum.py
@@ -1,0 +1,143 @@
+"""
+The DBVacuum service. Responsible for deleting old Prefect resources past their retention period.
+
+The retention period can be configured by changing `PREFECT_API_SERVICES_DB_VACUUM_RETENTION_DAYS`.
+Resources are deleted in batches to avoid long-running transactions and table locks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from prefect.server.database import PrefectDBInterface, inject_db
+from prefect.server.database.dependencies import db_injector
+from prefect.server.services.base import LoopService
+from prefect.settings.context import get_current_settings
+from prefect.settings.models.server.services import (
+    ServerServicesDBVacuumSettings,
+    ServicesBaseSetting,
+)
+from prefect.types._datetime import now
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class DBVacuum(LoopService):
+    """
+    Deletes Prefect resources from the database older than the configured retention period.
+
+    The resources deleted are:
+    - flow runs
+    - task runs
+    - logs
+    - artifacts
+    """
+
+    @classmethod
+    def service_settings(cls) -> ServicesBaseSetting:
+        return cls.settings()
+
+    @classmethod
+    def settings(cls) -> ServerServicesDBVacuumSettings:
+        return get_current_settings().server.services.db_vacuum
+
+    def __init__(
+        self,
+        loop_seconds: float | None = None,
+        **kwargs: Any,
+    ):
+        """
+        Args:
+            loop_seconds: How often to run the cleanup (default: 3600 = 1 hour)
+            retention_days: Delete runs older than this many days (default: 90)
+            batch_size: Number of runs to delete per transaction (default: 500)
+        """
+        super().__init__(
+            loop_seconds=loop_seconds or DBVacuum.settings().loop_seconds,
+            **kwargs,
+        )
+
+    @inject_db
+    async def delete_logs(
+        self,
+        db: PrefectDBInterface,
+        session: AsyncSession,
+    ) -> int:
+        keep_going = True
+        total_count = 0
+        while keep_going:
+            deleted_logs = await db.queries.delete_old_logs(
+                session=session, limit=DBVacuum.settings().batch_size
+            )
+            total_count += deleted_logs
+            keep_going = deleted_logs > 0
+
+        return total_count
+
+    @inject_db
+    async def delete_artifacts(
+        self,
+        db: PrefectDBInterface,
+        session: AsyncSession,
+    ) -> int:
+        keep_going = True
+        total_count = 0
+        while keep_going:
+            deleted_artifacts = await db.queries.delete_old_artifacts(
+                session=session, limit=DBVacuum.settings().batch_size
+            )
+            total_count += deleted_artifacts
+            keep_going = deleted_artifacts > 0
+
+        return total_count
+
+    @inject_db
+    async def delete_flow_runs(
+        self,
+        db: PrefectDBInterface,
+        session: AsyncSession,
+        before: datetime.datetime,
+    ) -> tuple[int, int]:
+        return await db.queries.delete_old_flow_runs(
+            session=session, before=before, limit=DBVacuum.settings().batch_size
+        )
+
+    @db_injector
+    async def run_once(self, db: PrefectDBInterface) -> None:
+        """
+        Delete old Prefect resources from the database older than the configured retention period.
+        """
+        cutoff_time = now("UTC") - timedelta(days=DBVacuum.settings().retention_days)
+
+        self.logger.info(
+            f"Running DB Vacuum: deleting Prefect resources older than {DBVacuum.settings().retention_days} days (before {cutoff_time.isoformat()})."
+        )
+
+        async with db.session_context(begin_transaction=False) as session:
+            # The deletion is performed as follows. First, all top level flow runs (parent_task_id=null) are deleted.
+            # This will cascade delete child tasks (and thus orphaning any sub-flows).
+            # Secondly, all associated logs are deleted, which will no longer have an associated flow run.
+            # Finally, all associated artifacts are deleted, which will no longer have an associated flow run.
+            # Subsequent runs will delete the now task-less flow runs, thus eventually deleting all nested flow runs
+            # and tasks of a flow run.
+            deleted_flow_runs, deleted_task_runs = await self.delete_flow_runs(
+                db=db, session=session, before=cutoff_time
+            )
+            deleted_logs = await self.delete_logs(db=db, session=session)
+            deleted_artifacts = await self.delete_artifacts(db=db, session=session)
+
+        self.logger.info(
+            f"Finished running DB Vacuum: deleted {deleted_flow_runs} flow runs, {deleted_task_runs} task runs, {deleted_logs} logs, {deleted_artifacts} artifacts."
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(
+        DBVacuum(
+            handle_signals=True,
+        ).start()
+    )

--- a/src/prefect/settings/models/server/services.py
+++ b/src/prefect/settings/models/server/services.py
@@ -44,6 +44,56 @@ class ServerServicesCancellationCleanupSettings(ServicesBaseSetting):
     )
 
 
+class ServerServicesDBVacuumSettings(ServicesBaseSetting):
+    """
+    Settings for controlling the DB Vacuum service
+    """
+
+    model_config: ClassVar[SettingsConfigDict] = build_settings_config(
+        ("server", "services", "db_vacuum")
+    )
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether or not to start the DB Vacuum service in the server application.",
+        validation_alias=AliasChoices(
+            AliasPath("enabled"),
+            "prefect_server_services_db_vacuum_enabled",
+            "prefect_api_services_db_vacuum_enabled",
+        ),
+    )
+
+    loop_seconds: float = Field(
+        default=300,
+        description="The DB Vacuum service will delete old Prefect resources this often. Defaults to `300`.",
+        validation_alias=AliasChoices(
+            AliasPath("loop_seconds"),
+            "prefect_server_services_db_vacuum_loop_seconds",
+            "prefect_api_services_db_vacuum_loop_seconds",
+        ),
+    )
+
+    retention_days: float = Field(
+        default=90,
+        description="How many days Prefect resources will be retained for before being deleted. Defaults to `90`.",
+        validation_alias=AliasChoices(
+            AliasPath("retention_days"),
+            "prefect_server_services_db_vacuum_retention_days",
+            "prefect_api_services_db_vacuum_retention_days",
+        ),
+    )
+
+    batch_size: int = Field(
+        default=10000,
+        description="How many old Prefect resources the DB Vacuum service will delete at a time. Defaults to `10000`.",
+        validation_alias=AliasChoices(
+            AliasPath("batch_size"),
+            "prefect_server_services_db_vacuum_batch_size",
+            "prefect_api_services_db_vacuum_batch_size",
+        ),
+    )
+
+
 class ServerServicesEventPersisterSettings(ServicesBaseSetting):
     """
     Settings for controlling the event persister service
@@ -507,6 +557,10 @@ class ServerServicesSettings(PrefectBaseSettings):
     cancellation_cleanup: ServerServicesCancellationCleanupSettings = Field(
         default_factory=ServerServicesCancellationCleanupSettings,
         description="Settings for controlling the cancellation cleanup service",
+    )
+    db_vacuum: ServerServicesDBVacuumSettings = Field(
+        default_factory=ServerServicesDBVacuumSettings,
+        description="Settings for controlling the DB vacuum service",
     )
     event_persister: ServerServicesEventPersisterSettings = Field(
         default_factory=ServerServicesEventPersisterSettings,

--- a/tests/server/database/test_dependencies.py
+++ b/tests/server/database/test_dependencies.py
@@ -67,6 +67,8 @@ async def test_injecting_existing_query_components(QueryComponents):
 
 async def test_injecting_really_dumb_query_components():
     class ReallyBrokenQueries(BaseQueryComponents):
+        def _get_query_template_path(self, template_path: str) -> str: ...
+
         # --- dialect-specific SqlAlchemy bindings
 
         def insert(self, obj): ...

--- a/tests/server/services/test_db_vacuum.py
+++ b/tests/server/services/test_db_vacuum.py
@@ -1,0 +1,496 @@
+"""
+Tests for the DBVacuum service which deletes old Prefect resources.
+"""
+
+from datetime import timedelta
+from typing import Sequence
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server import models, schemas
+from prefect.server.database.orm_models import (
+    ORMArtifact,
+    ORMFlow,
+    ORMFlowRun,
+    ORMLog,
+    ORMTaskRun,
+)
+from prefect.server.schemas import states
+from prefect.server.services.db_vacuum import DBVacuum
+from prefect.types._datetime import now
+
+# Time constants for test data
+THE_RECENT_PAST = now("UTC") - timedelta(hours=1)
+THE_ANCIENT_PAST = now("UTC") - timedelta(days=100)
+
+
+@pytest.fixture
+async def old_flow_run(session: AsyncSession, flow: ORMFlow):
+    """Create a flow run older than the default retention period."""
+    flow_run = await models.flow_runs.create_flow_run(
+        session=session,
+        flow_run=schemas.core.FlowRun(
+            flow_id=flow.id,
+            state=states.Completed(),
+        ),
+    )
+    # Manually set the created timestamp to be old
+    flow_run.created = THE_ANCIENT_PAST
+    session.add(flow_run)
+    await session.commit()
+    return flow_run
+
+
+@pytest.fixture
+async def recent_flow_run(session: AsyncSession, flow: ORMFlow):
+    """Create a recent flow run within the retention period."""
+    flow_run = await models.flow_runs.create_flow_run(
+        session=session,
+        flow_run=schemas.core.FlowRun(
+            flow_id=flow.id,
+            state=states.Completed(),
+        ),
+    )
+    # Manually set the created timestamp to be recent
+    flow_run.created = THE_RECENT_PAST
+    session.add(flow_run)
+    await session.commit()
+    return flow_run
+
+
+@pytest.fixture
+async def old_flow_run_with_task_runs(session: AsyncSession, flow: ORMFlow):
+    """Create an old flow run with multiple task runs."""
+    flow_run = await models.flow_runs.create_flow_run(
+        session=session,
+        flow_run=schemas.core.FlowRun(
+            flow_id=flow.id,
+            state=states.Completed(),
+        ),
+    )
+    # Manually set the created timestamp to be old
+    flow_run.created = THE_ANCIENT_PAST
+    session.add(flow_run)
+    await session.flush()
+
+    task_runs = []
+    for i in range(3):
+        task_run = await models.task_runs.create_task_run(
+            session=session,
+            task_run=schemas.core.TaskRun(
+                flow_run_id=flow_run.id,
+                task_key=f"task-{i}",
+                dynamic_key=f"dynamic-{i}",
+                state=states.Completed(),
+            ),
+        )
+        task_runs.append(task_run)
+
+    await session.commit()
+    return flow_run, task_runs
+
+
+@pytest.fixture
+async def orphaned_log_maker(session: AsyncSession):
+    """Factory to create orphaned logs (logs with no associated flow run)."""
+
+    async def make_orphaned_log():
+        log = ORMLog(
+            name="Log",
+            flow_run_id=UUID("00000000-0000-0000-0000-000000000000"),
+            message="This is an orphaned log",
+            level=20,
+            timestamp=now("UTC"),
+        )
+        session.add(log)
+        await session.commit()
+        return log
+
+    return make_orphaned_log
+
+
+@pytest.fixture
+async def log_with_flow_run(session: AsyncSession, flow: ORMFlow):
+    """Create a log associated with a flow run."""
+    flow_run = await models.flow_runs.create_flow_run(
+        session=session,
+        flow_run=schemas.core.FlowRun(
+            flow_id=flow.id,
+            state=states.Running(),
+        ),
+    )
+    await session.flush()
+
+    log = ORMLog(
+        name="Log",
+        flow_run_id=flow_run.id,
+        message="This log has a flow run",
+        level=20,
+        timestamp=now("UTC"),
+    )
+    session.add(log)
+    await session.commit()
+    return log, flow_run
+
+
+@pytest.fixture
+async def orphaned_artifact_maker(session: AsyncSession):
+    """Factory to create orphaned artifacts (artifacts with no associated flow run)."""
+
+    async def make_orphaned_artifact():
+        artifact = ORMArtifact(
+            key="orphaned-artifact",
+            data={"value": "test"},
+            type="result",
+            flow_run_id=UUID("00000000-0000-0000-0000-000000000000"),
+        )
+        session.add(artifact)
+        await session.commit()
+        return artifact
+
+    return make_orphaned_artifact
+
+
+@pytest.fixture
+async def artifact_with_flow_run(session: AsyncSession, flow: ORMFlow):
+    """Create an artifact associated with a flow run."""
+    flow_run = await models.flow_runs.create_flow_run(
+        session=session,
+        flow_run=schemas.core.FlowRun(
+            flow_id=flow.id,
+            state=states.Running(),
+        ),
+    )
+    await session.flush()
+
+    artifact = ORMArtifact(
+        key="valid-artifact",
+        data={"value": "test"},
+        type="result",
+        flow_run_id=flow_run.id,
+    )
+    session.add(artifact)
+    await session.commit()
+    return artifact, flow_run
+
+
+async def test_delete_old_flow_runs(
+    session: AsyncSession,
+    old_flow_run: ORMFlowRun,
+    recent_flow_run: ORMFlowRun,
+):
+    """Test that old flow runs are deleted but recent ones are kept."""
+    # Run the vacuum service once
+    await DBVacuum().start(loops=1)
+
+    # Check that the old flow run was deleted
+    result = await session.execute(
+        select(ORMFlowRun).where(ORMFlowRun.id == old_flow_run.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+    # Check that the recent flow run still exists
+    result = await session.execute(
+        select(ORMFlowRun).where(ORMFlowRun.id == recent_flow_run.id)
+    )
+    assert result.scalar_one_or_none() is not None
+
+
+async def test_delete_old_flow_runs_with_task_runs(
+    session: AsyncSession,
+    old_flow_run_with_task_runs: tuple,
+):
+    """Test that deleting flow runs also deletes associated task runs (cascade)."""
+    old_flow_run, task_runs = old_flow_run_with_task_runs
+
+    # Run the vacuum service once
+    await DBVacuum().start(loops=1)
+
+    # Check that the old flow run was deleted
+    result = await session.execute(
+        select(ORMFlowRun).where(ORMFlowRun.id == old_flow_run.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+    # Check that all task runs were cascade deleted
+    for task_run in task_runs:
+        result = await session.execute(
+            select(ORMTaskRun).where(ORMTaskRun.id == task_run.id)
+        )
+        assert result.scalar_one_or_none() is None
+
+
+async def test_delete_orphaned_logs(
+    session: AsyncSession,
+    orphaned_log_maker,
+    log_with_flow_run: tuple,
+):
+    """Test that orphaned logs are deleted but logs with flow runs are kept."""
+    # Create orphaned logs
+    orphaned_log = await orphaned_log_maker()
+
+    log, flow_run = log_with_flow_run
+
+    # Run the vacuum service once
+    await DBVacuum().start(loops=1)
+
+    # Check that the orphaned log was deleted
+    result = await session.execute(select(ORMLog).where(ORMLog.id == orphaned_log.id))
+    assert result.scalar_one_or_none() is None
+
+    # Check that the log with a flow run still exists
+    result = await session.execute(select(ORMLog).where(ORMLog.id == log.id))
+    assert result.scalar_one_or_none() is not None
+
+
+async def test_delete_orphaned_artifacts(
+    session: AsyncSession,
+    orphaned_artifact_maker,
+    artifact_with_flow_run: tuple,
+):
+    """Test that orphaned artifacts are deleted but artifacts with flow runs are kept."""
+    # Create orphaned artifacts
+    orphaned_artifact = await orphaned_artifact_maker()
+
+    artifact, flow_run = artifact_with_flow_run
+
+    # Run the vacuum service once
+    await DBVacuum().start(loops=1)
+
+    # Check that the orphaned artifact was deleted
+    result = await session.execute(
+        select(ORMArtifact).where(ORMArtifact.id == orphaned_artifact.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+    # Check that the artifact with a flow run still exists
+    result = await session.execute(
+        select(ORMArtifact).where(ORMArtifact.id == artifact.id)
+    )
+    assert result.scalar_one_or_none() is not None
+
+
+async def test_vacuum_integration(
+    session: AsyncSession,
+    flow: ORMFlow,
+    orphaned_log_maker,
+    orphaned_artifact_maker,
+):
+    """Test the full vacuum process: delete old flow runs, then clean up orphaned resources."""
+    # Create an old flow run with task runs
+    old_flow_run = await models.flow_runs.create_flow_run(
+        session=session,
+        flow_run=schemas.core.FlowRun(
+            flow_id=flow.id,
+            state=states.Completed(),
+        ),
+    )
+    old_flow_run.created = THE_ANCIENT_PAST
+    session.add(old_flow_run)
+    await session.flush()
+    await session.refresh(old_flow_run)
+
+    # Create task runs
+    for i in range(2):
+        await models.task_runs.create_task_run(
+            session=session,
+            task_run=schemas.core.TaskRun(
+                flow_run_id=old_flow_run.id,
+                task_key=f"task-{i}",
+                dynamic_key=f"dynamic-{i}",
+                state=states.Completed(),
+            ),
+        )
+
+    # Create logs and artifacts for this flow run
+    log = ORMLog(
+        name="Log",
+        flow_run_id=old_flow_run.id,
+        message="Log for old flow run",
+        level=20,
+        timestamp=now("UTC"),
+    )
+    session.add(log)
+
+    artifact = ORMArtifact(
+        key="artifact-for-old-run",
+        data={"value": "test"},
+        type="result",
+        flow_run_id=old_flow_run.id,
+    )
+    session.add(artifact)
+    await session.flush()
+    await session.refresh(log)
+    await session.refresh(artifact)
+    await session.commit()
+
+    # Also create some already orphaned resources
+    orphaned_log = await orphaned_log_maker()
+    orphaned_artifact = await orphaned_artifact_maker()
+
+    # Run the vacuum service once
+    await DBVacuum().start(loops=1)
+
+    # Check that the old flow run was deleted
+    result = await session.execute(
+        select(ORMFlowRun).where(ORMFlowRun.id == old_flow_run.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+    # The logs and artifacts should now be orphaned, but might not be deleted in the first run
+    # Run again to clean up newly orphaned resources
+    await DBVacuum().start(loops=1)
+
+    # Now check that all orphaned logs are deleted
+    result = await session.execute(select(ORMLog).where(ORMLog.id == log.id))
+    assert result.scalar_one_or_none() is None
+
+    result = await session.execute(select(ORMLog).where(ORMLog.id == orphaned_log.id))
+    assert result.scalar_one_or_none() is None
+
+    # And all orphaned artifacts are deleted
+    result = await session.execute(
+        select(ORMArtifact).where(ORMArtifact.id == artifact.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+    result = await session.execute(
+        select(ORMArtifact).where(ORMArtifact.id == orphaned_artifact.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.fixture
+async def many_old_flow_runs(
+    session: AsyncSession, flow: ORMFlow
+) -> Sequence[ORMFlowRun]:
+    """Create many old flow runs for batch testing."""
+    runs: list[ORMFlowRun] = []
+    async with session.begin():
+        for i in range(15):
+            flow_run = await models.flow_runs.create_flow_run(
+                session=session,
+                flow_run=schemas.core.FlowRun(
+                    flow_id=flow.id,
+                    state=states.Completed(),
+                ),
+            )
+            flow_run.created = THE_ANCIENT_PAST
+            session.add(flow_run)
+
+            # Add task runs to each flow run
+            for j in range(2):
+                await models.task_runs.create_task_run(
+                    session=session,
+                    task_run=schemas.core.TaskRun(
+                        flow_run_id=flow_run.id,
+                        task_key=f"task-{i}-{j}",
+                        dynamic_key=f"dynamic-{i}-{j}",
+                        state=states.Completed(),
+                    ),
+                )
+            runs.append(flow_run)
+
+    return runs
+
+
+async def test_vacuum_respects_batch_size(
+    session: AsyncSession,
+    many_old_flow_runs: Sequence[ORMFlowRun],
+):
+    """Test that the vacuum service processes deletions in batches."""
+    # Create a vacuum service with a small batch size
+    service = DBVacuum()
+
+    # The batch size is controlled by settings, but we can verify that
+    # not all runs are deleted instantly by checking after one loop
+    initial_count = len(many_old_flow_runs)
+    assert initial_count == 15
+
+    # Run the service once
+    await service.start(loops=1)
+
+    # Count remaining flow runs
+    result = await session.execute(select(ORMFlowRun))
+    remaining_runs = result.scalars().all()
+
+    # Depending on batch size and how the service works, some runs may be deleted
+    # The important thing is that the service completes without error
+    # and eventually all old runs get deleted
+    assert len(remaining_runs) <= initial_count
+
+
+async def test_vacuum_leaves_recent_runs_alone(
+    session: AsyncSession,
+    flow: ORMFlow,
+):
+    """Test that recent flow runs within the retention period are not deleted."""
+    # Create multiple recent flow runs
+    recent_runs = []
+    async with session.begin():
+        for i in range(5):
+            flow_run = await models.flow_runs.create_flow_run(
+                session=session,
+                flow_run=schemas.core.FlowRun(
+                    flow_id=flow.id,
+                    state=states.Completed(),
+                ),
+            )
+            flow_run.created = THE_RECENT_PAST
+            session.add(flow_run)
+            recent_runs.append(flow_run)
+
+    # Run the vacuum service
+    await DBVacuum().start(loops=1)
+
+    # Check that all recent runs still exist
+    for run in recent_runs:
+        result = await session.execute(
+            select(ORMFlowRun).where(ORMFlowRun.id == run.id)
+        )
+        assert result.scalar_one_or_none() is not None
+
+
+async def test_delete_multiple_orphaned_logs(
+    session: AsyncSession,
+    orphaned_log_maker,
+):
+    """Test deletion of multiple orphaned logs."""
+    # Create multiple orphaned logs
+    orphaned_logs = []
+    for i in range(10):
+        log = await orphaned_log_maker()
+        orphaned_logs.append(log)
+
+    # Run the vacuum service
+    await DBVacuum().start(loops=1)
+
+    # Check that all orphaned logs were deleted
+    for log in orphaned_logs:
+        result = await session.execute(select(ORMLog).where(ORMLog.id == log.id))
+        assert result.scalar_one_or_none() is None
+
+
+async def test_delete_multiple_orphaned_artifacts(
+    session: AsyncSession,
+    orphaned_artifact_maker,
+):
+    """Test deletion of multiple orphaned artifacts."""
+    # Create multiple orphaned artifacts
+    orphaned_artifacts = []
+    for i in range(10):
+        artifact = await orphaned_artifact_maker()
+        orphaned_artifacts.append(artifact)
+
+    # Run the vacuum service
+    await DBVacuum().start(loops=1)
+
+    # Check that all orphaned artifacts were deleted
+    for artifact in orphaned_artifacts:
+        result = await session.execute(
+            select(ORMArtifact).where(ORMArtifact.id == artifact.id)
+        )
+        assert result.scalar_one_or_none() is None


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

Closes #16054 

<!-- Include an overview of the proposed changes here -->

This PR adds a new LoopService called DBVacuum that allows for the automatic clean up of Prefect resources that are older than a configurable retention period. This is to help keep the Prefect DB from overflowing with old flow runs/task runs/etc. 

The DBVacuum deletes the following:
1. flow runs
2. associated logs
3. associated artifacts

Task runs are handled by the DELETE CASCADE rules setup on the flow run table. 

The DBVacuum queries a limited amount of parent flow runs (those that do not have a parent_task_run_id) that are older than the retention and deletes them. It then deletes logs that no longer have any flow runs associated with them and finally performs the same deletion for artifacts.

The deletion of a parent flow run will delete child task runs and set their child flow runs parent_task_run_id to null, which will get picked up on the next round of the loop. This gives a guarantee that eventually all flow runs and their sub flow runs will be deleted (along with the associated logs and artifacts).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
