### PR TITLE
Fix release workflows not triggering on prereleases

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -3,7 +3,7 @@ name: Docker images
 on:
   # On release events (also when a published release is converted from/to prerelease), push all patterns
   release:
-    types: [released, prereleased]
+    types: [published]
 
   # On workflow_dispatch, allow publishing 3-latest images or a specific tag
   workflow_dispatch:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -2,7 +2,7 @@ name: Publish Python package
 
 on:
   release:
-    types: [released, prereleased]
+    types: [published]
   workflow_dispatch:
     inputs:
       commit:


### PR DESCRIPTION
Dev releases haven't been triggering the Docker and Python package workflows since December 24, 2025 (3.6.8.dev3 was the last one that worked). Turns out this was caused by a behavior change in how `softprops/action-gh-release@v2` handles release creation.

The nightly-release workflow uses `softprops/action-gh-release@v2`, which in [v2.5.0](https://github.com/softprops/action-gh-release/releases/tag/v2.5.0) added a feature to mark releases as drafts until artifacts are uploaded. Even when `draft: false` is specified, the action creates the release as a draft first, then immediately publishes it.

According to [GitHub's docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release): "The `prereleased` type will not trigger for pre-releases published from draft releases, but the published type will trigger."

This changes the release event type from `types: [released, prereleased]` to `types: [published]` in both workflows, which is what GitHub recommends for handling both stable and pre-releases.

Related to https://linear.app/prefect/issue/PLA-2275/clarify-and-fix-docker-image-publishing-strategy-for-dev-releases

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - No issue exists, but this is a workflow fix for automated releases not triggering
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
  - N/A - workflow configuration change only
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
  - N/A
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
  - N/A