### PR TITLE
fix: number input step validation to allow high-precision floats

### DIFF
--- a/ui-v2/src/components/schemas/schema-form-input-number.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-number.tsx
@@ -41,6 +41,7 @@ export function SchemaFormInputNumber({
 			type="number"
 			min={property.minimum}
 			max={property.maximum}
+			step="any"
 			value={value ?? ""}
 			onChange={(e) => handleChange(e.target.value)}
 			id={id}


### PR DESCRIPTION
### Overview

fix: #19416

- fixes issue where deployments with precise float default values (>0.01 precision) cannot be edited due to HTML number input step validation restrictions.

**Changes:**
- Add `step="any"` to number input fields to allow any numeric precision
- Enables editing deployments with high-precision float parameters