### PR TITLE
Add release notes for integration packages

### DIFF
--- a/docs/v3/release-notes/integrations/prefect-aws.mdx
+++ b/docs/v3/release-notes/integrations/prefect-aws.mdx
@@ -2,6 +2,30 @@
 title: prefect-aws
 ---
 
+## 0.7.4
+
+_Released on January 15, 2026_
+
+**Features**
+
+- Add `kill_infrastructure` method to worker integrations [#20075](https://github.com/PrefectHQ/prefect/pull/20075) by [@joshuastagner](https://github.com/joshuastagner)
+
+**Bug Fixes**
+
+- Fix comparison for container essential field [#20162](https://github.com/PrefectHQ/prefect/pull/20162) by [@bdalpe](https://github.com/bdalpe)
+
+---
+
+## 0.7.3
+
+_Released on January 07, 2026_
+
+**Bug Fixes**
+
+- Refactor deployment steps to use `AwsCredentials.get_s3_client()` [#20140](https://github.com/PrefectHQ/prefect/pull/20140) by [@bdalpe](https://github.com/bdalpe)
+
+---
+
 ## 0.7.2
 
 _Released on December 19, 2025_

--- a/docs/v3/release-notes/integrations/prefect-azure.mdx
+++ b/docs/v3/release-notes/integrations/prefect-azure.mdx
@@ -2,6 +2,16 @@
 title: prefect-azure
 ---
 
+## 0.4.8
+
+_Released on January 15, 2026_
+
+**Features**
+
+- Add `kill_infrastructure` method to worker integrations [#20075](https://github.com/PrefectHQ/prefect/pull/20075) by [@joshuastagner](https://github.com/joshuastagner)
+
+---
+
 ## 0.4.7
 
 _Released on December 05, 2025_

--- a/docs/v3/release-notes/integrations/prefect-dbt.mdx
+++ b/docs/v3/release-notes/integrations/prefect-dbt.mdx
@@ -2,6 +2,40 @@
 title: prefect-dbt
 ---
 
+## 0.7.15
+
+_Released on January 15, 2026_
+
+**Features**
+
+- Add create and delete job tasks to prefect-dbt Cloud integration [#20216](https://github.com/PrefectHQ/prefect/pull/20216) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+**Bug Fixes**
+
+- Fix PrefectDbtRunner for multi-word commands [#20221](https://github.com/PrefectHQ/prefect/pull/20221) by [@lostkamp](https://github.com/lostkamp)
+
+---
+
+## 0.7.14
+
+_Released on December 29, 2025_
+
+**Bug Fixes**
+
+- Fix incorrect handling of dbt ephemeral models in PrefectDbtRunner [#19962](https://github.com/PrefectHQ/prefect/pull/19962) by [@vyagubov](https://github.com/vyagubov)
+
+---
+
+## 0.7.13
+
+_Released on December 16, 2025_
+
+**Bug Fixes**
+
+- Skip asset creation for ephemeral models in `_call_task` [#19822](https://github.com/PrefectHQ/prefect/pull/19822) by [@app/devin-ai-integration](https://github.com/app/devin-ai-integration)
+
+---
+
 ## 0.7.12
 
 _Released on December 16, 2025_

--- a/docs/v3/release-notes/integrations/prefect-docker.mdx
+++ b/docs/v3/release-notes/integrations/prefect-docker.mdx
@@ -2,6 +2,20 @@
 title: prefect-docker
 ---
 
+## 0.7.1
+
+_Released on January 15, 2026_
+
+**Features**
+
+- Add `kill_infrastructure` method to worker integrations [#20075](https://github.com/PrefectHQ/prefect/pull/20075) by [@joshuastagner](https://github.com/joshuastagner)
+
+**Bug Fixes**
+
+- Fix `DockerRegistryCredentials` and `DockerHost` to fallback to standard logger [#20105](https://github.com/PrefectHQ/prefect/pull/20105) by [@app/devin-ai-integration](https://github.com/app/devin-ai-integration)
+
+---
+
 ## 0.7.0
 
 _Released on December 19, 2025_

--- a/docs/v3/release-notes/integrations/prefect-gcp.mdx
+++ b/docs/v3/release-notes/integrations/prefect-gcp.mdx
@@ -2,6 +2,16 @@
 title: prefect-gcp
 ---
 
+## 0.6.15
+
+_Released on January 15, 2026_
+
+**Features**
+
+- Add `kill_infrastructure` method to worker integrations [#20075](https://github.com/PrefectHQ/prefect/pull/20075) by [@joshuastagner](https://github.com/joshuastagner)
+
+---
+
 ## 0.6.12
 
 _Released on November 19, 2025_

--- a/docs/v3/release-notes/integrations/prefect-github.mdx
+++ b/docs/v3/release-notes/integrations/prefect-github.mdx
@@ -2,6 +2,20 @@
 title: prefect-github
 ---
 
+## 0.4.0
+
+_Released on January 15, 2026_
+
+**Bug Fixes**
+
+- Preserve symlinks in `get_directory` instead of following them [#19993](https://github.com/PrefectHQ/prefect/pull/19993) by [@majiayu000](https://github.com/majiayu000)
+
+**Documentation**
+
+- Remove Python 3.9 support [#19273](https://github.com/PrefectHQ/prefect/pull/19273) by [@desertaxle](https://github.com/desertaxle)
+
+---
+
 ## 0.3.2
 
 _Released on October 23, 2025_

--- a/docs/v3/release-notes/integrations/prefect-kubernetes.mdx
+++ b/docs/v3/release-notes/integrations/prefect-kubernetes.mdx
@@ -2,6 +2,16 @@
 title: prefect-kubernetes
 ---
 
+## 0.7.3
+
+_Released on January 15, 2026_
+
+**Features**
+
+- Add worker-side cancellation for pending flow runs [#20022](https://github.com/PrefectHQ/prefect/pull/20022) by [@joshuastagner](https://github.com/joshuastagner)
+
+---
+
 ## 0.7.2
 
 _Released on December 24, 2025_


### PR DESCRIPTION
## Summary

- Adds release notes for multiple integration packages
- prefect-aws: 0.7.3, 0.7.4
- prefect-azure: 0.4.8
- prefect-dbt: 0.7.13, 0.7.14, 0.7.15
- prefect-docker: 0.7.1
- prefect-gcp: 0.6.15
- prefect-github: 0.4.0
- prefect-kubernetes: 0.7.3

Releases of prefect-azure, prefect-docker, prefect-gcp, prefect-github, and prefect-kubernetes will be kicked off after this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)