### PR TITLE
Fix some wrong unit tests in prefect_dbt

### DIFF
--- a/src/integrations/prefect-dbt/tests/cloud/test_clients.py
+++ b/src/integrations/prefect-dbt/tests/cloud/test_clients.py
@@ -68,7 +68,7 @@ def test_metadata_client_query(monkeypatch):
     }
     """
     assert dbt_cloud_metadata_client.query(mock_query) == mock_response
-    mock_headers = urlopen_mock.call_args_list[0][0][0].headers
+    mock_headers = urlopen_mock.call_args_list[0].args[0].headers
     assert mock_headers["X-dbt-partner-source"] == "prefect"
     assert mock_headers["Authorization"] == "Bearer my_api_key"
     assert mock_headers["User-agent"] == f"prefect-{prefect.__version__}"

--- a/src/integrations/prefect-dbt/tests/core/test_tracker.py
+++ b/src/integrations/prefect-dbt/tests/core/test_tracker.py
@@ -463,7 +463,7 @@ class TestNodeTaskTrackerThreadExecution:
         # Verify run_task_sync was called with correct dependencies
         mock_thread_execution_setup.assert_called_once()
         call_args = mock_thread_execution_setup.call_args
-        assert len(call_args[1]["wait_for"]) == expected_wait_count
+        assert len(call_args.kwargs["wait_for"]) == expected_wait_count
 
     def test_run_task_in_thread_starts_daemon_thread(
         self, sample_node_id, mock_task, sample_task_run_id, mock_thread_execution_setup


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
### Changes
While working on #20221 I noticed some strange assert statements in other tests, like here:
https://github.com/PrefectHQ/prefect/blob/585767f7410c8121225190224f19ae8b818d0c64/src/integrations/prefect-dbt/tests/core/test_runner.py#L612-L613

These asserts don't check what it looks like they are checking, they evaluate the first argument, i.e. `bool("--target-path")` and show the second argument as an error message in case the assert fails. You can verify this by changing these lines to
```python
assert "--target-path", "/cli/path" not in call_args[0]
assert "--target-path", "/kwargs/path" in call_args[0]
```
and seeing that the test still passes.

So I introduced a helper function to make these asserts correct.

Also I changed `call_args[0]` to `call_args.args` and `call_args[1]` to `call_args.kwargs` everywhere, because it is not guaranteed that args is the 0th and kwargs the 1st element of the `call_args` tuple. [see docs here](https://docs.python.org/3/library/unittest.mock.html#calls-as-tuples).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
