### PR TITLE
fix: use tag input for testbed image update in workflow_dispatch

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -176,7 +176,8 @@ jobs:
       - name: Trigger cluster-deployment workflow
         run: |
           # Construct the Kubernetes image tag (e.g., 3.4.16-python3.11-kubernetes)
-          IMAGE_TAG="${{ github.ref_name }}-python3.11-kubernetes"
+          # Use the tag input if provided (workflow_dispatch), otherwise use ref_name (release event)
+          IMAGE_TAG="${{ github.event.inputs.tag || github.ref_name }}-python3.11-kubernetes"
           
           gh workflow run update-prefect-image-version.yaml \
             --repo PrefectHQ/cluster-deployment \


### PR DESCRIPTION
## Summary
- Fixes the `trigger-oss-testbed-update` job to use the `tag` input when triggered via `workflow_dispatch`

When `docker-images.yaml` is triggered via `workflow_dispatch` with a tag input (e.g., `tag=3.6.7.dev6`), the `trigger-oss-testbed-update` job was incorrectly using `github.ref_name` (which is `main`) instead of the provided tag input.

This caused the cluster-deployment PR to update the testbed to use `main-python3.11-kubernetes` instead of the actual version tag like `3.6.7.dev6-python3.11-kubernetes`.

## Test plan
- [x] Verified the fix by code review
- After merge, trigger `gh workflow run docker-images.yaml -f tag=<next-dev-version>` and verify the cluster-deployment PR uses the correct tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)