### PR TITLE
Fix plan label to only apply when all changed files are in plans/

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 plan:
   - changed-files:
-      - any-glob-to-any-file: plans/**
+      - all-globs-to-all-files: plans/**
 
 docs:
   - all:


### PR DESCRIPTION
## Summary
- Changes the plan labeler from `any-glob-to-any-file` to `all-globs-to-all-files`
- Ensures the 'plan' label is only applied to PRs that exclusively touch files in `plans/`
- Implementation PRs (those that modify files in `plans/` along with other files) will no longer receive the 'plan' label

🤖 Generated with [Claude Code](https://claude.com/claude-code)