### PR TITLE
fix(schemas): include duration fields in TaskRunResponse

### DIFF
--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -389,6 +389,27 @@ class TaskRunResponse(ORMBaseModel):
         description="A list of tags for the task run.",
         examples=[["tag-1", "tag-2"]],
     )
+    start_time: Optional[DateTime] = Field(
+        default=None, description="The actual start time."
+    )
+    end_time: Optional[DateTime] = Field(
+        default=None, description="The actual end time."
+    )
+    total_run_time: datetime.timedelta = Field(
+        default=datetime.timedelta(0),
+        description=(
+            "Total run time. If the task run was executed multiple times, the time of"
+            " each run will be summed."
+        ),
+    )
+    estimated_run_time: datetime.timedelta = Field(
+        default=datetime.timedelta(0),
+        description="A real-time estimate of the total run time.",
+    )
+    estimated_start_time_delta: datetime.timedelta = Field(
+        default=datetime.timedelta(0),
+        description="The difference between actual and expected start time.",
+    )
 
 
 class DeploymentResponse(ORMBaseModel):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.


  Problem: /api/task_runs/paginate was missing duration fields that the UI expects.

  Solution: Added all 5 missing fields to TaskRunResponse schema (src/prefect/server/schemas/responses.py:392-412):
  - start_time
  - end_time
  - total_run_time
  - estimated_run_time
  - estimated_start_time_delta

Before:
<img width="1141" height="795" alt="Screenshot 2026-02-13 at 14 25 19" src="https://github.com/user-attachments/assets/697990a7-ce1c-4e56-ac3f-4fc6153c054a" />
After:
<img width="1138" height="796" alt="Screenshot 2026-02-13 at 14 24 59" src="https://github.com/user-attachments/assets/3f20a804-32ce-4af5-afd5-3c1fee0e003b" />


Closes: #20663