### PR TITLE
Fix flakes in `TestReadTaskRunCountsByState::test_returns_all_state_types`

### DIFF
--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -440,6 +440,7 @@ async def count_task_runs_by_state(
         select(db.TaskRun.state_type, sa.func.count(None).label("count"))
         .select_from(db.TaskRun)
         .group_by(db.TaskRun.state_type)
+        .where(db.TaskRun.state_type.isnot(None))
     )
 
     query = await _apply_task_run_filters(


### PR DESCRIPTION
Fixes test flakes seen in CI (https://github.com/PrefectHQ/prefect/actions/runs/19904399182/job/57056712305?pr=19565) by ensuring that task runs without a state_type aren't included in the query result
