### PR TITLE
improve database maintenance documentation and examples

### DIFF
--- a/docs/v3/advanced/database-maintenance.mdx
+++ b/docs/v3/advanced/database-maintenance.mdx
@@ -217,6 +217,7 @@ from prefect import flow, task, get_run_logger
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.filters import FlowRunFilter, FlowRunFilterState, FlowRunFilterStateType, FlowRunFilterStartTime
 from prefect.client.schemas.objects import StateType
+from prefect.exceptions import ObjectNotFound
 
 @task
 async def delete_old_flow_runs(
@@ -225,10 +226,10 @@ async def delete_old_flow_runs(
 ):
     """Delete completed flow runs older than specified days."""
     logger = get_run_logger()
-    
+
     async with get_client() as client:
         cutoff = datetime.now(timezone.utc) - timedelta(days=days_to_keep)
-        
+
         # Create filter for old completed flow runs
         # Note: Using start_time because created time filtering is not available
         flow_run_filter = FlowRunFilter(
@@ -239,46 +240,50 @@ async def delete_old_flow_runs(
                 )
             )
         )
-        
+
         # Get flow runs to delete
         flow_runs = await client.read_flow_runs(
             flow_run_filter=flow_run_filter,
             limit=batch_size
         )
-        
+
         deleted_total = 0
-        
+
         while flow_runs:
             batch_deleted = 0
             failed_deletes = []
-            
+
             # Delete each flow run through the API
             for flow_run in flow_runs:
                 try:
                     await client.delete_flow_run(flow_run.id)
                     deleted_total += 1
                     batch_deleted += 1
+                except ObjectNotFound:
+                    # Already deleted (e.g., by concurrent cleanup) - treat as success
+                    deleted_total += 1
+                    batch_deleted += 1
                 except Exception as e:
                     logger.warning(f"Failed to delete flow run {flow_run.id}: {e}")
                     failed_deletes.append(flow_run.id)
-                    
+
                 # Rate limiting - adjust based on your API capacity
                 if batch_deleted % 10 == 0:
                     await asyncio.sleep(0.5)
-                    
+
             logger.info(f"Deleted {batch_deleted}/{len(flow_runs)} flow runs (total: {deleted_total})")
             if failed_deletes:
                 logger.warning(f"Failed to delete {len(failed_deletes)} flow runs")
-            
+
             # Get next batch
             flow_runs = await client.read_flow_runs(
                 flow_run_filter=flow_run_filter,
                 limit=batch_size
             )
-            
+
             # Delay between batches to avoid overwhelming the API
             await asyncio.sleep(1.0)
-        
+
         logger.info(f"Retention complete. Total deleted: {deleted_total}")
 
 @flow(name="database-retention")
@@ -321,7 +326,13 @@ Events are automatically generated for all state changes in Prefect and can quic
 
 ### Configure event retention
 
-The default retention period is 7 days. For high-volume deployments, consider reducing this:
+The default retention period is 7 days. For high-volume deployments running many flow runs per minute, this default can lead to rapid database growth. Consider your workload when setting retention:
+
+| Workload | Suggested retention | Rationale |
+|----------|---------------------|-----------|
+| Low volume (< 100 runs/day) | 7 days (default) | Default is appropriate |
+| Medium volume (100-1000 runs/day) | 3-5 days | Balance history with growth |
+| High volume (1000+ runs/day) | 1-2 days | Prioritize database performance |
 
 ```bash
 # Set retention to 2 days (as environment variable)
@@ -330,6 +341,8 @@ export PREFECT_EVENTS_RETENTION_PERIOD="2d"
 # Or in your prefect configuration
 prefect config set PREFECT_EVENTS_RETENTION_PERIOD="2d"
 ```
+
+The event trimmer runs automatically as part of the background services. If you're running in a [scaled deployment](/v3/advanced/self-hosted) with separate API servers and background services, ensure the background services pod is running to enable automatic trimming.
 
 ### Check event table size
 

--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -140,6 +140,10 @@ prefect server start --host 0.0.0.0 --port 4200 --no-services
 prefect server services start
 ```
 
+<Tip>
+For high-volume deployments, consider reducing the event retention period from the default 7 days to prevent rapid database growth. See [database maintenance](/v3/advanced/database-maintenance#configure-event-retention) for configuration details.
+</Tip>
+
 ### Database migrations
 
 Disable automatic migrations in multi-server deployments:
@@ -433,5 +437,6 @@ Monitor your multi-server deployment:
 
 ## Further reading
 
+- [Database maintenance](/v3/advanced/database-maintenance) - Monitor table sizes, configure event retention, and manage data growth
 - [Server concepts](/v3/concepts/server)
 - Deploy [Helm charts](/v3/advanced/server-helm) for Kubernetes

--- a/examples/ai_database_cleanup_with_approval.py
+++ b/examples/ai_database_cleanup_with_approval.py
@@ -52,6 +52,7 @@ from prefect.client.schemas.filters import (
     FlowRunFilterStartTime,
     FlowRunFilterStateName,
 )
+from prefect.exceptions import ObjectNotFound
 from prefect.flow_runs import pause_flow_run
 from prefect.input import RunInput
 
@@ -247,6 +248,9 @@ async def database_cleanup_flow(config: RetentionConfig | None = None) -> dict:
             for run in batch:
                 try:
                     await client.delete_flow_run(run.id)
+                    deleted += 1
+                except ObjectNotFound:
+                    # Already deleted (e.g., by concurrent cleanup) - treat as success
                     deleted += 1
                 except Exception as e:
                     print(f"failed to delete {run.id}: {e}")


### PR DESCRIPTION
## Summary

- add `ObjectNotFound` exception handling for idempotent deletes in the retention flow example (`database-maintenance.mdx`)
- add `ObjectNotFound` handling to `ai_database_cleanup_with_approval.py` example
- add event retention guidance table with workload-based recommendations
- cross-reference database maintenance from self-hosted guide
- add tip about event retention for high-volume deployments

## Context

During OSS testbed database cleanup work, we discovered that concurrent cleanup runs can race and cause `ObjectNotFound` (404) errors when a flow run is already deleted. The existing example code didn't handle this case, leading to spurious "failed to delete" warnings.

The `ObjectNotFound` pattern was empirically tested:

```
✓ ObjectNotFound raised as expected
  type: ObjectNotFound
  str(e): 'None'
  help_message: None
✓ Idempotent delete pattern works: deleted=True
Created flow run: 39f6062b-a148-4a50-af45-a30e833680a8
✓ First delete succeeded
✓ Second delete raised ObjectNotFound (expected, idempotent)
```

## Test plan

- [ ] verify documentation renders correctly
- [ ] the code patterns were empirically tested against the OSS testbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)