### PR TITLE
Fix observer pod event handling: use camelCase keys from Kubernetes API

### DIFF
--- a/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/test_crash_detection.py
+++ b/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/test_crash_detection.py
@@ -159,7 +159,7 @@ async def test_backoff_limit_exhausted(
     event_types = {event.event for event in events}
     assert "prefect.kubernetes.pod.pending" in event_types, "Missing pending event"
     assert "prefect.kubernetes.pod.running" in event_types, "Missing running event"
-    assert "prefect.kubernetes.pod.failed" in event_types, "Missing failed event"
+    assert "prefect.kubernetes.pod.evicted" in event_types, "Missing evicted event"
 
     # Verify we have events from both pod attempts
     event_list = [event.event for event in events]
@@ -168,11 +168,11 @@ async def test_backoff_limit_exhausted(
     assert pending_count >= 1, "Expected at least one pending event"
     running_count = event_list.count("prefect.kubernetes.pod.running")
     assert running_count >= 1, "Expected at least one running event"
-    failed_count = event_list.count("prefect.kubernetes.pod.failed")
-    assert failed_count >= 1, "Expected at least one failed event"
+    evicted_count = event_list.count("prefect.kubernetes.pod.evicted")
+    assert evicted_count >= 1, "Expected at least one evicted event"
 
     # Verify the backoff retry happened
-    total_events = pending_count + running_count + failed_count
+    total_events = pending_count + running_count + evicted_count
     assert total_events >= 4, (
         f"Expected at least 4 events for retry, got {total_events}"
     )

--- a/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/test_eviction.py
+++ b/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/test_eviction.py
@@ -328,10 +328,10 @@ async def test_pod_eviction_with_backoff_limit(
     # Instead of checking exact order, check that we have the required event types
     event_types = {event.event for event in events}
 
-    # Must have pending, running, and failed events
+    # Must have pending, running, and evicted events
     assert "prefect.kubernetes.pod.pending" in event_types, "Missing pending event"
     assert "prefect.kubernetes.pod.running" in event_types, "Missing running event"
-    assert "prefect.kubernetes.pod.failed" in event_types, "Missing failed event"
+    assert "prefect.kubernetes.pod.evicted" in event_types, "Missing evicted event"
 
     # We should either have exactly the right 6 events or at least the first 4
     if len(events) == 6:
@@ -339,7 +339,7 @@ async def test_pod_eviction_with_backoff_limit(
         assert [event.event for event in events] == [
             "prefect.kubernetes.pod.pending",
             "prefect.kubernetes.pod.running",
-            "prefect.kubernetes.pod.failed",
+            "prefect.kubernetes.pod.evicted",
             "prefect.kubernetes.pod.pending",
             "prefect.kubernetes.pod.running",
             "prefect.kubernetes.pod.succeeded",

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -117,7 +117,10 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
             {
                 "uid": uid,
                 "phase": phase,
-                "restart_count": status.get("restart_count", 0),
+                "restart_count": sum(
+                    cs.get("restartCount", 0)
+                    for cs in status.get("containerStatuses", [])
+                ),
             },
             sort_keys=True,
         ),
@@ -168,7 +171,7 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
     }
     # Add eviction reason if the pod was evicted for debugging purposes
     if event_type == "MODIFIED" and phase == "Failed":
-        for container_status in status.get("container_statuses", []):
+        for container_status in status.get("containerStatuses", []):
             if (
                 terminated := container_status.get("state", {}).get("terminated", {})
             ) and (reason := terminated.get("reason")):

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -154,7 +154,7 @@ class TestReplicatePodEvent:
             },
             status={
                 "phase": "Failed",
-                "container_statuses": [
+                "containerStatuses": [
                     {"state": {"terminated": {"reason": "OOMKilled"}}}
                 ],
             },


### PR DESCRIPTION
The observer's eviction detection checked `status.get("container_statuses", [])` but kopf passes raw Kubernetes API JSON which uses camelCase (`containerStatuses`). This caused the lookup to always return an empty list, so OOMKilled pods emitted `prefect.kubernetes.pod.failed` instead of `prefect.kubernetes.pod.evicted`, preventing OOM automations from firing.

Also fixes the test mock data to use the correct camelCase key so the test validates real-world behavior.

Closes https://github.com/PrefectHQ/prefect/issues/20785

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
