### PR TITLE
add debug log for fork handler registration failure

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -45,8 +45,12 @@ def _reset_services_after_fork():
 if hasattr(os, "register_at_fork"):
     try:
         os.register_at_fork(after_in_child=_reset_services_after_fork)
-    except RuntimeError:
+    except RuntimeError as e:
         # Might fail in certain contexts (e.g., if already in a child process)
+        logger.debug(
+            "failed to register fork handler: %s (this may occur in child processes)",
+            e,
+        )
         pass
 
 


### PR DESCRIPTION
follow up to #19116

this PR adds a debug log when fork handler registration fails, as requested by @desertaxle in [review feedback](https://github.com/PrefectHQ/prefect/pull/19116#discussion_r2479483308) from the original PR.

the log provides breadcrumbs in case this becomes an issue in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)