### PR TITLE
docs: add negative matching documentation for automation triggers

### DIFF
--- a/docs/v3/concepts/event-triggers.mdx
+++ b/docs/v3/concepts/event-triggers.mdx
@@ -28,10 +28,10 @@ Event triggers are indicated with `{"type": "event"}`.
 
 This is the schema that defines an event trigger:
 
-| Name              | Type                      | Supports trailing wildcards | Description                                                                                                                                                                                                                                                                                                                                          |
-| ----------------- | ------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **match**         | object                    | ✅            | Labels for resources which this Automation will match.                                                                                                                                                                                                                                                                                               |
-| **match_related** | object OR array of object | ✅            | Labels for related resources which this Automation will match.                                                                                                                                                                                                                                                                                       |
+| Name              | Type                      | Supports wildcards and negative matching | Description                                                                                                                                                                                                                                                                                                                                          |
+| ----------------- | ------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **match**         | object                    | ✅            | Labels for resources which this Automation will match. Supports trailing wildcards (`*`) and negative matching (`!`).                                                                                                                                                                                                                                               |
+| **match_related** | object OR array of object | ✅            | Labels for related resources which this Automation will match. Supports trailing wildcards (`*`) and negative matching (`!`).                                                                                                                                                                                                                                       |
 | **posture**       | string enum               | N/A                         | The posture of this Automation, either Reactive or Proactive. Reactive automations respond to the presence of the expected events, while Proactive automations respond to the absence of those expected events.                                                                                                                                      |
 | **after**         | array of strings          | ✅            | Event(s), one of which must have first been seen to start this automation.                                                                                                                                                                                                                                                                           |
 | **expect**        | array of strings          | ✅            | The event(s) this automation expects to see. If empty, this automation will evaluate any matched event.                                                                                                                                                                                                                                         |
@@ -151,6 +151,60 @@ To match flow runs on a work pool with specific tags, you can use the following 
 ]
 ...
 ```
+
+##### Negative matching
+
+Use the `!` prefix to exclude resources with specific label values. This allows you to filter out
+events you don't want to trigger automations.
+
+For example, to match all flow runs _except_ those tagged with `dev`:
+
+```json
+"match": {
+  "prefect.resource.id": "prefect.flow-run.*"
+},
+"match_related": {
+  "prefect.resource.id": "!prefect.tag.dev",
+  "prefect.resource.role": "tag"
+}
+```
+
+You can combine positive and negative patterns in the same label. The following matches flow runs
+with names starting with `production-` but NOT `production-test-`:
+
+```json
+"match": {
+  "prefect.resource.id": "prefect.flow-run.*",
+  "prefect.resource.name": ["production-*", "!production-test-*"]
+}
+```
+
+Combining multiple related resource conditions with exclusions:
+
+```json
+"match": {
+  "prefect.resource.id": "prefect.flow-run.*"
+},
+"match_related": [
+  {
+    "prefect.resource.name": "k8s-pool",
+    "prefect.resource.role": "work-pool"
+  },
+  {
+    "prefect.resource.id": "prefect.tag.production",
+    "prefect.resource.role": "tag"
+  },
+  {
+    "prefect.resource.id": "!prefect.tag.test",
+    "prefect.resource.role": "tag"
+  }
+]
+```
+
+This configuration matches flow runs that:
+- Run on the `k8s-pool` work pool
+- Are tagged with `production`
+- Are NOT tagged with `test`
 
 ### Expected events
 


### PR DESCRIPTION
Adds documentation for the `!` prefix syntax that allows excluding resources from automation triggers. This feature was already implemented and tested but wasn't documented.

The docs now cover:
- Simple negative matching (`!value`)
- Wildcard negative matching (`!prefix*`)
- Combining positive and negative patterns
- Multiple related resource conditions with exclusions

Closes #8410

🤖 Generated with [Claude Code](https://claude.com/claude-code)