### PR TITLE
Fix docker deploy integration test failing due to uv import

### DIFF
--- a/integration-tests/test_docker_deploy.py
+++ b/integration-tests/test_docker_deploy.py
@@ -4,8 +4,6 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
-import uv
-
 from prefect import flow, get_client
 from prefect.deployments import run_deployment
 from prefect.docker.docker_image import DockerImage
@@ -37,7 +35,7 @@ def test_docker_deploy():
     try:
         subprocess.check_call(
             [
-                uv.find_uv_bin(),
+                "uv",
                 "run",
                 "--isolated",
                 "prefect",
@@ -87,7 +85,7 @@ def test_docker_deploy():
         # Execute the flow run
         subprocess.check_call(
             [
-                uv.find_uv_bin(),
+                "uv",
                 "run",
                 "--isolated",
                 "--with",
@@ -111,7 +109,7 @@ def test_docker_deploy():
         # Cleanup
         subprocess.check_call(
             [
-                uv.find_uv_bin(),
+                "uv",
                 "run",
                 "--isolated",
                 "prefect",


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/actions/runs/20376019550/job/58554957152

## Summary
- Remove module-level `import uv` which causes the test to fail when the Docker container imports the test file to run the flow
- Replace `uv.find_uv_bin()` with `"uv"` since uv is already on PATH

The `test_docker_deploy` integration test was failing because when the Docker container imported the test file to execute `flow_that_needs_pandas`, the module-level `import uv` failed with `ModuleNotFoundError: No module named 'uv'`. The uv module is only available on the host, not inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)