### PR TITLE
migrate prefect-gcp bigquery and cloud_storage from @sync_compatible to @async_dispatch

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/bigquery.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/bigquery.py
@@ -9,9 +9,10 @@ from anyio import to_thread
 from pydantic import Field
 
 from prefect import task
+from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.blocks.abstract import DatabaseBlock
 from prefect.logging import get_run_logger
-from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.hashing import hash_objects
 from prefect_gcp.credentials import GcpCredentials
 
@@ -43,8 +44,135 @@ def _result_sync(func, *args, **kwargs):
 
 
 @task
-@sync_compatible
-async def bigquery_query(
+async def abigquery_query(
+    query: str,
+    gcp_credentials: GcpCredentials,
+    query_params: Optional[List[tuple]] = None,  # 3-tuples
+    dry_run_max_bytes: Optional[int] = None,
+    dataset: Optional[str] = None,
+    table: Optional[str] = None,
+    to_dataframe: bool = False,
+    job_config: Optional[dict] = None,
+    project: Optional[str] = None,
+    result_transformer: Optional[Callable[[List["Row"]], Any]] = None,
+    location: str = "US",
+) -> Any:
+    """
+    Runs a BigQuery query (async version).
+
+    Args:
+        query: String of the query to execute.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        query_params: List of 3-tuples specifying BigQuery query parameters; currently
+            only scalar query parameters are supported.  See the
+            [Google documentation](https://cloud.google.com/bigquery/docs/parameterized-queries#bigquery-query-params-python)
+            for more details on how both the query and the query parameters should be formatted.
+        dry_run_max_bytes: If provided, the maximum number of bytes the query
+            is allowed to process; this will be determined by executing a dry run
+            and raising a `ValueError` if the maximum is exceeded.
+        dataset: Name of a destination dataset to write the query results to,
+            if you don't want them returned; if provided, `table` must also be provided.
+        table: Name of a destination table to write the query results to,
+            if you don't want them returned; if provided, `dataset` must also be provided.
+        to_dataframe: If provided, returns the results of the query as a pandas
+            dataframe instead of a list of `bigquery.table.Row` objects.
+        job_config: Dictionary of job configuration parameters;
+            note that the parameters provided here must be pickleable
+            (e.g., dataset references will be rejected).
+        project: The project to initialize the BigQuery Client with; if not
+            provided, will default to the one inferred from your credentials.
+        result_transformer: Function that can be passed to transform the result of a query before returning. The function will be passed the list of rows returned by BigQuery for the given query.
+        location: Location of the dataset that will be queried.
+
+    Returns:
+        A list of rows, or pandas DataFrame if to_dataframe,
+        matching the query criteria.
+
+    Example:
+        Queries the public names database, returning 10 results.
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.bigquery import abigquery_query
+
+        @flow
+        async def example_bigquery_query_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json",
+                project="project"
+            )
+            query = '''
+                SELECT word, word_count
+                FROM `bigquery-public-data.samples.shakespeare`
+                WHERE corpus = @corpus
+                AND word_count >= @min_word_count
+                ORDER BY word_count DESC;
+            '''
+            query_params = [
+                ("corpus", "STRING", "romeoandjuliet"),
+                ("min_word_count", "INT64", 250)
+            ]
+            result = await abigquery_query(
+                query, gcp_credentials, query_params=query_params
+            )
+            return result
+
+        example_bigquery_query_flow()
+        ```
+    """  # noqa
+    logger = get_run_logger()
+    logger.info("Running BigQuery query")
+
+    client = gcp_credentials.get_bigquery_client(project=project, location=location)
+
+    # setup job config
+    job_config = QueryJobConfig(**job_config or {})
+    if query_params is not None:
+        job_config.query_parameters = [ScalarQueryParameter(*qp) for qp in query_params]
+
+    # perform dry_run if requested
+    if dry_run_max_bytes is not None:
+        saved_info = dict(
+            dry_run=job_config.dry_run, use_query_cache=job_config.use_query_cache
+        )
+        job_config.dry_run = True
+        job_config.use_query_cache = False
+        partial_query = partial(client.query, query, job_config=job_config)
+        response = await to_thread.run_sync(partial_query)
+        total_bytes_processed = response.total_bytes_processed
+        if total_bytes_processed > dry_run_max_bytes:
+            raise RuntimeError(
+                f"Query will process {total_bytes_processed} bytes which is above "
+                f"the set maximum of {dry_run_max_bytes} for this task."
+            )
+        job_config.dry_run = saved_info["dry_run"]
+        job_config.use_query_cache = saved_info["use_query_cache"]
+
+    # if writing to a destination table
+    if dataset is not None:
+        table_ref = client.dataset(dataset).table(table)
+        job_config.destination = table_ref
+
+    partial_query = partial(
+        _result_sync,
+        client.query,
+        query,
+        job_config=job_config,
+    )
+    result = await to_thread.run_sync(partial_query)
+
+    if to_dataframe:
+        return result.to_dataframe()
+    else:
+        if result_transformer:
+            return result_transformer(result)
+        else:
+            return list(result)
+
+
+@task
+@async_dispatch(abigquery_query)
+def bigquery_query(
     query: str,
     gcp_credentials: GcpCredentials,
     query_params: Optional[List[tuple]] = None,  # 3-tuples
@@ -120,9 +248,6 @@ async def bigquery_query(
         example_bigquery_query_flow()
         ```
     """  # noqa
-    logger = get_run_logger()
-    logger.info("Running BigQuery query")
-
     client = gcp_credentials.get_bigquery_client(project=project, location=location)
 
     # setup job config
@@ -137,8 +262,7 @@ async def bigquery_query(
         )
         job_config.dry_run = True
         job_config.use_query_cache = False
-        partial_query = partial(client.query, query, job_config=job_config)
-        response = await to_thread.run_sync(partial_query)
+        response = client.query(query, job_config=job_config)
         total_bytes_processed = response.total_bytes_processed
         if total_bytes_processed > dry_run_max_bytes:
             raise RuntimeError(
@@ -153,13 +277,7 @@ async def bigquery_query(
         table_ref = client.dataset(dataset).table(table)
         job_config.destination = table_ref
 
-    partial_query = partial(
-        _result_sync,
-        client.query,
-        query,
-        job_config=job_config,
-    )
-    result = await to_thread.run_sync(partial_query)
+    result = _result_sync(client.query, query, job_config=job_config)
 
     if to_dataframe:
         return result.to_dataframe()
@@ -171,8 +289,7 @@ async def bigquery_query(
 
 
 @task
-@sync_compatible
-async def bigquery_create_table(
+async def abigquery_create_table(
     dataset: str,
     table: str,
     gcp_credentials: GcpCredentials,
@@ -184,7 +301,7 @@ async def bigquery_create_table(
     external_config: Optional["ExternalConfig"] = None,
 ) -> str:
     """
-    Creates table in BigQuery.
+    Creates table in BigQuery (async version).
     Args:
         dataset: Name of a dataset in that the table will be created.
         table: Name of a table to create.
@@ -203,18 +320,18 @@ async def bigquery_create_table(
         ```python
         from prefect import flow
         from prefect_gcp import GcpCredentials
-        from prefect_gcp.bigquery import bigquery_create_table
+        from prefect_gcp.bigquery import abigquery_create_table
         from google.cloud.bigquery import SchemaField
 
         @flow
-        def example_bigquery_create_table_flow():
+        async def example_bigquery_create_table_flow():
             gcp_credentials = GcpCredentials(project="project")
             schema = [
                 SchemaField("number", field_type="INTEGER", mode="REQUIRED"),
                 SchemaField("text", field_type="STRING", mode="REQUIRED"),
                 SchemaField("bool", field_type="BOOLEAN")
             ]
-            result = bigquery_create_table(
+            result = await abigquery_create_table(
                 dataset="dataset",
                 table="test_table",
                 schema=schema,
@@ -267,8 +384,169 @@ async def bigquery_create_table(
 
 
 @task
-@sync_compatible
-async def bigquery_insert_stream(
+@async_dispatch(abigquery_create_table)
+def bigquery_create_table(
+    dataset: str,
+    table: str,
+    gcp_credentials: GcpCredentials,
+    schema: Optional[List["SchemaField"]] = None,
+    clustering_fields: List[str] = None,
+    time_partitioning: "TimePartitioning" = None,
+    project: Optional[str] = None,
+    location: str = "US",
+    external_config: Optional["ExternalConfig"] = None,
+) -> str:
+    """
+    Creates table in BigQuery.
+    Args:
+        dataset: Name of a dataset in that the table will be created.
+        table: Name of a table to create.
+        schema: Schema to use when creating the table.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        clustering_fields: List of fields to cluster the table by.
+        time_partitioning: `bigquery.TimePartitioning` object specifying a partitioning
+            of the newly created table
+        project: Project to initialize the BigQuery Client with; if
+            not provided, will default to the one inferred from your credentials.
+        location: The location of the dataset that will be written to.
+        external_config: The [external data source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_external_data_configuration).  # noqa
+    Returns:
+        Table name.
+    Example:
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.bigquery import bigquery_create_table
+        from google.cloud.bigquery import SchemaField
+
+        @flow
+        def example_bigquery_create_table_flow():
+            gcp_credentials = GcpCredentials(project="project")
+            schema = [
+                SchemaField("number", field_type="INTEGER", mode="REQUIRED"),
+                SchemaField("text", field_type="STRING", mode="REQUIRED"),
+                SchemaField("bool", field_type="BOOLEAN")
+            ]
+            result = bigquery_create_table(
+                dataset="dataset",
+                table="test_table",
+                schema=schema,
+                gcp_credentials=gcp_credentials
+            )
+            return result
+        example_bigquery_create_table_flow()
+        ```
+    """
+    if not external_config and not schema:
+        raise ValueError("Either a schema or an external config must be provided.")
+
+    client = gcp_credentials.get_bigquery_client(project=project, location=location)
+    try:
+        dataset_ref = client.get_dataset(dataset)
+    except NotFound:
+        dataset_ref = client.create_dataset(dataset)
+
+    table_ref = dataset_ref.table(table)
+    try:
+        client.get_table(table_ref)
+    except NotFound:
+        table_obj = Table(table_ref, schema=schema)
+
+        # external data configuration
+        if external_config:
+            table_obj.external_data_configuration = external_config
+
+        # cluster for optimal data sorting/access
+        if clustering_fields:
+            table_obj.clustering_fields = clustering_fields
+
+        # partitioning
+        if time_partitioning:
+            table_obj.time_partitioning = time_partitioning
+
+        client.create_table(table_obj)
+
+    return table
+
+
+@task
+async def abigquery_insert_stream(
+    dataset: str,
+    table: str,
+    records: List[dict],
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: str = "US",
+) -> List:
+    """
+    Insert records in a Google BigQuery table via the [streaming
+    API](https://cloud.google.com/bigquery/streaming-data-into-bigquery) (async version).
+
+    Args:
+        dataset: Name of a dataset where the records will be written to.
+        table: Name of a table to write to.
+        records: The list of records to insert as rows into the BigQuery table;
+            each item in the list should be a dictionary whose keys correspond to
+            columns in the table.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: The project to initialize the BigQuery Client with; if
+            not provided, will default to the one inferred from your credentials.
+        location: Location of the dataset that will be written to.
+
+    Returns:
+        List of inserted rows.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.bigquery import abigquery_insert_stream
+        from google.cloud.bigquery import SchemaField
+
+        @flow
+        async def example_bigquery_insert_stream_flow():
+            gcp_credentials = GcpCredentials(project="project")
+            records = [
+                {"number": 1, "text": "abc", "bool": True},
+                {"number": 2, "text": "def", "bool": False},
+            ]
+            result = await abigquery_insert_stream(
+                dataset="integrations",
+                table="test_table",
+                records=records,
+                gcp_credentials=gcp_credentials
+            )
+            return result
+
+        example_bigquery_insert_stream_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Inserting into %s.%s as a stream", dataset, table)
+
+    client = gcp_credentials.get_bigquery_client(project=project, location=location)
+    table_ref = client.dataset(dataset).table(table)
+    partial_insert = partial(
+        client.insert_rows_json, table=table_ref, json_rows=records
+    )
+    response = await to_thread.run_sync(partial_insert)
+
+    errors = []
+    output = []
+    for row in response:
+        output.append(row)
+        if "errors" in row:
+            errors.append(row["errors"])
+
+    if errors:
+        raise ValueError(errors)
+
+    return output
+
+
+@task
+@async_dispatch(abigquery_insert_stream)
+def bigquery_insert_stream(
     dataset: str,
     table: str,
     records: List[dict],
@@ -319,15 +597,9 @@ async def bigquery_insert_stream(
         example_bigquery_insert_stream_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info("Inserting into %s.%s as a stream", dataset, table)
-
     client = gcp_credentials.get_bigquery_client(project=project, location=location)
     table_ref = client.dataset(dataset).table(table)
-    partial_insert = partial(
-        client.insert_rows_json, table=table_ref, json_rows=records
-    )
-    response = await to_thread.run_sync(partial_insert)
+    response = client.insert_rows_json(table=table_ref, json_rows=records)
 
     errors = []
     output = []
@@ -343,8 +615,7 @@ async def bigquery_insert_stream(
 
 
 @task
-@sync_compatible
-async def bigquery_load_cloud_storage(
+async def abigquery_load_cloud_storage(
     dataset: str,
     table: str,
     uri: str,
@@ -355,7 +626,7 @@ async def bigquery_load_cloud_storage(
     location: str = "US",
 ) -> "LoadJob":
     """
-    Run method for this Task.  Invoked by _calling_ this
+    Run method for this Task (async version). Invoked by _calling_ this
     Task within a Flow context, after initialization.
     Args:
         uri: GCS path to load data from.
@@ -377,12 +648,12 @@ async def bigquery_load_cloud_storage(
         ```python
         from prefect import flow
         from prefect_gcp import GcpCredentials
-        from prefect_gcp.bigquery import bigquery_load_cloud_storage
+        from prefect_gcp.bigquery import abigquery_load_cloud_storage
 
         @flow
-        def example_bigquery_load_cloud_storage_flow():
+        async def example_bigquery_load_cloud_storage_flow():
             gcp_credentials = GcpCredentials(project="project")
-            result = bigquery_load_cloud_storage(
+            result = await abigquery_load_cloud_storage(
                 dataset="dataset",
                 table="test_table",
                 uri="uri",
@@ -432,8 +703,195 @@ async def bigquery_load_cloud_storage(
 
 
 @task
-@sync_compatible
-async def bigquery_load_file(
+@async_dispatch(abigquery_load_cloud_storage)
+def bigquery_load_cloud_storage(
+    dataset: str,
+    table: str,
+    uri: str,
+    gcp_credentials: GcpCredentials,
+    schema: Optional[List["SchemaField"]] = None,
+    job_config: Optional[dict] = None,
+    project: Optional[str] = None,
+    location: str = "US",
+) -> "LoadJob":
+    """
+    Run method for this Task.  Invoked by _calling_ this
+    Task within a Flow context, after initialization.
+    Args:
+        uri: GCS path to load data from.
+        dataset: The id of a destination dataset to write the records to.
+        table: The name of a destination table to write the records to.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        schema: The schema to use when creating the table.
+        job_config: Dictionary of job configuration parameters;
+            note that the parameters provided here must be pickleable
+            (e.g., dataset references will be rejected).
+        project: The project to initialize the BigQuery Client with; if
+            not provided, will default to the one inferred from your credentials.
+        location: Location of the dataset that will be written to.
+
+    Returns:
+        The response from `load_table_from_uri`.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.bigquery import bigquery_load_cloud_storage
+
+        @flow
+        def example_bigquery_load_cloud_storage_flow():
+            gcp_credentials = GcpCredentials(project="project")
+            result = bigquery_load_cloud_storage(
+                dataset="dataset",
+                table="test_table",
+                uri="uri",
+                gcp_credentials=gcp_credentials
+            )
+            return result
+
+        example_bigquery_load_cloud_storage_flow()
+        ```
+    """
+    client = gcp_credentials.get_bigquery_client(project=project, location=location)
+    table_ref = client.dataset(dataset).table(table)
+
+    job_config = job_config or {}
+    if "autodetect" not in job_config:
+        job_config["autodetect"] = True
+    job_config = LoadJobConfig(**job_config)
+    if schema:
+        job_config.schema = schema
+
+    result = None
+    try:
+        result = _result_sync(
+            client.load_table_from_uri,
+            uri,
+            table_ref,
+            job_config=job_config,
+        )
+    except Exception:
+        if result is not None and result.errors is not None:
+            for error in result.errors:
+                pass  # errors logged in async version
+        raise
+
+    if result is not None:
+        # remove unpickleable attributes
+        result._client = None
+        result._completion_lock = None
+
+    return result
+
+
+@task
+async def abigquery_load_file(
+    dataset: str,
+    table: str,
+    path: Union[str, Path],
+    gcp_credentials: GcpCredentials,
+    schema: Optional[List["SchemaField"]] = None,
+    job_config: Optional[dict] = None,
+    rewind: bool = False,
+    size: Optional[int] = None,
+    project: Optional[str] = None,
+    location: str = "US",
+) -> "LoadJob":
+    """
+    Loads file into BigQuery (async version).
+
+    Args:
+        dataset: ID of a destination dataset to write the records to;
+            if not provided here, will default to the one provided at initialization.
+        table: Name of a destination table to write the records to;
+            if not provided here, will default to the one provided at initialization.
+        path: A string or path-like object of the file to be loaded.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        schema: Schema to use when creating the table.
+        job_config: An optional dictionary of job configuration parameters;
+            note that the parameters provided here must be pickleable
+            (e.g., dataset references will be rejected).
+        rewind: if True, seek to the beginning of the file handle
+            before reading the file.
+        size: Number of bytes to read from the file handle. If size is None or large,
+            resumable upload will be used. Otherwise, multipart upload will be used.
+        project: Project to initialize the BigQuery Client with; if
+            not provided, will default to the one inferred from your credentials.
+        location: location of the dataset that will be written to.
+
+    Returns:
+        The response from `load_table_from_file`.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.bigquery import abigquery_load_file
+        from google.cloud.bigquery import SchemaField
+
+        @flow
+        async def example_bigquery_load_file_flow():
+            gcp_credentials = GcpCredentials(project="project")
+            result = await abigquery_load_file(
+                dataset="dataset",
+                table="test_table",
+                path="path",
+                gcp_credentials=gcp_credentials
+            )
+            return result
+
+        example_bigquery_load_file_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Loading into %s.%s from file", dataset, table)
+
+    if not os.path.exists(path):
+        raise ValueError(f"{path} does not exist")
+    elif not os.path.isfile(path):
+        raise ValueError(f"{path} is not a file")
+
+    client = gcp_credentials.get_bigquery_client(project=project)
+    table_ref = client.dataset(dataset).table(table)
+
+    job_config = job_config or {}
+    if "autodetect" not in job_config:
+        job_config["autodetect"] = True
+        # TODO: test if autodetect is needed when schema is passed
+    job_config = LoadJobConfig(**job_config)
+    if schema:
+        # TODO: test if schema can be passed directly in job_config
+        job_config.schema = schema
+
+    try:
+        with open(path, "rb") as file_obj:
+            partial_load = partial(
+                _result_sync,
+                client.load_table_from_file,
+                file_obj,
+                table_ref,
+                rewind=rewind,
+                size=size,
+                location=location,
+                job_config=job_config,
+            )
+            result = await to_thread.run_sync(partial_load)
+    except IOError:
+        logger.exception(f"Could not open and read from {path}")
+        raise
+
+    if result is not None:
+        # remove unpickleable attributes
+        result._client = None
+        result._completion_lock = None
+
+    return result
+
+
+@task
+@async_dispatch(abigquery_load_file)
+def bigquery_load_file(
     dataset: str,
     table: str,
     path: Union[str, Path],
@@ -491,9 +949,6 @@ async def bigquery_load_file(
         example_bigquery_load_file_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info("Loading into %s.%s from file", dataset, table)
-
     if not os.path.exists(path):
         raise ValueError(f"{path} does not exist")
     elif not os.path.isfile(path):
@@ -505,28 +960,20 @@ async def bigquery_load_file(
     job_config = job_config or {}
     if "autodetect" not in job_config:
         job_config["autodetect"] = True
-        # TODO: test if autodetect is needed when schema is passed
     job_config = LoadJobConfig(**job_config)
     if schema:
-        # TODO: test if schema can be passed directly in job_config
         job_config.schema = schema
 
-    try:
-        with open(path, "rb") as file_obj:
-            partial_load = partial(
-                _result_sync,
-                client.load_table_from_file,
-                file_obj,
-                table_ref,
-                rewind=rewind,
-                size=size,
-                location=location,
-                job_config=job_config,
-            )
-            result = await to_thread.run_sync(partial_load)
-    except IOError:
-        logger.exception(f"Could not open and read from {path}")
-        raise
+    with open(path, "rb") as file_obj:
+        result = _result_sync(
+            client.load_table_from_file,
+            file_obj,
+            table_ref,
+            rewind=rewind,
+            size=size,
+            location=location,
+            job_config=job_config,
+        )
 
     if result is not None:
         # remove unpickleable attributes
@@ -630,8 +1077,66 @@ class BigQueryWarehouse(DatabaseBlock):
                     f"Failed to close cursor for input hash {input_hash!r}: {exc}"
                 )
 
-    @sync_compatible
-    async def fetch_one(
+    async def afetch_one(
+        self,
+        operation: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        **execution_options: Dict[str, Any],
+    ) -> "Row":
+        """
+        Fetch a single result from the database (async version).
+
+        Repeated calls using the same inputs to *any* of the fetch methods of this
+        block will skip executing the operation again, and instead,
+        return the next set of results from the previous execution,
+        until the reset_cursors method is called.
+
+        Args:
+            operation: The SQL query or other operation to be executed.
+            parameters: The parameters for the operation.
+            **execution_options: Additional options to pass to `connection.execute`.
+
+        Returns:
+            A tuple containing the data returned by the database,
+                where each row is a tuple and each column is a value in the tuple.
+
+        Examples:
+            Execute operation with parameters, fetching one new row at a time:
+            ```python
+            from prefect_gcp.bigquery import BigQueryWarehouse
+
+            async with BigQueryWarehouse.load("BLOCK_NAME") as warehouse:
+                operation = '''
+                    SELECT word, word_count
+                    FROM `bigquery-public-data.samples.shakespeare`
+                    WHERE corpus = %(corpus)s
+                    AND word_count >= %(min_word_count)s
+                    ORDER BY word_count DESC
+                    LIMIT 3;
+                '''
+                parameters = {
+                    "corpus": "romeoandjuliet",
+                    "min_word_count": 250,
+                }
+                for _ in range(0, 3):
+                    result = await warehouse.afetch_one(operation, parameters=parameters)
+                    print(result)
+            ```
+        """
+        inputs = dict(
+            operation=operation,
+            parameters=parameters,
+            **execution_options,
+        )
+        new, cursor = self._get_cursor(inputs)
+        if new:
+            await run_sync_in_worker_thread(cursor.execute, **inputs)
+
+        result = await run_sync_in_worker_thread(cursor.fetchone)
+        return result
+
+    @async_dispatch(afetch_one)
+    def fetch_one(
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
@@ -684,13 +1189,78 @@ class BigQueryWarehouse(DatabaseBlock):
         )
         new, cursor = self._get_cursor(inputs)
         if new:
+            cursor.execute(**inputs)
+
+        return cursor.fetchone()
+
+    async def afetch_many(
+        self,
+        operation: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        size: Optional[int] = None,
+        **execution_options: Dict[str, Any],
+    ) -> List["Row"]:
+        """
+        Fetch a limited number of results from the database (async version).
+
+        Repeated calls using the same inputs to *any* of the fetch methods of this
+        block will skip executing the operation again, and instead,
+        return the next set of results from the previous execution,
+        until the reset_cursors method is called.
+
+        Args:
+            operation: The SQL query or other operation to be executed.
+            parameters: The parameters for the operation.
+            size: The number of results to return; if None or 0, uses the value of
+                `fetch_size` configured on the block.
+            **execution_options: Additional options to pass to `connection.execute`.
+
+        Returns:
+            A list of tuples containing the data returned by the database,
+                where each row is a tuple and each column is a value in the tuple.
+
+        Examples:
+            Execute operation with parameters, fetching two new rows at a time:
+            ```python
+            from prefect_gcp.bigquery import BigQueryWarehouse
+
+            async with BigQueryWarehouse.load("BLOCK_NAME") as warehouse:
+                operation = '''
+                    SELECT word, word_count
+                    FROM `bigquery-public-data.samples.shakespeare`
+                    WHERE corpus = %(corpus)s
+                    AND word_count >= %(min_word_count)s
+                    ORDER BY word_count DESC
+                    LIMIT 6;
+                '''
+                parameters = {
+                    "corpus": "romeoandjuliet",
+                    "min_word_count": 250,
+                }
+                for _ in range(0, 3):
+                    result = await warehouse.afetch_many(
+                        operation,
+                        parameters=parameters,
+                        size=2
+                    )
+                    print(result)
+            ```
+        """
+        inputs = dict(
+            operation=operation,
+            parameters=parameters,
+            **execution_options,
+        )
+        new, cursor = self._get_cursor(inputs)
+        if new:
             await run_sync_in_worker_thread(cursor.execute, **inputs)
 
-        result = await run_sync_in_worker_thread(cursor.fetchone)
+        size = size or self.fetch_size
+        result = await run_sync_in_worker_thread(cursor.fetchmany, size=size)
         return result
 
-    @sync_compatible
-    async def fetch_many(
+    @async_dispatch(afetch_many)
+    def fetch_many(
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
@@ -750,14 +1320,69 @@ class BigQueryWarehouse(DatabaseBlock):
         )
         new, cursor = self._get_cursor(inputs)
         if new:
-            await run_sync_in_worker_thread(cursor.execute, **inputs)
+            cursor.execute(**inputs)
 
         size = size or self.fetch_size
-        result = await run_sync_in_worker_thread(cursor.fetchmany, size=size)
+        return cursor.fetchmany(size=size)
+
+    async def afetch_all(
+        self,
+        operation: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        **execution_options: Dict[str, Any],
+    ) -> List["Row"]:
+        """
+        Fetch all results from the database (async version).
+
+        Repeated calls using the same inputs to *any* of the fetch methods of this
+        block will skip executing the operation again, and instead,
+        return the next set of results from the previous execution,
+        until the reset_cursors method is called.
+
+        Args:
+            operation: The SQL query or other operation to be executed.
+            parameters: The parameters for the operation.
+            **execution_options: Additional options to pass to `connection.execute`.
+
+        Returns:
+            A list of tuples containing the data returned by the database,
+                where each row is a tuple and each column is a value in the tuple.
+
+        Examples:
+            Execute operation with parameters, fetching all rows:
+            ```python
+            from prefect_gcp.bigquery import BigQueryWarehouse
+
+            async with BigQueryWarehouse.load("BLOCK_NAME") as warehouse:
+                operation = '''
+                    SELECT word, word_count
+                    FROM `bigquery-public-data.samples.shakespeare`
+                    WHERE corpus = %(corpus)s
+                    AND word_count >= %(min_word_count)s
+                    ORDER BY word_count DESC
+                    LIMIT 3;
+                '''
+                parameters = {
+                    "corpus": "romeoandjuliet",
+                    "min_word_count": 250,
+                }
+                result = await warehouse.afetch_all(operation, parameters=parameters)
+            ```
+        """
+        inputs = dict(
+            operation=operation,
+            parameters=parameters,
+            **execution_options,
+        )
+        new, cursor = self._get_cursor(inputs)
+        if new:
+            await run_sync_in_worker_thread(cursor.execute, **inputs)
+
+        result = await run_sync_in_worker_thread(cursor.fetchall)
         return result
 
-    @sync_compatible
-    async def fetch_all(
+    @async_dispatch(afetch_all)
+    def fetch_all(
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
@@ -808,13 +1433,59 @@ class BigQueryWarehouse(DatabaseBlock):
         )
         new, cursor = self._get_cursor(inputs)
         if new:
-            await run_sync_in_worker_thread(cursor.execute, **inputs)
+            cursor.execute(**inputs)
 
-        result = await run_sync_in_worker_thread(cursor.fetchall)
-        return result
+        return cursor.fetchall()
 
-    @sync_compatible
-    async def execute(
+    async def aexecute(
+        self,
+        operation: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        **execution_options: Dict[str, Any],
+    ) -> None:
+        """
+        Executes an operation on the database (async version). This method is intended
+        to be used for operations that do not return data, such as INSERT, UPDATE,
+        or DELETE.
+
+        Unlike the fetch methods, this method will always execute the operation
+        upon calling.
+
+        Args:
+            operation: The SQL query or other operation to be executed.
+            parameters: The parameters for the operation.
+            **execution_options: Additional options to pass to `connection.execute`.
+
+        Examples:
+            Execute operation with parameters:
+            ```python
+            from prefect_gcp.bigquery import BigQueryWarehouse
+
+            async with BigQueryWarehouse.load("BLOCK_NAME") as warehouse:
+                operation = '''
+                    CREATE TABLE mydataset.trips AS (
+                    SELECT
+                        bikeid,
+                        start_time,
+                        duration_minutes
+                    FROM
+                        bigquery-public-data.austin_bikeshare.bikeshare_trips
+                    LIMIT %(limit)s
+                    );
+                '''
+                await warehouse.aexecute(operation, parameters={"limit": 5})
+            ```
+        """
+        inputs = dict(
+            operation=operation,
+            parameters=parameters,
+            **execution_options,
+        )
+        cursor = self._get_cursor(inputs)[1]
+        await run_sync_in_worker_thread(cursor.execute, **inputs)
+
+    @async_dispatch(aexecute)
+    def execute(
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
@@ -858,10 +1529,61 @@ class BigQueryWarehouse(DatabaseBlock):
             **execution_options,
         )
         cursor = self._get_cursor(inputs)[1]
-        await run_sync_in_worker_thread(cursor.execute, **inputs)
+        cursor.execute(**inputs)
 
-    @sync_compatible
-    async def execute_many(
+    async def aexecute_many(
+        self,
+        operation: str,
+        seq_of_parameters: List[Dict[str, Any]],
+    ) -> None:
+        """
+        Executes many operations on the database (async version). This method is
+        intended to be used for operations that do not return data, such as INSERT,
+        UPDATE, or DELETE.
+
+        Unlike the fetch methods, this method will always execute the operations
+        upon calling.
+
+        Args:
+            operation: The SQL query or other operation to be executed.
+            seq_of_parameters: The sequence of parameters for the operation.
+
+        Examples:
+            Create mytable in mydataset and insert two rows into it:
+            ```python
+            from prefect_gcp.bigquery import BigQueryWarehouse
+
+            async with BigQueryWarehouse.load("bigquery") as warehouse:
+                create_operation = '''
+                CREATE TABLE IF NOT EXISTS mydataset.mytable (
+                    col1 STRING,
+                    col2 INTEGER,
+                    col3 BOOLEAN
+                )
+                '''
+                await warehouse.aexecute(create_operation)
+                insert_operation = '''
+                INSERT INTO mydataset.mytable (col1, col2, col3) VALUES (%s, %s, %s)
+                '''
+                seq_of_parameters = [
+                    ("a", 1, True),
+                    ("b", 2, False),
+                ]
+                await warehouse.aexecute_many(
+                    insert_operation,
+                    seq_of_parameters=seq_of_parameters
+                )
+            ```
+        """
+        inputs = dict(
+            operation=operation,
+            seq_of_parameters=seq_of_parameters,
+        )
+        cursor = self._get_cursor(inputs)[1]
+        await run_sync_in_worker_thread(cursor.executemany, **inputs)
+
+    @async_dispatch(aexecute_many)
+    def execute_many(
         self,
         operation: str,
         seq_of_parameters: List[Dict[str, Any]],
@@ -909,7 +1631,7 @@ class BigQueryWarehouse(DatabaseBlock):
             seq_of_parameters=seq_of_parameters,
         )
         cursor = self._get_cursor(inputs)[1]
-        await run_sync_in_worker_thread(cursor.executemany, **inputs)
+        cursor.executemany(**inputs)
 
     def close(self):
         """

--- a/src/integrations/prefect-gcp/prefect_gcp/cloud_storage.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/cloud_storage.py
@@ -10,10 +10,11 @@ from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
 from pydantic import Field, field_validator
 
 from prefect import task
+from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.blocks.abstract import ObjectStorageBlock
 from prefect.filesystems import WritableDeploymentStorage, WritableFileSystem
 from prefect.logging import get_run_logger
-from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.filesystem import filter_files
 
 # cannot be type_checking only or else `fields = cls.schema()` raises
@@ -33,8 +34,56 @@ except ModuleNotFoundError:
 
 
 @task
-@sync_compatible
-async def cloud_storage_create_bucket(
+async def acloud_storage_create_bucket(
+    bucket: str,
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    **create_kwargs: Dict[str, Any],
+) -> str:
+    """
+    Creates a bucket (async version).
+
+    Args:
+        bucket: Name of the bucket.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Name of the project to use; overrides the
+            gcp_credentials project if provided.
+        location: Location of the bucket.
+        **create_kwargs: Additional keyword arguments to pass to `client.create_bucket`.
+
+    Returns:
+        The bucket name.
+
+    Example:
+        Creates a bucket named "prefect".
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.cloud_storage import acloud_storage_create_bucket
+
+        @flow()
+        async def example_cloud_storage_create_bucket_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json")
+            bucket = await acloud_storage_create_bucket("prefect", gcp_credentials)
+
+        example_cloud_storage_create_bucket_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Creating %s bucket", bucket)
+
+    client = gcp_credentials.get_cloud_storage_client(project=project)
+    await run_sync_in_worker_thread(
+        client.create_bucket, bucket, location=location, **create_kwargs
+    )
+    return bucket
+
+
+@task
+@async_dispatch(acloud_storage_create_bucket)
+def cloud_storage_create_bucket(
     bucket: str,
     gcp_credentials: GcpCredentials,
     project: Optional[str] = None,
@@ -71,13 +120,8 @@ async def cloud_storage_create_bucket(
         example_cloud_storage_create_bucket_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info("Creating %s bucket", bucket)
-
     client = gcp_credentials.get_cloud_storage_client(project=project)
-    await run_sync_in_worker_thread(
-        client.create_bucket, bucket, location=location, **create_kwargs
-    )
+    client.create_bucket(bucket, location=location, **create_kwargs)
     return bucket
 
 
@@ -135,8 +179,96 @@ async def _download_blob_as_bytes(
 
 
 @task
-@sync_compatible
-async def cloud_storage_download_blob_as_bytes(
+async def acloud_storage_download_blob_as_bytes(
+    bucket: str,
+    blob: str,
+    gcp_credentials: GcpCredentials,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **download_kwargs: Dict[str, Any],
+) -> bytes:
+    """
+    Downloads a blob as bytes (async version).
+
+    Args:
+        bucket: Name of the bucket.
+        blob: Name of the Cloud Storage blob.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        chunk_size (int, optional): The size of a chunk of data whenever
+            iterating (in bytes). This must be a multiple of 256 KB
+            per the API specification.
+        encryption_key: An encryption key.
+        timeout: The number of seconds the transport should wait
+            for the server response. Can also be passed as a tuple
+            (connect_timeout, read_timeout).
+        project: Name of the project to use; overrides the
+            gcp_credentials project if provided.
+        **download_kwargs: Additional keyword arguments to pass to
+            `Blob.download_as_bytes`.
+
+    Returns:
+        A bytes or string representation of the blob object.
+
+    Example:
+        Downloads blob from bucket.
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.cloud_storage import acloud_storage_download_blob_as_bytes
+
+        @flow()
+        async def example_cloud_storage_download_blob_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json")
+            contents = await acloud_storage_download_blob_as_bytes(
+                "bucket", "blob", gcp_credentials)
+            return contents
+
+        example_cloud_storage_download_blob_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Downloading blob named %s from the %s bucket", blob, bucket)
+
+    return await _download_blob_as_bytes(
+        bucket=bucket,
+        blob=blob,
+        gcp_credentials=gcp_credentials,
+        chunk_size=chunk_size,
+        encryption_key=encryption_key,
+        timeout=timeout,
+        project=project,
+        **download_kwargs,
+    )
+
+
+def _download_blob_as_bytes_sync(
+    bucket: str,
+    blob: str,
+    gcp_credentials: GcpCredentials,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **download_kwargs: Dict[str, Any],
+) -> bytes:
+    """
+    Internal sync function to download a blob as bytes.
+    """
+    bucket_obj = _get_bucket(bucket, gcp_credentials, project=project)
+    blob_obj = bucket_obj.blob(
+        blob, chunk_size=chunk_size, encryption_key=encryption_key
+    )
+
+    contents = blob_obj.download_as_bytes(timeout=timeout, **download_kwargs)
+    return contents
+
+
+@task
+@async_dispatch(acloud_storage_download_blob_as_bytes)
+def cloud_storage_download_blob_as_bytes(
     bucket: str,
     blob: str,
     gcp_credentials: GcpCredentials,
@@ -186,10 +318,7 @@ async def cloud_storage_download_blob_as_bytes(
         example_cloud_storage_download_blob_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info("Downloading blob named %s from the %s bucket", blob, bucket)
-
-    return await _download_blob_as_bytes(
+    return _download_blob_as_bytes_sync(
         bucket=bucket,
         blob=blob,
         gcp_credentials=gcp_credentials,
@@ -236,8 +365,109 @@ async def _download_blob_to_file(
 
 
 @task
-@sync_compatible
-async def cloud_storage_download_blob_to_file(
+async def acloud_storage_download_blob_to_file(
+    bucket: str,
+    blob: str,
+    path: Union[str, Path],
+    gcp_credentials: GcpCredentials,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **download_kwargs: Dict[str, Any],
+) -> Union[str, Path]:
+    """
+    Downloads a blob to a file path (async version).
+
+    Args:
+        bucket: Name of the bucket.
+        blob: Name of the Cloud Storage blob.
+        path: Downloads the contents to the provided file path;
+            if the path is a directory, automatically joins the blob name.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        chunk_size (int, optional): The size of a chunk of data whenever
+            iterating (in bytes). This must be a multiple of 256 KB
+            per the API specification.
+        encryption_key: An encryption key.
+        timeout: The number of seconds the transport should wait
+            for the server response. Can also be passed as a tuple
+            (connect_timeout, read_timeout).
+        project: Name of the project to use; overrides the
+            gcp_credentials project if provided.
+        **download_kwargs: Additional keyword arguments to pass to
+            `Blob.download_to_filename`.
+
+    Returns:
+        The path to the blob object.
+
+    Example:
+        Downloads blob from bucket.
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.cloud_storage import acloud_storage_download_blob_to_file
+
+        @flow()
+        async def example_cloud_storage_download_blob_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json")
+            path = await acloud_storage_download_blob_to_file(
+                "bucket", "blob", "file_path", gcp_credentials)
+            return path
+
+        example_cloud_storage_download_blob_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info(
+        "Downloading blob named %s from the %s bucket to %s", blob, bucket, path
+    )
+
+    return await _download_blob_to_file(
+        bucket=bucket,
+        blob=blob,
+        path=path,
+        gcp_credentials=gcp_credentials,
+        chunk_size=chunk_size,
+        encryption_key=encryption_key,
+        timeout=timeout,
+        project=project,
+        **download_kwargs,
+    )
+
+
+def _download_blob_to_file_sync(
+    bucket: str,
+    blob: str,
+    path: Union[str, Path],
+    gcp_credentials: GcpCredentials,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **download_kwargs: Dict[str, Any],
+) -> Union[str, Path]:
+    """
+    Internal sync function to download a blob to a file.
+    """
+    bucket_obj = _get_bucket(bucket, gcp_credentials, project=project)
+    blob_obj = bucket_obj.blob(
+        blob, chunk_size=chunk_size, encryption_key=encryption_key
+    )
+
+    if os.path.isdir(path):
+        if isinstance(path, Path):
+            path = path.joinpath(blob)
+        else:
+            path = os.path.join(path, blob)
+
+    blob_obj.download_to_filename(path, timeout=timeout, **download_kwargs)
+    return path
+
+
+@task
+@async_dispatch(acloud_storage_download_blob_to_file)
+def cloud_storage_download_blob_to_file(
     bucket: str,
     blob: str,
     path: Union[str, Path],
@@ -290,12 +520,7 @@ async def cloud_storage_download_blob_to_file(
         example_cloud_storage_download_blob_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info(
-        "Downloading blob named %s from the %s bucket to %s", blob, bucket, path
-    )
-
-    return await _download_blob_to_file(
+    return _download_blob_to_file_sync(
         bucket=bucket,
         blob=blob,
         path=path,
@@ -342,8 +567,109 @@ async def _upload_blob_from_string(
 
 
 @task
-@sync_compatible
-async def cloud_storage_upload_blob_from_string(
+async def acloud_storage_upload_blob_from_string(
+    data: Union[str, bytes],
+    bucket: str,
+    blob: str,
+    gcp_credentials: GcpCredentials,
+    content_type: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **upload_kwargs: Dict[str, Any],
+) -> str:
+    """
+    Uploads a blob from a string or bytes representation of data (async version).
+
+    Args:
+        data: String or bytes representation of data to upload.
+        bucket: Name of the bucket.
+        blob: Name of the Cloud Storage blob.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        content_type: Type of content being uploaded.
+        chunk_size: The size of a chunk of data whenever
+            iterating (in bytes). This must be a multiple of 256 KB
+            per the API specification.
+        encryption_key: An encryption key.
+        timeout: The number of seconds the transport should wait
+            for the server response. Can also be passed as a tuple
+            (connect_timeout, read_timeout).
+        project: Name of the project to use; overrides the
+            gcp_credentials project if provided.
+        **upload_kwargs: Additional keyword arguments to pass to
+            `Blob.upload_from_string`.
+
+    Returns:
+        The blob name.
+
+    Example:
+        Uploads blob to bucket.
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.cloud_storage import acloud_storage_upload_blob_from_string
+
+        @flow()
+        async def example_cloud_storage_upload_blob_from_string_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json")
+            blob = await acloud_storage_upload_blob_from_string(
+                "data", "bucket", "blob", gcp_credentials)
+            return blob
+
+        example_cloud_storage_upload_blob_from_string_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Uploading blob named %s to the %s bucket", blob, bucket)
+
+    return await _upload_blob_from_string(
+        data=data,
+        bucket=bucket,
+        blob=blob,
+        gcp_credentials=gcp_credentials,
+        content_type=content_type,
+        chunk_size=chunk_size,
+        encryption_key=encryption_key,
+        timeout=timeout,
+        project=project,
+        **upload_kwargs,
+    )
+
+
+def _upload_blob_from_string_sync(
+    data: Union[str, bytes],
+    bucket: str,
+    blob: str,
+    gcp_credentials: GcpCredentials,
+    content_type: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **upload_kwargs: Dict[str, Any],
+) -> str:
+    """
+    Internal sync function to upload a blob from a string or bytes.
+    """
+    bucket_obj = _get_bucket(bucket, gcp_credentials, project=project)
+    blob_obj = bucket_obj.blob(
+        blob, chunk_size=chunk_size, encryption_key=encryption_key
+    )
+
+    blob_obj.upload_from_string(
+        data,
+        content_type=content_type,
+        timeout=timeout,
+        **upload_kwargs,
+    )
+    return blob
+
+
+@task
+@async_dispatch(acloud_storage_upload_blob_from_string)
+def cloud_storage_upload_blob_from_string(
     data: Union[str, bytes],
     bucket: str,
     blob: str,
@@ -397,10 +723,7 @@ async def cloud_storage_upload_blob_from_string(
         example_cloud_storage_upload_blob_from_string_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info("Uploading blob named %s to the %s bucket", blob, bucket)
-
-    return await _upload_blob_from_string(
+    return _upload_blob_from_string_sync(
         data=data,
         bucket=bucket,
         blob=blob,
@@ -415,8 +738,92 @@ async def cloud_storage_upload_blob_from_string(
 
 
 @task
-@sync_compatible
-async def cloud_storage_upload_blob_from_file(
+async def acloud_storage_upload_blob_from_file(
+    file: Union[str, Path, BytesIO],
+    bucket: str,
+    blob: str,
+    gcp_credentials: GcpCredentials,
+    content_type: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    encryption_key: Optional[str] = None,
+    timeout: Union[float, Tuple[float, float]] = 60,
+    project: Optional[str] = None,
+    **upload_kwargs: Dict[str, Any],
+) -> str:
+    """
+    Uploads a blob from file path or file-like object (async version). Usage for
+    passing in file-like object is if the data was downloaded from the web;
+    can bypass writing to disk and directly upload to Cloud Storage.
+
+    Args:
+        file: Path to data or file like object to upload.
+        bucket: Name of the bucket.
+        blob: Name of the Cloud Storage blob.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        content_type: Type of content being uploaded.
+        chunk_size: The size of a chunk of data whenever
+            iterating (in bytes). This must be a multiple of 256 KB
+            per the API specification.
+        encryption_key: An encryption key.
+        timeout: The number of seconds the transport should wait
+            for the server response. Can also be passed as a tuple
+            (connect_timeout, read_timeout).
+        project: Name of the project to use; overrides the
+            gcp_credentials project if provided.
+        **upload_kwargs: Additional keyword arguments to pass to
+            `Blob.upload_from_file` or `Blob.upload_from_filename`.
+
+    Returns:
+        The blob name.
+
+    Example:
+        Uploads blob to bucket.
+        ```python
+        from prefect import flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.cloud_storage import acloud_storage_upload_blob_from_file
+
+        @flow()
+        async def example_cloud_storage_upload_blob_from_file_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json")
+            blob = await acloud_storage_upload_blob_from_file(
+                "/path/somewhere", "bucket", "blob", gcp_credentials)
+            return blob
+
+        example_cloud_storage_upload_blob_from_file_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Uploading blob named %s to the %s bucket", blob, bucket)
+
+    bucket_obj = await _get_bucket_async(bucket, gcp_credentials, project=project)
+    blob_obj = bucket_obj.blob(
+        blob, chunk_size=chunk_size, encryption_key=encryption_key
+    )
+
+    if isinstance(file, BytesIO):
+        await run_sync_in_worker_thread(
+            blob_obj.upload_from_file,
+            file,
+            content_type=content_type,
+            timeout=timeout,
+            **upload_kwargs,
+        )
+    else:
+        await run_sync_in_worker_thread(
+            blob_obj.upload_from_filename,
+            file,
+            content_type=content_type,
+            timeout=timeout,
+            **upload_kwargs,
+        )
+    return blob
+
+
+@task
+@async_dispatch(acloud_storage_upload_blob_from_file)
+def cloud_storage_upload_blob_from_file(
     file: Union[str, Path, BytesIO],
     bucket: str,
     blob: str,
@@ -472,25 +879,20 @@ async def cloud_storage_upload_blob_from_file(
         example_cloud_storage_upload_blob_from_file_flow()
         ```
     """
-    logger = get_run_logger()
-    logger.info("Uploading blob named %s to the %s bucket", blob, bucket)
-
-    bucket_obj = await _get_bucket_async(bucket, gcp_credentials, project=project)
+    bucket_obj = _get_bucket(bucket, gcp_credentials, project=project)
     blob_obj = bucket_obj.blob(
         blob, chunk_size=chunk_size, encryption_key=encryption_key
     )
 
     if isinstance(file, BytesIO):
-        await run_sync_in_worker_thread(
-            blob_obj.upload_from_file,
+        blob_obj.upload_from_file(
             file,
             content_type=content_type,
             timeout=timeout,
             **upload_kwargs,
         )
     else:
-        await run_sync_in_worker_thread(
-            blob_obj.upload_from_filename,
+        blob_obj.upload_from_filename(
             file,
             content_type=content_type,
             timeout=timeout,
@@ -735,14 +1137,13 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             path = None
         return path
 
-    @sync_compatible
-    async def get_directory(
+    async def aget_directory(
         self, from_path: Optional[str] = None, local_path: Optional[str] = None
     ) -> List[Union[str, Path]]:
         """
-        Copies a folder from the configured GCS bucket to a local directory.
-        Defaults to copying the entire contents of the block's bucket_folder
-        to the current working directory.
+        Copies a folder from the configured GCS bucket to a local directory
+        (async version). Defaults to copying the entire contents of the block's
+        bucket_folder to the current working directory.
 
         Args:
             from_path: Path in GCS bucket to download from. Defaults to the block's
@@ -788,8 +1189,57 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             file_paths.append(file_path)
         return file_paths
 
-    @sync_compatible
-    async def put_directory(
+    @async_dispatch(aget_directory)
+    def get_directory(
+        self, from_path: Optional[str] = None, local_path: Optional[str] = None
+    ) -> List[Union[str, Path]]:
+        """
+        Copies a folder from the configured GCS bucket to a local directory.
+        Defaults to copying the entire contents of the block's bucket_folder
+        to the current working directory.
+
+        Args:
+            from_path: Path in GCS bucket to download from. Defaults to the block's
+                configured bucket_folder.
+            local_path: Local path to download GCS bucket contents to.
+                Defaults to the current working directory.
+
+        Returns:
+            A list of downloaded file paths.
+        """
+        from_path = (
+            self.bucket_folder if from_path is None else self._resolve_path(from_path)
+        )
+
+        if local_path is None:
+            local_path = os.path.abspath(".")
+        else:
+            local_path = os.path.abspath(os.path.expanduser(local_path))
+
+        project = self.gcp_credentials.project
+        client = self.gcp_credentials.get_cloud_storage_client(project=project)
+
+        blobs = client.list_blobs(self.bucket, prefix=from_path)
+
+        file_paths = []
+        for blob in blobs:
+            blob_path = blob.name
+            if blob_path[-1] == "/":
+                continue
+            relative_blob_path = os.path.relpath(blob_path, from_path)
+            local_file_path = os.path.join(local_path, relative_blob_path)
+            os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
+
+            file_path = _download_blob_to_file_sync(
+                bucket=self.bucket,
+                blob=blob_path,
+                path=local_file_path,
+                gcp_credentials=self.gcp_credentials,
+            )
+            file_paths.append(file_path)
+        return file_paths
+
+    async def aput_directory(
         self,
         local_path: Optional[str] = None,
         to_path: Optional[str] = None,
@@ -797,7 +1247,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
     ) -> int:
         """
         Uploads a directory from a given local path to the configured GCS bucket in a
-        given folder.
+        given folder (async version).
 
         Defaults to uploading the entire contents the current working directory to the
         block's bucket_folder.
@@ -868,11 +1318,72 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
 
         return len(files_to_upload)
 
-    @sync_compatible
-    async def read_path(self, path: str) -> bytes:
+    @async_dispatch(aput_directory)
+    def put_directory(
+        self,
+        local_path: Optional[str] = None,
+        to_path: Optional[str] = None,
+        ignore_file: Optional[str] = None,
+    ) -> int:
         """
-        Read specified path from GCS and return contents. Provide the entire
-        path to the key in GCS.
+        Uploads a directory from a given local path to the configured GCS bucket in a
+        given folder.
+
+        Defaults to uploading the entire contents the current working directory to the
+        block's bucket_folder.
+
+        Args:
+            local_path: Path to local directory to upload from.
+            to_path: Path in GCS bucket to upload to. Defaults to block's configured
+                bucket_folder.
+            ignore_file: Path to file containing gitignore style expressions for
+                filepaths to ignore.
+
+        Returns:
+            The number of files uploaded.
+        """
+        if local_path is None:
+            local_path = os.path.abspath(".")
+        else:
+            local_path = os.path.expanduser(local_path)
+
+        to_path = self.bucket_folder if to_path is None else self._resolve_path(to_path)
+
+        included_files = None
+        if ignore_file:
+            with open(ignore_file, "r") as f:
+                ignore_patterns = f.readlines()
+            included_files = filter_files(local_path, ignore_patterns)
+
+        files_to_upload = []
+        for local_file_path in Path(local_path).rglob("*"):
+            if (
+                included_files is not None
+                and str(local_file_path.relative_to(local_path)) not in included_files
+            ):
+                continue
+            elif not local_file_path.is_dir():
+                remote_file_path = str(
+                    PurePosixPath(to_path, local_file_path.relative_to(local_path))
+                )
+                files_to_upload.append((local_file_path, remote_file_path))
+
+        # Upload files sequentially in sync mode
+        if files_to_upload:
+            client = self.gcp_credentials.get_cloud_storage_client()
+            bucket_obj = client.get_bucket(self.bucket)
+
+            for local_file_path, remote_file_path in files_to_upload:
+                local_file_content = local_file_path.read_bytes()
+                blob_obj = bucket_obj.blob(remote_file_path)
+                blob_obj.upload_from_string(local_file_content)
+
+        return len(files_to_upload)
+
+    async def aread_path(self, path: str) -> bytes:
+        """
+        Read specified path from GCS and return contents (async version). Provide the
+        entire path to the key in GCS.
 
         Args:
             path: Entire path to (and including) the key.
@@ -886,8 +1397,47 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
         )
         return contents
 
-    @sync_compatible
-    async def write_path(self, path: str, content: bytes) -> str:
+    @async_dispatch(aread_path)
+    def read_path(self, path: str) -> bytes:
+        """
+        Read specified path from GCS and return contents. Provide the entire
+        path to the key in GCS.
+
+        Args:
+            path: Entire path to (and including) the key.
+
+        Returns:
+            A bytes or string representation of the blob object.
+        """
+        path = self._resolve_path(path)
+        contents = _download_blob_as_bytes_sync(
+            bucket=self.bucket, blob=path, gcp_credentials=self.gcp_credentials
+        )
+        return contents
+
+    async def awrite_path(self, path: str, content: bytes) -> str:
+        """
+        Writes to an GCS bucket (async version).
+
+        Args:
+            path: The key name. Each object in your bucket has a unique
+                key (or key name).
+            content: What you are uploading to GCS Bucket.
+
+        Returns:
+            The path that the contents were written to.
+        """
+        path = self._resolve_path(path)
+        await _upload_blob_from_string(
+            data=content,
+            bucket=self.bucket,
+            blob=path,
+            gcp_credentials=self.gcp_credentials,
+        )
+        return path
+
+    @async_dispatch(awrite_path)
+    def write_path(self, path: str, content: bytes) -> str:
         """
         Writes to an GCS bucket.
 
@@ -900,7 +1450,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             The path that the contents were written to.
         """
         path = self._resolve_path(path)
-        await _upload_blob_from_string(
+        _upload_blob_from_string_sync(
             data=content,
             bucket=self.bucket,
             blob=path,
@@ -932,8 +1482,38 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             bucket_path = None
         return bucket_path
 
-    @sync_compatible
-    async def create_bucket(
+    async def acreate_bucket(
+        self, location: Optional[str] = None, **create_kwargs
+    ) -> "Bucket":
+        """
+        Creates a bucket (async version).
+
+        Args:
+            location: The location of the bucket.
+            **create_kwargs: Additional keyword arguments to pass to the
+                `create_bucket` method.
+
+        Returns:
+            The bucket object.
+
+        Examples:
+            Create a bucket.
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket(bucket="my-bucket")
+            await gcs_bucket.acreate_bucket()
+            ```
+        """
+        self.logger.info(f"Creating bucket {self.bucket!r}.")
+        client = self.gcp_credentials.get_cloud_storage_client()
+        bucket = await run_sync_in_worker_thread(
+            client.create_bucket, self.bucket, location=location, **create_kwargs
+        )
+        return bucket
+
+    @async_dispatch(acreate_bucket)
+    def create_bucket(
         self, location: Optional[str] = None, **create_kwargs
     ) -> "Bucket":
         """
@@ -956,15 +1536,33 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             gcs_bucket.create_bucket()
             ```
         """
-        self.logger.info(f"Creating bucket {self.bucket!r}.")
         client = self.gcp_credentials.get_cloud_storage_client()
-        bucket = await run_sync_in_worker_thread(
-            client.create_bucket, self.bucket, location=location, **create_kwargs
-        )
+        bucket = client.create_bucket(self.bucket, location=location, **create_kwargs)
         return bucket
 
-    @sync_compatible
-    async def get_bucket(self) -> "Bucket":
+    async def aget_bucket(self) -> "Bucket":
+        """
+        Returns the bucket object (async version).
+
+        Returns:
+            The bucket object.
+
+        Examples:
+            Get the bucket object.
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.aget_bucket()
+            ```
+        """
+        self.logger.info(f"Getting bucket {self.bucket!r}.")
+        client = self.gcp_credentials.get_cloud_storage_client()
+        bucket = await run_sync_in_worker_thread(client.get_bucket, self.bucket)
+        return bucket
+
+    @async_dispatch(aget_bucket)
+    def get_bucket(self) -> "Bucket":
         """
         Returns the bucket object.
 
@@ -980,13 +1578,48 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             gcs_bucket.get_bucket()
             ```
         """
-        self.logger.info(f"Getting bucket {self.bucket!r}.")
         client = self.gcp_credentials.get_cloud_storage_client()
-        bucket = await run_sync_in_worker_thread(client.get_bucket, self.bucket)
+        bucket = client.get_bucket(self.bucket)
         return bucket
 
-    @sync_compatible
-    async def list_blobs(self, folder: str = "") -> List["Blob"]:
+    async def alist_blobs(self, folder: str = "") -> List["Blob"]:
+        """
+        Lists all blobs in the bucket that are in a folder (async version).
+        Folders are not included in the output.
+
+        Args:
+            folder: The folder to list blobs from.
+
+        Returns:
+            A list of Blob objects.
+
+        Examples:
+            Get all blobs from a folder named "prefect".
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.alist_blobs("prefect")
+            ```
+        """
+        client = self.gcp_credentials.get_cloud_storage_client()
+
+        bucket_path = self._join_bucket_folder(folder)
+        if bucket_path is None:
+            self.logger.info(f"Listing blobs in bucket {self.bucket!r}.")
+        else:
+            self.logger.info(
+                f"Listing blobs in folder {bucket_path!r} in bucket {self.bucket!r}."
+            )
+        blobs = await run_sync_in_worker_thread(
+            client.list_blobs, self.bucket, prefix=bucket_path
+        )
+
+        # Ignore folders
+        return [blob for blob in blobs if not blob.name.endswith("/")]
+
+    @async_dispatch(alist_blobs)
+    def list_blobs(self, folder: str = "") -> List["Blob"]:
         """
         Lists all blobs in the bucket that are in a folder.
         Folders are not included in the output.
@@ -1009,21 +1642,57 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
         client = self.gcp_credentials.get_cloud_storage_client()
 
         bucket_path = self._join_bucket_folder(folder)
-        if bucket_path is None:
-            self.logger.info(f"Listing blobs in bucket {self.bucket!r}.")
-        else:
-            self.logger.info(
-                f"Listing blobs in folder {bucket_path!r} in bucket {self.bucket!r}."
-            )
-        blobs = await run_sync_in_worker_thread(
-            client.list_blobs, self.bucket, prefix=bucket_path
-        )
+        blobs = client.list_blobs(self.bucket, prefix=bucket_path)
 
         # Ignore folders
         return [blob for blob in blobs if not blob.name.endswith("/")]
 
-    @sync_compatible
-    async def list_folders(self, folder: str = "") -> List[str]:
+    async def alist_folders(self, folder: str = "") -> List[str]:
+        """
+        Lists all folders and subfolders in the bucket (async version).
+
+        Args:
+            folder: List all folders and subfolders inside given folder.
+
+        Returns:
+            A list of folders.
+
+        Examples:
+            Get all folders from a bucket named "my-bucket".
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.alist_folders()
+            ```
+
+            Get all folders from a folder called years
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.alist_folders("years")
+            ```
+        """
+
+        # Beware of calling _join_bucket_folder twice, see note in method.
+        # However, we just want to use it to check if we are listing the root folder
+        bucket_path = self._join_bucket_folder(folder)
+        if bucket_path is None:
+            self.logger.info(f"Listing folders in bucket {self.bucket!r}.")
+        else:
+            self.logger.info(
+                f"Listing folders in {bucket_path!r} in bucket {self.bucket!r}."
+            )
+
+        blobs = await self.alist_blobs(folder)
+        # gets all folders with full path
+        folders = {str(PurePosixPath(blob.name).parent) for blob in blobs}
+
+        return [folder for folder in folders if folder != "."]
+
+    @async_dispatch(alist_folders)
+    def list_folders(self, folder: str = "") -> List[str]:
         """
         Lists all folders and subfolders in the bucket.
 
@@ -1050,25 +1719,63 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             gcs_bucket.list_folders("years")
             ```
         """
-
-        # Beware of calling _join_bucket_folder twice, see note in method.
-        # However, we just want to use it to check if we are listing the root folder
-        bucket_path = self._join_bucket_folder(folder)
-        if bucket_path is None:
-            self.logger.info(f"Listing folders in bucket {self.bucket!r}.")
-        else:
-            self.logger.info(
-                f"Listing folders in {bucket_path!r} in bucket {self.bucket!r}."
-            )
-
-        blobs = await self.list_blobs(folder)
+        blobs = self.list_blobs(folder)
         # gets all folders with full path
         folders = {str(PurePosixPath(blob.name).parent) for blob in blobs}
 
         return [folder for folder in folders if folder != "."]
 
-    @sync_compatible
-    async def download_object_to_path(
+    async def adownload_object_to_path(
+        self,
+        from_path: str,
+        to_path: Optional[Union[str, Path]] = None,
+        **download_kwargs: Dict[str, Any],
+    ) -> Path:
+        """
+        Downloads an object from the object storage service to a path (async version).
+
+        Args:
+            from_path: The path to the blob to download; this gets prefixed
+                with the bucket_folder.
+            to_path: The path to download the blob to. If not provided, the
+                blob's name will be used.
+            **download_kwargs: Additional keyword arguments to pass to
+                `Blob.download_to_filename`.
+
+        Returns:
+            The absolute path that the object was downloaded to.
+
+        Examples:
+            Download my_folder/notes.txt object to notes.txt.
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.adownload_object_to_path("my_folder/notes.txt", "notes.txt")
+            ```
+        """
+        if to_path is None:
+            to_path = Path(from_path).name
+
+        # making path absolute, but converting back to str here
+        # since !r looks nicer that way and filename arg expects str
+        to_path = str(Path(to_path).absolute())
+
+        bucket = await self.aget_bucket()
+        bucket_path = self._join_bucket_folder(from_path)
+        blob = bucket.blob(bucket_path)
+        self.logger.info(
+            f"Downloading blob from bucket {self.bucket!r} path {bucket_path!r}"
+            f"to {to_path!r}."
+        )
+
+        await run_sync_in_worker_thread(
+            blob.download_to_filename, filename=to_path, **download_kwargs
+        )
+        return Path(to_path)
+
+    @async_dispatch(adownload_object_to_path)
+    def download_object_to_path(
         self,
         from_path: str,
         to_path: Optional[Union[str, Path]] = None,
@@ -1100,25 +1807,71 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
         if to_path is None:
             to_path = Path(from_path).name
 
-        # making path absolute, but converting back to str here
-        # since !r looks nicer that way and filename arg expects str
         to_path = str(Path(to_path).absolute())
 
-        bucket = await self.get_bucket()
+        bucket = self.get_bucket()
+        bucket_path = self._join_bucket_folder(from_path)
+        blob = bucket.blob(bucket_path)
+
+        blob.download_to_filename(filename=to_path, **download_kwargs)
+        return Path(to_path)
+
+    async def adownload_object_to_file_object(
+        self,
+        from_path: str,
+        to_file_object: BinaryIO,
+        **download_kwargs: Dict[str, Any],
+    ) -> BinaryIO:
+        """
+        Downloads an object from the object storage service to a file-like object
+        (async version), which can be a BytesIO object or a BufferedWriter.
+
+        Args:
+            from_path: The path to the blob to download from; this gets prefixed
+                with the bucket_folder.
+            to_file_object: The file-like object to download the blob to.
+            **download_kwargs: Additional keyword arguments to pass to
+                `Blob.download_to_file`.
+
+        Returns:
+            The file-like object that the object was downloaded to.
+
+        Examples:
+            Download my_folder/notes.txt object to a BytesIO object.
+            ```python
+            from io import BytesIO
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            with BytesIO() as buf:
+                await gcs_bucket.adownload_object_to_file_object("my_folder/notes.txt", buf)
+            ```
+
+            Download my_folder/notes.txt object to a BufferedWriter.
+            ```python
+                from prefect_gcp.cloud_storage import GcsBucket
+
+                gcs_bucket = GcsBucket.load("my-bucket")
+                with open("notes.txt", "wb") as f:
+                    await gcs_bucket.adownload_object_to_file_object("my_folder/notes.txt", f)
+            ```
+        """
+        bucket = await self.aget_bucket()
+
         bucket_path = self._join_bucket_folder(from_path)
         blob = bucket.blob(bucket_path)
         self.logger.info(
             f"Downloading blob from bucket {self.bucket!r} path {bucket_path!r}"
-            f"to {to_path!r}."
+            f"to file object."
         )
 
         await run_sync_in_worker_thread(
-            blob.download_to_filename, filename=to_path, **download_kwargs
+            blob.download_to_file, file_obj=to_file_object, **download_kwargs
         )
-        return Path(to_path)
+        return to_file_object
 
-    @sync_compatible
-    async def download_object_to_file_object(
+    @async_dispatch(adownload_object_to_file_object)
+    def download_object_to_file_object(
         self,
         from_path: str,
         to_file_object: BinaryIO,
@@ -1158,22 +1911,83 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
                     gcs_bucket.download_object_to_file_object("my_folder/notes.txt", f)
             ```
         """
-        bucket = await self.get_bucket()
+        bucket = self.get_bucket()
 
         bucket_path = self._join_bucket_folder(from_path)
         blob = bucket.blob(bucket_path)
-        self.logger.info(
-            f"Downloading blob from bucket {self.bucket!r} path {bucket_path!r}"
-            f"to file object."
-        )
 
-        await run_sync_in_worker_thread(
-            blob.download_to_file, file_obj=to_file_object, **download_kwargs
-        )
+        blob.download_to_file(file_obj=to_file_object, **download_kwargs)
         return to_file_object
 
-    @sync_compatible
-    async def download_folder_to_path(
+    async def adownload_folder_to_path(
+        self,
+        from_folder: str,
+        to_folder: Optional[Union[str, Path]] = None,
+        **download_kwargs: Dict[str, Any],
+    ) -> Path:
+        """
+        Downloads objects *within* a folder (excluding the folder itself)
+        from the object storage service to a folder (async version).
+
+        Args:
+            from_folder: The path to the folder to download from; this gets prefixed
+                with the bucket_folder.
+            to_folder: The path to download the folder to. If not provided, will default
+                to the current directory.
+            **download_kwargs: Additional keyword arguments to pass to
+                `Blob.download_to_filename`.
+
+        Returns:
+            The absolute path that the folder was downloaded to.
+
+        Examples:
+            Download my_folder to a local folder named my_folder.
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.adownload_folder_to_path("my_folder", "my_folder")
+            ```
+        """
+        if to_folder is None:
+            to_folder = ""
+        to_folder = Path(to_folder).absolute()
+
+        blobs = await self.alist_blobs(folder=from_folder)
+        if len(blobs) == 0:
+            self.logger.warning(
+                f"No blobs were downloaded from "
+                f"bucket {self.bucket!r} path {from_folder!r}."
+            )
+            return to_folder
+
+        # do not call self._join_bucket_folder for list_blobs
+        # because it's built-in to that method already!
+        # however, we still need to do it because we're using relative_to
+        bucket_folder = self._join_bucket_folder(from_folder)
+
+        async_coros = []
+        for blob in blobs:
+            bucket_path = PurePosixPath(blob.name).relative_to(bucket_folder)
+            if str(bucket_path).endswith("/"):
+                continue
+            to_path = to_folder / bucket_path
+            to_path.parent.mkdir(parents=True, exist_ok=True)
+            self.logger.info(
+                f"Downloading blob from bucket {self.bucket!r} path "
+                f"{str(bucket_path)!r} to {to_path}."
+            )
+            async_coros.append(
+                run_sync_in_worker_thread(
+                    blob.download_to_filename, filename=str(to_path), **download_kwargs
+                )
+            )
+        await asyncio.gather(*async_coros)
+
+        return to_folder
+
+    @async_dispatch(adownload_folder_to_path)
+    def download_folder_to_path(
         self,
         from_folder: str,
         to_folder: Optional[Union[str, Path]] = None,
@@ -1207,7 +2021,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             to_folder = ""
         to_folder = Path(to_folder).absolute()
 
-        blobs = await self.list_blobs(folder=from_folder)
+        blobs = self.list_blobs(folder=from_folder)
         if len(blobs) == 0:
             self.logger.warning(
                 f"No blobs were downloaded from "
@@ -1215,33 +2029,65 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             )
             return to_folder
 
-        # do not call self._join_bucket_folder for list_blobs
-        # because it's built-in to that method already!
-        # however, we still need to do it because we're using relative_to
         bucket_folder = self._join_bucket_folder(from_folder)
 
-        async_coros = []
         for blob in blobs:
             bucket_path = PurePosixPath(blob.name).relative_to(bucket_folder)
             if str(bucket_path).endswith("/"):
                 continue
             to_path = to_folder / bucket_path
             to_path.parent.mkdir(parents=True, exist_ok=True)
-            self.logger.info(
-                f"Downloading blob from bucket {self.bucket!r} path "
-                f"{str(bucket_path)!r} to {to_path}."
-            )
-            async_coros.append(
-                run_sync_in_worker_thread(
-                    blob.download_to_filename, filename=str(to_path), **download_kwargs
-                )
-            )
-        await asyncio.gather(*async_coros)
+            blob.download_to_filename(filename=str(to_path), **download_kwargs)
 
         return to_folder
 
-    @sync_compatible
-    async def upload_from_path(
+    async def aupload_from_path(
+        self,
+        from_path: Union[str, Path],
+        to_path: Optional[str] = None,
+        **upload_kwargs: Dict[str, Any],
+    ) -> str:
+        """
+        Uploads an object from a path to the object storage service (async version).
+
+        Args:
+            from_path: The path to the file to upload from.
+            to_path: The path to upload the file to. If not provided, will use
+                the file name of from_path; this gets prefixed
+                with the bucket_folder.
+            **upload_kwargs: Additional keyword arguments to pass to
+                `Blob.upload_from_filename`.
+
+        Returns:
+            The path that the object was uploaded to.
+
+        Examples:
+            Upload notes.txt to my_folder/notes.txt.
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.aupload_from_path("notes.txt", "my_folder/notes.txt")
+            ```
+        """
+        if to_path is None:
+            to_path = Path(from_path).name
+
+        bucket_path = self._join_bucket_folder(to_path)
+        bucket = await self.aget_bucket()
+        blob = bucket.blob(bucket_path)
+        self.logger.info(
+            f"Uploading from {from_path!r} to the bucket "
+            f"{self.bucket!r} path {bucket_path!r}."
+        )
+
+        await run_sync_in_worker_thread(
+            blob.upload_from_filename, filename=from_path, **upload_kwargs
+        )
+        return bucket_path
+
+    @async_dispatch(aupload_from_path)
+    def upload_from_path(
         self,
         from_path: Union[str, Path],
         to_path: Optional[str] = None,
@@ -1274,20 +2120,68 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             to_path = Path(from_path).name
 
         bucket_path = self._join_bucket_folder(to_path)
-        bucket = await self.get_bucket()
+        bucket = self.get_bucket()
+        blob = bucket.blob(bucket_path)
+
+        blob.upload_from_filename(filename=from_path, **upload_kwargs)
+        return bucket_path
+
+    async def aupload_from_file_object(
+        self, from_file_object: BinaryIO, to_path: str, **upload_kwargs
+    ) -> str:
+        """
+        Uploads an object to the object storage service from a file-like object
+        (async version), which can be a BytesIO object or a BufferedReader.
+
+        Args:
+            from_file_object: The file-like object to upload from.
+            to_path: The path to upload the object to; this gets prefixed
+                with the bucket_folder.
+            **upload_kwargs: Additional keyword arguments to pass to
+                `Blob.upload_from_file`.
+
+        Returns:
+            The path that the object was uploaded to.
+
+        Examples:
+            Upload my_folder/notes.txt object to a BytesIO object.
+            ```python
+            from io import BytesIO
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            with open("notes.txt", "rb") as f:
+                await gcs_bucket.aupload_from_file_object(f, "my_folder/notes.txt")
+            ```
+
+            Upload BufferedReader object to my_folder/notes.txt.
+            ```python
+            from io import BufferedReader
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            with open("notes.txt", "rb") as f:
+                await gcs_bucket.aupload_from_file_object(
+                    BufferedReader(f), "my_folder/notes.txt"
+                )
+            ```
+        """
+        bucket = await self.aget_bucket()
+
+        bucket_path = self._join_bucket_folder(to_path)
         blob = bucket.blob(bucket_path)
         self.logger.info(
-            f"Uploading from {from_path!r} to the bucket "
+            f"Uploading from file object to the bucket "
             f"{self.bucket!r} path {bucket_path!r}."
         )
 
         await run_sync_in_worker_thread(
-            blob.upload_from_filename, filename=from_path, **upload_kwargs
+            blob.upload_from_file, from_file_object, **upload_kwargs
         )
         return bucket_path
 
-    @sync_compatible
-    async def upload_from_file_object(
+    @async_dispatch(aupload_from_file_object)
+    def upload_from_file_object(
         self, from_file_object: BinaryIO, to_path: str, **upload_kwargs
     ) -> str:
         """
@@ -1327,22 +2221,75 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
                 )
             ```
         """
-        bucket = await self.get_bucket()
+        bucket = self.get_bucket()
 
         bucket_path = self._join_bucket_folder(to_path)
         blob = bucket.blob(bucket_path)
-        self.logger.info(
-            f"Uploading from file object to the bucket "
-            f"{self.bucket!r} path {bucket_path!r}."
-        )
 
-        await run_sync_in_worker_thread(
-            blob.upload_from_file, from_file_object, **upload_kwargs
-        )
+        blob.upload_from_file(from_file_object, **upload_kwargs)
         return bucket_path
 
-    @sync_compatible
-    async def upload_from_folder(
+    async def aupload_from_folder(
+        self,
+        from_folder: Union[str, Path],
+        to_folder: Optional[str] = None,
+        **upload_kwargs: Dict[str, Any],
+    ) -> str:
+        """
+        Uploads files *within* a folder (excluding the folder itself)
+        to the object storage service folder (async version).
+
+        Args:
+            from_folder: The path to the folder to upload from.
+            to_folder: The path to upload the folder to. If not provided, will default
+                to bucket_folder or the base directory of the bucket.
+            **upload_kwargs: Additional keyword arguments to pass to
+                `Blob.upload_from_filename`.
+
+        Returns:
+            The path that the folder was uploaded to.
+
+        Examples:
+            Upload local folder my_folder to the bucket's folder my_folder.
+            ```python
+            from prefect_gcp.cloud_storage import GcsBucket
+
+            gcs_bucket = GcsBucket.load("my-bucket")
+            await gcs_bucket.aupload_from_folder("my_folder")
+            ```
+        """
+        from_folder = Path(from_folder)
+        # join bucket folder expects string for the first input
+        # when it returns None, we need to convert it back to empty string
+        # so relative_to works
+        bucket_folder = self._join_bucket_folder(to_folder or "") or ""
+
+        num_uploaded = 0
+        bucket = await self.aget_bucket()
+
+        async_coros = []
+        for from_path in from_folder.rglob("**/*"):
+            if from_path.is_dir():
+                continue
+            bucket_path = str(Path(bucket_folder) / from_path.relative_to(from_folder))
+            self.logger.info(
+                f"Uploading from {str(from_path)!r} to the bucket "
+                f"{self.bucket!r} path {bucket_path!r}."
+            )
+            blob = bucket.blob(bucket_path)
+            async_coros.append(
+                run_sync_in_worker_thread(
+                    blob.upload_from_filename, filename=from_path, **upload_kwargs
+                )
+            )
+            num_uploaded += 1
+        await asyncio.gather(*async_coros)
+        if num_uploaded == 0:
+            self.logger.warning(f"No files were uploaded from {from_folder}.")
+        return bucket_folder
+
+    @async_dispatch(aupload_from_folder)
+    def upload_from_folder(
         self,
         from_folder: Union[str, Path],
         to_folder: Optional[str] = None,
@@ -1372,37 +2319,83 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             ```
         """
         from_folder = Path(from_folder)
-        # join bucket folder expects string for the first input
-        # when it returns None, we need to convert it back to empty string
-        # so relative_to works
         bucket_folder = self._join_bucket_folder(to_folder or "") or ""
 
         num_uploaded = 0
-        bucket = await self.get_bucket()
+        bucket = self.get_bucket()
 
-        async_coros = []
         for from_path in from_folder.rglob("**/*"):
             if from_path.is_dir():
                 continue
             bucket_path = str(Path(bucket_folder) / from_path.relative_to(from_folder))
-            self.logger.info(
-                f"Uploading from {str(from_path)!r} to the bucket "
-                f"{self.bucket!r} path {bucket_path!r}."
-            )
             blob = bucket.blob(bucket_path)
-            async_coros.append(
-                run_sync_in_worker_thread(
-                    blob.upload_from_filename, filename=from_path, **upload_kwargs
-                )
-            )
+            blob.upload_from_filename(filename=from_path, **upload_kwargs)
             num_uploaded += 1
-        await asyncio.gather(*async_coros)
+
         if num_uploaded == 0:
             self.logger.warning(f"No files were uploaded from {from_folder}.")
         return bucket_folder
 
-    @sync_compatible
-    async def upload_from_dataframe(
+    async def aupload_from_dataframe(
+        self,
+        df: "DataFrame",
+        to_path: str,
+        serialization_format: Union[
+            str, DataFrameSerializationFormat
+        ] = DataFrameSerializationFormat.CSV_GZIP,
+        **upload_kwargs: Dict[str, Any],
+    ) -> str:
+        """
+        Upload a Pandas DataFrame to Google Cloud Storage in various formats
+        (async version).
+
+        This function uploads the data in a Pandas DataFrame to Google Cloud Storage
+        in a specified format, such as .csv, .csv.gz, .parquet,
+        .parquet.snappy, and .parquet.gz.
+
+        Args:
+            df: The Pandas DataFrame to be uploaded.
+            to_path: The destination path for the uploaded DataFrame.
+            serialization_format: The format to serialize the DataFrame into.
+                When passed as a `str`, the valid options are:
+                'csv', 'csv_gzip',  'parquet', 'parquet_snappy', 'parquet_gzip'.
+                Defaults to `DataFrameSerializationFormat.CSV_GZIP`.
+            **upload_kwargs: Additional keyword arguments to pass to the underlying
+                `upload_from_dataframe` method.
+
+        Returns:
+            The path that the object was uploaded to.
+        """
+        if isinstance(serialization_format, str):
+            serialization_format = DataFrameSerializationFormat[
+                serialization_format.upper()
+            ]
+
+        with BytesIO() as bytes_buffer:
+            if serialization_format.format == "parquet":
+                df.to_parquet(
+                    path=bytes_buffer,
+                    compression=serialization_format.compression,
+                    index=False,
+                )
+            elif serialization_format.format == "csv":
+                df.to_csv(
+                    path_or_buf=bytes_buffer,
+                    compression=serialization_format.compression,
+                    index=False,
+                )
+
+            bytes_buffer.seek(0)
+            to_path = serialization_format.fix_extension_with(gcs_blob_path=to_path)
+
+            return await self.aupload_from_file_object(
+                from_file_object=bytes_buffer,
+                to_path=to_path,
+                **{"content_type": serialization_format.content_type, **upload_kwargs},
+            )
+
+    @async_dispatch(aupload_from_dataframe)
+    def upload_from_dataframe(
         self,
         df: "DataFrame",
         to_path: str,
@@ -1453,7 +2446,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             bytes_buffer.seek(0)
             to_path = serialization_format.fix_extension_with(gcs_blob_path=to_path)
 
-            return await self.upload_from_file_object(
+            return self.upload_from_file_object(
                 from_file_object=bytes_buffer,
                 to_path=to_path,
                 **{"content_type": serialization_format.content_type, **upload_kwargs},


### PR DESCRIPTION
closes #15008 (partially)

this pr migrates the remaining prefect-gcp modules from `@sync_compatible` to `@async_dispatch`

- migrated `bigquery.py`: 5 standalone tasks (`bigquery_query`, `bigquery_create_table`, `bigquery_insert_stream`, `bigquery_load_cloud_storage`, `bigquery_load_file`) and 5 `BigQueryWarehouse` methods (`fetch_one`, `fetch_many`, `fetch_all`, `execute`, `execute_many`)
- migrated `cloud_storage.py`: 5 standalone tasks (`cloud_storage_create_bucket`, `cloud_storage_download_blob_as_bytes`, `cloud_storage_download_blob_to_file`, `cloud_storage_upload_blob_from_string`, `cloud_storage_upload_blob_from_file`) and 15 `GcsBucket` methods
- follows the same pattern established in #20513 for `secret_manager.py`

<details>
<summary>async method naming convention</summary>

async versions are prefixed with `a` (e.g., `aread_path`, `alist_blobs`, `abigquery_query`)
sync versions use `@async_dispatch(async_version)` decorator and call blocking client methods directly
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)