### PR TITLE
auto-label PRs that touch plans/ directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+plan:
+  - changed-files:
+      - any-glob-to-any-file: plans/**
+
 docs:
   - all:
     - changed-files:


### PR DESCRIPTION
follow-up to #20182

this PR adds a labeler rule to automatically apply the `plan` label to PRs that add or modify files in the `plans/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)