### PR TITLE
Add httpx.ConnectError to retry exceptions

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -361,6 +361,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
                 httpx.ReadTimeout,
                 httpx.PoolTimeout,
                 httpx.ConnectTimeout,
+                httpx.ConnectError,
                 # `ConnectionResetError` when reading socket raises as a `ReadError`
                 httpx.ReadError,
                 # Sockets can be closed during writes resulting in a `WriteError`

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -207,6 +207,7 @@ class TestPrefectHttpxAsyncClient:
             httpx.PoolTimeout,
             httpx.ReadTimeout,
             httpx.ConnectTimeout,
+            httpx.ConnectError,
         ],
     )
     async def test_prefect_httpx_client_retries_on_designated_exceptions(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

Add httpx.ConnectError to retry exceptions


Context:

We are seeing this error in our runs
```
 File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/futures.py", line 222, in result
    _result = self._final_state.result(
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/_internal/compatibility/async_dispatch.py", line 94, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/client/schemas/objects.py", line 375, in result
    return run_coro_as_sync(
           ^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/utilities/asyncutils.py", line 207, in run_coro_as_sync
    return call.result()
           ^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/_internal/concurrency/calls.py", line 365, in result
    return self.future.result(timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/_internal/concurrency/calls.py", line 192, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/_internal/concurrency/calls.py", line 441, in _run_async
    result = await coro
             ^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/utilities/asyncutils.py", line 188, in coroutine_wrapper
    return await task
           ^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/states.py", line 85, in get_state_result
    return await _get_state_result(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/prefect/lib/python3.11/site-packages/prefect/states.py", line 157, in _get_state_result
    raise await aget_state_exception(state)
httpx.ConnectError: [Errno 111] Connection refused
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
