### PR TITLE
Migrate Task.serve() from @sync_compatible to @async_dispatch

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -41,6 +41,7 @@ from typing_extensions import (
 )
 
 import prefect.states
+from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.uuid7 import uuid7
 from prefect.assets import Asset
 from prefect.cache_policies import DEFAULT, NO_CACHE, CachePolicy
@@ -69,7 +70,7 @@ from prefect.results import (
 from prefect.settings.context import get_current_settings
 from prefect.states import Pending, Scheduled, State
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import run_coro_as_sync, sync_compatible
+from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.callables import (
     expand_mapping_parameters,
     get_call_parameters,
@@ -1797,8 +1798,33 @@ class Task(Generic[P, R]):
         """
         return self.apply_async(args=args, kwargs=kwargs)
 
-    @sync_compatible
-    async def serve(self) -> NoReturn:
+    async def aserve(self) -> NoReturn:
+        """Serve the task using the provided task runner. This method is used to
+        establish a websocket connection with the Prefect server and listen for
+        submitted task runs to execute.
+
+        This is the async version of serve().
+
+        Args:
+            task_runner: The task runner to use for serving the task. If not provided,
+                the default task runner will be used.
+
+        Examples:
+            Serve a task using the default task runner in an async context
+            ```python
+            @task
+            def my_task():
+                return 1
+
+            await my_task.aserve()
+            ```
+        """
+        from prefect.task_worker import aserve
+
+        await aserve(self)
+
+    @async_dispatch(aserve)
+    def serve(self) -> NoReturn:
         """Serve the task using the provided task runner. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
@@ -1819,7 +1845,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_worker import serve
 
-        await serve(self)
+        serve(self)
 
 
 @overload

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -1017,3 +1017,21 @@ class TestAsyncDispatchMigration:
         """Test that serve dispatches to aserve in async context."""
         await serve(foo_task)
         mock_task_worker_start.assert_called_once()
+
+    def test_task_serve_aio_attribute_exists(self, foo_task):
+        """Test that Task.serve has .aio attribute for backward compatibility."""
+        assert hasattr(foo_task.serve, "aio")
+
+    async def test_task_aserve_works_in_async_context(
+        self, foo_task, mock_task_worker_start
+    ):
+        """Test that Task.aserve works when awaited directly."""
+        await foo_task.aserve()
+        mock_task_worker_start.assert_called_once()
+
+    async def test_task_serve_dispatches_to_aserve_in_async_context(
+        self, foo_task, mock_task_worker_start
+    ):
+        """Test that Task.serve dispatches to aserve in async context."""
+        await foo_task.serve()
+        mock_task_worker_start.assert_called_once()


### PR DESCRIPTION
## Summary
- Part of #15008 - continuing the migration from `@sync_compatible` to `@async_dispatch`
- Migrates `Task.serve()` to use the `@async_dispatch` pattern
- Adds `Task.aserve()` as the explicit async implementation

## Test plan
- [x] Added tests for `Task.serve()` `.aio` attribute exists
- [x] Added tests for `Task.aserve()` works in async context
- [x] Added tests for `Task.serve()` dispatches to `aserve` in async context
- [x] All existing task worker tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)