### PR TITLE
Refactor `Task.__call__` typing to be mypy compliant

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1088,17 +1088,17 @@ class Task(Generic[P, R]):
     # These preserve full parameter type checking when users call tasks normally
     @overload
     def __call__(
-        self: "Task[P, Coroutine[Any, Any, R]]",
+        self: "Task[P, Coroutine[Any, Any, T]]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> Coroutine[Any, Any, R]: ...
+    ) -> Coroutine[Any, Any, T]: ...
 
     @overload
     def __call__(
-        self: "Task[P, R]",
+        self: "Task[P, T]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> R: ...
+    ) -> T: ...
 
     @overload
     def __call__(
@@ -1116,65 +1116,65 @@ class Task(Generic[P, R]):
     # are advanced use cases.
     @overload
     def __call__(
-        self: "Task[..., Coroutine[Any, Any, R]]",
+        self: "Task[..., Coroutine[Any, Any, T]]",
         *args: Any,
         return_state: Literal[False],
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         **kwargs: Any,
-    ) -> Coroutine[Any, Any, R]: ...
+    ) -> Coroutine[Any, Any, T]: ...
 
     @overload
     def __call__(
-        self: "Task[..., Coroutine[Any, Any, R]]",
+        self: "Task[..., Coroutine[Any, Any, T]]",
         *args: Any,
         return_state: Literal[True],
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         **kwargs: Any,
-    ) -> State[R]: ...
+    ) -> State[T]: ...
 
     @overload
     def __call__(
-        self: "Task[..., R]",
+        self: "Task[..., T]",
         *args: Any,
         return_state: Literal[False],
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         **kwargs: Any,
-    ) -> R: ...
+    ) -> T: ...
 
     @overload
     def __call__(
-        self: "Task[..., R]",
+        self: "Task[..., T]",
         *args: Any,
         return_state: Literal[True],
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         **kwargs: Any,
-    ) -> State[R]: ...
+    ) -> State[T]: ...
 
     @overload
     def __call__(
-        self: "Task[..., Coroutine[Any, Any, R]]",
+        self: "Task[..., Coroutine[Any, Any, T]]",
         *args: Any,
         wait_for: OneOrManyFutureOrResult[Any],
         return_state: Literal[False] = False,
         **kwargs: Any,
-    ) -> Coroutine[Any, Any, R]: ...
+    ) -> Coroutine[Any, Any, T]: ...
 
     @overload
     def __call__(
-        self: "Task[..., R]",
+        self: "Task[..., T]",
         *args: Any,
         wait_for: OneOrManyFutureOrResult[Any],
         return_state: Literal[False] = False,
         **kwargs: Any,
-    ) -> R: ...
+    ) -> T: ...
 
     def __call__(
-        self: "Union[Task[..., R], Task[..., NoReturn]]",
+        self: "Union[Task[..., T], Task[..., NoReturn]]",
         *args: Any,
         return_state: bool = False,
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         **kwargs: Any,
-    ) -> Union[R, State[R], None]:
+    ) -> Union[T, State[T], None]:
         """
         Run the task and return the result. If `return_state` is True returns
         the result is wrapped in a Prefect State which provides error handling.

--- a/tests/typesafety/test_flows.yml
+++ b/tests/typesafety/test_flows.yml
@@ -47,3 +47,34 @@
   out: "main:6: note: Revealed type is \"\
       builtins.int\
     \""
+
+- case: prefect_flow_async_call
+  main: |
+    from prefect import flow
+    @flow
+    async def foo(bar: str) -> int:
+        return 42
+    
+    async def main() -> None:
+       ret = await foo(bar="baz")
+       reveal_type(ret)
+  out: "main:8: note: Revealed type is \"\
+      builtins.int\
+    \""
+
+- case: prefect_flow_async_call_wrong_args
+  regex: yes
+  main: |
+    from prefect import flow
+    @flow
+    async def foo(bar: str) -> int:
+        return 42
+    
+    async def main() -> None:
+       ret = await foo(None)
+  out: |
+    main:7: error: No overload variant of "__call__" of "Flow" matches argument type "None"  \[call-overload\]
+    main:7: note: Possible overload variants:
+    main:7: note:     def __call__.*
+    main:7: note:     def __call__.*
+    main:7: note:     def __call__.*

--- a/tests/typesafety/test_tasks.yml
+++ b/tests/typesafety/test_tasks.yml
@@ -84,3 +84,56 @@
   out: "main:6: note: Revealed type is \"\
       builtins.int\
     \""
+
+- case: prefect_task_async_call
+  main: |
+    from prefect import task
+    @task
+    async def foo(bar: str) -> int:
+        return 42
+    
+    async def main() -> None:
+      ret = await foo(bar="baz")
+      reveal_type(ret)
+  out: "main:8: note: Revealed type is \"\
+      builtins.int\
+    \""
+
+- case: prefect_task_async_call_wrong_args
+  regex: yes
+  main: |
+    from prefect import task
+    @task
+    async def foo(bar: str) -> int:
+        return 42
+    
+    async def main() -> None:
+      ret = await foo(None)
+  out: |
+    main:7: error: No overload variant of "__call__" of "Task" matches argument type "None"  \[call-overload\]
+    main:7: note: Possible overload variants:
+    main:7: note:     def __call__.*
+    main:7: note:     def __call__.*
+    main:7: note:     def __call__.*
+    main:7: note:     def __call__.*
+    main:7: note:     def __call__.*
+
+- case: prefect_task_async_call_no_capture
+  main: |
+    import prefect
+    from prefect import flow, task
+
+    @task
+    async def async_task_with_return() -> dict[str, str]:
+        return {"status": "completed"}
+
+    @task
+    async def async_task_no_return() -> None:
+        print("Task executed")
+    
+    async def main() -> None:
+        # Regression test that not capturing the return value is allowed.
+        # This would error if the return type is considered a `Coroutine[Any, Any, R]` rather than plain `R`.
+        # See https://github.com/PrefectHQ/prefect/issues/19469
+        await async_task_no_return()
+        await async_task_with_return()


### PR DESCRIPTION
This PR refactors the typing used in the `Task.__call__` overloads.

With Prefect 3.6 and https://github.com/PrefectHQ/prefect/pull/19327 we and others (https://github.com/PrefectHQ/prefect/issues/19469) have found typing to be broken with mypy.

Here I transform the typing from `R` to an independent `T` which clears everything up. I've added tests for the issues we have found and seen in https://github.com/PrefectHQ/prefect/issues/19469. I also note that `T` (rather than `R`) is used in the `Flow.__call__` overloads.

Closes https://github.com/PrefectHQ/prefect/issues/19469

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
