### PR TITLE
Fix incorrect concurrency_options key in debouncing guide

### DIFF
--- a/docs/v3/advanced/debouncing-events.mdx
+++ b/docs/v3/advanced/debouncing-events.mdx
@@ -196,8 +196,8 @@ deployments:
     entrypoint: flows/s3_processor.py:process_files
     work_pool:
       name: my-work-pool
-    concurrency_limit: 1
-    concurrency_options:
+    concurrency_limit:
+      limit: 1
       collision_strategy: CANCEL_NEW
     triggers:
       - type: event


### PR DESCRIPTION
`concurrency_options` is not a valid key in prefect.yaml — DeploymentConfig
uses extra="ignore", so it gets silently dropped. The correct form nests
`collision_strategy` under `concurrency_limit` alongside `limit`.

https://claude.ai/code/session_01FxVGQUThjN2pBKFQ2Avp3d