### PR TITLE
add plan label to exclude from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@
 changelog:
   exclude:
     labels:
+      - plan # implementation plans, not user-facing
       - ui-dependency # these dont affect user environments
       - ui-replatform # lots of ongoing work, but not user facing... yet
   categories:


### PR DESCRIPTION
this PR adds a `plan` label for PRs that introduce implementation plans to `./plans`.

- creates `plan` label on the repo
- adds `plan` to the exclude list in `.github/release.yml`

implementation plans are internal development artifacts, not user-facing changes, so they should be excluded from auto-generated release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)