### PR TITLE
fix docker image workflow to only push to prod repos on non-prerelease

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -94,7 +94,7 @@ jobs:
         id: metadata-prod
         uses: docker/metadata-action@v5
         # generate the production tags on release events or when manually triggered for 3-latest
-        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_3_latest == 'true') }}
+        if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_3_latest == 'true') }}
         with:
           images: ${{ matrix.image }}
           # push `latest`, `X.Y` and `X` tags only when the release is not marked as prerelease


### PR DESCRIPTION
closes the issue where nightly dev releases fail to push docker images

## summary
- the nightly workflow creates prerelease tags which trigger the docker-images workflow
- previously, the `metadata-prod` step would run for ANY release event (including prereleases), generating tags for both the `-dev` repos and the production repos
- this caused failures because the dockerhub token only has push access to the `-dev` repos
- this fix ensures `metadata-prod` only runs for non-prerelease releases, so prerelease/dev builds only push to the `-dev` repos

## error
the docker images workflow was failing with:
```
ERROR: failed to push prefecthq/prefect:3.6.1.dev1-python3.11: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://auth.docker.io/token?scope=repository%3Aprefecthq%2Fprefect%3Apull%2Cpush&service=registry.docker.io: 401 Unauthorized: access token has insufficient scopes
```

failing action: https://github.com/PrefectHQ/prefect/actions/runs/19180138126

the token has push access to `prefecthq/prefect-dev` and `prefecthq/prefect-client-dev`, but the workflow was trying to push to `prefecthq/prefect` and `prefecthq/prefect-client` (without the `-dev` suffix) for prerelease builds.

<details>
<summary>details</summary>

the condition on line 97 was:
```yaml
if: ${{ github.event_name == 'release' || ... }}
```

this would trigger for all releases, including prereleases. changed to:
```yaml
if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || ... }}
```

now it only triggers for non-prerelease releases.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)