### PR TITLE
S3 bucket folder double prefix with tasks executed on Ray workers

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -902,7 +902,8 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         # Prefect ResultStore pre-resolves paths for blocks without block_document_id).
         # See https://github.com/PrefectHQ/prefect-aws/issues/141 and GCS equivalent.
         if self.bucket_folder and (
-            path == self.bucket_folder or path.startswith(self.bucket_folder + "/")
+            path == self.bucket_folder
+            or path.startswith(self.bucket_folder.rstrip("/") + "/")
         ):
             return path
 

--- a/src/integrations/prefect-aws/tests/test_s3.py
+++ b/src/integrations/prefect-aws/tests/test_s3.py
@@ -759,12 +759,32 @@ def test_resolve_path(s3_bucket):
 
 def test_resolve_path_no_double_prefix(s3_bucket):
     """When path already contains bucket_folder, _resolve_path should not duplicate it."""
-    s3_bucket.bucket_folder = "prefect-flow-template-dev/prefect-3"
+    s3_bucket.bucket_folder = "twinspector/stereo-pairs"
     # Simple key - should get prefix
-    assert s3_bucket._resolve_path("abc123") == "prefect-flow-template-dev/prefect-3/abc123"
+    assert (
+        s3_bucket._resolve_path("scene_2025-06-01_T32UQD.tif")
+        == "twinspector/stereo-pairs/scene_2025-06-01_T32UQD.tif"
+    )
     # Already-prefixed path - should NOT get duplicated
-    already_prefixed = "prefect-flow-template-dev/prefect-3/task_cache_key"
+    already_prefixed = "twinspector/stereo-pairs/scene_2025-08-12_T32UQD.tif"
     assert s3_bucket._resolve_path(already_prefixed) == already_prefixed
+    # Exact match (path equals bucket_folder)
+    assert (
+        s3_bucket._resolve_path("twinspector/stereo-pairs")
+        == "twinspector/stereo-pairs"
+    )
+    # Prefix-substring that is NOT a sub-path should still get prefixed
+    s3_bucket.bucket_folder = "sentinel-2"
+    assert (
+        s3_bucket._resolve_path("sentinel-2A/T32UQD/ndvi.tif")
+        == "sentinel-2/sentinel-2A/T32UQD/ndvi.tif"
+    )
+    # Trailing slash on bucket_folder should not break the guard
+    s3_bucket.bucket_folder = "insar/deformation/"
+    assert (
+        s3_bucket._resolve_path("insar/deformation/velocity_map.tif")
+        == "insar/deformation/velocity_map.tif"
+    )
 
 
 class TestS3Bucket:


### PR DESCRIPTION
With `S3Bucket` + bucket folder and Ray task runner, task results are stored under `folder/folder/key` instead of `folder/key` -> so caching fails.

**Root cause**
- Block serialization includes `_block_document_id` (via `@model_serializer`), but `Block.model_validate()` explicitly strips it during deserialization.
- A dump/validate (happens while sending the block to a Ray worker) leaves `_block_document_id = None`
- With no block ID, `ResultStore` pre-resolves keys via `_resolve_path`, prepending the bucket folder.
- Then `S3Bucket.write_path` calls` _resolve_path` again, doubling the prefix.

**Fix**
- Make `S3Bucket._resolve_path` idempotent: return paths that already equal or start with the bucket folder unchanged, so already-prefixed paths are not modified.
 
-> Same pattern as for GCS `_resolve_path` (#20174) and prefect-aws#141

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [X] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [X] If this pull request adds functions or classes, it includes helpful docstrings.
