### PR TITLE
Add in_process mode to prefect_test_harness to avoid VCR/httpcore hangs

### DIFF
--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Generator
 import prefect.context
 import prefect.settings
 from prefect.blocks.core import Block
-from prefect.client.orchestration import get_client
+from prefect.client.orchestration import enable_in_process_client, get_client
 from prefect.client.schemas import sorting
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName
 from prefect.client.utilities import inject_client
@@ -30,7 +30,7 @@ from prefect.results import (
     get_default_result_storage,
 )
 from prefect.serializers import Serializer
-from prefect.server.api.server import SubprocessASGIServer
+from prefect.server.api.server import SubprocessASGIServer, create_app
 from prefect.states import State
 from prefect.utilities.asyncutils import run_coro_as_sync
 
@@ -111,7 +111,10 @@ def assert_does_not_warn(
 
 
 @contextmanager
-def prefect_test_harness(server_startup_timeout: int | None = 30):
+def prefect_test_harness(
+    server_startup_timeout: int | None = 30,
+    in_process: bool = False,
+):
     """
     Temporarily run flows against a local SQLite database for testing.
 
@@ -119,6 +122,14 @@ def prefect_test_harness(server_startup_timeout: int | None = 30):
         server_startup_timeout: The maximum time to wait for the server to start.
             Defaults to 30 seconds. If set to `None`, the value of
             `PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS` will be used.
+            Only used when `in_process=False`.
+        in_process: If `True`, run the server in-process using ASGI transport
+            instead of starting a subprocess HTTP server. This bypasses HTTP
+            connection pooling entirely, which can help avoid issues with
+            HTTP mocking libraries (like VCR/vcrpy) that interfere with
+            connection management. Note that `in_process=True` does not support
+            WebSockets, so event-related features will not work.
+            Defaults to `False` for backwards compatibility.
 
     Examples:
         ```python
@@ -132,6 +143,11 @@ def prefect_test_harness(server_startup_timeout: int | None = 30):
 
         with prefect_test_harness():
             assert my_flow() == 'Done!' # run against temporary db
+
+        # Use in_process=True to avoid HTTP connection pool issues
+        # (e.g., when using VCR/vcrpy for HTTP mocking)
+        with prefect_test_harness(in_process=True):
+            assert my_flow() == 'Done!'
         ```
     """
     from prefect.server.database.dependencies import temporary_database_interface
@@ -157,22 +173,33 @@ def prefect_test_harness(server_startup_timeout: int | None = 30):
                 },
             )
         )
-        # start a subprocess server to test against
-        test_server = SubprocessASGIServer()
-        test_server.start(
-            timeout=server_startup_timeout
-            if server_startup_timeout is not None
-            else prefect.settings.PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS.value()
-        )
-        stack.enter_context(
-            prefect.settings.temporary_settings(
-                # Use a temporary directory for the database
-                updates={
-                    prefect.settings.PREFECT_API_URL: test_server.api_url,
-                },
+
+        if in_process:
+            # Use in-process ASGI transport - bypasses HTTP connection pooling
+            # This avoids issues with HTTP mocking libraries (like VCR) that
+            # interfere with httpcore connection management.
+            # Note: Does not support WebSockets (events won't work)
+            app = create_app()
+            stack.enter_context(enable_in_process_client(app))
+        else:
+            # start a subprocess server to test against
+            test_server = SubprocessASGIServer()
+            test_server.start(
+                timeout=server_startup_timeout
+                if server_startup_timeout is not None
+                else prefect.settings.PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS.value()
             )
-        )
+            stack.enter_context(
+                prefect.settings.temporary_settings(
+                    # Use a temporary directory for the database
+                    updates={
+                        prefect.settings.PREFECT_API_URL: test_server.api_url,
+                    },
+                )
+            )
+
         yield
+
         # drain the logs before stopping the server to avoid connection errors on shutdown
         # When running in an async context, drain() and drain_all() return awaitables.
         # We use a wrapper coroutine passed to run_coro_as_sync to ensure the awaitable
@@ -194,7 +221,8 @@ def prefect_test_harness(server_startup_timeout: int | None = 30):
 
         run_coro_as_sync(drain_workers())
 
-        test_server.stop()
+        if not in_process:
+            test_server.stop()
 
 
 async def get_most_recent_flow_run(


### PR DESCRIPTION
## Summary

When using `prefect_test_harness` with HTTP mocking libraries like VCR/vcrpy, nested subflows hang due to `httpcore.PoolTimeout`. 

This PR adds `in_process=True` option that uses ASGI transport instead of HTTP, bypassing connection pooling entirely.

### For downstream projects experiencing this issue

Once this is released, you can replace VCR httpcore patches with:

```python
@pytest.fixture(scope="session")
def setup_prefect_test_harness():
    with prefect_test_harness(in_process=True):
        yield
```

This replaces workarounds like [pydantic-ai#3930](https://github.com/pydantic/pydantic-ai/pull/3930) that patch VCR's httpcore stubs directly.

**Note:** `in_process=True` does not support WebSockets, so event-related features won't work. If you need events, keep using the default subprocess mode with your existing workaround.

<details>
<summary>Why does this happen?</summary>

1. `prefect_test_harness` starts a subprocess HTTP server
2. VCR wraps httpcore's connection handling to mock HTTP requests
3. VCR's httpcore stubs don't properly release connections between subflows
4. The second subflow can't get a connection from the exhausted pool → hang

</details>

<details>
<summary>Why subprocess mode exists</summary>

The subprocess server was introduced in PR #14722 (August 2024) because the in-memory ASGI approach doesn't support WebSockets, which are required for event-related features. The `in_process=True` option is opt-in to maintain backwards compatibility.

</details>

<details>
<summary>Architecture</summary>

Uses a ContextVar (`_in_process_asgi_app`) to avoid backwards imports:
- `prefect.client.orchestration` defines the ContextVar and `enable_in_process_client()` context manager
- `prefect.testing.utilities` imports and uses it
- Dependency flows correctly: testing utilities → client code

</details>

<details>
<summary>Empirical verification</summary>

Tested with VCR:
- `in_process=False` + VCR: **HANGS** (first subflow completes, second hangs on connection pool)
- `in_process=True` + VCR: **SUCCESS** (both subflows complete immediately)

</details>

### Related Issues

- pydantic/pydantic-ai#3929 - Prefect tests hang with nested subflows
- pydantic/pydantic-ai#3930 - Workaround PR (patching VCR's httpcore stubs)
- #14722 - PR that introduced subprocess server (for WebSocket support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)