### PR TITLE
Fix MDX parsing error in events CLI documentation

### DIFF
--- a/docs/v3/api-ref/cli/event.mdx
+++ b/docs/v3/api-ref/cli/event.mdx
@@ -130,6 +130,7 @@ Emit a single event to Prefect.
 <Note>
 **Example:**
 
+```bash
 # Simple event with resource ID
 prefect event emit user.logged_in --resource-id user-123
 
@@ -138,5 +139,6 @@ prefect event emit order.shipped --resource-id order-456 --payload '{"tracking":
 
 # Event with full resource specification
 prefect event emit customer.subscribed --resource '{"prefect.resource.id": "customer-789", "prefect.resource.name": "ACME Corp"}'
+```
 </Note>
 

--- a/docs/v3/api-ref/cli/events.mdx
+++ b/docs/v3/api-ref/cli/events.mdx
@@ -130,6 +130,7 @@ Emit a single event to Prefect.
 <Note>
 **Example:**
 
+```bash
 # Simple event with resource ID
 prefect event emit user.logged_in --resource-id user-123
 
@@ -138,5 +139,6 @@ prefect event emit order.shipped --resource-id order-456 --payload '{"tracking":
 
 # Event with full resource specification
 prefect event emit customer.subscribed --resource '{"prefect.resource.id": "customer-789", "prefect.resource.name": "ACME Corp"}'
+```
 </Note>
 

--- a/docs/v3/api-ref/python/prefect-cli-events.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-events.mdx
@@ -42,6 +42,7 @@ Emit a single event to Prefect.
 
 **Examples:**
 
+```bash
 # Simple event with resource ID
 prefect event emit user.logged_in --resource-id user-123
 
@@ -50,6 +51,7 @@ prefect event emit order.shipped --resource-id order-456 --payload '{"tracking":
 
 # Event with full resource specification
 prefect event emit customer.subscribed --resource '{"prefect.resource.id": "customer-789", "prefect.resource.name": "ACME Corp"}'
+```
 
 
 ## Classes

--- a/src/prefect/cli/events.py
+++ b/src/prefect/cli/events.py
@@ -117,6 +117,7 @@ async def emit(
     """Emit a single event to Prefect.
 
     Examples:
+        ```bash
         # Simple event with resource ID
         prefect event emit user.logged_in --resource-id user-123
 
@@ -125,6 +126,7 @@ async def emit(
 
         # Event with full resource specification
         prefect event emit customer.subscribed --resource '{"prefect.resource.id": "customer-789", "prefect.resource.name": "ACME Corp"}'
+        ```
     """
     resource_dict = {}
 


### PR DESCRIPTION
## Summary
- Wrap examples containing JSON with curly braces in code blocks in the `prefect event emit` docstring
- Regenerate affected documentation files

The curly braces in JSON payloads (e.g., `--payload '{"tracking": "ABC123"}'`) were being interpreted as JSX expressions by the MDX parser, causing "Could not parse expression with acorn" errors when running `just docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)