### PR TITLE
consolidate strip_auth_from_url into prefect._internal.urls

### DIFF
--- a/src/integrations/prefect-github/prefect_github/repository.py
+++ b/src/integrations/prefect-github/prefect_github/repository.py
@@ -21,6 +21,7 @@ from pydantic import Field
 from sgqlc.operation import Operation
 
 from prefect import task
+from prefect._internal.urls import strip_auth_from_url
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.processutils import run_process
@@ -35,21 +36,9 @@ return_fields_defaults = initialize_return_fields_defaults(config_path)
 _URL_PATTERN = re.compile(r"https?://[^\s'\"<>]+")
 
 
-def _strip_auth_from_url(url: str) -> str:
-    parsed = urlparse(url)
-    if not (parsed.username or parsed.password):
-        return url
-
-    netloc = parsed.hostname or ""
-    if parsed.port:
-        netloc = f"{netloc}:{parsed.port}"
-
-    return urlunparse(parsed._replace(netloc=netloc))
-
-
 def _sanitize_git_error(message: str) -> str:
     def _replace(match: re.Match[str]) -> str:
-        return _strip_auth_from_url(match.group(0))
+        return strip_auth_from_url(match.group(0))
 
     return _URL_PATTERN.sub(_replace, message)
 

--- a/src/prefect/_internal/urls.py
+++ b/src/prefect/_internal/urls.py
@@ -1,0 +1,29 @@
+from urllib.parse import urlparse, urlunparse
+
+
+def strip_auth_from_url(url: str) -> str:
+    """
+    Remove authentication credentials (username/password) from a URL.
+
+    Useful for sanitizing URLs before including them in error messages
+    or logs to avoid leaking secrets.
+    """
+    parsed = urlparse(url)
+
+    if not parsed.hostname:
+        return url
+
+    netloc = parsed.hostname
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+
+    return urlunparse(
+        (
+            parsed.scheme,
+            netloc,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )

--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -20,6 +20,7 @@ from anyio import run_process
 from pydantic import SecretStr
 
 from prefect._internal.concurrency.api import create_call, from_async
+from prefect._internal.urls import strip_auth_from_url
 from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
@@ -344,7 +345,7 @@ class GitRepository:
                 cwd=str(self.destination),
             )
             existing_repo_url = None
-            existing_repo_url = _strip_auth_from_url(result.stdout.decode().strip())
+            existing_repo_url = strip_auth_from_url(result.stdout.decode().strip())
 
             if existing_repo_url != self._url:
                 raise ValueError(
@@ -458,7 +459,7 @@ class GitRepository:
                 else exc
             )
             raise RuntimeError(
-                f"Failed to clone repository {_strip_auth_from_url(self._url)!r} with exit code"
+                f"Failed to clone repository {strip_auth_from_url(self._url)!r} with exit code"
                 f" {exc.returncode}."
             ) from exc_chain
 
@@ -966,24 +967,3 @@ def _format_token_from_credentials(
 
     # GitHub and other providers: plain token
     return user_provided_token
-
-
-def _strip_auth_from_url(url: str) -> str:
-    parsed = urlparse(url)
-
-    # Construct a new netloc without the auth info
-    netloc = parsed.hostname
-    if parsed.port and netloc:
-        netloc += f":{parsed.port}"
-
-    # Build the sanitized URL
-    return urlunparse(
-        (
-            parsed.scheme,
-            netloc,
-            parsed.path,
-            parsed.params,
-            parsed.query,
-            parsed.fragment,
-        )
-    )

--- a/tests/_internal/test_urls.py
+++ b/tests/_internal/test_urls.py
@@ -1,0 +1,50 @@
+import pytest
+
+from prefect._internal.urls import strip_auth_from_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # URL with username and password
+        (
+            "https://user:pass@github.com/org/repo.git",
+            "https://github.com/org/repo.git",
+        ),
+        # URL with only token (as username)
+        (
+            "https://token@github.com/org/repo.git",
+            "https://github.com/org/repo.git",
+        ),
+        # URL without auth - unchanged
+        (
+            "https://github.com/org/repo.git",
+            "https://github.com/org/repo.git",
+        ),
+        # URL with port
+        (
+            "https://user:pass@gitlab.example.com:8443/org/repo.git",
+            "https://gitlab.example.com:8443/org/repo.git",
+        ),
+        # HTTP URL
+        (
+            "http://token@example.com/repo",
+            "http://example.com/repo",
+        ),
+        # URL with query string
+        (
+            "https://user:pass@example.com/path?query=1",
+            "https://example.com/path?query=1",
+        ),
+        # URL with fragment
+        (
+            "https://user:pass@example.com/path#section",
+            "https://example.com/path#section",
+        ),
+        # Empty/malformed URL - returned as-is
+        ("", ""),
+        ("not-a-url", "not-a-url"),
+    ],
+)
+def test_strip_auth_from_url(url: str, expected: str):
+    assert strip_auth_from_url(url) == expected


### PR DESCRIPTION
follow-up to #20330

this PR consolidates the `strip_auth_from_url` function that was duplicated between `runner/storage.py` and `prefect-github/repository.py` into a shared internal module.

- add `prefect._internal.urls` module with `strip_auth_from_url` utility
- update `runner/storage.py` to import from shared location
- update `prefect-github/repository.py` to import from shared location (keeping `_sanitize_git_error` local)
- add unit tests for the utility

**note:** this will require an updated prefect pin in prefect-github

<details>
<summary>context</summary>

PR #20330 added token redaction to prefect-github by implementing `_strip_auth_from_url`, but this function already existed in `runner/storage.py`. this consolidates both into `prefect._internal.urls` to avoid duplication and ensure consistent behavior for URL credential stripping across the codebase.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)