### PR TITLE
fix(prefect-dbt): skip ephemeral models in upstream node lookup

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -240,8 +240,11 @@ class PrefectDbtRunner:
             if not depends_manifest_node:
                 continue
 
+            # Skip nodes without relation_name. This primarily occurs for ephemeral
+            # models which are CTEs that don't create database objects. We skip rather
+            # than error because nodes without relation_name can't be tracked as assets.
             if not depends_manifest_node.relation_name:
-                raise ValueError("Relation name not found in manifest")
+                continue
 
             upstream_manifest_nodes.append(
                 (

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -777,28 +777,55 @@ class TestPrefectDbtRunnerManifestNodeOperations:
 
         assert result == []
 
-    def test_get_upstream_manifest_nodes_and_configs_handles_missing_relation_name(
+    def test_get_upstream_manifest_nodes_and_configs_skips_ephemeral_models(
         self, mock_manifest, mock_manifest_node
     ):
-        """Test that missing relation_name is handled gracefully."""
+        """Test that ephemeral models (which have relation_name=None) are skipped.
+
+        Ephemeral models in dbt are CTEs that get inlined into downstream models.
+        They don't create database objects, so relation_name is None by design.
+        The runner should skip these rather than raising an error.
+
+        See: https://github.com/PrefectHQ/prefect/issues/19706
+        """
         runner = PrefectDbtRunner(manifest=mock_manifest)
 
-        # Create a node without relation_name
-        upstream_node = Mock(spec=ManifestNode)
-        upstream_node.unique_id = "model.test_project.upstream_model"
-        upstream_node.config = Mock()
-        upstream_node.config.meta = {"prefect": {}}
-        upstream_node.config.materialized = "view"
-        upstream_node.relation_name = None
-        upstream_node.resource_type = NodeType.Model
-        upstream_node.depends_on_nodes = []
+        # Create an ephemeral model (relation_name=None is expected for ephemeral)
+        ephemeral_node = Mock(spec=ManifestNode)
+        ephemeral_node.unique_id = "model.test_project.ephemeral_staging"
+        ephemeral_node.config = Mock()
+        ephemeral_node.config.meta = {"prefect": {}}
+        ephemeral_node.config.materialized = "ephemeral"
+        ephemeral_node.relation_name = None  # Expected for ephemeral models
+        ephemeral_node.resource_type = NodeType.Model
+        ephemeral_node.depends_on_nodes = []
 
-        mock_manifest.nodes = {"model.test_project.upstream_model": upstream_node}
-        mock_manifest_node.depends_on_nodes = ["model.test_project.upstream_model"]
+        # Create a regular model with relation_name
+        regular_node = Mock(spec=ManifestNode)
+        regular_node.unique_id = "model.test_project.regular_model"
+        regular_node.config = Mock()
+        regular_node.config.meta = {"prefect": {}}
+        regular_node.config.materialized = "view"
+        regular_node.relation_name = "test_db.test_schema.regular_model"
+        regular_node.resource_type = NodeType.Model
+        regular_node.depends_on_nodes = []
 
-        # Should raise ValueError
-        with pytest.raises(ValueError, match="Relation name not found in manifest"):
-            runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
+        mock_manifest.nodes = {
+            "model.test_project.ephemeral_staging": ephemeral_node,
+            "model.test_project.regular_model": regular_node,
+        }
+        # The main node depends on both an ephemeral and a regular model
+        mock_manifest_node.depends_on_nodes = [
+            "model.test_project.ephemeral_staging",
+            "model.test_project.regular_model",
+        ]
+
+        # Should NOT raise - ephemeral models should be skipped
+        result = runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
+
+        # Only the regular model should be returned (ephemeral skipped)
+        assert len(result) == 1
+        assert result[0][0].unique_id == "model.test_project.regular_model"
 
     def test_get_upstream_manifest_nodes_and_configs_with_source_definition(
         self, mock_manifest, mock_manifest_node, mock_source_definition
@@ -881,7 +908,7 @@ class TestPrefectDbtRunnerManifestNodeOperations:
     def test_get_upstream_manifest_nodes_and_configs_source_definition_missing_relation_name(
         self, mock_manifest, mock_manifest_node, mock_source_definition
     ):
-        """Test that source definitions without relation_name raise an error."""
+        """Test that source definitions without relation_name are skipped."""
         runner = PrefectDbtRunner(manifest=mock_manifest)
 
         # Remove relation_name from source definition
@@ -891,8 +918,9 @@ class TestPrefectDbtRunnerManifestNodeOperations:
         }
         mock_manifest_node.depends_on_nodes = ["source.test_project.test_source"]
 
-        with pytest.raises(ValueError, match="Relation name not found in manifest"):
-            runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
+        # Should skip sources without relation_name rather than raising
+        result = runner._get_upstream_manifest_nodes_and_configs(mock_manifest_node)
+        assert result == []
 
 
 class TestPrefectDbtRunnerTaskCreation:


### PR DESCRIPTION
## Summary

Fixes #19706 - "Relation name not found in manifest" error when using `PrefectDbtRunner` with ephemeral models.

**Root cause:** Ephemeral models in dbt have `relation_name=None` by design because they don't create database objects - they're compiled as CTEs (Common Table Expressions) into downstream models. When a model depends on an ephemeral model, the `_get_upstream_manifest_nodes_and_configs` method was raising `ValueError` when it encountered the ephemeral upstream node.

**Fix:** Skip nodes without `relation_name` in `_get_upstream_manifest_nodes_and_configs()` instead of raising an error. We check `relation_name` (rather than `is_ephemeral_model`) because any node without a `relation_name` can't be tracked as a Prefect asset regardless of why it's missing.

## Changes
- Changed `raise ValueError("Relation name not found")` to `continue` for upstream nodes in `_get_upstream_manifest_nodes_and_configs()`
- Added test for ephemeral model handling
- Updated existing test that expected the error to be raised

## Test plan
- [x] Added regression test `test_get_upstream_manifest_nodes_and_configs_skips_ephemeral_models`
- [x] All 70 tests in `test_runner.py` pass
- [x] Pre-commit hooks pass

<details>
<summary>Reproduction script</summary>

```python
# /// script
# dependencies = ["dbt-core>=1.8", "dbt-duckdb", "sgqlc"]
# ///
"""
Reproduction for https://github.com/PrefectHQ/prefect/issues/19706
"""
import sys
import tempfile
from pathlib import Path

sys.path.insert(0, "src/integrations/prefect-dbt")


def create_test_project(project_dir: Path):
    """Create a minimal dbt project with an ephemeral model."""

    (project_dir / "dbt_project.yml").write_text("""
name: 'test_project'
version: '1.0.0'
profile: 'test_profile'
model-paths: ["models"]
""")

    (project_dir / "profiles.yml").write_text(f"""
test_profile:
  outputs:
    dev:
      type: duckdb
      path: {project_dir}/test.duckdb
      threads: 1
  target: dev
""")

    models_dir = project_dir / "models"
    models_dir.mkdir(exist_ok=True)

    # Ephemeral model - has relation_name=None by design (it's a CTE, not a db object)
    (models_dir / "ephemeral_staging.sql").write_text("""
{{ config(materialized='ephemeral') }}
SELECT 1 as id, 'test' as name
""")

    # Regular model depending on ephemeral
    (models_dir / "final_model.sql").write_text("""
SELECT * FROM {{ ref('ephemeral_staging') }}
""")


def test_ephemeral_model_bug():
    from prefect_dbt import PrefectDbtRunner, PrefectDbtSettings

    with tempfile.TemporaryDirectory() as tmpdir:
        project_dir = Path(tmpdir)
        create_test_project(project_dir)

        settings = PrefectDbtSettings(
            project_dir=str(project_dir),
            profiles_dir=str(project_dir),
        )

        runner = PrefectDbtRunner(
            settings=settings,
            raise_on_failure=False,
            _disable_callbacks=True,
        )

        # Compile to generate manifest
        print("Compiling...")
        result = runner.invoke(["compile"])
        if not result.success:
            print(f"Compile failed: {result.exception}")
            return False

        # Show manifest state
        manifest = runner.manifest
        print(f"\nManifest has {len(manifest.nodes)} nodes:")
        for node_id, node in manifest.nodes.items():
            mat = getattr(node.config, 'materialized', '?')
            rel = node.relation_name
            print(f"  {node_id}: materialized={mat}, relation_name={rel}")

        # Now test with callbacks enabled (this triggers the bug)
        print("\nRunning with callbacks (simulating Prefect flow context)...")
        runner2 = PrefectDbtRunner(
            settings=settings,
            raise_on_failure=False,
            _force_nodes_as_tasks=True,
        )

        try:
            result = runner2.invoke(["run"])
            print(f"Run succeeded: {result.success}")
            return False
        except ValueError as e:
            if "Relation name not found" in str(e):
                print(f"\n✗ BUG CONFIRMED: {e}")
                return True
            raise


if __name__ == "__main__":
    print("=" * 70)
    print("Issue #19706: Manifest read error with PrefectDbtRunner")
    print("=" * 70)
    bug_found = test_ephemeral_model_bug()
    sys.exit(1 if bug_found else 0)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)