### PR TITLE
feat(azure): add service principal authentication for AzureBlobStorageCredentials

### DIFF
--- a/src/integrations/prefect-azure/prefect_azure/credentials.py
+++ b/src/integrations/prefect-azure/prefect_azure/credentials.py
@@ -2,9 +2,12 @@
 
 import base64
 import functools
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from azure.identity.aio import (
+    ClientSecretCredential as AClientSecretCredential,
+)
 from azure.identity.aio import DefaultAzureCredential as ADefaultAzureCredential
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.resource import ResourceManagementClient
@@ -76,12 +79,24 @@ class AzureBlobStorageCredentials(Block):
     """
     Stores credentials for authenticating with Azure Blob Storage.
 
+    Authentication can be done using one of the following methods:
+    1. Connection string: Provide a connection string for your Azure storage account.
+    2. Account URL with DefaultAzureCredential: Provide an account URL and credentials
+       will be discovered automatically using DefaultAzureCredential.
+    3. Account URL with Service Principal: Provide an account URL along with client_id,
+       tenant_id, and client_secret for service principal authentication.
+
     Args:
-        account_url: The URL for your Azure storage account. If provided, the account
-            URL will be used to authenticate with the discovered default Azure
-            credentials.
+        account_url: The URL for your Azure storage account. Required for
+            DefaultAzureCredential or service principal authentication.
         connection_string: The connection string to your Azure storage account. If
             provided, the connection string will take precedence over the account URL.
+        client_id: The service principal client ID. If provided, tenant_id and
+            client_secret must also be provided.
+        tenant_id: The service principal tenant ID. If provided, client_id and
+            client_secret must also be provided.
+        client_secret: The service principal client secret. If provided, client_id and
+            tenant_id must also be provided.
 
     Example:
         Load stored Azure Blob Storage credentials and retrieve a blob service client:
@@ -90,14 +105,29 @@ class AzureBlobStorageCredentials(Block):
 
         azure_credentials_block = AzureBlobStorageCredentials.load("BLOCK_NAME")
 
-        blob_service_client = azure_credentials_block.get_blob_client()
+        blob_service_client = azure_credentials_block.get_client()
+        ```
+
+        Using service principal authentication:
+        ```python
+        from prefect_azure import AzureBlobStorageCredentials
+
+        credentials = AzureBlobStorageCredentials(
+            account_url="https://mystorageaccount.blob.core.windows.net",
+            client_id="my-client-id",
+            tenant_id="my-tenant-id",
+            client_secret="my-client-secret",
+        )
+        blob_service_client = credentials.get_client()
         ```
     """
 
     _block_type_name = "Azure Blob Storage Credentials"
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/54e3fa7e00197a4fbd1d82ed62494cb58d08c96a-250x250.png"  # noqa
     _documentation_url = "https://docs.prefect.io/integrations/prefect-azure"  # noqa
-    _credential: Optional[ADefaultAzureCredential] = PrivateAttr(default=None)
+    _credential: Optional[Union[ADefaultAzureCredential, AClientSecretCredential]] = (
+        PrivateAttr(default=None)
+    )
 
     connection_string: Optional[SecretStr] = Field(
         default=None,
@@ -110,9 +140,31 @@ class AzureBlobStorageCredentials(Block):
         default=None,
         title="Account URL",
         description=(
-            "The URL for your Azure storage account. If provided, the account "
-            "URL will be used to authenticate with the discovered default "
-            "Azure credentials."
+            "The URL for your Azure storage account. Required for "
+            "DefaultAzureCredential or service principal authentication."
+        ),
+    )
+    client_id: Optional[str] = Field(
+        default=None,
+        title="Client ID",
+        description=(
+            "The service principal client ID. If provided, tenant_id and "
+            "client_secret must also be provided for service principal authentication."
+        ),
+    )
+    tenant_id: Optional[str] = Field(
+        default=None,
+        title="Tenant ID",
+        description=(
+            "The service principal tenant ID. If provided, client_id and "
+            "client_secret must also be provided for service principal authentication."
+        ),
+    )
+    client_secret: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "The service principal client secret. If provided, client_id and "
+            "tenant_id must also be provided for service principal authentication."
         ),
     )
 
