### PR TITLE
perf: run read and count queries concurrently in paginate endpoints

### DIFF
--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -234,35 +234,40 @@ async def paginate_task_runs(
     """
     offset = (page - 1) * limit
 
-    async with db.session_context() as session:
-        runs = await models.task_runs.read_task_runs(
-            session=session,
-            flow_filter=flows,
-            flow_run_filter=flow_runs,
-            task_run_filter=task_runs,
-            deployment_filter=deployments,
-            offset=offset,
-            limit=limit,
-            sort=sort,
-        )
-
-        total_count = await models.task_runs.count_task_runs(
-            session=session,
-            flow_filter=flows,
-            flow_run_filter=flow_runs,
-            task_run_filter=task_runs,
-            deployment_filter=deployments,
-        )
-
-        return TaskRunPaginationResponse.model_validate(
-            dict(
-                results=runs,
-                count=total_count,
+    async def get_runs():
+        async with db.session_context() as session:
+            return await models.task_runs.read_task_runs(
+                session=session,
+                flow_filter=flows,
+                flow_run_filter=flow_runs,
+                task_run_filter=task_runs,
+                deployment_filter=deployments,
+                offset=offset,
                 limit=limit,
-                pages=(total_count + limit - 1) // limit,
-                page=page,
+                sort=sort,
             )
+
+    async def get_count():
+        async with db.session_context() as session:
+            return await models.task_runs.count_task_runs(
+                session=session,
+                flow_filter=flows,
+                flow_run_filter=flow_runs,
+                task_run_filter=task_runs,
+                deployment_filter=deployments,
+            )
+
+    runs, total_count = await asyncio.gather(get_runs(), get_count())
+
+    return TaskRunPaginationResponse.model_validate(
+        dict(
+            results=runs,
+            count=total_count,
+            limit=limit,
+            pages=(total_count + limit - 1) // limit,
+            page=page,
         )
+    )
 
 
 @router.delete("/{id:uuid}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary

Runs the `read` and `count` database queries concurrently in the paginate endpoints using `asyncio.gather()` instead of awaiting them sequentially.

**Affected endpoints:**
- `POST /flow_runs/paginate`
- `POST /task_runs/paginate`

## Methodology

Performance analysis was conducted using Logfire telemetry from the testbed environment connected to a production-scale Postgres database. The `http.server.duration` metrics were queried to identify the slowest API endpoints.

### Query used for dashboard analysis:
```sql
WITH dataset AS (
    SELECT
        ROUND(SUM(histogram_sum) / SUM(histogram_count) / 1000, 2) AS amount,
        COALESCE(attributes ->> 'http.route', attributes ->> 'http.target') AS endpoint
    FROM metrics
    WHERE metric_name = 'http.server.duration'
    GROUP BY endpoint
    HAVING endpoint is not null
    ORDER BY amount DESC
    LIMIT 10
)
SELECT amount, endpoint FROM dataset ORDER BY amount ASC
```

## Empirical Observations

Top 10 slowest endpoints by average response time (last 7 days):

| Avg (sec) | Endpoint |
|-----------|----------|
| **1.99** | `/api/task_runs/history` |
| **1.59** | `/api/flow_runs/paginate` |
| **1.15** | `/api/task_runs/paginate` |
| 0.58 | `/api/deployments/paginate` |
| 0.40 | `/api/task_runs/count` |
| 0.16 | `/api/work_pools/filter` |
| 0.14 | `/api/flow_runs/lateness` |
| 0.14 | `/api/ui/flows/next-runs` |
| 0.11 | `/api/flow_runs/{id}/set_state` |
| 0.09 | `/api/deployments/{id}` |

### Request distribution for affected endpoints:

**`/api/flow_runs/paginate`** (7 requests):
- 1 request: 6.1s
- 2 requests: ~955ms avg
- 2 requests: ~932ms avg
- 2 requests: ~633ms avg

**`/api/task_runs/paginate`** (5 requests):
- 1 request: 4.6s
- 1 request: 359ms
- 2 requests: ~234ms avg
- 1 request: 263ms

## Root Cause

Code inspection revealed that both paginate endpoints execute two sequential queries:

```python
# Before (sequential):
runs = await models.flow_runs.read_flow_runs(...)   # Query 1
count = await models.flow_runs.count_flow_runs(...) # Query 2 - waits for Query 1
```

Since both queries apply the same filters and are independent of each other, they can safely execute concurrently.

## Solution

```python
# After (concurrent):
runs, count = await asyncio.gather(
    models.flow_runs.read_flow_runs(...),
    models.flow_runs.count_flow_runs(...),
)
```

## Expected Impact

This change should reduce latency by approximately 40-50% for these endpoints when the read and count queries have similar execution times, as they will now execute concurrently instead of sequentially.

## Test Plan

- [x] Existing paginate tests pass for flow_runs (24 tests)
- [x] Existing paginate tests pass for task_runs (15 tests)
- [ ] Monitor Logfire metrics post-deployment to validate improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)