### PR TITLE
Also parametrize xautoclaim batch size

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -398,9 +398,7 @@ class Consumer(_Consumer):
             if self.should_process_pending_messages:
                 try:
                     await self.process_pending_messages(
-                        handler,
-                        redis_client,
-                        1,  # Use batch size of 1 for now
+                        handler, redis_client, self._read_batch_size
                     )
                 except StopConsumer:
                     return


### PR DESCRIPTION
Follow on missed in https://github.com/PrefectHQ/prefect/pull/19545 (https://github.com/PrefectHQ/prefect/issues/19544) -also parametrize xautoclaim calls according to the read batch size setting in Redis consumer.
 
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `[<link to issue>](https://github.com/PrefectHQ/prefect/issues/19544)`"
(https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
