### PR TITLE
Fix `prefect deploy` stripping `{{ ctx.flow.* }}` templates from job variables

### DIFF
--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -300,7 +300,15 @@ async def _run_single_deploy(
     # Save triggers before templating to preserve event template parameters
     _triggers = deploy_config.pop("triggers", None)
 
-    deploy_config = apply_values(deploy_config, step_outputs, warn_on_notset=True)
+    # Preserve {{ ctx.* }} placeholders during deploy-time templating.
+    # These are runtime templates resolved by the worker's
+    # prepare_for_flow_run() and must not be stripped here.
+    deploy_config = apply_values(
+        deploy_config,
+        step_outputs,
+        warn_on_notset=True,
+        skip_prefixes=["ctx."],
+    )
     deploy_config["parameter_openapi_schema"] = _parameter_schema
     deploy_config["schedules"] = _schedules
 


### PR DESCRIPTION
Add `skip_prefixes` parameter to `apply_values` so callers can preserve
specific placeholder namespaces during templating. The deploy CLI now
passes `skip_prefixes=["ctx."]` to the main `apply_values` call, which
keeps `{{ ctx.flow.name }}` and `{{ ctx.flow_run.name }}` intact while
still resolving build/push step outputs and warning on genuinely missing
placeholders.

Previously, `apply_values` with `remove_notset=True` (the default)
would either strip the key entirely or replace the placeholder with an
empty string, destroying templates that are meant to be resolved at flow
run time by the worker's `prepare_for_flow_run()` method.