### PR TITLE
fix: skip lease renewal and release when no concurrency limits exist

### DIFF
--- a/src/prefect/concurrency/_asyncio.py
+++ b/src/prefect/concurrency/_asyncio.py
@@ -216,6 +216,11 @@ async def concurrency(
         holder=holder,
         suppress_warnings=suppress_warnings,
     )
+
+    if not response.limits:
+        yield
+        return
+
     emitted_events = emit_concurrency_acquisition_events(response.limits, occupy)
 
     try:

--- a/src/prefect/concurrency/_sync.py
+++ b/src/prefect/concurrency/_sync.py
@@ -128,6 +128,11 @@ def concurrency(
         holder=holder,
         suppress_warnings=suppress_warnings,
     )
+
+    if not acquisition_response.limits:
+        yield
+        return
+
     emitted_events = emit_concurrency_acquisition_events(
         acquisition_response.limits, occupy
     )


### PR DESCRIPTION
related to #19367

PR #19625 added client-side caching for the concurrency slot *acquire* path, but the lease renewal and release paths still fire unnecessary API calls when no limits exist for the given tags. this pr skips lease renewal and release entirely when the acquire response comes back with empty `limits`.

- when `response.limits` is empty, early-return from both async and sync `concurrency()` context managers — skip `maintain_concurrency_lease` and `release_concurrency_slots_with_lease`
- add regression tests for both async and sync paths

<details>
<summary>impact: tasks with tags but no concurrency limits configured</summary>

when tasks have tags (e.g. `@task(tags=["process-customer"])`) but no concurrency limit is configured for that tag, the acquire path correctly caches the "no limits" response after the first API call. however, each task still made:

1. a `renew_concurrency_lease` call with a synthetic lease ID (fails on the server)
2. a `release_concurrency_slots_with_lease` call with that same synthetic lease ID

for 300 submitted tasks, this meant ~600 unnecessary API calls. on prefect cloud's free plan (250 req/min), this caused significant rate limiting (429s), turning a 5-second batch into ~90 seconds.

**before fix:** 50 tasks → 56 API calls (1 acquire + 50 releases + 5 renewals)
**after fix:** 50 tasks → 1 API call (1 acquire, everything else skipped)
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)