### PR TITLE
Fix visit_collection to handle NamedTuples

### DIFF
--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -481,7 +481,11 @@ def visit_collection(
         if return_data:
             modified = any(item is not orig for item, orig in zip(items, seq))
             if modified:
-                result = type(seq)(items)
+                # Use _make for NamedTuples
+                if hasattr(type(seq), "_make"):
+                    result = type(seq)._make(items)
+                else:
+                    result = type(seq)(items)
 
     # --- Dictionaries
 

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -2,7 +2,7 @@ import io
 import json
 import uuid
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy as np
 import pydantic
@@ -678,6 +678,24 @@ class TestVisitCollection:
         # The circular reference is preserved (though not with perfect identity)
         assert "self" in result
         assert "self" in result["self"]
+
+    def test_visit_collection_namedtuple(self):
+        class DoneAndNotDoneFutures(NamedTuple):
+            done: set
+            not_done: set
+
+        original = DoneAndNotDoneFutures(done={1, 2}, not_done={3, 4})
+
+        def double_ints(x):
+            if isinstance(x, int):
+                return x * 2
+            return x
+
+        result = visit_collection(original, double_ints, return_data=True)
+
+        assert isinstance(result, DoneAndNotDoneFutures)
+        assert result.done == {2, 4}
+        assert result.not_done == {6, 8}
 
 
 class TestRemoveKeys:


### PR DESCRIPTION
When a DoneAndNotDoneFutures (from wait()) is passed as a flow/task parameter, visit_collection fails to reconstruct it because NamedTuples expect positional args in __new__, not an iterable.

Use _make() to construct NamedTuples from iterables instead.

Closes https://github.com/PrefectHQ/prefect/issues/20516

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
