### PR TITLE
Fix compatibility with `fastapi==0.123.7`

### DIFF
--- a/src/prefect/server/database/dependencies.py
+++ b/src/prefect/server/database/dependencies.py
@@ -31,12 +31,12 @@ from prefect.server.database.configurations import (
     AsyncPostgresConfiguration,
     BaseDatabaseConfiguration,
 )
+from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.utilities.database import get_dialect
 from prefect.server.utilities.schemas import PrefectDescriptorBase
 from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL
 
 if TYPE_CHECKING:
-    from prefect.server.database.interface import PrefectDBInterface
     from prefect.server.database.orm_models import BaseORMConfiguration
     from prefect.server.database.query_components import BaseQueryComponents
 
@@ -65,7 +65,7 @@ MODELS_DEPENDENCIES: _ModelDependencies = {
 }
 
 
-def provide_database_interface() -> "PrefectDBInterface":
+def provide_database_interface() -> PrefectDBInterface:
     """
     Get the current Prefect REST API database interface.
 

--- a/src/prefect/server/schemas/sorting.py
+++ b/src/prefect/server/schemas/sorting.py
@@ -3,15 +3,11 @@ Schemas for sorting Prefect REST API objects.
 """
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import sqlalchemy as sa
 
-from prefect.server.utilities.database import db_injector
 from prefect.utilities.collections import AutoEnum
-
-if TYPE_CHECKING:
-    from prefect.server.database import PrefectDBInterface
 
 # TODO: Consider moving the `as_sql_sort` functions out of here since they are a
 #       database model level function and do not properly separate concerns when
@@ -31,9 +27,11 @@ class FlowRunSort(AutoEnum):
     NEXT_SCHEDULED_START_TIME_ASC = AutoEnum.auto()
     END_TIME_DESC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort flow runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "ID_DESC": [db.FlowRun.id.desc()],
             "START_TIME_ASC": [
@@ -69,9 +67,11 @@ class TaskRunSort(AutoEnum):
     NEXT_SCHEDULED_START_TIME_ASC = AutoEnum.auto()
     END_TIME_DESC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "ID_DESC": [db.TaskRun.id.desc()],
             "EXPECTED_START_TIME_ASC": [db.TaskRun.expected_start_time.asc()],
@@ -92,9 +92,11 @@ class LogSort(AutoEnum):
     TIMESTAMP_ASC = AutoEnum.auto()
     TIMESTAMP_DESC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "TIMESTAMP_ASC": [db.Log.timestamp.asc()],
             "TIMESTAMP_DESC": [db.Log.timestamp.desc()],
@@ -110,9 +112,11 @@ class FlowSort(AutoEnum):
     NAME_ASC = AutoEnum.auto()
     NAME_DESC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "CREATED_DESC": [db.Flow.created.desc()],
             "UPDATED_DESC": [db.Flow.updated.desc()],
@@ -130,9 +134,11 @@ class DeploymentSort(AutoEnum):
     NAME_ASC = AutoEnum.auto()
     NAME_DESC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "CREATED_DESC": [db.Deployment.created.desc()],
             "UPDATED_DESC": [db.Deployment.updated.desc()],
@@ -151,9 +157,11 @@ class ArtifactSort(AutoEnum):
     KEY_DESC = AutoEnum.auto()
     KEY_ASC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "CREATED_DESC": [db.Artifact.created.desc()],
             "UPDATED_DESC": [db.Artifact.updated.desc()],
@@ -173,9 +181,11 @@ class ArtifactCollectionSort(AutoEnum):
     KEY_DESC = AutoEnum.auto()
     KEY_ASC = AutoEnum.auto()
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "CREATED_DESC": [db.ArtifactCollection.created.desc()],
             "UPDATED_DESC": [db.ArtifactCollection.updated.desc()],
@@ -194,9 +204,11 @@ class VariableSort(AutoEnum):
     NAME_DESC = "NAME_DESC"
     NAME_ASC = "NAME_ASC"
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "CREATED_DESC": [db.Variable.created.desc()],
             "UPDATED_DESC": [db.Variable.updated.desc()],
@@ -213,9 +225,11 @@ class BlockDocumentSort(AutoEnum):
     NAME_ASC = "NAME_ASC"
     BLOCK_TYPE_AND_NAME_ASC = "BLOCK_TYPE_AND_NAME_ASC"
 
-    @db_injector
-    def as_sql_sort(self, db: "PrefectDBInterface") -> Iterable[sa.ColumnElement[Any]]:
+    def as_sql_sort(self) -> Iterable[sa.ColumnElement[Any]]:
         """Return an expression used to sort task runs"""
+        from prefect.server.database.dependencies import provide_database_interface
+
+        db = provide_database_interface()
         sort_mapping: dict[str, Iterable[sa.ColumnElement[Any]]] = {
             "NAME_DESC": [db.BlockDocument.name.desc()],
             "NAME_ASC": [db.BlockDocument.name.asc()],

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1825,7 +1825,7 @@ class TestClientAPIKey:
     async def test_client_no_auth_header_without_api_key(self, test_app: FastAPI):
         async with PrefectClient(test_app) as client:
             with pytest.raises(
-                httpx.HTTPStatusError, match=str(status.HTTP_403_FORBIDDEN)
+                httpx.HTTPStatusError, match=str(status.HTTP_401_UNAUTHORIZED)
             ):
                 await client._client.get("/check_for_auth_header")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1343,7 +1343,7 @@ lua = [
 
 [[package]]
 name = "fastapi"
-version = "0.121.1"
+version = "0.123.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1351,9 +1351,9 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/a4/29e1b861fc9017488ed02ff1052feffa40940cb355ed632a8845df84ce84/fastapi-0.121.1.tar.gz", hash = "sha256:b6dba0538fd15dab6fe4d3e5493c3957d8a9e1e9257f56446b5859af66f32441", size = 342523, upload-time = "2025-11-08T21:48:14.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/99/8f2d4be9af90b3e56b865a07bdd390398e53d67c9c95c729b5772e528179/fastapi-0.123.8.tar.gz", hash = "sha256:d106de125c8dd3d4341517fa2ae36d9cffe82a6500bd910d3c080e6c42b1b490", size = 354253, upload-time = "2025-12-04T13:02:54.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fd/2e6f7d706899cc08690c5f6641e2ffbfffe019e8f16ce77104caa5730910/fastapi-0.121.1-py3-none-any.whl", hash = "sha256:2c5c7028bc3a58d8f5f09aecd3fd88a000ccc0c5ad627693264181a3c33aa1fc", size = 109192, upload-time = "2025-11-08T21:48:12.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/dd53f49e8309454e2c52bdfffe7493cc0f00d10e2fc885d3f4d64c90731f/fastapi-0.123.8-py3-none-any.whl", hash = "sha256:d7c8db95f61d398f7e1491ad52e6b2362755f8ec61c7a740b29e70f18a2901e3", size = 111645, upload-time = "2025-12-04T13:02:53.163Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Removes forward reference of `PrefectDBInterface` in `provide_db_interface` dependency by defering other imports to "fix" a circular dependency.

Closes https://github.com/PrefectHQ/prefect/issues/19621