### PR TITLE
Add GitHub Actions workflow to trigger Devin.ai on test failures

### DIFF
--- a/.github/workflows/devin-fix-flaky-tests.yaml
+++ b/.github/workflows/devin-fix-flaky-tests.yaml
@@ -33,9 +33,6 @@ jobs:
           echo "workflow_run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
           echo "workflow_url=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
           echo "head_sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
-          echo "head_commit_message<<EOF" >> $GITHUB_OUTPUT
-          echo "${{ github.event.workflow_run.head_commit.message }}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Trigger Devin session to fix flaky tests
         env:
@@ -44,9 +41,8 @@ jobs:
           curl -X POST "https://api.devin.ai/v1/sessions" \
             -H "Authorization: Bearer $DEVIN_API_TOKEN" \
             -H "Content-Type: application/json" \
-            -d @- << EOF
-          {
-            "prompt": "The '${{ steps.workflow-info.outputs.workflow_name }}' workflow failed on the main branch of the PrefectHQ/prefect repository.\n\nWorkflow run: ${{ steps.workflow-info.outputs.workflow_url }}\nCommit SHA: ${{ steps.workflow-info.outputs.head_sha }}\nCommit message: ${{ steps.workflow-info.outputs.head_commit_message }}\n\nPlease investigate the test failures:\n1. Review the failed workflow run logs at the URL above\n2. Identify which tests failed and why\n3. Determine if this is a flaky test (intermittent failure) or a real bug\n4. If it's a flaky test, fix the underlying cause of the flakiness\n5. If it's a real bug introduced by the commit, fix the bug\n6. Create a pull request with the fix\n\nCommon causes of flaky tests include:\n- Race conditions in async code\n- Timing-dependent assertions\n- Shared state between tests\n- Network/database connection issues\n- Resource cleanup problems\n\nMake sure to run the tests locally to verify your fix before creating the PR.",
-            "idempotent": true
-          }
-          EOF
+            -d '{
+              "prompt": "The ${{ steps.workflow-info.outputs.workflow_name }} workflow failed on main. Workflow: ${{ steps.workflow-info.outputs.workflow_url }}, Commit: ${{ steps.workflow-info.outputs.head_sha }}. Investigate and fix the flaky test.",
+              "playbook_id": "playbook-8967ef2920e24b9cbd076184b53e170e",
+              "idempotent": true
+            }'


### PR DESCRIPTION
## Summary
- Adds a new workflow that automatically triggers a Devin session when test workflows fail on the main branch
- Monitors both "Unit tests" and "Integration tests" workflows
- Provides Devin with context about the failure including workflow URL, commit SHA, and commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)