### PR TITLE
Adding json output in prefect deployment schedule cli

### DIFF
--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -128,6 +128,53 @@ def test_list_schedules(flojo_deployment: DeploymentResponse):
     )
 
 
+def test_list_schedules_with_json_output(flojo_deployment: DeploymentResponse):
+    create_commands = [
+        "deployment",
+        "schedule",
+        "create",
+        "rence-griffith/test-deployment",
+    ]
+
+    invoke_and_assert(
+        [
+            *create_commands,
+            "--cron",
+            "5 4 * * *",
+        ],
+        expected_code=0,
+    )
+
+    invoke_and_assert(
+        [
+            *create_commands,
+            "--rrule",
+            '{"rrule": "RRULE:FREQ=HOURLY"}',
+        ],
+        expected_code=0,
+    )
+
+    invoke_and_assert(
+        [
+            "deployment",
+            "schedule",
+            "ls",
+            "-o",
+            "json",
+            "rence-griffith/test-deployment",
+        ],
+        expected_code=0,
+        expected_output_contains=[
+            str(flojo_deployment.schedules[0].id)[:8],
+            "interval: 0:00:10.760000s",
+            "cron: 5 4 * * *",
+            "rrule: RRULE:FREQ=HOURLY",
+            "true",
+        ],
+        expected_output_does_not_contain="false",
+    )
+
+
 class TestDeploymentSchedules:
     @pytest.fixture(autouse=True)
     def enable_triggers(self):


### PR DESCRIPTION
Added json output in:

`prefect deployment schedule ls`

 - [x] "closes part of https://github.com/PrefectHQ/prefect/issues/19483 "
 - [x] it includes unit tests that cover the changes
