### PR TITLE
fix: resolve race condition in compound trigger evaluation

### DIFF
--- a/src/prefect/server/events/models/composite_trigger_child_firing.py
+++ b/src/prefect/server/events/models/composite_trigger_child_firing.py
@@ -7,10 +7,44 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.database import PrefectDBInterface, db_injector
 from prefect.server.events.schemas.automations import CompositeTrigger, Firing
+from prefect.server.utilities.database import get_dialect
 from prefect.types._datetime import DateTime, now
 
 if TYPE_CHECKING:
     from prefect.server.database.orm_models import ORMCompositeTriggerChildFiring
+
+
+async def acquire_composite_trigger_lock(
+    session: AsyncSession,
+    trigger: CompositeTrigger,
+) -> None:
+    """
+    Acquire a transaction-scoped advisory lock for the given composite trigger.
+
+    This serializes concurrent child trigger evaluations for the same compound
+    trigger, preventing a race condition where multiple transactions each see
+    only their own child firing and neither fires the parent.
+
+    The lock is automatically released when the transaction commits or rolls back.
+    """
+    bind = session.get_bind()
+    if bind is None:
+        return
+
+    # Get the engine from either an Engine or Connection
+    engine: sa.Engine = bind if isinstance(bind, sa.Engine) else bind.engine  # type: ignore[union-attr]
+    dialect = get_dialect(engine)
+
+    if dialect.name == "postgresql":
+        # Use the trigger's UUID as the lock key
+        # pg_advisory_xact_lock takes a bigint, so we use the UUID's int representation
+        # truncated to fit (collision is extremely unlikely and benign)
+        lock_key = int(trigger.id) % (2**63)
+        await session.execute(
+            sa.text("SELECT pg_advisory_xact_lock(:key)"), {"key": lock_key}
+        )
+    # SQLite doesn't support advisory locks, but SQLite also serializes writes
+    # at the database level, so the race condition is less likely to occur
 
 
 @db_injector
@@ -102,11 +136,22 @@ async def clear_child_firings(
     session: AsyncSession,
     trigger: CompositeTrigger,
     firing_ids: Sequence[UUID],
-) -> None:
-    await session.execute(
-        sa.delete(db.CompositeTriggerChildFiring).filter(
+) -> set[UUID]:
+    """
+    Delete the specified child firings and return the IDs that were actually deleted.
+
+    Returns the set of child_firing_ids that were successfully deleted. Callers can
+    compare this to the expected firing_ids to detect races and avoid double-firing
+    composite triggers.
+    """
+    result = await session.execute(
+        sa.delete(db.CompositeTriggerChildFiring)
+        .filter(
             db.CompositeTriggerChildFiring.automation_id == trigger.automation.id,
             db.CompositeTriggerChildFiring.parent_trigger_id == trigger.id,
             db.CompositeTriggerChildFiring.child_firing_id.in_(firing_ids),
         )
+        .returning(db.CompositeTriggerChildFiring.child_firing_id)
     )
+
+    return set(result.scalars().all())


### PR DESCRIPTION
## Summary

Fixes two race conditions in compound trigger evaluation:

1. **Never-firing race** (transactional): Advisory locks serialize concurrent evaluations
2. **Double-firing race** (autocommit): DELETE ... RETURNING makes clearing a claim operation

<details>
<summary>Race Condition 1: Never-firing (with transactions)</summary>

When two child triggers fire concurrently in separate transactions, each only sees its own uncommitted insert due to READ COMMITTED isolation:

```
Transaction T1 (event A):              Transaction T2 (event B):
  │                                      │
  ▼                                      ▼
  INSERT child_firing A                  INSERT child_firing B
  (uncommitted)                          (uncommitted)
  │                                      │
  ▼                                      ▼
  SELECT child_firings                   SELECT child_firings
  → sees only A (own insert)             → sees only B (own insert)
  │                                      │
  ▼                                      ▼
  ready_to_fire? NO (1 of 2)             ready_to_fire? NO (1 of 2)
  │                                      │
  ▼                                      ▼
  COMMIT                                 COMMIT

Result: Both firings are now in database, but parent never fired!
```

**Fix**: PostgreSQL advisory locks serialize concurrent evaluations.

</details>

<details>
<summary>Race Condition 2: Double-firing (with autocommit)</summary>

When both workers see all firings, both delete and both fire:

```
Worker A:                              Worker B:
  SELECT child_firings → [A, B]          SELECT child_firings → [A, B]
  ready_to_fire? YES                     ready_to_fire? YES
  DELETE child_firings                   DELETE child_firings
  (succeeds)                             (succeeds - rows already gone)
  FIRE parent                            FIRE parent

Result: Parent fires TWICE!
```

**Fix**: `DELETE ... RETURNING` makes clearing a claim. Only the worker that successfully deletes proceeds.

</details>

## Changes

- `src/prefect/server/events/models/composite_trigger_child_firing.py`:
  - Added `acquire_composite_trigger_lock()` for advisory locking
  - Updated `clear_child_firings()` to use `DELETE ... RETURNING`
- `src/prefect/server/events/triggers.py`:
  - Acquire advisory lock before evaluation
  - Check return value of `clear_child_firings()` before firing
- `tests/events/server/triggers/test_composite_triggers.py`:
  - Added regression tests for concurrent child firing scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)