### PR TITLE
fix: remove CANCELLED from EnforceCancellingToCancelledTransition to allow retrying cancelled flows

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1738,7 +1738,7 @@ class EnforceCancellingToCancelledTransition(TaskRunOrchestrationRule):
     Rejects transitions from Cancelling to any terminal state except for Cancelled.
     """
 
-    FROM_STATES = {StateType.CANCELLED, StateType.CANCELLING}
+    FROM_STATES = {StateType.CANCELLING}
     TO_STATES = ALL_ORCHESTRATION_STATES - {StateType.CANCELLED}
 
     async def before_transition(


### PR DESCRIPTION
## Summary
- Remove `CANCELLED` from `FROM_STATES` in `EnforceCancellingToCancelledTransition`
- This rule should only block transitions FROM `CANCELLING`, not `CANCELLED`
- Add regression test

## Background
This behavior was introduced in commit 9fb9c001379 ("Improve engine shutdown handling of SIGTERM (#8127)", Jan 2023). The rule was added with both `CANCELLING` and `CANCELLED` in `FROM_STATES` from day one, but the docstring, rule name, and error message all only reference "cancelling" states - suggesting `CANCELLED` was included unintentionally.

Fixes #20271

🤖 Generated with [Claude Code](https://claude.com/claude-code)