### PR TITLE
Add Postgres Driver Dependency to Prevent psycopg2 Import Error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "python-dateutil>=2.8.2,<3.0.0",
     "python-slugify>=5.0,<9.0",
     "pyyaml>=5.4.1,<7.0.0",
+    "psycopg2-binary>=2.9.11",
     "rfc3339-validator>=0.1.4,<0.2.0",
     "rich>=11.0,<15.0",
     "ruamel.yaml>=0.17.0",


### PR DESCRIPTION
### Overview

This PR fixes a `ModuleNotFoundError: No module named 'psycopg2'` that occurs when running Prefect against a PostgreSQL backend using a `postgresql+psycopg2://` database URL.

The change ensures that the Prefect runtime environment includes a PostgreSQL driver (`psycopg2` / `psycopg2-binary`), allowing SQLAlchemy to create engine connections successfully when `PREFECT_API_DATABASE_CONNECTION_URL` (or other PG URLs) are configured.

### Notes

- This directly addresses failures in deployments where Prefect Server or the API is configured to use PostgreSQL but the image/env did not include `psycopg2`, leading to startup crashes.
- With this change applied, users can configure a Postgres connection URL without additional manual dependency installation steps.