### PR TITLE
fix: remove incorrect docstrings from CLI ls commands

### DIFF
--- a/src/prefect/cli/artifact.py
+++ b/src/prefect/cli/artifact.py
@@ -45,11 +45,6 @@ async def list_artifacts(
 ):
     """
     List artifacts.
-
-    Arguments:
-        limit: Maximum number of flow runs to list. Defaults to 100.
-        all: Whether or not to only return the latest version of each artifact.
-        output: Return variables in specified format.
     """
 
     if output and output.lower() != "json":

--- a/src/prefect/cli/variable.py
+++ b/src/prefect/cli/variable.py
@@ -35,11 +35,6 @@ async def list_variables(
 ):
     """
     List variables.
-
-    Arguments:
-
-    limit: Maximum number of flow runs to list. Defaults to 100.
-    output: Return variables in specified format.
     """
     if output and output.lower() != "json":
         exit_with_error("Only 'json' output format is supported.")


### PR DESCRIPTION
## Summary

- Removes copy-pasted docstrings from `variable ls` and `artifact ls` that incorrectly referenced "flow runs"
- These argument descriptions are already covered by the typer Option help text

Fast-follow to PRs #20192-#20198.

Related to #19903

🤖 Generated with [Claude Code](https://claude.com/claude-code)