### PR TITLE
fix:  retry delay display in flow run details

### DIFF
--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-details.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-details.test.tsx
@@ -268,7 +268,7 @@ describe("FlowRunDetails", () => {
 		});
 		expect(screen.getByText("3")).toBeInTheDocument();
 		expect(screen.getByText("Retry Delay")).toBeInTheDocument();
-		expect(screen.getByText("60")).toBeInTheDocument();
+		expect(screen.getByText("60s")).toBeInTheDocument();
 	});
 
 	it("should not display retry configuration when retries is null", async () => {
@@ -291,6 +291,29 @@ describe("FlowRunDetails", () => {
 			expect(screen.getByText("Run Count")).toBeInTheDocument();
 		});
 		expect(screen.queryByText("Retries")).not.toBeInTheDocument();
+		expect(screen.queryByText("Retry Delay")).not.toBeInTheDocument();
+	});
+
+	it("should not display retry delay when retry_delay is null even if retries is set", async () => {
+		const flowRun = createFakeFlowRun({
+			empirical_policy: {
+				max_retries: 0,
+				retry_delay_seconds: 0,
+				retries: 5,
+				retry_delay: null,
+				pause_keys: [],
+				resuming: false,
+				retry_type: null,
+			},
+		});
+		render(<FlowRunDetailsRouter flowRun={flowRun} />, {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText("Retries")).toBeInTheDocument();
+		});
+		expect(screen.getByText("5")).toBeInTheDocument();
 		expect(screen.queryByText("Retry Delay")).not.toBeInTheDocument();
 	});
 

--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-details.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-details.tsx
@@ -55,10 +55,12 @@ export function FlowRunDetails({ flowRun }: FlowRunDetailsProps) {
 			{flowRun.empirical_policy?.retries != null && (
 				<>
 					<KeyValue label="Retries" value={flowRun.empirical_policy.retries} />
-					<KeyValue
-						label="Retry Delay"
-						value={flowRun.empirical_policy.retry_delay}
-					/>
+					{flowRun.empirical_policy.retry_delay != null && (
+						<KeyValue
+							label="Retry Delay"
+							value={`${flowRun.empirical_policy.retry_delay}s`}
+						/>
+					)}
 				</>
 			)}
 		</div>


### PR DESCRIPTION
fix:  PrefectHQ/prefect-ui-library#3122

- fix retry delay display in flow run details

- The UI was incorrectly displaying retry delay as "0s" instead of the actual configured value. The component was already using the correct `retry_delay` field from the API response, but needed proper null handling and for