### PR TITLE
docs: add accordion for logging pydantic-ai tool calls to Prefect

### DIFF
--- a/docs/v3/examples/ai-data-analyst-with-pydantic-ai.mdx
+++ b/docs/v3/examples/ai-data-analyst-with-pydantic-ai.mdx
@@ -362,9 +362,10 @@ If you want tool call arguments and results to appear in Prefect's native flow l
 ```python
 from collections.abc import AsyncIterable
 
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 
 from pydantic_ai import Agent
+from pydantic_ai.durable_exec.prefect import PrefectAgent
 from pydantic_ai.messages import (
     AgentStreamEvent,
     FunctionToolCallEvent,
@@ -392,10 +393,12 @@ async def log_tool_calls(
             logger.info(f"Tool {event.result.tool_name} returned: {result_str}")
 
 
-@flow
-async def my_flow():
-    agent = Agent("openai:gpt-4o", name="my-agent", tools=[...])
-    result = await agent.run(
+agent = Agent("openai:gpt-4o", name="my-agent", tools=[...])
+prefect_agent = PrefectAgent(agent)
+
+
+async def main():
+    result = await prefect_agent.run(
         "Analyze this data",
         event_stream_handler=log_tool_calls,
     )


### PR DESCRIPTION
## Summary

- Adds an accordion to the pydantic-ai example docs showing how to log tool call arguments and results to Prefect's native flow logs using `event_stream_handler`

This addresses a need for tool call visibility in Prefect logs without relying solely on Logfire/OpenTelemetry spans.

## Test plan

- [x] Tested the code example locally - produces expected logs:
  ```
  15:05:44.149 | INFO | Flow run 'crouching-walrus' - Calling tool: get_weather with args: {"city":"Seattle"}
  15:05:44.152 | INFO | Flow run 'crouching-walrus' - Tool get_weather returned: Weather in Seattle: 72°F, sunny
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)