### PR TITLE
fix: show detailed validation errors for top-level prefect.yaml fields

### DIFF
--- a/.claude/commands/repro.md
+++ b/.claude/commands/repro.md
@@ -7,7 +7,7 @@ before reproducing, `rg` for documentation in `docs/` that may be relevant to th
 if a `repros/` directory already exists (it will be locally gitignored), `rg` for relevant SDK usage to gain context.
 
 
-To reproduce, create a file named by issue number (ie. `1234.py`) in a locally gitignored (.git/info/exclude) `repros/` directory with a minimal reproducible example that reproduces the issue.
+To reproduce, create a file named by issue number (ie. `1234.py`) in a locally gitignored (.git/info/exclude) `repros/` directory with a minimal reproducible example that reproduces the issue. Because `repros/` is gitignored, you should NEVER reference it in a PR body, instead put the entire reproduction script in a python snippet inside a `<details>` tag.
 
 If the reproduction requires external dependencies, use `uv` to inline script dependencies to install them like this:
 


### PR DESCRIPTION
closes #19467

this PR fixes an issue where validation errors for top-level fields in prefect.yaml (like `prefect-version`, `name`, `build`, `push`, `pull`) were showing a generic "Validation error in config file" message instead of the actual validation error details.

## problem

the `_format_validation_error` function in `src/prefect/cli/deploy/_config.py` only handled validation errors for fields within the `deployments` list. when an error occurred in a top-level field, it fell through to a generic error message with no details.

### before

```
Validation error in config file

Skipping deployment configuration due to validation errors.
```

### after

```
Invalid top-level fields in config file:

  • prefect-version: Input should be a valid string

For valid prefect.yaml fields, see: https://docs.prefect.io/v3/how-to-guides/deployments/prefect-yaml
```

## changes

- updated `_format_validation_error` to track both deployment-level and top-level errors separately
- added separate formatting sections for top-level vs deployment-level errors
- added two regression tests to ensure the fix works correctly

<details>
<summary>reproduction script</summary>

```python
"""Reproduction for issue #19467: prefect deploy cli reporting validation error with no details

The issue is that when there's a validation error in top-level fields of prefect.yaml
(like prefect-version or name), the error message doesn't show the actual validation
problem. The _format_validation_error function only handles errors within the
deployments list, not top-level fields.

Expected: Should show specific error like "prefect-version: Input should be a valid string"
Actual: Shows generic "Validation error in config file" with no details
"""

from pathlib import Path
from pydantic import ValidationError
import yaml

from prefect.cli.deploy._models import PrefectYamlModel
from prefect.cli.deploy._config import _format_validation_error

# Create a test YAML config with an integer prefect-version (should be string)
test_config = """
name: example-deployment
prefect-version: 3

pull:
  - prefect.deployments.steps.git_clone:
      id: clone-step-scripts
      repository: https://github.com/me/myrepo.git
      branch: main

deployments:
  - name: example-deployment
    description: Test flow deployed from github
    entrypoint: flow.py:test_flow
    work_pool:
      name: my-pool
"""

print("=" * 80)
print("Testing top-level field validation error (prefect-version: 3)")
print("=" * 80)

# Load the YAML
data = yaml.safe_load(test_config)
print(f"\nParsed YAML data:")
print(f"  prefect-version type: {type(data.get('prefect-version'))}")
print(f"  prefect-version value: {data.get('prefect-version')}")

# Try to validate - this should raise a ValidationError
try:
    model = PrefectYamlModel.model_validate(data)
    print("\n❌ UNEXPECTED: Validation succeeded when it should have failed!")
except ValidationError as exc:
    print(f"\n✓ Validation failed as expected")
    print(f"\nRaw Pydantic error:")
    for error in exc.errors():
        print(f"  {error}")

    # Now test the _format_validation_error function
    formatted_error = _format_validation_error(exc, data)
    print(f"\nFormatted error message from _format_validation_error:")
    print(f"  {formatted_error!r}")

    if formatted_error == "Validation error in config file":
        print("\n🐛 BUG REPRODUCED: Generic error message with no details!")
        print("   The function doesn't handle top-level field errors")
    else:
        print("\n✓ Error message includes details")

# Test with a deployment-level error to show it works for those
print("\n" + "=" * 80)
print("Testing deployment-level field validation error (for comparison)")
print("=" * 80)

test_config_deployment_error = """
deployments:
  - name: example-deployment
    entrypoint: flow.py:test_flow
    paused: "not-a-boolean"
"""

data2 = yaml.safe_load(test_config_deployment_error)
try:
    model = PrefectYamlModel.model_validate(data2)
    print("\n❌ UNEXPECTED: Validation succeeded when it should have failed!")
except ValidationError as exc:
    print(f"\n✓ Validation failed as expected")
    formatted_error = _format_validation_error(exc, data2)
    print(f"\nFormatted error message:")
    print(f"  {formatted_error!r}")

    if "Invalid fields in deployments" in formatted_error:
        print("\n✓ Deployment-level errors ARE formatted properly")
    else:
        print(f"\n⚠️  Unexpected format for deployment error")

print("\n" + "=" * 80)
print("SUMMARY")
print("=" * 80)
print("""
The bug is in _format_validation_error() in src/prefect/cli/deploy/_config.py:

- It only handles errors where loc[0] == "deployments" (line 28)
- Top-level field errors (prefect-version, name, build, push, pull) fall through
  to line 52 which returns the generic message "Validation error in config file"
- This makes it impossible for users to debug top-level field validation issues

The fix should handle top-level field errors by checking if loc[0] is NOT
"deployments" and formatting those errors appropriately.
""")
```

</details>