### PR TITLE
fix(workers): prevent uvloop from setting global event loop policy in healthcheck

### DIFF
--- a/src/prefect/workers/server.py
+++ b/src/prefect/workers/server.py
@@ -4,10 +4,7 @@ import uvicorn
 from fastapi import APIRouter, FastAPI, status
 from fastapi.responses import JSONResponse
 
-from prefect.settings import (
-    PREFECT_WORKER_WEBSERVER_HOST,
-    PREFECT_WORKER_WEBSERVER_PORT,
-)
+from prefect.settings import get_current_settings
 from prefect.workers.base import BaseWorker
 
 
@@ -42,11 +39,13 @@ def build_healthcheck_server(
 
     app.include_router(router)
 
+    settings = get_current_settings()
     config = uvicorn.Config(
         app=app,
-        host=PREFECT_WORKER_WEBSERVER_HOST.value(),
-        port=PREFECT_WORKER_WEBSERVER_PORT.value(),
+        host=settings.worker.webserver.host,
+        port=settings.worker.webserver.port,
         log_level=log_level,
+        loop="asyncio",  # prevent uvloop from setting global policy
     )
     return uvicorn.Server(config=config)
 


### PR DESCRIPTION
## Summary

- Fixes worker healthcheck breaking subprocess spawning when `uvloop` is installed (via `uvicorn[standard]`)
- Adds `loop="asyncio"` to uvicorn config to prevent uvloop from setting a global event loop policy
- Updates settings access to use `get_current_settings()` pattern

## Root cause

uvicorn ≤0.35.0 with uvloop installed calls `uvloop_setup()` which sets a **global** `uvloop.EventLoopPolicy()`. When the worker then tries to spawn a subprocess using a `SelectorEventLoop`, it fails because uvloop's policy doesn't implement `get_child_watcher()`.

## Test plan

- [ ] Verify healthcheck still works with `--with-healthcheck`
- [ ] Verify subprocesses can be spawned when uvloop is installed

Fixes #19658

🤖 Generated with [Claude Code](https://claude.com/claude-code)