### PR TITLE
fix: allow pause_flow_run() to pause parent flow when called from task

### DIFF
--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -249,9 +249,8 @@ async def _in_process_pause(
     if TYPE_CHECKING:
         assert client is not None
 
-    if TaskRunContext.get():
-        raise RuntimeError("Cannot pause task runs.")
-
+    # Get the flow run context - this works even when called from within a task
+    # since both FlowRunContext and TaskRunContext are independently active
     context = FlowRunContext.get()
     if not context:
         raise RuntimeError("Flow runs can only be paused from within a flow run.")


### PR DESCRIPTION
closes #19435

this pr changes `pause_flow_run()` to pause the parent flow when called from within a task, instead of raising "cannot pause task runs" error.

## context

previously, calling `pause_flow_run()` from within a task would raise:
```
RuntimeError: Cannot pause task runs.
```

this was overly restrictive since:
1. the function is named `pause_flow_run()`, not `pause_task_run()`
2. both `FlowRunContext` and `TaskRunContext` are independently active when a task runs inside a flow
3. users reasonably expect to encapsulate approval/pause logic in reusable tasks

## changes

**src/prefect/flow_runs.py:241-256**
- removed the guard that raised `RuntimeError` when `TaskRunContext.get()` was truthy
- now directly accesses `FlowRunContext.get()` (which works even inside tasks) to pause the parent flow

**tests/test_flow_engine.py:1137-1216**
- renamed `test_tasks_cannot_be_paused` to `test_pause_flow_run_from_task_pauses_parent_flow`
- updated to verify pause works correctly instead of expecting error
- added `test_pause_flow_run_from_task_with_input` to verify pause with `wait_for_input` works from tasks

<details>
<summary>reproduction script</summary>

```python
"""Reproduction for issue #19435: pause_flow_run() raises 'Cannot pause task runs' when called from within a task"""

import asyncio

from prefect import flow, task
from prefect.client.orchestration import get_client
from prefect.context import FlowRunContext
from prefect.flow_runs import pause_flow_run
from prefect.input import RunInput


class ApprovalInput(RunInput):
    approved: bool


@task
async def get_approval():
    # This should pause the parent flow, not raise an error
    approval = await pause_flow_run(timeout=5, wait_for_input=ApprovalInput)
    return approval.approved


@flow
async def my_flow():
    approved = await get_approval()
    print(f"approved: {approved}")
    return approved


async def main():
    """Run the flow and verify it gets paused correctly."""
    flow_run_id = None

    @flow
    async def test_flow():
        nonlocal flow_run_id
        context = FlowRunContext.get()
        flow_run_id = context.flow_run.id
        approved = await get_approval()
        return approved

    # Run the flow in the background and check its state
    async def check_pause_state():
        # Wait for the flow run to start
        while not flow_run_id:
            await asyncio.sleep(0.1)

        # Give it a moment to reach the pause
        await asyncio.sleep(0.5)

        # Check that the flow run is actually paused
        async with get_client() as client:
            flow_run = await client.read_flow_run(flow_run_id)
            print(f"\nFlow run state: {flow_run.state.type}")
            print(f"Flow run state name: {flow_run.state.name}")
            assert flow_run.state.is_paused(), f"Expected flow to be paused, but got state: {flow_run.state.type}"
            print("✅ SUCCESS: Flow was paused from within a task!")

    try:
        # Race the flow against the state checker
        await asyncio.wait_for(
            asyncio.gather(
                test_flow(return_state=True),
                check_pause_state(),
                return_exceptions=True,
            ),
            timeout=3.0,
        )
    except asyncio.TimeoutError:
        # This is expected - the flow pauses and waits
        print("✅ Flow timed out as expected (paused and waiting for resume)")


if __name__ == "__main__":
    asyncio.run(main())
```

**output:**
```
Flow run state: StateType.PAUSED
Flow run state name: Paused
✅ SUCCESS: Flow was paused from within a task!
✅ Flow timed out as expected (paused and waiting for resume)
```

</details>

all existing pause tests still pass (8 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)