### PR TITLE
Add httpx.ConnectError to client retry exceptions

### DIFF
--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -499,6 +499,64 @@ class TestPrefectHttpxAsyncClient:
 
         mock_anyio_sleep.assert_not_called()
 
+    async def test_prefect_httpx_client_does_not_retry_connect_error_on_first_request(
+        self, mock_anyio_sleep, monkeypatch
+    ):
+        """ConnectError should NOT be retried on the first request (before any successful connection)."""
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxAsyncClient()
+
+        # Simulate connection refused on first attempt
+        base_client_send.side_effect = [httpx.ConnectError("Connection refused")]
+
+        with pytest.raises(httpx.ConnectError, match="Connection refused"):
+            async with client:
+                await client.post(
+                    url="fake.url/fake/route", data={"evenmorefake": "data"}
+                )
+
+        # Should not have retried
+        assert base_client_send.call_count == 1
+        mock_anyio_sleep.assert_not_called()
+
+    @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
+    async def test_prefect_httpx_client_retries_connect_error_after_successful_connection(
+        self, monkeypatch, caplog
+    ):
+        """ConnectError SHOULD be retried after a successful connection has been made."""
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxAsyncClient()
+
+        # First request succeeds, subsequent requests fail with ConnectError then succeed
+        base_client_send.side_effect = [
+            RESPONSE_200,  # First request succeeds, sets _has_connected=True
+            httpx.ConnectError("Connection refused"),  # Second request fails
+            httpx.ConnectError("Connection refused"),  # Retry 1
+            httpx.ConnectError("Connection refused"),  # Retry 2
+            RESPONSE_200,  # Retry 3 succeeds
+        ]
+
+        async with client:
+            # First request - establishes connection
+            response1 = await client.get(url="fake.url/fake/route")
+            assert response1.status_code == status.HTTP_200_OK
+
+            # Second request - should retry on ConnectError
+            response2 = await client.post(
+                url="fake.url/fake/route", data={"evenmorefake": "data"}
+            )
+            assert response2.status_code == status.HTTP_200_OK
+
+        # 1 initial + 1 failed + 3 retries (2 failures + 1 success) = 5
+        assert base_client_send.call_count == 5
+
+        # We should see retry logging
+        assert "Encountered retryable exception during request" in caplog.text
+
     async def test_prefect_httpx_client_returns_prefect_response(self, monkeypatch):
         """Test that the PrefectHttpxAsyncClient returns a PrefectResponse"""
         client = PrefectHttpxAsyncClient()


### PR DESCRIPTION
## Summary
- Adds `httpx.ConnectError` to the list of retryable exceptions in both async and sync HTTP clients
- **Key behavior**: Only retries `ConnectError` after a successful connection has been established
  - First request: Fails fast on `ConnectError` (e.g., wrong URL, server never started)
  - Subsequent requests: Retries on `ConnectError` with exponential backoff (server restart resilience)

## Root Cause
When the server goes down during flow run execution:
1. Worker picks up flow run (state = Pending)
2. Server becomes unavailable
3. Flow run process exits but can't update state
4. Both runner and worker try to call `_propose_crashed_state` but fail with `httpx.ConnectError`
5. The exception is caught and logged, but **not retried** because `ConnectError` wasn't in the retry list
6. Flow run remains stuck in Pending state forever

## Fix
- Add `_has_connected` flag to track whether the client has successfully communicated with the server
- Only include `httpx.ConnectError` in `retry_exceptions` after `_has_connected` is `True`
- Set `_has_connected = True` after each successful response

This allows:
- Fast failure on startup (wrong URL, server not running)
- Resilience during server restarts (~62s of retries with exponential backoff)

## Test plan
- [x] Test that `ConnectError` is NOT retried on first request
- [x] Test that `ConnectError` IS retried after successful connection
- [x] All existing base client tests pass (65 tests)
- [ ] Manual testing with server restart scenario

Closes #18324

🤖 Generated with [Claude Code](https://claude.ai/code)