### PR TITLE
Add Google Tag Manager integration to docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,7 +34,7 @@
       "measurementId": "G-8GR5P04T5Y"
     },
     "gtm": {
-      "tagId": "GTM-XXXXXX"
+      "tagId": "GTM-WKTHW8MK"
     }
   },
   "logo": {


### PR DESCRIPTION
Adds GTM integration placeholder to Mintlify config for marketing pixel tracking.
