### PR TITLE
docs: clarify that primitive `wait_for_input` types generate a `value` field for programmatic resume

### DIFF
--- a/docs/v3/advanced/interactive.mdx
+++ b/docs/v3/advanced/interactive.mdx
@@ -68,6 +68,7 @@ Prefect automatically creates a Pydantic model containing one field annotated wi
 The auto-generated field is always named `value`. This matters when resuming a paused flow run programmatically with
 `resume_flow_run()`—you must provide the input as a dictionary with that field name:
 
+{/* pmd-metadata: notest */}
 ```python
 from prefect.flow_runs import resume_flow_run
 


### PR DESCRIPTION
Related to https://github.com/PrefectHQ/prefect/discussions/20733

This PR clarifies a gap in the interactive workflows docs that confused users trying to call `resume_flow_run()` programmatically after pausing with a primitive type.

<details>
<summary>What was missing</summary>

When you pass a built-in type to `pause_flow_run(wait_for_input=str)`, Prefect auto-generates a Pydantic model with a single field named `value`. The docs mentioned the auto-generated model but never stated the field name or its implication for programmatic resumption—leaving users unsure how to construct the `run_input` dict for `resume_flow_run()`.

The fix adds a concrete example showing:

```python
resume_flow_run(flow_run_id, run_input={"value": "Alice"})
```

and points users toward `RunInput`/`BaseModel` if they want control over the field name.
</details>