### PR TITLE
fix: prevent dictionary mutation during iteration in preprocess_schema

### DIFF
--- a/src/prefect/utilities/schema_tools/validation.py
+++ b/src/prefect/utilities/schema_tools/validation.py
@@ -257,7 +257,7 @@ def preprocess_schema(
 
     if "definitions" in schema:  # Also process definitions for reused models
         definitions = cast(dict[str, Any], schema["definitions"])
-        for definition in definitions.values():
+        for definition in list(definitions.values()):
             if "properties" in definition:
                 required_fields = definition.get("required", [])
                 process_properties(


### PR DESCRIPTION
## Summary

Fixes #19935

When processing schema definitions with `block_type_slug` where the definition's `title` differs from the dict key, `preprocess_schema()` would add a new key to the definitions dict while iterating over it, causing:

```
RuntimeError: dictionary changed size during iteration
```

The bug is at line 260 in `src/prefect/utilities/schema_tools/validation.py`:

```python
for definition in definitions.values():  # iterating over dict
    ...
    if "block_type_slug" in definition:
        schema["definitions"][definition["title"]] = {...}  # modifying dict!
```

When `definition["title"]` differs from the current dict key (e.g., key is `prefect__blocks__system__Secret` but title is `Secret`), a new key is added to the dict during iteration.

## Fix

Iterate over a snapshot of the dict values using `list(definitions.values())` to allow safe modification during iteration.

## Test plan

- [x] Added regression test that reproduces the bug
- [x] Verified test fails before the fix
- [x] Verified test passes after the fix
- [x] Verified all existing validation tests still pass

<details>
<summary>Reproduction script</summary>

```python
from prefect.utilities.schema_tools.validation import preprocess_schema

schema = {
    "properties": {
        "my_block": {"$ref": "#/definitions/prefect__blocks__system__Secret"}
    },
    "definitions": {
        # Key is the full module path, but title is just "Secret"
        "prefect__blocks__system__Secret": {
            "title": "Secret",  # Different from the dict key!
            "block_type_slug": "secret",
            "type": "object",
            "properties": {"value": {"type": "string"}},
        }
    },
}

# Before fix: RuntimeError: dictionary changed size during iteration
# After fix: succeeds
result = preprocess_schema(schema)
print("Success!")
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)