### PR TITLE
Clarify deployment intent in Quickstart

### DIFF
--- a/docs/v3/get-started/quickstart.mdx
+++ b/docs/v3/get-started/quickstart.mdx
@@ -83,8 +83,15 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
       </Step>
       <Step title="Where should it run?">
         At this point, you've successfully run a Prefect `flow` locally. Let's get it running off of your machine! Again, for simplicity, 
-        we'll deploy this workflow to Prefect's Serverless Compute (so we don't have to wrangle any infrastructure). We'll tell Prefect to clone
+        we'll deploy this workflow to Prefect's Serverless Compute (so we don't have to wrangle any infrastructure). 
+        
+        :::note
+        Deployment is optional — it’s only required if you want Prefect to run your workflow remotely or on a schedule.
+        :::
+
+        We'll tell Prefect to clone
         `https://github.com/PrefectHQ/quickstart` and invoke `01_getting_started.py:main`.
+        
         ```bash
         uvx prefect-cloud deploy 01_getting_started.py:main \
         --name my_first_deployment \


### PR DESCRIPTION
### Overview

This PR clarifies that deploying a workflow in the Quickstart is optional and only required when users want to run workflows remotely or on a schedule.

The added note helps reduce confusion for first-time users who may assume deployment is mandatory after running a flow locally.

### Scope

- Documentation-only change
- No functional or behavioural changes

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
