### PR TITLE
fix(prefect-redis): add retry logic for consumer reconnection on Redis errors

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -77,6 +77,18 @@ def close_all_cached_connections() -> None:
         loop.run_until_complete(client.aclose())
 
 
+async def clear_cached_clients() -> None:
+    """Clear all cached Redis clients to force fresh connections.
+
+    This should be called when a connection error is detected to ensure
+    subsequent calls to get_async_redis_client() return fresh clients
+    rather than stale ones with broken connections.
+    """
+    global _client_cache
+
+    _client_cache.clear()
+
+
 @cached
 def get_async_redis_client(
     host: Union[str, None] = None,


### PR DESCRIPTION
## Summary

Fixes #19080

When Redis restarts or becomes temporarily unavailable, event-consuming services (ReactiveTriggers, Actions, EventPersister, EventLogger, TaskRunRecorder) would silently die because `Consumer.run()` only caught `ResponseError`, not `ConnectionError`. The pod would remain "Running" but events wouldn't be processed.

### Changes
- Added `clear_cached_clients()` to `client.py` to invalidate stale connections
- Wrapped `Consumer.run()` in an outer retry loop that catches all `RedisError`
- Uses exponential backoff with jitter (1s base, 60s max) for retries
- Clears cached clients before retry to force fresh connections
- Logs warning on connection error and info on successful reconnection

### Root Cause
The `Consumer.run()` method would get a cached Redis client at startup and run in an infinite loop calling `xreadgroup()`. When Redis disconnected, it raised `ConnectionError` (a subclass of `RedisError`), but only `ResponseError` was caught. This caused the consumer task to exit silently while the pod continued running.

## Test plan

- [x] Added unit tests for retry logic and cache clearing
- [x] Verified fix with helm chart deployment in kind cluster:
  - Before fix: 6 xreadgroup clients → 0 after Redis restart (consumers dead)
  - After fix: 6 xreadgroup clients → 6 after Redis restart (all reconnected)

Log output showing recovery:
```
Redis connection error in consumer actions-..., reconnecting in 19.0s (attempt 5)
Consumer events reconnected to Redis successfully
Consumer task-run-recorder-... reconnected to Redis successfully
Consumer event-persister-... reconnected to Redis successfully
Consumer reactive-triggers-... reconnected to Redis successfully
Consumer actions-... reconnected to Redis successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)