### PR TITLE
Add kill_infrastructure method to worker integrations

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -16,6 +16,7 @@ from googleapiclient.errors import HttpError
 from jsonpatch import JsonPatch
 from pydantic import Field, PrivateAttr, field_validator
 
+from prefect.exceptions import InfrastructureNotFound
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
@@ -895,6 +896,14 @@ class CloudRunWorkerV2(
                 execution=execution,
                 poll_interval=poll_interval,
             )
+        except InfrastructureNotFound:
+            logger.info(
+                f"Cloud Run V2 Job {configuration.job_name!r} was deleted. "
+                "The flow run will be marked based on its current state."
+            )
+            return CloudRunWorkerV2Result(
+                identifier=configuration.job_name, status_code=-1
+            )
         except Exception as exc:
             logger.critical(
                 f"Encountered an exception while waiting for job run completion - {exc}"
@@ -958,12 +967,22 @@ class CloudRunWorkerV2(
 
         Returns:
             The execution.
+
+        Raises:
+            InfrastructureNotFound: If the execution is deleted (e.g., by kill_infrastructure).
         """
         while execution.is_running():
-            execution = ExecutionV2.get(
-                cr_client=cr_client,
-                execution_id=execution.name,
-            )
+            try:
+                execution = ExecutionV2.get(
+                    cr_client=cr_client,
+                    execution_id=execution.name,
+                )
+            except HttpError as exc:
+                if exc.status_code == 404:
+                    raise InfrastructureNotFound(
+                        f"Cloud Run V2 execution {execution.name!r} was deleted."
+                    ) from exc
+                raise
 
             time.sleep(poll_interval)
 
@@ -998,3 +1017,57 @@ class CloudRunWorkerV2(
                 ) from exc
             else:
                 raise exc
+
+    async def kill_infrastructure(
+        self,
+        infrastructure_pid: str,
+        configuration: CloudRunWorkerJobV2Configuration,
+        grace_seconds: int = 30,
+    ) -> None:
+        """
+        Kill a Cloud Run V2 Job by deleting it.
+
+        Args:
+            infrastructure_pid: The job name.
+            configuration: The job configuration used to connect to GCP.
+            grace_seconds: Not used for Cloud Run V2 (GCP handles graceful shutdown).
+
+        Raises:
+            InfrastructureNotFound: If the job doesn't exist.
+        """
+        job_name = infrastructure_pid
+
+        await run_sync_in_worker_thread(self._delete_job, job_name, configuration)
+
+    def _delete_job(
+        self, job_name: str, configuration: CloudRunWorkerJobV2Configuration
+    ) -> None:
+        """
+        Delete a Cloud Run V2 Job.
+
+        Args:
+            job_name: The name of the job to delete.
+            configuration: The job configuration used to connect to GCP.
+
+        Raises:
+            InfrastructureNotFound: If the job doesn't exist.
+        """
+        with self._get_client(configuration) as cr_client:
+            try:
+                JobV2.delete(
+                    cr_client=cr_client,
+                    project=configuration.project,
+                    location=configuration.region,
+                    job_name=job_name,
+                )
+                self._logger.info(
+                    f"Deleted Cloud Run V2 Job {job_name!r} in project "
+                    f"{configuration.project!r} region {configuration.region!r}"
+                )
+            except HttpError as exc:
+                if exc.status_code == 404:
+                    raise InfrastructureNotFound(
+                        f"Cloud Run V2 Job {job_name!r} not found in project "
+                        f"{configuration.project!r} region {configuration.region!r}"
+                    )
+                raise


### PR DESCRIPTION
- Implement kill_infrastructure for ECS, Azure Container Instance, Docker, Cloud Run, Cloud Run V2, Vertex AI, and SPCS workers
- Add tests for kill_infrastructure across all worker implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
