### PR TITLE
Add semaphore to limit concurrent API calls during Kubernetes observer startup

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
@@ -56,6 +56,13 @@ class KubernetesObserverSettings(PrefectBaseSettings):
         "should be provided in the format `key=value`.",
     )
 
+    startup_event_concurrency: int = Field(
+        default=5,
+        description="Maximum number of concurrent API calls when checking for "
+        "duplicate events during observer startup. This helps prevent overloading "
+        "the API server when there are many existing pods/jobs in the cluster.",
+    )
+
 
 class KubernetesWorkerSettings(PrefectBaseSettings):
     model_config = build_settings_config(("integrations", "kubernetes", "worker"))


### PR DESCRIPTION
closes #19937

## Summary

- Adds a configurable semaphore to rate-limit concurrent API calls during Kubernetes observer startup
- Prevents the "thundering herd" problem when there are many existing pods/jobs in the cluster
- Default concurrency limit is 5, configurable via `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_STARTUP_EVENT_CONCURRENCY`

<details>
<summary>Changes</summary>

- Added `startup_event_concurrency` setting to `KubernetesObserverSettings` with default value of 5
- Added module-level semaphore `_startup_event_semaphore` initialized during observer startup
- Wrapped the startup event deduplication API call with the semaphore to limit concurrent requests
- Added test to verify semaphore correctly limits concurrency

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)