### PR TITLE
Add ipc_mode and shm_size to Docker worker

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -119,6 +119,10 @@ class DockerWorkerJobConfiguration(BaseJobConfiguration):
             allowing the container to use as much swap as memory. For example, if
             `mem_limit` is 300m and `memswap_limit` is not set, containers can use
             600m in total of memory and swap.
+        ipc_mode: IPC namespace mode for the container (e.g. host).
+        shm_size: Size of /dev/shm for the container. Accepts a value with a unit
+            identifier (e.g. 64m, 1g). If a value is given without a unit, bytes
+            are assumed.
         privileged: Give extended privileges to created containers.
         container_create_kwargs: Extra args for docker py when creating container.
     """
@@ -184,6 +188,24 @@ class DockerWorkerJobConfiguration(BaseJobConfiguration):
             "`mem_limit` is 300m and `memswap_limit` is not set, containers can use "
             "600m in total of memory and swap."
         ),
+    )
+    ipc_mode: Optional[str] = Field(
+        default=None,
+        description=(
+            "IPC namespace mode for the container (e.g. host). Defaults to Docker's"
+            " default if not set."
+        ),
+        examples=["host"],
+    )
+    shm_size: Optional[str] = Field(
+        default=None,
+        title="Shared Memory Size",
+        description=(
+            "Size of /dev/shm for the container. Accepts a value with a unit "
+            "identifier (e.g. 64m, 1g). If a value is given without a unit, bytes "
+            "are assumed."
+        ),
+        examples=["64m", "1g"],
     )
     privileged: bool = Field(
         default=False,
@@ -723,6 +745,8 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
             volumes=configuration.volumes,
             mem_limit=configuration.mem_limit,
             memswap_limit=configuration.memswap_limit,
+            ipc_mode=configuration.ipc_mode,
+            shm_size=configuration.shm_size,
             privileged=configuration.privileged,
             **container_create_kwargs,
         )

--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -453,6 +453,32 @@ async def test_uses_mem_limit_setting(
     assert mock_docker_client.containers.create.call_args[1].get("mem_limit") == "1g"
 
 
+async def test_uses_ipc_mode_setting(
+    mock_docker_client, flow_run, default_docker_worker_job_configuration
+):
+    default_docker_worker_job_configuration.ipc_mode = "host"
+    async with DockerWorker(work_pool_name="test") as worker:
+        await worker.run(
+            flow_run=flow_run, configuration=default_docker_worker_job_configuration
+        )
+
+    mock_docker_client.containers.create.assert_called_once()
+    assert mock_docker_client.containers.create.call_args[1].get("ipc_mode") == "host"
+
+
+async def test_uses_shm_size_setting(
+    mock_docker_client, flow_run, default_docker_worker_job_configuration
+):
+    default_docker_worker_job_configuration.shm_size = "1g"
+    async with DockerWorker(work_pool_name="test") as worker:
+        await worker.run(
+            flow_run=flow_run, configuration=default_docker_worker_job_configuration
+        )
+
+    mock_docker_client.containers.create.assert_called_once()
+    assert mock_docker_client.containers.create.call_args[1].get("shm_size") == "1g"
+
+
 @pytest.mark.parametrize("networks", [[], ["a"], ["a", "b"]])
 async def test_uses_network_setting(
     mock_docker_client, networks, flow_run, default_docker_worker_job_configuration


### PR DESCRIPTION
closes #12924
this PR exposes Docker container ipc_mode and shm_size settings on DockerWorkerJobConfiguration and passes them through to container creation.

<details>
- Add ipc_mode and shm_size fields to DockerWorkerJobConfiguration
- Pass ipc_mode/shm_size to docker_client.containers.create
- Add tests asserting both settings are forwarded
- Testing: uv run pytest -s src/integrations/prefect-docker/tests/test_worker.py -k "ipc_mode or shm_size" (pass; Windows cleanup warning: WinError 32 on temp db removal)
</details>