### PR TITLE
Fix mattermost botname issue

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -679,7 +679,7 @@ class MattermostWebhook(AbstractAppriseNotificationBlock):
                 token=self.token.get_secret_value(),
                 fullpath=self.path,
                 host=self.hostname,
-                botname=self.botname,
+                user=self.botname,
                 channels=self.channels,
                 include_image=self.include_image,
                 port=self.port,


### PR DESCRIPTION
I did not find any issue for this matter and as the fix is quite small I did not created one.

# TLDR
Changing the variable `botname` to `user` at [line 682 of the notifications.py file](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L682) fixes an issue where the username of a Mattermost notifications is always "Prefect Notifications" even if a botname value was set.

# Detailed explanation
When using Mattermost webhooks to send messages, the sender's username/botname displayed on the channel can be set as we which. 
However, even when updating the botname section of the Mattermost block, the botname was : `Prefect Notifications`. 
<img width="1385" height="231" alt="image" src="https://github.com/user-attachments/assets/39596284-2c3a-4e0d-a7a9-9564b17cb750" />
_Screenshot of Mattermost block from Prefect UI_
<img width="303" height="77" alt="image" src="https://github.com/user-attachments/assets/41521758-1f25-45cb-809d-4b3bc9aae4e0" />
_Screenshot of Mattermost instance_

This string is declared in [notifications.py file](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L39) as the app_id of an AppriseAsset:
```python
# A custom `AppriseAsset` that ensures Prefect 
# appear correctly across multiple messaging platforms
prefect_app_data = AppriseAsset(
    app_id="Prefect Notifications",
    app_desc="Prefect Notifications",
    app_url="https://prefect.io",
)
```
We'll get to this string later. In the Mattermost class of the same notifications.py file, a [botname can be set](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L641): 
```python
botname: Optional[str] = Field(
    title="Bot name",
    default=None,
    description="The name of the bot that will send the message.",
)
```
and is [later used in](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L677) the NotifyMattermost class when calling its url() method:
```python
def block_initialization(self) -> None:
    try:
        # Try importing for apprise>=1.18.0
        from apprise.plugins.mattermost import NotifyMattermost
    except ImportError:
        # Fallback for versions apprise<1.18.0
        from apprise.plugins.NotifyMattermost import (  # pyright: ignore[reportMissingImports] this is a fallback
            NotifyMattermost,  # pyright: ignore[reportUnknownVariableType] incomplete type hints in apprise
        )

    url = SecretStr(
        NotifyMattermost(
            token=self.token.get_secret_value(),
            fullpath=self.path,
            host=self.hostname,
            botname=self.botname,
            channels=self.channels,
            include_image=self.include_image,
            port=self.port,
            secure=self.secure,
        ).url()  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] incomplete type hints in apprise
    )
    self._start_apprise_client(url)
```

However, in the apprise code, the botname variable doesn't exist in the [url method](https://github.com/caronc/apprise/blob/master/apprise/plugins/mattermost.py#L323). Instead, the botname value is inherited from the [user variable](https://github.com/caronc/apprise/blob/master/apprise/plugins/mattermost.py#L345):  
```python
# Determine if there is a botname present
botname = ""
if self.user:
    botname = "{botname}@".format(
        botname=NotifyMattermost.quote(self.user, safe=""),
    )
```
Thus, the botname value is never filled with the value provided by Prefect as the self.botname doesn't exist. But when the botname is empty, a username must still be provided to Mattermost. In the [send function](https://github.com/caronc/apprise/blob/master/apprise/plugins/mattermost.py#L188), the username is set as self.user or self.app_id:
```python
# Set our user
payload["username"] = self.user if self.user else self.app_id
```
As such, the value specified earlier in the AppriseAsset was used and thus `Prefect Notifications` was the username used. Tests showed that changing the self.app_id value to another (when no botname was set) changed the username in the Mattermost notification.
Tests also confirmed that changing the variable `botname` to `user` at [line 682 of the notifications.py file](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/blocks/notifications.py#L682) allowed to chose the username of the Mattermost notification (without `Prefect Notifications` overwriting it).


If you want to reproduce the issue, ensure integrations are allowed to replace the usernames in your Mattermost otherwise the name of the Mattermost user that created the webhook will be always used.
