### PR TITLE
Add explicit stream config to logging handlers for env var override

### DIFF
--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -43,6 +43,7 @@ handlers:
     level: 0
     class: prefect.logging.handlers.PrefectConsoleHandler
     formatter: standard
+    stream: ext://sys.stderr
     styles:
       log.web_url: bright_blue
       log.local_url: bright_blue
@@ -69,6 +70,7 @@ handlers:
     level: 0
     class: logging.StreamHandler
     formatter: debug
+    stream: ext://sys.stderr
 
   worker_api:
     level: 0


### PR DESCRIPTION
## Summary
- Adds explicit `stream: ext://sys.stderr` to the `console` and `debug` handlers in `logging.yml`
- Preserves the current default behavior (logs to stderr)
- Enables users to redirect logs to stdout via environment variable override

## Problem
The logging configuration override system (in `configuration.py`) only allows overriding keys that already exist in `logging.yml`. Since `stream` was not defined, users couldn't redirect logs via `PREFECT_LOGGING_HANDLERS_CONSOLE_STREAM`.

## Solution
By adding the explicit `stream` key with the current default (`ext://sys.stderr`), users can now override it:

```bash
PREFECT_LOGGING_HANDLERS_CONSOLE_STREAM=ext://sys.stdout
```

This is particularly useful in containerized environments (e.g., Kubernetes) where stdout and stderr may be handled differently by log aggregation systems.

## Test plan
- [ ] Verify default behavior unchanged (logs still go to stderr)
- [ ] Verify env var override works: `PREFECT_LOGGING_HANDLERS_CONSOLE_STREAM=ext://sys.stdout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)