### PR TITLE
fix: correct GitHub Actions conditional syntax in integration release workflow

### DIFF
--- a/.github/workflows/integration-package-release.yaml
+++ b/.github/workflows/integration-package-release.yaml
@@ -43,13 +43,13 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
-        if: ${{ steps.package_name.outputs.PACKAGE_NAME }} == 'prefect-aws'
+        if: steps.package_name.outputs.PACKAGE_NAME == 'prefect-aws'
         with:
           version: latest
 
       - name: Set up node
         uses: actions/setup-node@v6
-        if: ${{ steps.package_name.outputs.PACKAGE_NAME }} == 'prefect-aws'
+        if: steps.package_name.outputs.PACKAGE_NAME == 'prefect-aws'
         with:
           node-version-file: "src/integrations/prefect-aws/infra/.nvmrc"
           cache-dependency-path: "src/integrations/prefect-aws/infra/package-lock.json"
@@ -64,7 +64,7 @@ jobs:
         working-directory: src/integrations/${{ steps.package_name.outputs.PACKAGE_NAME }}
 
       - name: Generate CloudFormation templates
-        if: ${{ steps.package_name.outputs.PACKAGE_NAME }} == 'prefect-aws'
+        if: steps.package_name.outputs.PACKAGE_NAME == 'prefect-aws'
         run: |
           just generate-cfn
         working-directory: src/integrations/prefect-aws/infra


### PR DESCRIPTION
this PR fixes incorrect conditional syntax in the integration package release workflow that was causing CloudFormation template generation to run for all integration releases, not just prefect-aws.

<details>
<summary>problem</summary>

the workflow used:
```yaml
if: ${{ steps.package_name.outputs.PACKAGE_NAME }} == 'prefect-aws'
```

this is incorrect because the `${{ }}` syntax in an `if` condition evaluates the inner expression as a string, resulting in invalid syntax. this caused the condition to always evaluate as truthy, running the CloudFormation generation step for all integrations (e.g., prefect-bitbucket).

</details>

<details>
<summary>solution</summary>

corrected to proper GitHub Actions expression syntax:
```yaml
if: steps.package_name.outputs.PACKAGE_NAME == 'prefect-aws'
```

in `if` conditions, the expression context is already active, so `${{ }}` wrappers are unnecessary and cause parsing issues.

</details>

fixes: https://github.com/PrefectHQ/prefect/actions/runs/19349035681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>