### PR TITLE
Pin miniconda3 image to fix conda Docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN mv "dist/prefect-"*".tar.gz" "dist/prefect.tar.gz"
 
 
 # Setup a base final image from miniconda
-FROM continuumio/miniconda3 AS prefect-conda
+FROM continuumio/miniconda3:25.3.1-1 AS prefect-conda
 
 # Create a new conda environment with our required Python version
 ARG PYTHON_VERSION


### PR DESCRIPTION
## Summary

Fixes Docker build failure for conda image variants by pinning the miniconda3 base image to version `25.3.1-1`.

<details>
<summary>Root Cause</summary>

The build fails because of a git version mismatch:

1. The `python-builder` stage uses `python:${BUILD_PYTHON_VERSION}-slim` (Debian Trixie) which has git 2.47.3+ available
2. The `final` stage for conda images uses `continuumio/miniconda3`, which was based on an older Debian release (Bookworm) that only has git ~2.39.x available

The git version requirement (1:2.47.3) was added in PR #18916 for security scanner compliance.

</details>

## Changes

Pin `continuumio/miniconda3` to version `25.3.1-1`, which uses Debian 13.3-slim (Trixie) and includes git 2.47.3+.

🤖 Generated with [Claude Code](https://claude.ai/code)