### PR TITLE
Fix interactive deploy CLI selecting wrong flow when opting out

### DIFF
--- a/src/prefect/cli/deploy/_config.py
+++ b/src/prefect/cli/deploy/_config.py
@@ -462,7 +462,7 @@ def _pick_deploy_configs(
         selected_deploy_config = _handle_pick_deploy_without_name(deploy_configs)
         if not selected_deploy_config:
             return [
-                _merge_with_default_deploy_config(deploy_configs[0]),
+                _merge_with_default_deploy_config({}),
             ]
         return selected_deploy_config
 


### PR DESCRIPTION
Closes #19378

## Summary

Fixes a bug where using `prefect deploy` interactively and selecting "No, configure a new deployment" would incorrectly deploy the **first deployment** in the list instead of prompting for a new deployment configuration.

## Root Cause

The bug was in `src/prefect/cli/deploy/_config.py` at line 465 in the `_pick_deploy_configs` function.

When the user selected "No, configure a new deployment":
1. `_handle_pick_deploy_without_name` correctly returned an empty list `[]`
2. The condition `if not selected_deploy_config:` evaluated to `True` (empty list is falsy)
3. **Bug**: The code returned `deploy_configs[0]` instead of an empty config `{}`
4. This caused the first deployment's configuration to be used instead of creating a new one

## Fix

Changed line 465 from:
```python
_merge_with_default_deploy_config(deploy_configs[0]),
```

to:
```python
_merge_with_default_deploy_config({}),
```

This matches the behavior in other code paths (e.g., lines 430-436) where a new deployment is created.

## Testing

Added a regression test `test_deploy_opt_out_of_existing_deployments` that:
1. Creates a `prefect.yaml` with two existing deployments
2. Simulates user selecting "No, configure a new deployment" 
3. Verifies that a new deployment is created with a fresh configuration
4. Ensures the new deployment doesn't inherit properties from the first deployment (which would be the bug behavior)

<details>
<summary>Reproduction script</summary>

The following script demonstrates the bug before the fix:

```python
from __future__ import annotations

import io
from unittest.mock import patch

import readchar
from rich.console import Console

from prefect.cli.deploy._config import _pick_deploy_configs


# Create sample deployment configs (as would be loaded from prefect.yaml)
deploy_configs = [
    {"name": "first-deployment", "entrypoint": "flow1.py:my_flow"},
    {"name": "second-deployment", "entrypoint": "flow2.py:my_flow"},
    {"name": "third-deployment", "entrypoint": "flow3.py:my_flow"},
]

# Simulate user navigating to opt-out and selecting it
user_input = [readchar.key.DOWN, readchar.key.DOWN, readchar.key.DOWN, readchar.key.ENTER]
input_iter = iter(user_input)

def mock_readchar():
    return next(input_iter)

console = Console(file=io.StringIO(), width=120)

with patch("readchar.readkey", side_effect=mock_readchar):
    with patch("prefect.cli.root.is_interactive", return_value=True):
        with patch("prefect.cli.deploy._config.app.console", console):
            result = _pick_deploy_configs(
                deploy_configs=deploy_configs,
                names=None,
                deploy_all=False,
            )

# Before fix: result[0]["name"] == "first-deployment" (BUG!)
# After fix: result[0]["name"] == None (correct - new deployment)
print(f"Deployment name: {result[0].get('name')}")
```

**Before the fix**: Prints `Deployment name: first-deployment` (wrong!)  
**After the fix**: Prints `Deployment name: None` (correct - prompts user for name)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>