### PR TITLE
fix: add work_queue_id to DeploymentResponse

### DIFF
--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -450,6 +450,10 @@ class DeploymentResponse(ORMBaseModel):
             " be scheduled."
         ),
     )
+    work_queue_id: Optional[UUID] = Field(
+        default=None,
+        description="The id of the work pool queue to which this deployment is assigned.",
+    )
     last_polled: Optional[DateTime] = Field(
         default=None,
         description="The last time the deployment was polled for status updates.",
@@ -520,6 +524,7 @@ class DeploymentResponse(ORMBaseModel):
 
         if from_attributes:
             if obj.work_queue:
+                response.work_queue_id = obj.work_queue.id
                 response.work_queue_name = obj.work_queue.name
                 if obj.work_queue.work_pool:
                     response.work_pool_name = obj.work_queue.work_pool.name

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -607,6 +607,7 @@ class TestCreateDeployment:
         assert deployment_response.job_variables == {"cpu": 24}
         assert deployment_response.work_pool_name == work_pool.name
         assert deployment_response.work_queue_name == work_queue_1.name
+        assert deployment_response.work_queue_id == work_queue_1.id
 
         deployment = await models.deployments.read_deployment(
             session=session, deployment_id=deployment_response.id
@@ -650,6 +651,7 @@ class TestCreateDeployment:
         assert deployment_response.job_variables == {"cpu": 24}
         assert deployment_response.work_pool_name == work_pool.name
         assert deployment_response.work_queue_name == default_queue.name
+        assert deployment_response.work_queue_id == work_pool.default_queue_id
 
         deployment = await models.deployments.read_deployment(
             session=session, deployment_id=deployment_response.id
@@ -691,6 +693,9 @@ class TestCreateDeployment:
             session=session, work_pool_name=work_pool.name, work_queue_name="new-queue"
         )
         assert work_queue is not None
+
+        # Regression test for #19415: work_queue_id should be in API response
+        assert response.json()["work_queue_id"] == str(work_queue.id)
 
         deployment = await models.deployments.read_deployment(
             session=session, deployment_id=deployment_id


### PR DESCRIPTION
closes #19415

## Summary
This PR fixes an issue where the `work_queue_id` field was missing from the `DeploymentResponse` schema, even though it exists in the database and in the client-side schema.

## Problem
When a deployment is created with both `work_pool_name` and `work_queue_name`, the server correctly:
- Finds/creates the work queue
- Stores the `work_queue_id` in the database

However, the API response was missing the `work_queue_id` field, only returning `work_queue_name` and `work_pool_name`. This caused confusion for users who expected to see the work queue ID in the deployment response.

## Changes
- Added `work_queue_id` field to server-side `DeploymentResponse` schema
- Updated `model_validate` method to populate `work_queue_id` from the ORM object's work queue relationship, matching the pattern used in `FlowRunResponse`
- Added regression test assertions to verify `work_queue_id` is included in API responses

## Background
When schemas were split between client and server in May 2023 (commit 5d2e5f8595), the client-side `DeploymentResponse` included `work_queue_id`, but the server-side response schema never properly exposed it in its `model_validate` method. This was an oversight rather than an intentional design decision.

The client schema already has this field defined, so this PR brings the server schema into alignment with the client expectations.

## Testing
- ✅ Verified with reproduction script that `work_queue_id` is now populated correctly
- ✅ Updated existing tests to assert `work_queue_id` is present in responses
- ✅ All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)