### PR TITLE
Fix conda Docker build by installing git from Trixie on Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,11 +156,27 @@ LABEL maintainer="help@prefect.io" \
 WORKDIR /opt/prefect
 
 # Install system requirements
+# For Debian Bookworm (used by conda base), we need to add Trixie sources to get git >= 2.47.3
+# This is because miniconda3 images are still based on Bookworm which only has git ~2.39
+# We install tini and build-essential first (from the base distro), then handle git separately
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     tini=0.19.* \
     build-essential \
-    git=1:2.* \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install git - for Bookworm, we need to use Trixie sources since git >= 2.47.3 is required
+# and Bookworm only provides ~2.39. We allow apt to pull git's dependencies from Trixie as needed.
+RUN DEBIAN_VERSION=$(. /etc/os-release && echo $VERSION_CODENAME) && \
+    if [ "$DEBIAN_VERSION" = "bookworm" ]; then \
+        echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list; \
+        apt-get update; \
+        apt-get install --no-install-recommends -y -t trixie git; \
+        rm -f /etc/apt/sources.list.d/trixie.list; \
+    else \
+        apt-get update; \
+        apt-get install --no-install-recommends -y git; \
+    fi \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' git)" ge '1:2.47.3' || \
     (echo "ERROR: git version must be >= 1:2.47.3" && exit 1)


### PR DESCRIPTION
Closes the conda Docker build failure seen in https://github.com/PrefectHQ/prefect/actions/runs/21240887956/job/61118360384

## Summary

- Fixes the conda Docker build which was failing due to git version mismatch
- Detects Debian version at build time and conditionally adds Trixie apt sources for git installation on Bookworm

## Background

PR #20309 attempted to fix the conda build by pinning `continuumio/miniconda3:25.3.1-1`, assuming it was based on Debian Trixie (13). However, that image is actually based on **Debian Bookworm (12)**, which only provides git ~2.39 - not the required >= 2.47.3.

This PR fixes the issue by:
1. Detecting the Debian version at build time
2. For Bookworm: Adding Trixie apt sources and installing git with `-t trixie` to pull git and its dependencies from Trixie
3. For Trixie: Installing git normally
4. Cleaning up the temporary Trixie sources after installation

<details>
<summary>Verification</summary>

Tested git installation on both base images:

**Bookworm (conda)**:
```
Detected Debian version: bookworm
Adding Trixie sources for git...
...
Installed git version:
git version 2.47.3
SUCCESS: git version meets requirement >= 1:2.47.3
```

**Trixie (regular Python)**:
```
Detected Debian version: trixie
...
Installed git version:
git version 2.47.3
SUCCESS: git version meets requirement >= 1:2.47.3
```

</details>

🤖 Generated with [Claude Code](https://claude.ai/code)