### PR TITLE
feat: support parsing TOML 1.0 on Python 3.11+

### DIFF
--- a/src/prefect/_internal/compatibility/backports.py
+++ b/src/prefect/_internal/compatibility/backports.py
@@ -1,0 +1,11 @@
+"""Functionality we want to use from later Python versions."""
+
+try:
+    import tomllib  # 3.11+
+except ImportError:
+    import toml as tomllib  # fallback on Python <3.11
+
+    tomllib.TOMLDecodeError = tomllib.TomlDecodeError
+
+
+__all__ = ["tomllib"]

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -8,13 +8,13 @@ import os
 from pathlib import Path
 from typing import Any, Union, cast
 
-import toml
 import typer
 from dotenv import dotenv_values
 from typing_extensions import Literal
 
 import prefect.context
 import prefect.settings
+from prefect._internal.compatibility.backports import tomllib
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app, is_interactive
@@ -273,12 +273,14 @@ def view(
 
     # Process settings from prefect.toml
     if Path("prefect.toml").exists():
-        toml_settings = toml.load(Path("prefect.toml"))
+        toml_settings = tomllib.loads(Path("prefect.toml").read_text(encoding="utf-8"))
         _process_toml_settings(toml_settings, base_path=[], source="prefect.toml")
 
     # Process settings from pyproject.toml
     if Path("pyproject.toml").exists():
-        pyproject_settings = toml.load(Path("pyproject.toml"))
+        pyproject_settings = tomllib.loads(
+            Path("pyproject.toml").read_text(encoding="utf-8")
+        )
         pyproject_settings = pyproject_settings.get("tool", {}).get("prefect", {})
         _process_toml_settings(
             pyproject_settings, base_path=[], source="pyproject.toml"

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -559,6 +559,7 @@ def _memoize_block_auto_registration(
     import toml
 
     import prefect.plugins
+    from prefect._internal.compatibility.backports import tomllib
     from prefect.blocks.core import Block
     from prefect.server.models.block_registration import _load_collection_blocks_data
     from prefect.utilities.dispatch import get_registry_for_type
@@ -585,9 +586,9 @@ def _memoize_block_auto_registration(
         memo_store_path = PREFECT_MEMO_STORE_PATH.value()
         try:
             if memo_store_path.exists():
-                saved_blocks_loading_hash = toml.load(memo_store_path).get(
-                    "block_auto_registration"
-                )
+                saved_blocks_loading_hash = tomllib.loads(
+                    memo_store_path.read_text(encoding="utf-8")
+                ).get("block_auto_registration")
                 if (
                     saved_blocks_loading_hash is not None
                     and current_blocks_loading_hash == saved_blocks_loading_hash

--- a/src/prefect/settings/profiles.py
+++ b/src/prefect/settings/profiles.py
@@ -20,6 +20,7 @@ from pydantic import (
     ValidationError,
 )
 
+from prefect._internal.compatibility.backports import tomllib
 from prefect.exceptions import ProfileSettingsValidationError
 from prefect.settings.constants import DEFAULT_PROFILES_PATH
 from prefect.settings.context import get_current_settings
@@ -276,7 +277,7 @@ def _read_profiles_from(path: Path) -> ProfilesCollection:
         <SETTING: str> = <value: Any>
         ```
     """
-    contents = toml.loads(path.read_text())
+    contents = tomllib.loads(path.read_text())
     active_profile = contents.get("active")
     raw_profiles = contents.get("profiles", {})
 

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type
 
 import dotenv
-import toml
 from cachetools import TTLCache
 from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
@@ -21,6 +20,7 @@ from pydantic_settings.sources import (
     DotenvType,
 )
 
+from prefect._internal.compatibility.backports import tomllib
 from prefect.settings.constants import DEFAULT_PREFECT_HOME, DEFAULT_PROFILES_PATH
 from prefect.utilities.collections import get_from_dict
 
@@ -33,7 +33,7 @@ def _read_toml_file(path: Path) -> dict[str, Any]:
     cache_key = f"toml_file:{path}:{modified_time}"
     if value := _file_cache.get(cache_key):
         return value
-    data = toml.load(path)  # type: ignore
+    data = tomllib.loads(path.read_text(encoding="utf-8"))  # type: ignore
     _file_cache[cache_key] = data
     return data
 
@@ -139,7 +139,7 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
 
         try:
             all_profile_data = _read_toml_file(self.profiles_path)
-        except toml.TomlDecodeError:
+        except tomllib.TOMLDecodeError:
             warnings.warn(
                 f"Failed to load profiles from {self.profiles_path}. Please ensure the file is valid TOML."
             )

--- a/tests/_internal/compatibility/test_backports.py
+++ b/tests/_internal/compatibility/test_backports.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+
+from prefect._internal.compatibility.backports import tomllib
+
+min_python_version = (3, 11)
+
+
+@pytest.fixture(scope="session")
+def toml1_0_content() -> str:
+    return """\
+[dependency-groups]
+dev = [
+    "dummy-dependency~=1.2.0",
+    {include-group = "dummy-group-name"},
+]
+"""
+
+
+@pytest.mark.skipif(
+    sys.version_info < min_python_version,
+    reason=f"Test requires Python version {min_python_version[0]}.{min_python_version[1]} or higher",
+)
+def test_can_parse_toml1_0_on_python311_plus(toml1_0_content):
+    assert tomllib.loads(toml1_0_content)
+
+
+@pytest.mark.skipif(
+    sys.version_info >= min_python_version,
+    reason=f"Test requires Python version less than {min_python_version[0]}.{min_python_version[1]}",
+)
+def test_error_parsing_toml1_0_before_python311(toml1_0_content):
+    with pytest.raises(IndexError):
+        tomllib.loads(toml1_0_content)


### PR DESCRIPTION
It fixes parsing pyproject.toml that contains:

```toml
[dependency-groups]
dev = [
    "dummy-dependency~=1.2.0",
    {include-group = "dummy-group-name"},
]
```

See https://peps.python.org/pep-0735/#dependency-group-include

Before the patch (toml), there is IndexError:

```shell
prefect --help
Failed to initialize plugins: list index out of range
Traceback (most recent call last):
  File "/.venv/bin/prefect", line 4, in <module>
    from prefect.cli import app
  File "/.venv/lib/python3.11/site-packages/prefect/cli/__init__.py", line 2, in <module>
    from prefect.cli.root import app
  File "/.venv/lib/python3.11/site-packages/prefect/cli/root.py", line 15, in <module>
    import prefect.context
  File "/.venv/lib/python3.11/site-packages/prefect/context.py", line 990, in <module>
    GLOBAL_SETTINGS_CONTEXT: SettingsContext = root_settings_context()
                                               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/context.py", line 949, in root_settings_context
    profiles = prefect.settings.load_profiles()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/settings/profiles.py", line 307, in load_profiles
    current_settings = get_current_settings()
                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/settings/context.py", line 21, in get_current_settings
    return Settings()
           ^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/pydantic_settings/main.py", line 195, in __init__
    **__pydantic_self__._settings_build_values(
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/pydantic_settings/main.py", line 391, in _settings_build_values
    sources = self.settings_customise_sources(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/settings/base.py", line 87, in settings_customise_sources    PyprojectTomlConfigSettingsSource(settings_cls),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/settings/sources.py", line 302, in __init__
    self.toml_data: dict[str, Any] = self._read_files(self.toml_file_path)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/pydantic_settings/sources/base.py", line 204, in _read_files
    vars.update(self._read_file(file_path))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/settings/sources.py", line 233, in _read_file
    return _read_toml_file(path)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/prefect/settings/sources.py", line 36, in _read_toml_file
    data = toml.load(path)  # type: ignore
           ^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 134, in load
    return loads(ffile.read(), _dict, decoder)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 511, in loads
    ret = decoder.load_line(line, currentlevel, multikey,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 778, in load_line
    value, vtype = self.load_value(pair[1], strictly_valid)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 880, in load_value
    return (self.load_array(v), "array")
            ^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 1002, in load_array
    a[b] = a[b] + ',' + a[b + 1]
                        ~^^^^^^^
IndexError: list index out of range
```

that boils down to:

```shell
$ python -c 'import sys, toml; print(toml.load(sys.stdin))' < pyproject.toml
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 156, in load
    return loads(f.read(), _dict, decoder)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 511, in loads
    ret = decoder.load_line(line, currentlevel, multikey,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 778, in load_line
    value, vtype = self.load_value(pair[1], strictly_valid)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 880, in load_value
    return (self.load_array(v), "array")
            ^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.11/site-packages/toml/decoder.py", line 1002, in load_array
    a[b] = a[b] + ',' + a[b + 1]
                        ~^^^^^^^
IndexError: list index out of range
```

With the patch (tomllib on Python 3.11+), no error:

```
$ python -c 'import sys, tomllib; print(tomllib.load(sys.stdin.buffer))' < pyproject.toml
{'dependency-groups': {'dev': ['dummy-dependency~=1.2.0', {'include-group': 'dummy-group-name'}]}}
```

No change in behavior on Python <3.11

No change in behavior for toml files that were previously understood (valid according to the `toml` lib) even on Python 3.11+. Some files (such in the example above) are accepted now.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
