### PR TITLE
fix: correct docket_url setting path to server.docket.url

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -724,7 +724,7 @@ async def _run_all_services() -> None:
     from prefect.server.services.base import Service
     from prefect.settings.context import get_current_settings
 
-    docket_url = get_current_settings().server.docket_url
+    docket_url = get_current_settings().server.docket.url
 
     async with Docket(name="prefect", url=docket_url) as docket:
         async with background_worker(docket, ephemeral=False, webserver_only=False):


### PR DESCRIPTION
## Summary
- Fixes incorrect setting path reference in `_run_all_services()`
- Changed `server.docket_url` to `server.docket.url`

## Problem
The docket PR (#19756) introduced a bug where `server.docket_url` was referenced, but the actual setting path is `server.docket.url` (nested under `ServerDocketSettings`).

This causes the background services to crash with:
```
AttributeError: 'ServerSettings' object has no attribute 'docket_url'
```

## Test plan
- [x] Verified `get_current_settings().server.docket.url` returns the expected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)