### PR TITLE
Fix anyio fail_after usage - async with was removed in recent version

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/ordering.py
+++ b/src/integrations/prefect-redis/prefect_redis/ordering.py
@@ -183,7 +183,7 @@ class CausalOrdering(_CausalOrdering):
         # done being processed as a quicker alternative to sitting on the waitlist
         if await self.event_has_started_processing(event.follows):
             try:
-                async with anyio.fail_after(IN_FLIGHT_EVENT_TIMEOUT.total_seconds()):
+                with anyio.fail_after(IN_FLIGHT_EVENT_TIMEOUT.total_seconds()):
                     while not await self.event_has_been_seen(event.follows):
                         await asyncio.sleep(0.25)
                     return


### PR DESCRIPTION
Fix anyio fail_after usage - async with was removed in recent version

Closes https://github.com/PrefectHQ/prefect/issues/19584

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `[<link to issue>](https://github.com/PrefectHQ/prefect/issues/19582)`"
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
