### PR TITLE
Add timeout to Docket worker shutdown

### DIFF
--- a/src/prefect/server/api/background_workers.py
+++ b/src/prefect/server/api/background_workers.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
+from logging import Logger
 from typing import Any, AsyncGenerator, Callable
 
 from docket import Docket, Worker
@@ -21,7 +22,7 @@ from prefect.server.services.perpetual_services import (
 )
 from prefect.server.services.repossessor import revoke_expired_lease
 
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 # Task functions to register with docket for background processing
 task_functions: list[Callable[..., Any]] = [


### PR DESCRIPTION
The Docket worker cancellation is causing the server to hang on shutdown. This PR doesn't solve the underlying issue, but it does prevent the server from hanging by adding a max time that the server will wait for Docket worker shutdown.

Closes https://github.com/PrefectHQ/prefect/issues/19924

Related to https://github.com/chrisguidry/docket/issues/260