### PR TITLE
Replace UI_COMPONENTS_CONTENTS_PRS_RW with GITHUB_TOKEN in nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   nightly-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -79,4 +81,4 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: true
-          token: ${{ secrets.UI_COMPONENTS_CONTENTS_PRS_RW }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces the inappropriate `UI_COMPONENTS_CONTENTS_PRS_RW` token with the default `GITHUB_TOKEN` in the nightly release workflow.

## Background

The `UI_COMPONENTS_CONTENTS_PRS_RW` token was originally designed for UI component repositories to create pull requests across multiple repositories. It's not the right fit for creating releases in the `prefect` repo itself.

## Changes

This PR:
1. Replaces `UI_COMPONENTS_CONTENTS_PRS_RW` with `GITHUB_TOKEN` in the nightly release workflow
2. Adds explicit `permissions: contents: write` to the job to ensure the token has sufficient permissions
3. Follows GitHub best practices for repository-scoped automation

Resolves [PLA-2280](https://linear.app/prefect/issue/PLA-2280/)