### PR TITLE
docs: add ECS base job template customization guide

### DIFF
--- a/docs/integrations/prefect-aws/ecs-worker/manual-deployment.mdx
+++ b/docs/integrations/prefect-aws/ecs-worker/manual-deployment.mdx
@@ -931,6 +931,7 @@ To add a new variable that can be set per-deployment, you need to:
 
 For example, to allow per-deployment customization of container secrets (for injecting values from AWS Secrets Manager or Parameter Store):
 
+{/* pmd-metadata: notest */}
 ```python
 from prefect.client.schemas.actions import WorkPoolUpdate
 from prefect import get_client


### PR DESCRIPTION
## Summary

Adds documentation for customizing the ECS work pool's base job template to expose additional variables that can be overridden per-deployment.

This addresses the common request (see #20246) to customize `containerDefinitions` values like `secrets` (for AWS Secrets Manager/Parameter Store) on a per-deployment basis rather than at the work pool level.

## Changes

- Added new "Customize the base job template" section to the ECS manual deployment guide
- Includes Python example for adding `task_definition` as a job variable
- Shows how to use it in `prefect.yaml` with secrets example
- Added warning about needing to reference variables in job_configuration
- Added tip about more granular variable options

Closes #20246

🤖 Generated with [Claude Code](https://claude.com/claude-code)