### PR TITLE
Turn off depdendabot for Vue UI package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,6 @@ updates:
     schedule:
       interval: "daily"
     labels: ["development"]
-
-  - package-ecosystem: "npm"
-    directory: '/ui/'
-    schedule:
-      interval: "weekly"
-    labels: ["ui", "ui-dependency"]
   
   - package-ecosystem: "npm"
     directory: '/ui-v2/'
@@ -32,6 +26,7 @@ updates:
           - "@eslint*"
           - "eslint*"
           - "typescript-eslint"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The Vue UI isn't being actively devloped, so we'll keep the package versions consistent for stability
