### PR TITLE
fix git url comparison when credentials are embedded in url

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -346,11 +346,12 @@ class GitRepository:
             )
             existing_repo_url = None
             existing_repo_url = strip_auth_from_url(result.stdout.decode().strip())
+            configured_repo_url = strip_auth_from_url(self._url)
 
-            if existing_repo_url != self._url:
+            if existing_repo_url != configured_repo_url:
                 raise ValueError(
                     f"The existing repository at {str(self.destination)} "
-                    f"does not match the configured repository {self._url}"
+                    f"does not match the configured repository {configured_repo_url}"
                 )
 
             # Sparsely checkout the repository if directories are specified and the repo is not in sparse-checkout mode already


### PR DESCRIPTION
follow-up to #20331

this PR fixes a bug where `pull_code` would incorrectly report a repository mismatch when credentials were embedded directly in the URL (rather than passed via a separate credentials object).

- strip auth from both URLs before comparing in `pull_code`
- strip auth from error message to avoid leaking credentials
- add regression test

<details>
<summary>root cause</summary>

when a URL like `https://x-access-token:TOKEN@github.com/org/repo.git` is passed directly to `GitRepository` (without a separate `credentials` object), git stores the full URL with credentials in `.git/config`. on subsequent pulls, the code reads the URL from git config and strips credentials, but compared it to `self._url` which still had credentials - causing a false mismatch.

the error message also leaked credentials since it printed `self._url` directly.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)