### PR TITLE
hide "Join the Community" in air-gapped deployments

### DIFF
--- a/ui/src/components/ContextSidebar.vue
+++ b/ui/src/components/ContextSidebar.vue
@@ -29,7 +29,7 @@
         </p-context-nav-item>
       </a>
 
-      <p-context-nav-item @click="openJoinCommunityModal">
+      <p-context-nav-item v-if="showPromotionalContent" @click="openJoinCommunityModal">
         Join the Community
         <JoinTheCommunityModal :show-modal="showJoinCommunityModal || !joinTheCommunityModalDismissed" @update:show-modal="updateShowModal" />
       </p-context-nav-item>


### PR DESCRIPTION
## Summary
- Hide the "Join the Community" sidebar item when `PREFECT_SERVER_UI_SHOW_PROMOTIONAL_CONTENT=false`
- The modal links to external services (Slack, getform.io email signup) that don't work in air-gapped environments
- Uses the same `v-if="showPromotionalContent"` pattern as the existing "Ready to scale?" upgrade link

Closes #18425

## Test plan
- [ ] Set `PREFECT_SERVER_UI_SHOW_PROMOTIONAL_CONTENT=false` and verify the community link is hidden
- [ ] Verify default behavior (flag not set or true) still shows the community link

🤖 Generated with [Claude Code](https://claude.com/claude-code)