### PR TITLE
fix: convert dynamic_key to str in sync client's create_task_run

### DIFF
--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -1485,7 +1485,7 @@ class SyncPrefectClient(
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
-            dynamic_key=dynamic_key,
+            dynamic_key=str(dynamic_key),
             tags=list(tags),
             task_version=task.version,
             empirical_policy=TaskRunPolicy(


### PR DESCRIPTION
## Summary
- Adds missing `str()` conversion for `dynamic_key` in the sync client's `create_task_run` method
- The async client already had this conversion, but it was missed when the sync client was created

## Root cause
In #20160, when `SyncPrefectClient.create_task_run` was added, the `dynamic_key=str(dynamic_key)` conversion was accidentally omitted (the async version has it at line 827, but sync version at line 1488 was missing it).

## Test plan
- [x] Reproduced locally with sync `run_deployment` from within a flow
- [x] All 36 tests in `tests/deployment/test_flow_runs.py` pass

<details>
<summary>Reproduction script</summary>

```python
from prefect import flow
from prefect.deployments import run_deployment
from prefect.deployments.runner import RunnerDeployment

@flow
def parent_flow():
    # This fails with ValidationError on dynamic_key before fix
    run_deployment(
        name="test-flow/test-deployment",
        timeout=0,
    )

@flow
def test_flow():
    print("Hello from test flow!")

if __name__ == "__main__":
    deployment = RunnerDeployment.from_flow(test_flow, name="test-deployment")
    deployment.apply()
    parent_flow()
```
</details>

Fixes #20301

🤖 Generated with [Claude Code](https://claude.com/claude-code)