### PR TITLE
Migrate Flow.deploy() from @sync_compatible to @async_dispatch

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -47,7 +47,7 @@ from rich.console import Console
 from typing_extensions import Literal, ParamSpec
 
 from prefect._experimental.sla.objects import SlaTypes
-from prefect._internal.concurrency.api import create_call, from_async
+from prefect._internal.concurrency.api import create_call, from_async, from_sync
 from prefect._versioning import VersionType
 from prefect.client.schemas.filters import WorkerFilter, WorkerFilterStatus
 from prefect.client.schemas.objects import ConcurrencyLimitConfig, FlowRun
@@ -83,7 +83,6 @@ from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import (
     run_coro_as_sync,
     run_sync_in_worker_thread,
-    sync_compatible,
 )
 from prefect.utilities.callables import (
     ParameterSchema,
@@ -1382,8 +1381,206 @@ class Flow(Generic[P, R]):
 
         return flow
 
-    @sync_compatible
-    async def deploy(
+    async def adeploy(
+        self,
+        name: str,
+        work_pool_name: Optional[str] = None,
+        image: Optional[Union[str, "DockerImage"]] = None,
+        build: bool = True,
+        push: bool = True,
+        work_queue_name: Optional[str] = None,
+        job_variables: Optional[dict[str, Any]] = None,
+        interval: Optional[Union[int, float, datetime.timedelta]] = None,
+        cron: Optional[str] = None,
+        rrule: Optional[str] = None,
+        paused: Optional[bool] = None,
+        schedule: Optional[Schedule] = None,
+        schedules: Optional[list[Schedule]] = None,
+        concurrency_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None,
+        triggers: Optional[list[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
+        parameters: Optional[dict[str, Any]] = None,
+        description: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+        version: Optional[str] = None,
+        version_type: Optional[VersionType] = None,
+        enforce_parameter_schema: bool = True,
+        entrypoint_type: EntrypointType = EntrypointType.FILE_PATH,
+        print_next_steps: bool = True,
+        ignore_warnings: bool = False,
+        _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None,
+    ) -> UUID:
+        """
+        Deploys a flow to run on dynamic infrastructure via a work pool.
+
+        This is the async version of deploy().
+
+        By default, calling this method will build a Docker image for the flow, push it to a registry,
+        and create a deployment via the Prefect API that will run the flow on the given schedule.
+
+        If you want to use an existing image, you can pass `build=False` to skip building and pushing
+        an image.
+
+        Args:
+            name: The name to give the created deployment.
+            work_pool_name: The name of the work pool to use for this deployment. Defaults to
+                the value of `PREFECT_DEFAULT_WORK_POOL_NAME`.
+            image: The name of the Docker image to build, including the registry and
+                repository. Pass a DockerImage instance to customize the Dockerfile used
+                and build arguments.
+            build: Whether or not to build a new image for the flow. If False, the provided
+                image will be used as-is and pulled at runtime.
+            push: Whether or not to skip pushing the built image to a registry.
+            work_queue_name: The name of the work queue to use for this deployment's scheduled runs.
+                If not provided the default work queue for the work pool will be used.
+            job_variables: Settings used to override the values specified default base job template
+                of the chosen work pool. Refer to the base job template of the chosen work pool for
+                available settings.
+            interval: An interval on which to execute the deployment. Accepts a number or a
+                timedelta object to create a single schedule. If a number is given, it will be
+                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create
+                multiple schedules.
+            cron: A cron schedule string of when to execute runs of this deployment.
+                Also accepts an iterable of cron schedule strings to create multiple schedules.
+            rrule: An rrule schedule string of when to execute runs of this deployment.
+                Also accepts an iterable of rrule schedule strings to create multiple schedules.
+            triggers: A list of triggers that will kick off runs of this deployment.
+            paused: Whether or not to set this deployment as paused.
+            schedule: A schedule object defining when to execute runs of this deployment.
+                Used to provide additional scheduling options like `timezone` or `parameters`.
+            schedules: A list of schedule objects defining when to execute runs of this deployment.
+                Used to define multiple schedules or additional scheduling options like `timezone`.
+            concurrency_limit: The maximum number of runs that can be executed concurrently.
+            parameters: A dictionary of default parameter values to pass to runs of this deployment.
+            description: A description for the created deployment. Defaults to the flow's
+                description if not provided.
+            tags: A list of tags to associate with the created deployment for organizational
+                purposes.
+            version: A version for the created deployment. Defaults to the flow's version.
+            version_type: The type of version to use for the created deployment. The version type
+                will be inferred if not provided.
+            enforce_parameter_schema: Whether or not the Prefect API should enforce the
+                parameter schema for the created deployment.
+            entrypoint_type: Type of entrypoint to use for the deployment. When using a module path
+                entrypoint, ensure that the module will be importable in the execution environment.
+            print_next_steps_message: Whether or not to print a message with next steps
+                after deploying the deployments.
+            ignore_warnings: Whether or not to ignore warnings about the work pool type.
+            _sla: (Experimental) SLA configuration for the deployment. May be removed or modified at any time. Currently only supported on Prefect Cloud.
+        Returns:
+            The ID of the created/updated deployment.
+
+        Examples:
+            Deploy a local flow to a work pool:
+
+            ```python
+            import asyncio
+            from prefect import flow
+
+            @flow
+            def my_flow(name):
+                print(f"hello {name}")
+
+            if __name__ == "__main__":
+                asyncio.run(my_flow.adeploy(
+                    "example-deployment",
+                    work_pool_name="my-work-pool",
+                    image="my-repository/my-image:dev",
+                ))
+            ```
+        """
+        if not (
+            work_pool_name := work_pool_name or PREFECT_DEFAULT_WORK_POOL_NAME.value()
+        ):
+            raise ValueError(
+                "No work pool name provided. Please provide a `work_pool_name` or set the"
+                " `PREFECT_DEFAULT_WORK_POOL_NAME` environment variable."
+            )
+
+        from prefect.client.orchestration import get_client
+
+        try:
+            async with get_client() as client:
+                work_pool = await client.read_work_pool(work_pool_name)
+                active_workers = await client.read_workers_for_work_pool(
+                    work_pool_name,
+                    worker_filter=WorkerFilter(
+                        status=WorkerFilterStatus(any_=["ONLINE"])
+                    ),
+                )
+        except ObjectNotFound as exc:
+            raise ValueError(
+                f"Could not find work pool {work_pool_name!r}. Please create it before"
+                " deploying this flow."
+            ) from exc
+
+        deployment = await self.ato_deployment(
+            name=name,
+            interval=interval,
+            cron=cron,
+            rrule=rrule,
+            schedule=schedule,
+            schedules=schedules,
+            concurrency_limit=concurrency_limit,
+            paused=paused,
+            triggers=triggers,
+            parameters=parameters,
+            description=description,
+            tags=tags,
+            version=version,
+            version_type=version_type,
+            enforce_parameter_schema=enforce_parameter_schema,
+            work_queue_name=work_queue_name,
+            job_variables=job_variables,
+            entrypoint_type=entrypoint_type,
+            _sla=_sla,
+        )
+
+        from prefect.deployments.runner import adeploy
+
+        deployment_ids = await adeploy(
+            deployment,
+            work_pool_name=work_pool_name,
+            image=image,
+            build=build,
+            push=push,
+            print_next_steps_message=False,
+            ignore_warnings=ignore_warnings,
+        )
+
+        if print_next_steps:
+            console = Console()
+            if (
+                not work_pool.is_push_pool
+                and not work_pool.is_managed_pool
+                and not active_workers
+            ):
+                console.print(
+                    "\nTo execute flow runs from this deployment, start a worker in a"
+                    " separate terminal that pulls work from the"
+                    f" {work_pool_name!r} work pool:"
+                )
+                console.print(
+                    f"\n\t$ prefect worker start --pool {work_pool_name!r}",
+                    style="blue",
+                )
+            console.print(
+                "\nTo schedule a run for this deployment, use the following command:"
+            )
+            console.print(
+                f"\n\t$ prefect deployment run '{self.name}/{name}'\n",
+                style="blue",
+            )
+            if PREFECT_UI_URL:
+                message = (
+                    "\nYou can also run your flow via the Prefect UI:"
+                    f" [blue]{PREFECT_UI_URL.value()}/deployments/deployment/{deployment_ids[0]}[/]\n"
+                )
+                console.print(message, soft_wrap=True)
+
+        return deployment_ids[0]
+
+    @async_dispatch(adeploy)
+    def deploy(
         self,
         name: str,
         work_pool_name: Optional[str] = None,
@@ -1503,105 +1700,36 @@ class Flow(Generic[P, R]):
                 )
             ```
         """
-        if not (
-            work_pool_name := work_pool_name or PREFECT_DEFAULT_WORK_POOL_NAME.value()
-        ):
-            raise ValueError(
-                "No work pool name provided. Please provide a `work_pool_name` or set the"
-                " `PREFECT_DEFAULT_WORK_POOL_NAME` environment variable."
+        return from_sync.call_soon_in_loop_thread(
+            create_call(
+                self.adeploy,
+                name=name,
+                work_pool_name=work_pool_name,
+                image=image,
+                build=build,
+                push=push,
+                work_queue_name=work_queue_name,
+                job_variables=job_variables,
+                interval=interval,
+                cron=cron,
+                rrule=rrule,
+                paused=paused,
+                schedule=schedule,
+                schedules=schedules,
+                concurrency_limit=concurrency_limit,
+                triggers=triggers,
+                parameters=parameters,
+                description=description,
+                tags=tags,
+                version=version,
+                version_type=version_type,
+                enforce_parameter_schema=enforce_parameter_schema,
+                entrypoint_type=entrypoint_type,
+                print_next_steps=print_next_steps,
+                ignore_warnings=ignore_warnings,
+                _sla=_sla,
             )
-
-        from prefect.client.orchestration import get_client
-
-        try:
-            async with get_client() as client:
-                work_pool = await client.read_work_pool(work_pool_name)
-                active_workers = await client.read_workers_for_work_pool(
-                    work_pool_name,
-                    worker_filter=WorkerFilter(
-                        status=WorkerFilterStatus(any_=["ONLINE"])
-                    ),
-                )
-        except ObjectNotFound as exc:
-            raise ValueError(
-                f"Could not find work pool {work_pool_name!r}. Please create it before"
-                " deploying this flow."
-            ) from exc
-
-        to_deployment_coro = self.to_deployment(
-            name=name,
-            interval=interval,
-            cron=cron,
-            rrule=rrule,
-            schedule=schedule,
-            schedules=schedules,
-            concurrency_limit=concurrency_limit,
-            paused=paused,
-            triggers=triggers,
-            parameters=parameters,
-            description=description,
-            tags=tags,
-            version=version,
-            version_type=version_type,
-            enforce_parameter_schema=enforce_parameter_schema,
-            work_queue_name=work_queue_name,
-            job_variables=job_variables,
-            entrypoint_type=entrypoint_type,
-            _sla=_sla,
-        )
-
-        if inspect.isawaitable(to_deployment_coro):
-            deployment = await to_deployment_coro
-        else:
-            deployment = to_deployment_coro
-
-        from prefect.deployments.runner import deploy
-
-        deploy_coro = deploy(
-            deployment,
-            work_pool_name=work_pool_name,
-            image=image,
-            build=build,
-            push=push,
-            print_next_steps_message=False,
-            ignore_warnings=ignore_warnings,
-        )
-        if TYPE_CHECKING:
-            assert inspect.isawaitable(deploy_coro)
-
-        deployment_ids = await deploy_coro
-
-        if print_next_steps:
-            console = Console()
-            if (
-                not work_pool.is_push_pool
-                and not work_pool.is_managed_pool
-                and not active_workers
-            ):
-                console.print(
-                    "\nTo execute flow runs from this deployment, start a worker in a"
-                    " separate terminal that pulls work from the"
-                    f" {work_pool_name!r} work pool:"
-                )
-                console.print(
-                    f"\n\t$ prefect worker start --pool {work_pool_name!r}",
-                    style="blue",
-                )
-            console.print(
-                "\nTo schedule a run for this deployment, use the following command:"
-            )
-            console.print(
-                f"\n\t$ prefect deployment run '{self.name}/{name}'\n",
-                style="blue",
-            )
-            if PREFECT_UI_URL:
-                message = (
-                    "\nYou can also run your flow via the Prefect UI:"
-                    f" [blue]{PREFECT_UI_URL.value()}/deployments/deployment/{deployment_ids[0]}[/]\n"
-                )
-                console.print(message, soft_wrap=True)
-
-        return deployment_ids[0]
+        ).result()
 
     @overload
     def __call__(self: "Flow[P, NoReturn]", *args: P.args, **kwargs: P.kwargs) -> None:


### PR DESCRIPTION
## Summary

- Migrates `Flow.deploy()` from `@sync_compatible` to `@async_dispatch`
- Adds explicit `adeploy()` async method
- Adds `deploy()` sync method using `from_sync.call_soon_in_loop_thread` pattern (same as Task.serve in #20374)
- Updates tests to mock `adeploy` instead of `deploy`

Part of #15008

## Test plan

- [x] All 43 deploy tests pass
- [x] Full test_flows.py suite passes (361 passed)
- [x] Pre-commit hooks pass

<details>
<summary>Smoke tests (sandbox/test_flow_deploy.py)</summary>

```
============================================================
Flow.deploy() smoke tests
============================================================

=== Test 1: .aio attribute exists ===
✓ PASSED: .aio attribute exists

=== Test 2: sync context ===
stdout: SYNC_CONTEXT_PASSED
returncode: 0
✓ PASSED: sync context

=== Test 3: async context (await flow.deploy()) ===
stdout: ASYNC_CONTEXT_PASSED
returncode: 0
✓ PASSED: async context

=== Test 4: explicit adeploy() ===
stdout: ADEPLOY_EXPLICIT_PASSED
returncode: 0
✓ PASSED: explicit adeploy()

=== Test 5: deploy from within flow (regression #17434) ===
stdout: DEPLOY_FROM_FLOW_PASSED
returncode: 0
✓ PASSED: deploy from within flow

============================================================
SUMMARY
============================================================
  ✓ aio_attribute
  ✓ sync_context
  ✓ async_context
  ✓ adeploy_explicit
  ✓ deploy_from_flow

5/5 tests passed
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)