### PR TITLE
Add quantile_normalize task with quantile clipping and range scaling

### DIFF
--- a/src/prefect/tests_local/test_quantile_normalize.py
+++ b/src/prefect/tests_local/test_quantile_normalize.py
@@ -1,0 +1,34 @@
+import math
+import unittest
+from prefect.utilities.quantile_normalize import quantile_normalize
+
+class TestQuantileNormalize(unittest.TestCase):
+    def test_basic_unit_range(self):
+        out = quantile_normalize.fn([10, 20, 30, 40, 50], 0.0, 1.0, 0.0, 1.0)
+        self.assertEqual(out, [0.0, 0.25, 0.5, 0.75, 1.0])
+
+    def test_outlier_clipped(self):
+        out = quantile_normalize.fn([0, 1, 2, 1000], 0.1, 0.9, 0.0, 1.0)
+        self.assertTrue(out[-1] <= 1.0 + 1e-12)
+
+    def test_none_nan_passthrough(self):
+        out = quantile_normalize.fn([1.0, None, float("nan"), 3.0], 0.0, 1.0, 0.0, 1.0)
+        self.assertIsNone(out[1])
+        self.assertIsNone(out[2])
+        self.assertAlmostEqual(out[0], 0.0, places=9)
+        self.assertAlmostEqual(out[3], 1.0, places=9)
+
+    def test_custom_output_range(self):
+        out = quantile_normalize.fn([0.0, 5.0, 10.0], 0.0, 1.0, -1.0, 1.0)
+        self.assertEqual(out, [-1.0, 0.0, 1.0])
+
+    def test_bad_ranges_raise(self):
+        with self.assertRaises(ValueError):
+            quantile_normalize.fn([], 0.0, 1.0, 0.0, 1.0)
+        with self.assertRaises(ValueError):
+            quantile_normalize.fn([1.0, 2.0], 0.9, 0.1, 0.0, 1.0)
+        with self.assertRaises(ValueError):
+            quantile_normalize.fn([1.0, 2.0], 0.0, 1.0, 1.0, 1.0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/prefect/utilities/quantile_normalize.py
+++ b/src/prefect/utilities/quantile_normalize.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from typing import Iterable, List, Optional
+import math
+from prefect import task
+
+def _finite(vals):
+    return [v for v in vals if isinstance(v, (int, float)) and not math.isnan(v)]
+
+def _quantile(sorted_vals, q: float) -> float:
+    if not sorted_vals:
+        raise ValueError("Cannot compute quantile of empty data")
+    if q <= 0.0:
+        return sorted_vals[0]
+    if q >= 1.0:
+        return sorted_vals[-1]
+    pos = q * (len(sorted_vals) - 1)
+    lo = int(math.floor(pos))
+    hi = int(math.ceil(pos))
+    if lo == hi:
+        return sorted_vals[lo]
+    frac = pos - lo
+    return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac
+
+@task
+def quantile_normalize(
+    data: Iterable[Optional[float]],
+    low_q: float = 0.01,
+    high_q: float = 0.99,
+    out_min: float = 0.0,
+    out_max: float = 1.0,
+) -> List[Optional[float]]:
+    """
+    Winsorize by quantiles, then scale to [out_min, out_max].
+    None and NaN are preserved as None.
+    """
+    values = list(data)
+    vec = _finite(values)
+    if not vec:
+        raise ValueError("No finite values to normalize")
+
+    vec_sorted = sorted(vec)
+    qlo = _quantile(vec_sorted, low_q)
+    qhi = _quantile(vec_sorted, high_q)
+    if qhi <= qlo:
+        raise ValueError("Bad quantile range")
+
+    in_rng = qhi - qlo
+    out_rng = out_max - out_min
+    if out_rng == 0:
+        raise ValueError("Output range must be non zero")
+
+    out: List[Optional[float]] = []
+    for v in values:
+        if v is None or (isinstance(v, float) and math.isnan(v)):
+            out.append(None)
+        else:
+            v2 = min(max(float(v), qlo), qhi)
+            scaled = ((v2 - qlo) / in_rng) * out_rng + out_min
+            out.append(scaled)
+    return out


### PR DESCRIPTION
Summary:
Adds `quantile_normalize`, a Prefect task that clips values at configurable lower and upper quantiles, then scales to a target range. Preserves None and NaN.

Why it is useful:
Skewed numeric columns are common. Quantile clipping reduces extreme outliers, and scaling maps values into a consistent range for downstream steps.

Usage:
from prefect import flow
from prefect.utilities.quantile_normalize import quantile_normalize

@flow
def demo():
    data = [0, 1, 2, 1000]
    out = quantile_normalize.fn(data, low_q=0.1, high_q=0.9, out_min=0.0, out_max=1.0)
    print(out)

Tests:
Local tests pass with:
python -m unittest discover -s src/prefect/tests_local -q
