### PR TITLE
Use PAT token for nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -81,4 +81,4 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PREFECT_CONTENTS_RW }}


### PR DESCRIPTION
## Summary

Replace `GITHUB_TOKEN` with `PREFECT_CONTENTS_RW` PAT in the nightly release workflow to enable downstream workflows to trigger when releases are created.

## Related

-Relates to [PLA-2280](https://linear.app/prefect/issue/PLA-2280/replace-ui-components-contents-prs-rw-in-prefect-nightly-release)
- Platform PR: https://github.com/PrefectHQ/platform/pull/9759
- Original PR that introduced the issue: #20602