### PR TITLE
Cap concurrency limit retry-after to prevent excessive delays from burst traffic

### DIFF
--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -859,6 +859,81 @@ async def test_increment_concurrency_limit_locked_respects_low_avg(
     )
 
 
+@pytest.fixture
+async def locked_concurrency_limit_moderate_avg(
+    session: AsyncSession,
+) -> ConcurrencyLimitV2:
+    """
+    A locked concurrency limit with moderate avg occupancy but will have
+    very high denied_slots to test the retry-after cap on total wait time.
+    """
+    concurrency_limit = await create_concurrency_limit(
+        session=session,
+        concurrency_limit=ConcurrencyLimitV2(
+            name="moderate-avg-limit",
+            limit=30,
+            active_slots=30,
+            avg_slot_occupancy_seconds=10.0,  # 10 seconds - reasonable
+        ),
+    )
+    await session.commit()
+
+    return ConcurrencyLimitV2.model_validate(concurrency_limit)
+
+
+@pytest.mark.parametrize("endpoint", ["increment", "increment-with-lease"])
+async def test_increment_concurrency_limit_caps_retry_after_with_high_denied_slots(
+    endpoint: str,
+    locked_concurrency_limit_moderate_avg: ConcurrencyLimitV2,
+    client: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    Test that retry-after is capped even when denied_slots causes excessive values.
+
+    This is a regression test for the bug where burst traffic would accumulate
+    denied_slots, causing retry-after calculations to produce excessive values
+    (hours instead of seconds) even when avg_slot_occupancy_seconds is reasonable.
+
+    The bug scenario:
+    - slots = 1, denied_slots = 16000, limit = 30
+    - blocking_slots = (1 + 16000) / 30 = 533.7
+    - wait_time_per_slot = 10s (capped from avg_slot_occupancy_seconds)
+    - BUG: retry_after = 10s * 533.7 = 5337s (~89 minutes)
+    - FIX: retry_after = min(10s * 533.7, 30s) = ~30s
+
+    Reference: Nebula PR #10947
+    """
+    # Simulate burst traffic that accumulated many denied requests
+    await bulk_update_denied_slots(
+        session=session,
+        concurrency_limit_ids=[locked_concurrency_limit_moderate_avg.id],
+        slots=16000,  # High denied_slots from burst traffic
+    )
+    await session.commit()
+
+    response = await client.post(
+        f"/v2/concurrency_limits/{endpoint}",
+        json={
+            "names": [locked_concurrency_limit_moderate_avg.name],
+            "slots": 1,
+            "mode": "concurrency",
+        },
+    )
+    assert response.status_code == 423
+
+    retry_after = float(response.headers["Retry-After"])
+
+    # Without the fix, retry_after would be ~5337 seconds (89 minutes)
+    # With the fix, it should be capped at ~30 seconds (max_wait)
+    # Allow for jitter from clamped_poisson_interval
+    assert retry_after < 60, (
+        f"Expected retry_after to be capped at ~30s, got {retry_after}s. "
+        f"This suggests the fix for high denied_slots is not working. "
+        f"Without capping, the value would be ~{10.0 * (1 + 16000) / 30}s"
+    )
+
+
 @pytest.mark.parametrize("endpoint", ["increment", "increment-with-lease"])
 async def test_increment_concurrency_limit_slot_request_higher_than_limit(
     endpoint: str,


### PR DESCRIPTION
## Summary

Fixes excessive retry-after values in concurrency limit responses when burst traffic causes high denied_slots accumulation.

When burst traffic hits a concurrency limit, the `denied_slots` counter accumulates rapidly. Previously, the retry-after calculation would multiply the wait time by the number of blocking slots (including `denied_slots/limit`), leading to excessive delays - e.g., **89 minutes** when `avg_slot_occupancy_seconds` is 10s but `denied_slots` reaches 16000.

This fix caps the final `average_interval` at `max_wait` (default 30s) to ensure retry-after values remain reasonable even during burst traffic conditions. The per-slot wait time was already capped, but the total was not.

### Example scenario:
- `slots=1`, `denied_slots=16000`, `limit=30`
- `blocking_slots = (1 + 16000) / 30 = 533.7`
- **Before**: `retry_after = 10s * 533.7 = 5337s` (89 minutes)
- **After**: `retry_after = min(10s * 533.7, 30s) ≈ 30s`

## Test plan

- [x] Added test `test_increment_concurrency_limit_caps_retry_after_with_high_denied_slots` that simulates burst traffic with high denied_slots
- [x] All existing concurrency limit tests pass (54 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)