### PR TITLE
add plan for deployment CRUD events

### DIFF
--- a/plans/2026-01-12-deployment-crud-events.md
+++ b/plans/2026-01-12-deployment-crud-events.md
@@ -77,8 +77,8 @@ Event(
     payload={
         "updated_fields": ["description", "parameters"],
         "updates": {
-            "description": {"old": "...", "new": "..."},
-            "parameters": {"old": {...}, "new": {...}},
+            "description": {"from": "...", "to": "..."},
+            "parameters": {"from": {...}, "to": {...}},
         },
     },
 )
@@ -151,7 +151,7 @@ async def _deployment_related_resources(
 - [ ] `deployment_updated_event` function
 - [ ] `deployment_deleted_event` function
 - [ ] `_deployment_related_resources` helper
-- [ ] Unit tests for event factory functions
+- [ ] Unit tests for event factory functions (`tests/server/models/test_events.py`)
 
 ---
 
@@ -213,6 +213,7 @@ async def emit_deployment_deleted_event(
 - [ ] `emit_deployment_created_event` function
 - [ ] `emit_deployment_updated_event` function
 - [ ] `emit_deployment_deleted_event` function
+- [ ] Unit tests for emit functions
 
 ---
 
@@ -245,28 +246,12 @@ In `delete_deployment` model function:
 - [ ] Integrate `updated` event into update flow
 - [ ] Integrate `deleted` event into delete flow
 - [ ] Handle bulk delete if applicable
-- [ ] Integration tests
-
----
-
-### Phase 4: Testing
-
-**Unit tests** (`tests/server/models/test_events.py`):
-- Test event factory functions produce correct event structure
-- Test related resources are populated correctly
-- Test payload structure for updated events
-
-**Integration tests** (`tests/server/api/test_deployments.py`):
-- Test that creating a deployment emits `prefect.deployment.created`
-- Test that upserting (updating existing) emits `prefect.deployment.updated`
-- Test that updating via PATCH emits `prefect.deployment.updated`
-- Test that deleting emits `prefect.deployment.deleted`
-- Test that events include correct related resources
-
-**Status**:
-- [ ] Unit tests for event factory functions
-- [ ] Integration tests for API endpoints
-- [ ] Tests verify event payload structure matches Cloud
+- [ ] Integration tests (`tests/server/api/test_deployments.py`)
+  - creating a deployment emits `prefect.deployment.created`
+  - upserting (updating existing) emits `prefect.deployment.updated`
+  - updating via PATCH emits `prefect.deployment.updated`
+  - deleting emits `prefect.deployment.deleted`
+  - events include correct related resources
 
 ---
 

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -424,7 +424,7 @@ async def work_pool_updated_event(
     work_pool: "ORMWorkPool",
     changed_fields: Dict[
         str, Dict[str, Any]
-    ],  # {"field_name": {"old": value, "new": value}}
+    ],  # {"field_name": {"from": value, "to": value}}
     occurred: DateTime,
 ) -> Event:
     """Create an event for work pool field updates (non-status)."""


### PR DESCRIPTION
refs #20176

this PR adds an implementation plan for emitting `prefect.deployment.created`, `prefect.deployment.updated`, and `prefect.deployment.deleted` events in OSS.

- adds `plans/2026-01-12-deployment-crud-events.md` with phased implementation approach
- follows existing `work-pool.updated` / `work-queue.updated` patterns
- event names match Cloud (`prefect.deployment.*`) for automation portability
- includes event specifications, integration points, and testing strategy

<details>
<summary>design context</summary>

- Cloud emits these events with actor tracking for audit trail
- OSS events will be identical in shape, just without actor-related resources
- the `prefect.` prefix (not `prefect-cloud.`) is used for orchestration objects, so automations using these events will be portable between OSS and Cloud
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)