### PR TITLE
Fix deployment concurrency slot starvation bug

### DIFF
--- a/src/prefect/settings/models/server/deployments.py
+++ b/src/prefect/settings/models/server/deployments.py
@@ -12,11 +12,14 @@ class ServerDeploymentsSettings(PrefectBaseSettings):
     )
 
     concurrency_slot_wait_seconds: float = Field(
-        default=30.0,
+        default=5.0,
         ge=0.0,
         description=(
             "The number of seconds to wait before retrying when a deployment flow run"
-            " cannot secure a concurrency slot from the server."
+            " cannot secure a concurrency slot from the server. This value should be less"
+            " than the worker's prefetch_seconds setting (default 10s) to ensure runs in"
+            " AwaitingConcurrencySlot state become visible to workers within their polling"
+            " window."
         ),
         validation_alias=AliasChoices(
             AliasPath("concurrency_slot_wait_seconds"),


### PR DESCRIPTION
## Summary

Fixes a bug where flow runs stuck in `AwaitingConcurrencySlot` state would remain invisible to workers, causing indefinite starvation.

### Root Cause

When a flow run is rejected to `AwaitingConcurrencySlot` state due to deployment concurrency limits, its `scheduled_time` (and thus `next_scheduled_start_time`) was set to:

```
now + concurrency_slot_wait_seconds (default: 30 seconds)
```

However, workers poll for runs with:

```
scheduled_before = now + prefetch_seconds (default: 10 seconds)
```

This **20-second gap** meant runs were completely invisible to workers! When they finally became visible after 30 seconds, if the slot was still unavailable, they'd be rescheduled another 30 seconds out - creating indefinite starvation.

### Fix

Reduce `concurrency_slot_wait_seconds` default from 30s to 5s, ensuring runs become visible within the worker's prefetch window. This matches the behavior users expect: runs waiting for a concurrency slot should be picked up as soon as one becomes available.

### Why 5 seconds?

- Must be less than `prefetch_seconds` (10s default) to be visible to workers
- Provides a small delay to prevent thrashing on rapid polling cycles
- Balances responsiveness with server load

### Related Issues

- https://github.com/PrefectHQ/prefect/issues/16186 (closed, but this appears to be a regression or incomplete fix)
- https://github.com/PrefectHQ/prefect/issues/16027
- https://github.com/PrefectHQ/prefect/issues/17452

## Test plan

- [x] Added `test_enqueued_runs_acquire_slots_after_release` - verifies slots are properly released and can be re-acquired
- [x] Added `test_enqueued_runs_visible_in_worker_polling_query` - verifies polling query returns waiting runs
- [x] Added `test_awaiting_concurrency_slot_visible_within_worker_prefetch_window` - regression test that asserts `concurrency_slot_wait_seconds < prefetch_seconds`
- [x] All 68 `TestFlowConcurrencyLimits` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)