@@ -122,19 +174,82 @@ class AzureBlobStorageCredentials(Block):
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
-        Checks that either a connection string or account URL is provided, not both.
+        Validates authentication configuration.
+
+        Valid configurations:
+        1. connection_string only (no account_url, no SPN fields)
+        2. account_url only (uses DefaultAzureCredential)
+        3. account_url + client_id + tenant_id + client_secret (SPN auth)
         """
         has_account_url = values.get("account_url") is not None
         has_conn_str = values.get("connection_string") is not None
+
+        # Check SPN fields
+        spn_fields = ("client_id", "tenant_id", "client_secret")
+        has_any_spn = any(values.get(key) is not None for key in spn_fields)
+        has_all_spn = all(values.get(key) is not None for key in spn_fields)
+
+        # Validate SPN configuration
+        if has_any_spn and not has_all_spn:
+            raise ValueError(
+                "If any of `client_id`, `tenant_id`, or `client_secret` are provided, "
+                "all must be provided for service principal authentication."
+            )
+
+        # SPN requires account_url
+        if has_all_spn and not has_account_url:
+            raise ValueError(
+                "Must provide `account_url` when using service principal authentication."
+            )
+
+        # Connection string cannot be combined with SPN
+        if has_conn_str and has_any_spn:
+            raise ValueError(
+                "Cannot provide both a connection string and service principal "
+                "credentials. Use one or the other."
+            )
+
+        # Must have either connection_string or account_url
         if not has_account_url and not has_conn_str:
             raise ValueError(
                 "Must provide either a connection string or an account URL."
             )
+
+        # Cannot have both connection_string and account_url
         if has_account_url and has_conn_str:
             raise ValueError(
                 "Must provide either a connection string or account URL, but not both."
             )
+
         return values
+
+    def _create_credential(
+        self,
+    ) -> Union[ADefaultAzureCredential, AClientSecretCredential]:
+        """
+        Creates an async Azure credential based on the configured authentication method.
+
+        If service principal credentials are provided, uses ClientSecretCredential.
+        Otherwise, uses DefaultAzureCredential for automatic credential discovery.
+
+        Returns:
+            An async Azure credential ready to use with Azure SDK client classes.
+        """
+        if self._credential is not None:
+            return self._credential
+
+        if self.client_id is not None:
+            # Service principal authentication
+            self._credential = AClientSecretCredential(
+                tenant_id=self.tenant_id,
+                client_id=self.client_id,
+                client_secret=self.client_secret.get_secret_value(),
+            )
+        else:
+            # Default credential discovery
+            self._credential = ADefaultAzureCredential()
+
+        return self._credential
 
     @_raise_help_msg("blob_storage")
     def get_client(self) -> "BlobServiceClient":
@@ -164,10 +279,9 @@ class AzureBlobStorageCredentials(Block):
             ```
         """
         if self.connection_string is None:
