### PR TITLE
fix(ui): use count endpoint for deployments page empty state check

### DIFF
--- a/ui/src/pages/Deployments.vue
+++ b/ui/src/pages/Deployments.vue
@@ -10,7 +10,7 @@
       </template>
 
       <template v-else>
-        <DeploymentList @delete="deploymentsSubscription.refresh" />
+        <DeploymentList @delete="deploymentsCountSubscription.refresh" />
       </template>
     </template>
   </p-layout-default>
@@ -27,10 +27,10 @@
     interval: 30000,
   }
 
-  const deploymentsSubscription = useSubscription(api.deployments.getDeployments, [{}], subscriptionOptions)
-  const deployments = computed(() => deploymentsSubscription.response ?? [])
-  const empty = computed(() => deploymentsSubscription.executed && deployments.value.length === 0)
-  const loaded = computed(() => deploymentsSubscription.executed)
+  const deploymentsCountSubscription = useSubscription(api.deployments.getDeploymentsCount, [{}], subscriptionOptions)
+  const deploymentsCount = computed(() => deploymentsCountSubscription.response ?? 0)
+  const empty = computed(() => deploymentsCountSubscription.executed && deploymentsCount.value === 0)
+  const loaded = computed(() => deploymentsCountSubscription.executed)
 
   usePageTitle('Deployments')
 </script>


### PR DESCRIPTION
## Summary

Reduces redundant API calls on the Deployments page by using a lightweight count query instead of fetching all deployment objects for empty state detection.

Fixes part of #20397.

## Problem

When loading the Deployments page, the UI was making an expensive `POST /api/deployments/filter` call with an empty body to fetch **all deployment objects** just to check if `deployments.length === 0` for showing the empty state.

## Solution

Use `getDeploymentsCount` instead of `getDeployments`. This returns a single integer (2 bytes) instead of all deployment data (~3KB+ depending on deployment count).

This matches the pattern already established in `Flows.vue` (line 30).

## Empirical Verification

Tested locally using Chrome DevTools MCP to capture actual network requests:

**Before (original behavior):**
| Request | Endpoint | Body | Response Size |
|---------|----------|------|---------------|
| 1 | POST /api/deployments/**filter** | `{}` | ~3KB+ (all deployment objects) |
| 2 | POST /api/deployments/paginate | `{sort,limit,page}` | ~2.4KB |
| 3 | POST /api/deployments/paginate | `{}` | ~3KB |

**After (with fix):**
| Request | Endpoint | Body | Response Size |
|---------|----------|------|---------------|
| 1 | POST /api/deployments/**count** | `{}` | **2 bytes** (just `16`) |
| 2 | POST /api/deployments/paginate | `{sort,limit,page}` | ~2.4KB |
| 3 | POST /api/deployments/paginate | `{}` | ~3KB |

The expensive `/filter` call that returned all 16 deployment objects is replaced with a `/count` call that returns just the number `16`. The count is used **only** to decide empty state vs showing the list - `DeploymentList` still fetches its own paginated data.

## Note

This PR addresses **call 1** from issue #20397. Call 3 (the second `/paginate` with empty body) comes from `DeploymentTagsInput` in `prefect-ui-library` and would need to be addressed separately in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)