### PR TITLE
Increase timeout for prefect-dbt integration test server startup

### DIFF
--- a/src/integrations/prefect-dbt/tests/conftest.py
+++ b/src/integrations/prefect-dbt/tests/conftest.py
@@ -33,7 +33,8 @@ def prefect_db():
     Sets up test harness for temporary DB during test runs.
     """
     with temporary_settings({PREFECT_API_SERVICES_TRIGGERS_ENABLED: False}):
-        with prefect_test_harness():
+        # Increase timeout to 60s to handle slower CI environments (especially on Python 3.12)
+        with prefect_test_harness(server_startup_timeout=60):
             yield
 
 


### PR DESCRIPTION
## Summary

Increases the ephemeral server startup timeout in prefect-dbt tests from 30s to 60s.

## Problem

The prefect-dbt integration tests are consistently failing on Python 3.12 in CI with:
```
RuntimeError: Timed out while attempting to connect to ephemeral Prefect API server.
```

This is blocking PRs from merging (including #20205).

## Investigation

- Tests pass locally on Python 3.12 with pytest-xdist
- Tests pass in CI on Python 3.10, 3.11, and 3.13
- Only Python 3.12 in CI fails
- The ephemeral server subprocess starts but never responds to health checks within 30s
- Root cause unclear - could be CI environment-specific (resources, Python 3.12.3 vs 3.12.8)

## Fix

Increase timeout to 60s as a mitigation. This may not fully resolve the issue if the server is truly hanging rather than just slow, but it's a reasonable first step.

Fixes #20247

🤖 Generated with [Claude Code](https://claude.com/claude-code)