-            self._credential = self._credential or ADefaultAzureCredential()
             return BlobServiceClient(
                 account_url=self.account_url,
-                credential=self._credential,
+                credential=self._create_credential(),
             )
 
         return BlobServiceClient.from_connection_string(
@@ -208,11 +322,10 @@ class AzureBlobStorageCredentials(Block):
             ```
         """
         if self.connection_string is None:
-            self._credential = self._credential or ADefaultAzureCredential()
             return BlobClient(
                 account_url=self.account_url,
                 container_name=container,
-                credential=self._credential,
+                credential=self._create_credential(),
                 blob_name=blob,
             )
 
@@ -254,11 +367,10 @@ class AzureBlobStorageCredentials(Block):
             ```
         """
         if self.connection_string is None:
-            self._credential = self._credential or ADefaultAzureCredential()
             return ContainerClient(
                 account_url=self.account_url,
                 container_name=container,
-                credential=self._credential,
+                credential=self._create_credential(),
             )
 
         container_client = ContainerClient.from_connection_string(

--- a/src/integrations/prefect-azure/tests/test_credentials.py
+++ b/src/integrations/prefect-azure/tests/test_credentials.py
@@ -160,3 +160,142 @@ def test_get_azuredevops_auth_header_missing_token():
 
     with pytest.raises(ValueError, match="Azure DevOps Personal Access Token.*not set"):
         test_flow()
+
+
+# Service Principal Authentication Tests for AzureBlobStorageCredentials
+
+
+def test_spn_requires_all_fields():
+    """Test that partial SPN credentials raise an error."""
+    with pytest.raises(
+        ValueError,
+        match="If any of `client_id`, `tenant_id`, or `client_secret` are provided",
+    ):
+        AzureBlobStorageCredentials(
+            account_url="https://test.blob.core.windows.net",
+            client_id="client-id",
+            # Missing tenant_id and client_secret
+        )
+
+
+def test_spn_requires_account_url():
+    """Test that SPN credentials without account_url raise an error."""
+    with pytest.raises(
+        ValueError, match="Must provide `account_url` when using service principal"
+    ):
+        AzureBlobStorageCredentials(
+            client_id="client-id",
+            tenant_id="tenant-id",
+            client_secret=SecretStr("client-secret"),
+        )
+
+
+def test_spn_cannot_combine_with_connection_string():
+    """Test that SPN credentials cannot be combined with connection string."""
+    with pytest.raises(
+        ValueError,
+        match="Cannot provide both a connection string and service principal",
+    ):
+        AzureBlobStorageCredentials(
+            account_url="https://test.blob.core.windows.net",
+            connection_string="connection-string",
+            client_id="client-id",
+            tenant_id="tenant-id",
+            client_secret=SecretStr("client-secret"),
+        )
+
+
+def test_spn_get_service_client(account_url, monkeypatch):
+    """Test that SPN credentials work with get_client."""
+    mock_client_secret_credential = MagicMock()
+    monkeypatch.setattr(
+        "prefect_azure.credentials.AClientSecretCredential",
+        mock_client_secret_credential,
+    )
+
+    creds = AzureBlobStorageCredentials(
+        account_url=account_url,
+        client_id="client-id",
+        tenant_id="tenant-id",
+        client_secret=SecretStr("client-secret"),
+    )
+    client = creds.get_client()
+    assert isinstance(client, BlobServiceClient)
+    mock_client_secret_credential.assert_called_once_with(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+
+def test_spn_get_blob_client(account_url, monkeypatch):
+    """Test that SPN credentials work with get_blob_client."""
+    mock_client_secret_credential = MagicMock()
+    monkeypatch.setattr(
+        "prefect_azure.credentials.AClientSecretCredential",
+        mock_client_secret_credential,
+    )
+
+    creds = AzureBlobStorageCredentials(
+        account_url=account_url,
+        client_id="client-id",
+        tenant_id="tenant-id",
+        client_secret=SecretStr("client-secret"),
+    )
+    client = creds.get_blob_client("container", "blob")
+    assert isinstance(client, BlobClient)
+    assert client.container_name == "container"
+    assert client.blob_name == "blob"
+    mock_client_secret_credential.assert_called_once_with(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+
+def test_spn_get_container_client(account_url, monkeypatch):
+    """Test that SPN credentials work with get_container_client."""
+    mock_client_secret_credential = MagicMock()
+    monkeypatch.setattr(
+        "prefect_azure.credentials.AClientSecretCredential",
+        mock_client_secret_credential,
+    )
+
+    creds = AzureBlobStorageCredentials(
+        account_url=account_url,
+        client_id="client-id",
+        tenant_id="tenant-id",
+        client_secret=SecretStr("client-secret"),
+    )
+    client = creds.get_container_client("container")
+    assert isinstance(client, ContainerClient)
+    assert client.container_name == "container"
+    mock_client_secret_credential.assert_called_once_with(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+
+def test_spn_credential_reuse(account_url, monkeypatch):
+    """Test that the credential is reused across multiple client calls."""
+    mock_client_secret_credential = MagicMock()
+    monkeypatch.setattr(
+        "prefect_azure.credentials.AClientSecretCredential",
+        mock_client_secret_credential,
+    )
+
+    creds = AzureBlobStorageCredentials(
+        account_url=account_url,
+        client_id="client-id",
+        tenant_id="tenant-id",
+        client_secret=SecretStr("client-secret"),
+    )
+
+    # Make multiple client calls
+    creds.get_client()
+    creds.get_blob_client("container", "blob")
+    creds.get_container_client("container")
+
+    # Credential should only be created once
+    mock_client_secret_credential.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds service principal (SPN) authentication support to `AzureBlobStorageCredentials` block
- Allows users to authenticate using `client_id`, `tenant_id`, and `client_secret` in combination with `account_url`
- Brings `AzureBlobStorageCredentials` in line with other Azure credential blocks like `AzureContainerInstanceCredentials` and `AzureMlCredentials` which already support SPN auth

## Changes

- Added `client_id`, `tenant_id`, and `client_secret` fields to `AzureBlobStorageCredentials`
- Updated validator to handle SPN authentication requirements:
  - All three SPN fields must be provided together
  - SPN requires `account_url` (cannot use connection string)
  - Cannot combine connection string with SPN credentials
- Added `_create_credential()` helper method to create appropriate credential type
- Updated `get_client()`, `get_blob_client()`, and `get_container_client()` to use SPN credentials when provided
- Added comprehensive unit tests for SPN authentication

## Example Usage

```python
from prefect_azure import AzureBlobStorageCredentials

credentials = AzureBlobStorageCredentials(
    account_url="https://mystorageaccount.blob.core.windows.net",
    client_id="my-client-id",
    tenant_id="my-tenant-id",
    client_secret="my-client-secret",
)
blob_service_client = credentials.get_client()
```

## Test plan

- [x] Added unit tests for SPN validation (requires all fields, requires account_url, cannot combine with connection_string)
- [x] Added tests for `get_client()`, `get_blob_client()`, `get_container_client()` with SPN credentials
- [x] Added test for credential reuse across multiple client calls
- [x] All 154 existing prefect-azure tests pass

Closes #19644

🤖 Generated with [Claude Code](https://claude.com/claude-code)