### PR TITLE
fix: remove return type annotation from settings serializer to fix OpenAPI schema

### DIFF
--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -164,9 +164,9 @@ class PrefectBaseSettings(BaseSettings):
     @model_serializer(
         mode="wrap", when_used="always"
     )  # TODO: reconsider `when_used` default for more control
-    def ser_model(
+    def _ser_model(
         self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
-    ) -> Any:
+    ):  # No return type to avoid breaking OpenAPI schema generation (pydantic#8791)
         jsonable_self: dict[str, Any] = handler(self)
         # iterate over fields to ensure child models that have been updated are also included
         for key in type(self).model_fields.keys():

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5186,6 +5186,12 @@ export interface components {
              */
             enable_orchestration_telemetry: boolean;
             /**
+             * Max Log Size
+             * @description Maximum size in characters for a single log when sending logs to Prefect Cloud.
+             * @default 25000
+             */
+            max_log_size: number;
+            /**
              * Ui Url
              * @description The URL of the Prefect Cloud UI. If not set, the client will attempt to infer it.
              */
@@ -5588,32 +5594,7 @@ export interface components {
             expiration: string;
         };
         /** DependencyResult */
-        "DependencyResult-Input": {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Name */
-            name: string;
-            /** Upstream Dependencies */
-            upstream_dependencies: components["schemas"]["TaskRunResult"][];
-            state: components["schemas"]["State"] | null;
-            /** Expected Start Time */
-            expected_start_time: string | null;
-            /** Start Time */
-            start_time: string | null;
-            /** End Time */
-            end_time: string | null;
-            /** Total Run Time */
-            total_run_time: number | null;
-            /** Estimated Run Time */
-            estimated_run_time: number | null;
-            /** Untrackable Result */
-            untrackable_result: boolean;
-        };
-        /** DependencyResult */
-        "DependencyResult-Output": {
+        DependencyResult: {
             /**
              * Id
              * Format: uuid
@@ -6037,6 +6018,11 @@ export interface components {
              * @description The work queue for the deployment. If no work queue is set, work will not be scheduled.
              */
             work_queue_name?: string | null;
+            /**
+             * Work Queue Id
+             * @description The id of the work pool queue to which this deployment is assigned.
+             */
+            work_queue_id?: string | null;
             /**
              * Last Polled
              * @description The last time the deployment was polled for status updates.
@@ -6812,178 +6798,7 @@ export interface components {
          * FlowRun
          * @description An ORM representation of flow run data.
          */
-        "FlowRun-Input": {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Created */
-            created: string | null;
-            /** Updated */
-            updated: string | null;
-            /**
-             * Name
-             * @description The name of the flow run. Defaults to a random slug if not specified.
-             */
-            name?: string;
-            /**
-             * Flow Id
-             * Format: uuid
-             * @description The id of the flow being run.
-             */
-            flow_id: string;
-            /**
-             * State Id
-             * @description The id of the flow run's current state.
-             */
-            state_id?: string | null;
-            /**
-             * Deployment Id
-             * @description The id of the deployment associated with this flow run, if available.
-             */
-            deployment_id?: string | null;
-            /**
-             * Deployment Version
-             * @description The version of the deployment associated with this flow run.
-             */
-            deployment_version?: string | null;
-            /**
-             * Work Queue Name
-             * @description The work queue that handled this flow run.
-             */
-            work_queue_name?: string | null;
-            /**
-             * Flow Version
-             * @description The version of the flow executed in this flow run.
-             */
-            flow_version?: string | null;
-            /**
-             * Parameters
-             * @description Parameters for the flow run.
-             */
-            parameters?: {
-                [key: string]: unknown;
-            };
-            /**
-             * Idempotency Key
-             * @description An optional idempotency key for the flow run. Used to ensure the same flow run is not created multiple times.
-             */
-            idempotency_key?: string | null;
-            /**
-             * Context
-             * @description Additional context for the flow run.
-             */
-            context?: {
-                [key: string]: unknown;
-            };
-            empirical_policy?: components["schemas"]["FlowRunPolicy"];
-            /**
-             * Tags
-             * @description A list of tags on the flow run
-             */
-            tags?: string[];
-            /**
-             * Labels
-             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
-             */
-            labels?: {
-                [key: string]: boolean | number | string;
-            } | null;
-            /**
-             * Parent Task Run Id
-             * @description If the flow run is a subflow, the id of the 'dummy' task in the parent flow used to track subflow state.
-             */
-            parent_task_run_id?: string | null;
-            /** @description The type of the current flow run state. */
-            state_type?: components["schemas"]["StateType"] | null;
-            /**
-             * State Name
-             * @description The name of the current flow run state.
-             */
-            state_name?: string | null;
-            /**
-             * Run Count
-             * @description The number of times the flow run was executed.
-             * @default 0
-             */
-            run_count: number;
-            /**
-             * Expected Start Time
-             * @description The flow run's expected start time.
-             */
-            expected_start_time?: string | null;
-            /**
-             * Next Scheduled Start Time
-             * @description The next time the flow run is scheduled to start.
-             */
-            next_scheduled_start_time?: string | null;
-            /**
-             * Start Time
-             * @description The actual start time.
-             */
-            start_time?: string | null;
-            /**
-             * End Time
-             * @description The actual end time.
-             */
-            end_time?: string | null;
-            /**
-             * Total Run Time
-             * @description Total run time. If the flow run was executed multiple times, the time of each run will be summed.
-             * @default 0
-             */
-            total_run_time: number;
-            /**
-             * Estimated Run Time
-             * @description A real-time estimate of the total run time.
-             * @default 0
-             */
-            estimated_run_time: number;
-            /**
-             * Estimated Start Time Delta
-             * @description The difference between actual and expected start time.
-             * @default 0
-             */
-            estimated_start_time_delta: number;
-            /**
-             * Auto Scheduled
-             * @description Whether or not the flow run was automatically scheduled.
-             * @default false
-             */
-            auto_scheduled: boolean;
-            /**
-             * Infrastructure Document Id
-             * @description The block document defining infrastructure to use this flow run.
-             */
-            infrastructure_document_id?: string | null;
-            /**
-             * Infrastructure Pid
-             * @description The id of the flow run as returned by an infrastructure block.
-             */
-            infrastructure_pid?: string | null;
-            /** @description Optional information about the creator of this flow run. */
-            created_by?: components["schemas"]["CreatedBy"] | null;
-            /**
-             * Work Queue Id
-             * @description The id of the run's work pool queue.
-             */
-            work_queue_id?: string | null;
-            /** @description The current state of the flow run. */
-            state?: components["schemas"]["State"] | null;
-            /**
-             * Job Variables
-             * @description Variables used as overrides in the base job template
-             */
-            job_variables?: {
-                [key: string]: unknown;
-            } | null;
-        };
-        /**
-         * FlowRun
-         * @description An ORM representation of flow run data.
-         */
-        "FlowRun-Output": {
+        FlowRun: {
             /**
              * Id
              * Format: uuid
@@ -8009,30 +7824,7 @@ export interface components {
          * HistoryResponse
          * @description Represents a history of aggregation states over an interval
          */
-        "HistoryResponse-Input": {
-            /**
-             * Interval Start
-             * Format: date-time
-             * @description The start date of the interval.
-             */
-            interval_start: string;
-            /**
-             * Interval End
-             * Format: date-time
-             * @description The end date of the interval.
-             */
-            interval_end: string;
-            /**
-             * States
-             * @description A list of state histories during the interval.
-             */
-            states: components["schemas"]["HistoryResponseState"][];
-        };
-        /**
-         * HistoryResponse
-         * @description Represents a history of aggregation states over an interval
-         */
-        "HistoryResponse-Output": {
+        HistoryResponse: {
             /**
              * Interval Start
              * Format: date-time
@@ -8378,7 +8170,7 @@ export interface components {
             batch_size: number;
             /**
              * Max Log Size
-             * @description The maximum size in bytes for a single log.
+             * @description The maximum size in characters for a single log. When connected to Prefect Cloud, this value is capped at `PREFECT_CLOUD_MAX_LOG_SIZE` (default 25,000).
              * @default 1000000
              */
             max_log_size: number;
@@ -9128,37 +8920,23 @@ export interface components {
             value: unknown;
         };
         /** SchemaValueIndexError */
-        "SchemaValueIndexError-Input": {
+        SchemaValueIndexError: {
             /** Index */
             index: number;
             /** Errors */
-            errors: (string | components["schemas"]["SchemaValuePropertyError-Input"] | components["schemas"]["SchemaValueIndexError-Input"])[];
-        };
-        /** SchemaValueIndexError */
-        "SchemaValueIndexError-Output": {
-            /** Index */
-            index: number;
-            /** Errors */
-            errors: (string | components["schemas"]["SchemaValuePropertyError-Output"] | components["schemas"]["SchemaValueIndexError-Output"])[];
+            errors: (string | components["schemas"]["SchemaValuePropertyError"] | components["schemas"]["SchemaValueIndexError"])[];
         };
         /** SchemaValuePropertyError */
-        "SchemaValuePropertyError-Input": {
+        SchemaValuePropertyError: {
             /** Property */
             property: string;
             /** Errors */
-            errors: (string | components["schemas"]["SchemaValuePropertyError-Input"] | components["schemas"]["SchemaValueIndexError-Input"])[];
-        };
-        /** SchemaValuePropertyError */
-        "SchemaValuePropertyError-Output": {
-            /** Property */
-            property: string;
-            /** Errors */
-            errors: (string | components["schemas"]["SchemaValuePropertyError-Output"] | components["schemas"]["SchemaValueIndexError-Output"])[];
+            errors: (string | components["schemas"]["SchemaValuePropertyError"] | components["schemas"]["SchemaValueIndexError"])[];
         };
         /** SchemaValuesValidationResponse */
         SchemaValuesValidationResponse: {
             /** Errors */
-            errors: (string | components["schemas"]["SchemaValuePropertyError-Output"] | components["schemas"]["SchemaValueIndexError-Output"])[];
+            errors: (string | components["schemas"]["SchemaValuePropertyError"] | components["schemas"]["SchemaValueIndexError"])[];
             /** Valid */
             valid: boolean;
         };
@@ -9363,6 +9141,12 @@ export interface components {
              * @default 300
              */
             initial_deployment_lease_duration: number;
+            /**
+             * Maximum Concurrency Slot Wait Seconds
+             * @description The maximum number of seconds to wait before retrying when a concurrency slot cannot be acquired.
+             * @default 30
+             */
+            maximum_concurrency_slot_wait_seconds: number;
         };
         /**
          * ServerDatabaseSettings
@@ -9671,6 +9455,12 @@ export interface components {
              */
             batch_size: number;
             /**
+             * Read Batch Size
+             * @description The number of events the event persister will attempt to read from the message broker in one batch.
+             * @default 1
+             */
+            read_batch_size: number;
+            /**
              * Flush Interval
              * @description The maximum number of seconds between flushes of the event persister.
              * @default 5
@@ -9933,6 +9723,12 @@ export interface components {
              * @default true
              */
             enabled: boolean;
+            /**
+             * Read Batch Size
+             * @description The number of task runs the task run recorder will attempt to read from the message broker in one batch.
+             * @default 1
+             */
+            read_batch_size: number;
         };
         /**
          * ServerServicesTriggersSettings
@@ -9945,6 +9741,12 @@ export interface components {
              * @default true
              */
             enabled: boolean;
+            /**
+             * Read Batch Size
+             * @description The number of events the triggers service will attempt to read from the message broker in one batch.
+             * @default 1
+             */
+            read_batch_size: number;
             /**
              * Pg Notify Reconnect Interval Seconds
              * @description
@@ -10126,7 +9928,68 @@ export interface components {
          * @enum {string}
          */
         SetStateStatus: "ACCEPT" | "REJECT" | "ABORT" | "WAIT";
-        Settings: unknown;
+        /**
+         * Settings
+         * @description Settings for Prefect using Pydantic settings.
+         *
+         *     See https://docs.pydantic.dev/latest/concepts/pydantic_settings
+         */
+        Settings: {
+            /**
+             * Home
+             * Format: path
+             * @description The path to the Prefect home directory. Defaults to ~/.prefect
+             * @default ~/.prefect
+             */
+            home: string;
+            /**
+             * Profiles Path
+             * Format: path
+             * @description The path to a profiles configuration file. Supports \$PREFECT_HOME templating. Defaults to \$PREFECT_HOME/profiles.toml.
+             */
+            profiles_path?: string;
+            /**
+             * Debug Mode
+             * @description If True, enables debug mode which may provide additional logging and debugging features.
+             * @default false
+             */
+            debug_mode: boolean;
+            api?: components["schemas"]["APISettings"];
+            cli?: components["schemas"]["CLISettings"];
+            client?: components["schemas"]["ClientSettings"];
+            cloud?: components["schemas"]["CloudSettings"];
+            deployments?: components["schemas"]["DeploymentsSettings"];
+            /** @description Settings for controlling experimental features */
+            experiments?: components["schemas"]["ExperimentsSettings"];
+            flows?: components["schemas"]["FlowsSettings"];
+            /** @description Settings for internal Prefect machinery */
+            internal?: components["schemas"]["InternalSettings"];
+            logging?: components["schemas"]["LoggingSettings"];
+            results?: components["schemas"]["ResultsSettings"];
+            runner?: components["schemas"]["RunnerSettings"];
+            server?: components["schemas"]["ServerSettings"];
+            /** @description Settings for controlling task behavior */
+            tasks?: components["schemas"]["TasksSettings"];
+            /** @description Settings used during testing */
+            testing?: components["schemas"]["TestingSettings"];
+            /** @description Settings for controlling worker behavior */
+            worker?: components["schemas"]["WorkerSettings"];
+            /**
+             * Ui Url
+             * @description The URL of the Prefect UI. If not set, the client will attempt to infer it.
+             */
+            ui_url?: string | null;
+            /**
+             * Silence Api Url Misconfiguration
+             * @description
+             *             If `True`, disable the warning when a user accidentally misconfigure its `PREFECT_API_URL`
+             *             Sometimes when a user manually set `PREFECT_API_URL` to a custom url,reverse-proxy for example,
+             *             we would like to silence this warning so we will set it to `FALSE`.
+             *
+             * @default false
+             */
+            silence_api_url_misconfiguration: boolean;
+        };
         /** SimpleFlowRun */
         SimpleFlowRun: {
             /**
@@ -10510,20 +10373,7 @@ export interface components {
             /** @description The current task run state. */
             state?: components["schemas"]["State"] | null;
         };
-        /** TaskRunCount */
-        "TaskRunCount-Input": {
-            /**
-             * Completed
-             * @description The number of completed task runs.
-             */
-            completed: number;
-            /**
-             * Failed
-             * @description The number of failed task runs.
-             */
-            failed: number;
-        };
-        "TaskRunCount-Output": {
+        TaskRunCount: {
             [key: string]: number;
         };
         /**
@@ -10776,7 +10626,7 @@ export interface components {
         /** TaskRunPaginationResponse */
         TaskRunPaginationResponse: {
             /** Results */
-            results: components["schemas"]["TaskRunResponse-Output"][];
+            results: components["schemas"]["TaskRunResponse"][];
             /** Count */
             count: number;
             /** Limit */
@@ -10822,74 +10672,7 @@ export interface components {
             retry_jitter_factor?: number | null;
         };
         /** TaskRunResponse */
-        "TaskRunResponse-Input": {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Created */
-            created: string | null;
-            /** Updated */
-            updated: string | null;
-            /**
-             * Name
-             * @description The name of the task run. Defaults to a random slug if not specified.
-             */
-            name?: string;
-            /**
-             * Flow Run Id
-             * @description The id of the flow run this task run belongs to.
-             */
-            flow_run_id?: string | null;
-            /**
-             * Task Key
-             * @description The key of the task this run represents.
-             */
-            task_key: string;
-            /**
-             * State Id
-             * @description The id of the task run's current state.
-             */
-            state_id?: string | null;
-            /** @description The current state of the task run. */
-            state?: components["schemas"]["State"] | null;
-            /**
-             * Task Version
-             * @description The version of the task executed in this task run.
-             */
-            task_version?: string | null;
-            /**
-             * Parameters
-             * @description Parameters for the task run.
-             */
-            parameters?: {
-                [key: string]: unknown;
-            };
-            /**
-             * Task Inputs
-             * @description Inputs provided to the task run.
-             */
-            task_inputs?: {
-                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["FlowRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
-            };
-            /**
-             * Context
-             * @description Additional context for the task run.
-             */
-            context?: {
-                [key: string]: unknown;
-            };
-            /** @description The task run's empirical retry policy. */
-            empirical_policy?: components["schemas"]["TaskRunPolicy"];
-            /**
-             * Tags
-             * @description A list of tags for the task run.
-             */
-            tags?: string[];
-        };
-        /** TaskRunResponse */
-        "TaskRunResponse-Output": {
+        TaskRunResponse: {
             /**
              * Id
              * Format: uuid
@@ -11938,7 +11721,7 @@ export interface components {
             not_any_?: components["schemas"]["WorkerStatus"][] | null;
         };
         /** WorkerFlowRunResponse */
-        "WorkerFlowRunResponse-Input": {
+        WorkerFlowRunResponse: {
             /**
              * Work Pool Id
              * Format: uuid
@@ -11949,21 +11732,7 @@ export interface components {
              * Format: uuid
              */
             work_queue_id: string;
-            flow_run: components["schemas"]["FlowRun-Input"];
-        };
-        /** WorkerFlowRunResponse */
-        "WorkerFlowRunResponse-Output": {
-            /**
-             * Work Pool Id
-             * Format: uuid
-             */
-            work_pool_id: string;
-            /**
-             * Work Queue Id
-             * Format: uuid
-             */
-            work_queue_id: string;
-            flow_run: components["schemas"]["FlowRun-Output"];
+            flow_run: components["schemas"]["FlowRun"];
         };
         /** WorkerResponse */
         WorkerResponse: {
@@ -12600,7 +12369,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HistoryResponse-Output"][];
+                    "application/json": components["schemas"]["HistoryResponse"][];
                 };
             };
             /** @description Validation Error */
@@ -12634,7 +12403,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DependencyResult-Output"][];
+                    "application/json": components["schemas"]["DependencyResult"][];
                 };
             };
             /** @description Validation Error */
@@ -13242,7 +13011,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HistoryResponse-Output"][];
+                    "application/json": components["schemas"]["HistoryResponse"][];
                 };
             };
             /** @description Validation Error */
@@ -15753,7 +15522,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkerFlowRunResponse-Output"][];
+                    "application/json": components["schemas"]["WorkerFlowRunResponse"][];
                 };
             };
             /** @description Validation Error */
@@ -17968,7 +17737,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskRunCount-Output"][];
+                    "application/json": components["schemas"]["TaskRunCount"][];
                 };
             };
             /** @description Validation Error */

--- a/ui-v2/src/api/task-runs/index.ts
+++ b/ui-v2/src/api/task-runs/index.ts
@@ -284,7 +284,7 @@ export const useDeleteTaskRun = () => {
 export type TaskRunsHistoryFilter =
 	components["schemas"]["Body_task_run_history_task_runs_history_post"];
 
-export type HistoryResponse = components["schemas"]["HistoryResponse-Output"];
+export type HistoryResponse = components["schemas"]["HistoryResponse"];
 
 export type HistoryResponseState =
 	components["schemas"]["HistoryResponseState"];

--- a/ui-v2/src/components/schemas/types/errors.ts
+++ b/ui-v2/src/components/schemas/types/errors.ts
@@ -3,9 +3,9 @@ import { isRecord } from "../utilities/guards";
 
 export type SchemaValueError = string;
 export type SchemaValuePropertyError =
-	components["schemas"]["SchemaValuePropertyError-Output"];
+	components["schemas"]["SchemaValuePropertyError"];
 export type SchemaValueIndexError =
-	components["schemas"]["SchemaValueIndexError-Output"];
+	components["schemas"]["SchemaValueIndexError"];
 export type SchemaFormError =
 	| SchemaValueError
 	| SchemaValuePropertyError


### PR DESCRIPTION
## Summary

- Removes the `-> Any` return type annotation from the `ser_model()` method in `PrefectBaseSettings`
- Regenerates UI schema with correct type definitions
- Updates UI type references to use non-suffixed schema types

## Problem

The `@model_serializer(mode='wrap')` decorator with a return type annotation (e.g., `-> Any`) causes Pydantic to generate an empty serialization schema (`{}`). FastAPI 0.120+ uses serialization mode for response models, which causes types like `APISettings` to become `unknown` in the generated TypeScript schema.

## Solution

Removing the return type annotation allows Pydantic to fall back to the model schema, producing correct OpenAPI definitions for all settings types. This also removes the need for separate `-Input`/`-Output` schema variants.

## References

- https://github.com/pydantic/pydantic/issues/8791

## Test plan

- [x] UI lint passes
- [x] UI type validation passes
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)