### PR TITLE
ci: fix potential script injection in Docker build workflows

### DIFF
--- a/.github/workflows/prefect-aws-docker-images.yaml
+++ b/.github/workflows/prefect-aws-docker-images.yaml
@@ -38,9 +38,12 @@ jobs:
 
     steps:
       - name: Set version environment variables
+        env:
+          PREFECT_VERSION_INPUT: ${{ inputs.prefect_version || github.event.inputs.prefect_version }}
+          PREFECT_AWS_VERSION_INPUT: ${{ inputs.prefect_aws_version || github.event.inputs.prefect_aws_version }}
         run: |
-          echo "PREFECT_VERSION=${{ inputs.prefect_version || github.event.inputs.prefect_version }}" >> $GITHUB_ENV
-          echo "PREFECT_AWS_VERSION=${{ inputs.prefect_aws_version || github.event.inputs.prefect_aws_version }}" >> $GITHUB_ENV
+          echo "PREFECT_VERSION=$PREFECT_VERSION_INPUT" >> $GITHUB_ENV
+          echo "PREFECT_AWS_VERSION=$PREFECT_AWS_VERSION_INPUT" >> $GITHUB_ENV
       
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -86,14 +86,14 @@ jobs:
         run: |
           CURRENT_TIME=${{ steps.build_time.outputs.build_time }}
 
-          if [ "${{ github.base_ref }}" != "" ]; then
+          if [ "$GITHUB_BASE_REF" != "" ]; then
             BASE_TIME=${{ steps.base_build_time.outputs.base_time }}
 
             echo "### 🏗️ Docker Build Time Comparison" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "| Branch | Build Time | Difference |" >> $GITHUB_STEP_SUMMARY
             echo "|--------|------------|------------|" >> $GITHUB_STEP_SUMMARY
-            echo "| base (${{ github.base_ref }}) | ${BASE_TIME}s | - |" >> $GITHUB_STEP_SUMMARY
+            echo "| base ($GITHUB_BASE_REF) | ${BASE_TIME}s | - |" >> $GITHUB_STEP_SUMMARY
 
             DIFF=$((CURRENT_TIME - BASE_TIME))
             PERCENT=$(echo "scale=2; ($CURRENT_TIME - $BASE_TIME) * 100 / $BASE_TIME" | bc)
@@ -106,7 +106,7 @@ jobs:
               DIFF_TEXT="✨ No change"
             fi
 
-            echo "| current (${{ github.head_ref }}) | ${CURRENT_TIME}s | $DIFF_TEXT |" >> $GITHUB_STEP_SUMMARY
+            echo "| current ($GITHUB_HEAD_REF) | ${CURRENT_TIME}s | $DIFF_TEXT |" >> $GITHUB_STEP_SUMMARY
 
             # Fail if build time increased by more than 5%
             if (( $(echo "$PERCENT > 5" | bc -l) )); then


### PR DESCRIPTION
Updating the Docker build workflows to handle GitHub context variables more safely. Direct interpolation of `${{ github.head_ref }}` and `${{ github.base_ref }}` in shell scripts can sometimes lead to command injection if a branch name contains malicious characters. Passing these through intermediate environment variables is the standard practice I follow to prevent such script injection risks.

Reviewing the logic in `prefect-aws-docker-images.yaml` and `time-docker-build.yaml`, I found several spots where branch names and inputs were used directly in `run:` steps. Moving these to the `env:` block ensures they are handled securely by the runner. This small change significantly improves the security posture of the CI/CD pipeline.

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.