### PR TITLE
Add release notes for `prefect-databricks==0.4.0`

### DIFF
--- a/docs/v3/release-notes/integrations/prefect-databricks.mdx
+++ b/docs/v3/release-notes/integrations/prefect-databricks.mdx
@@ -1,0 +1,20 @@
+---
+title: prefect-databricks
+---
+
+## 0.4.0
+
+_Released on December 11, 2025_
+
+**Features**
+
+- Add service principal authentication support for Databricks credentials [#19707](https://github.com/PrefectHQ/prefect/pull/19707) by [@app/devin-ai-integration](https://github.com/app/devin-ai-integration)
+
+**Deprecations**
+
+- Remove Python 3.9 support [#19273](https://github.com/PrefectHQ/prefect/pull/19273) by [@desertaxle](https://github.com/desertaxle)
+
+**Maintenance**
+
+- Migrate to `pyproject.toml` [#17116](https://github.com/PrefectHQ/prefect/pull/17116) by [@zzstoatzz](https://github.com/zzstoatzz)
+- Update `Field` `examples` kwargs [#17526](https://github.com/PrefectHQ/prefect/pull/17526) by [@zzstoatzz](https://github.com/zzstoatzz)


### PR DESCRIPTION
Releasing `prefect-databricks` to get out the changes in https://github.com/PrefectHQ/prefect/pull/19707. This is `0.4.0` because we dropped Python 3.9 support since the last release.