### PR TITLE
Fix event filter in Kubernetes observer

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -143,7 +143,7 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
         response = await orchestration_client.request(
             "POST",
             "/events/filter",
-            json=event_filter.model_dump(exclude_unset=True, mode="json"),
+            json=dict(filter=event_filter.model_dump(exclude_unset=True, mode="json")),
         )
         # If the event already exists, we don't need to emit a new one.
         if response.json()["events"]:


### PR DESCRIPTION
This PR addresses an issue identified by @brett-patterson-ent in https://github.com/PrefectHQ/prefect/issues/19026#issuecomment-3469912893, where the events filter was improperly structured, resulting in excessive event retrieval. This fix should significantly improve the performance of the Kubernetes observer in environments with high event volume.

Closes https://github.com/PrefectHQ/prefect/issues/19026