### PR TITLE
docs: add security considerations to Prefect MCP server guide

### DIFF
--- a/docs/v3/how-to-guides/ai/use-prefect-mcp-server.mdx
+++ b/docs/v3/how-to-guides/ai/use-prefect-mcp-server.mdx
@@ -20,6 +20,16 @@ The Prefect MCP server is an [MCP](https://modelcontextprotocol.io/) server that
 
 The MCP tools are primarily designed for reading data and monitoring your Prefect instance. For creating or updating resources, the integrated docs proxy provides AI assistants with current information on how to use the `prefect` CLI.
 
+## Security considerations
+
+The Prefect MCP server provides **read-only access** to your Prefect instance. It can only access information available to the account you authenticate with—it cannot access data outside those bounds.
+
+<Warning>
+**Important:** The MCP server does not operate in isolation. MCP clients (such as Claude Code, Cursor, or Codex CLI) may have additional capabilities beyond the MCP server's read-only tools. For example, an AI assistant with terminal access could execute destructive CLI commands like `prefect deployment delete` independently of the MCP server.
+
+When using AI agents autonomously, consider the Prefect Role associated with your API key and what actions the agent could take through other means (CLI, SDK, etc.).
+</Warning>
+
 ## Installation
 
 ### Local installation


### PR DESCRIPTION
## Summary

Addresses customer questions about MCP server security by adding a dedicated section to the Prefect MCP server documentation:

- Clarifies that the MCP server provides **read-only access** to Prefect
- Explains authentication model (same permissions as the API key provided)
- Warns that MCP clients may have broader capabilities (like terminal access) independent of the server
- Recommends using service accounts with minimal permissions

## Test plan

- [ ] Preview docs build to verify admonition formatting renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)