### PR TITLE
Improve CLI connection message for self-hosted server (Fixes #20599)

### DIFF
--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -198,7 +198,7 @@ def view(
 
     if ui_url := prefect.settings.PREFECT_UI_URL.value():
         app.console.print(
-            f"🚀 you are connected to:\n[green]{ui_url}[/green]", soft_wrap=True
+            f"🚀 Prefect UI URL:\n[green]{ui_url}[/green]", soft_wrap=True
         )
 
     # Display the profile first


### PR DESCRIPTION
Fixes #20599

This PR improves the CLI connection message when using a self-hosted Prefect server.

Previously, the CLI displayed a generic message that could be confusing. Now, when a connection to a self-hosted server is successful, the CLI clearly shows the configured server URL. This makes it easier for users to distinguish between Prefect Cloud and self-hosted deployments.

The change only affects the success message for self-hosted server connections and does not alter existing error messages or cloud connection behavior.

Tested locally by switching profiles and verifying the relevant connection status paths.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
