### PR TITLE
Fix PrefectDbtRunner for multi-word commands

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -1080,7 +1080,7 @@ class PrefectDbtRunner:
                 command_name = arg
                 if isinstance(cli.commands[arg], click.Group):
                     # look one arg ahead for subcommand
-                    if (next_arg := args_copy[i+1]) in cli.commands[arg].commands:
+                    if (next_arg := args_copy[i + 1]) in cli.commands[arg].commands:
                         subcommand_name = next_arg
                 break
 

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -658,6 +658,26 @@ class TestPrefectDbtRunnerInvoke:
             f"--target-path should not be passed to 'deps' command, got: {args_list}"
         )
 
+    def test_invoke_handles_multi_word_commands(
+        self, mock_dbt_runner_class, mock_settings_context_manager
+    ):
+        """Test that multi-word commands include all necessary parameters."""
+        runner = PrefectDbtRunner()
+        mock_dbt_runner_class.return_value.invoke.return_value = Mock(
+            success=True, result=None
+        )
+
+        result = runner.invoke(["source", "freshness"])
+
+        assert result.success
+        mock_dbt_runner_class.assert_called_once()
+
+        call_args = mock_dbt_runner_class.return_value.invoke.call_args
+        args_list = call_args[0][0]
+        assert "--profiles-dir" in args_list
+        # --project-dir is accepted by `source freshness`, but not by `source`
+        assert "--project-dir" in args_list
+
 
 class TestPrefectDbtRunnerCallbackCreation:
     """Test callback creation functionality."""


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
### Changes
- sub-commands are now respected when determining what valid params are
  - this fixes `runner.invoke(["source", "freshness"])`

based on https://github.com/PrefectHQ/prefect/commit/5301c91d2bb0761c1bd2908daca3ca518f215c35

closes #19253

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
