### PR TITLE
add release notes for integration packages

### DIFF
--- a/docs/v3/release-notes/integrations/prefect-bitbucket.mdx
+++ b/docs/v3/release-notes/integrations/prefect-bitbucket.mdx
@@ -2,6 +2,20 @@
 title: prefect-bitbucket
 ---
 
+## 0.3.5
+
+_Released on February 03, 2026_
+
+**Bug Fixes**
+
+- fix: support username:password auth for self-hosted BitBucket instances [#19516](https://github.com/PrefectHQ/prefect/pull/19516) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+**Other**
+
+- migrate git integrations from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20407](https://github.com/PrefectHQ/prefect/pull/20407) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+---
+
 ## 0.3.4
 
 _Released on November 13, 2025_

--- a/docs/v3/release-notes/integrations/prefect-gcp.mdx
+++ b/docs/v3/release-notes/integrations/prefect-gcp.mdx
@@ -2,6 +2,23 @@
 title: prefect-gcp
 ---
 
+## 0.6.16
+
+_Released on February 03, 2026_
+
+**Features**
+
+- feat(cloud-run-v2): Add configurable UUID length for job names [#20468](https://github.com/PrefectHQ/prefect/pull/20468) by [@yukiyan](https://github.com/yukiyan)
+- feat: retry Cloud Run V2 job creation on transient errors [#20387](https://github.com/PrefectHQ/prefect/pull/20387) by [@Rodrigorm33](https://github.com/Rodrigorm33)
+
+**Other**
+
+- migrate prefect-gcp cloud_storage from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20522](https://github.com/PrefectHQ/prefect/pull/20522) by [@zzstoatzz](https://github.com/zzstoatzz)
+- migrate prefect-gcp bigquery from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20521](https://github.com/PrefectHQ/prefect/pull/20521) by [@zzstoatzz](https://github.com/zzstoatzz)
+- migrate prefect-gcp secret_manager from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20513](https://github.com/PrefectHQ/prefect/pull/20513) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+---
+
 ## 0.6.15
 
 _Released on January 15, 2026_

--- a/docs/v3/release-notes/integrations/prefect-github.mdx
+++ b/docs/v3/release-notes/integrations/prefect-github.mdx
@@ -2,6 +2,21 @@
 title: prefect-github
 ---
 
+## 0.4.1
+
+_Released on February 03, 2026_
+
+**Bug Fixes**
+
+- consolidate strip_auth_from_url into prefect._internal.urls [#20331](https://github.com/PrefectHQ/prefect/pull/20331) by [@zzstoatzz](https://github.com/zzstoatzz)
+- Prevent GitHub token leakage in git error messages [#20330](https://github.com/PrefectHQ/prefect/pull/20330) by [@Rodrigorm33](https://github.com/Rodrigorm33)
+
+**Other**
+
+- migrate git integrations from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20407](https://github.com/PrefectHQ/prefect/pull/20407) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+---
+
 ## 0.4.0
 
 _Released on January 15, 2026_

--- a/docs/v3/release-notes/integrations/prefect-gitlab.mdx
+++ b/docs/v3/release-notes/integrations/prefect-gitlab.mdx
@@ -2,6 +2,20 @@
 title: prefect-gitlab
 ---
 
+## 0.3.3
+
+_Released on February 03, 2026_
+
+**Documentation**
+
+- Remove Python 3.9 support [#19273](https://github.com/PrefectHQ/prefect/pull/19273) by [@desertaxle](https://github.com/desertaxle)
+
+**Other**
+
+- migrate git integrations from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20407](https://github.com/PrefectHQ/prefect/pull/20407) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+---
+
 ## 0.3.2
 
 _Released on October 23, 2025_

--- a/docs/v3/release-notes/integrations/prefect-kubernetes.mdx
+++ b/docs/v3/release-notes/integrations/prefect-kubernetes.mdx
@@ -2,6 +2,16 @@
 title: prefect-kubernetes
 ---
 
+## 0.7.4
+
+_Released on February 03, 2026_
+
+**Other**
+
+- migrate prefect-kubernetes from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20414](https://github.com/PrefectHQ/prefect/pull/20414) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+---
+
 ## 0.7.3
 
 _Released on January 15, 2026_

--- a/docs/v3/release-notes/integrations/prefect-shell.mdx
+++ b/docs/v3/release-notes/integrations/prefect-shell.mdx
@@ -1,0 +1,29 @@
+---
+title: prefect-shell
+---
+
+## 0.3.2
+
+_Released on February 03, 2026_
+
+**Features**
+
+- update classifiers and matrix generation for integrations 3.13 support [#17791](https://github.com/PrefectHQ/prefect/pull/17791) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+**Bug Fixes**
+
+- fix 3.9 test for prefect-shell [#18014](https://github.com/PrefectHQ/prefect/pull/18014) by [@zzstoatzz](https://github.com/zzstoatzz)
+- misc type fixes in `prefect-shell` [#18002](https://github.com/PrefectHQ/prefect/pull/18002) by [@zzstoatzz](https://github.com/zzstoatzz)
+- Migrate to `pyproject.toml` [#17116](https://github.com/PrefectHQ/prefect/pull/17116) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+**Documentation**
+
+- Remove Python 3.9 support [#19273](https://github.com/PrefectHQ/prefect/pull/19273) by [@desertaxle](https://github.com/desertaxle)
+- Bumps to `ruff==0.9.2` and `mypy==1.14.1` [#16916](https://github.com/PrefectHQ/prefect/pull/16916) by [@chrisguidry](https://github.com/chrisguidry)
+- Update links in blocks to not point to docs from archived repositories [#16031](https://github.com/PrefectHQ/prefect/pull/16031) by [@discdiver](https://github.com/discdiver)
+
+**Other**
+
+- migrate prefect-shell from [@sync](https://github.com/sync)_compatible to [@async](https://github.com/async)_dispatch [#20415](https://github.com/PrefectHQ/prefect/pull/20415) by [@zzstoatzz](https://github.com/zzstoatzz)
+- dev group for all integrations [#17273](https://github.com/PrefectHQ/prefect/pull/17273) by [@zzstoatzz](https://github.com/zzstoatzz)
+

--- a/docs/v3/release-notes/integrations/prefect-sqlalchemy.mdx
+++ b/docs/v3/release-notes/integrations/prefect-sqlalchemy.mdx
@@ -1,0 +1,16 @@
+---
+title: prefect-sqlalchemy
+---
+
+## 0.6.0
+
+_Released on February 03, 2026_
+
+**Breaking Changes**
+
+- Split prefect-sqlalchemy into `SqlAlchemyConnector` (sync) and `AsyncSqlAlchemyConnector` (async) [#20447](https://github.com/PrefectHQ/prefect/pull/20447) by [@zzstoatzz](https://github.com/zzstoatzz)
+
+**Documentation**
+
+- Remove Python 3.9 support [#19273](https://github.com/PrefectHQ/prefect/pull/19273) by [@desertaxle](https://github.com/desertaxle)
+


### PR DESCRIPTION
## Summary

Preparing releases related to #15008 (async_dispatch migration):

| Package | Version | Changes |
|---------|---------|---------|
| prefect-gcp | 0.6.16 | secret_manager, bigquery, cloud_storage async_dispatch + Cloud Run V2 improvements |
| prefect-kubernetes | 0.7.4 | async_dispatch migration |
| prefect-github | 0.4.1 | async_dispatch migration + token leakage fix |
| prefect-gitlab | 0.3.3 | async_dispatch migration |
| prefect-bitbucket | 0.3.5 | async_dispatch migration + self-hosted auth fix |
| prefect-shell | 0.3.2 | async_dispatch migration + 3.13 support |
| prefect-sqlalchemy | **0.6.0** | **Breaking**: splits `SqlAlchemyConnector` (sync) and `AsyncSqlAlchemyConnector` (async) |

## Test plan

- [x] Release notes generated via `just prepare-integration-release`
- [x] prefect-sqlalchemy version manually bumped to 0.6.0 (minor = breaking for pre-1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)