### PR TITLE
fix(cli): remove bogus alias="-jv" from cyclopts deployment command

### DIFF
--- a/src/prefect/cli/_cyclopts/deployment.py
+++ b/src/prefect/cli/_cyclopts/deployment.py
@@ -293,7 +293,6 @@ async def run(
         Optional[list[str]],
         cyclopts.Parameter(
             "--job-variable",
-            alias="-jv",
             help=(
                 "A key, value pair (key=value) specifying a flow run job variable. The value will"
                 " be interpreted as JSON. May be passed multiple times to specify multiple"


### PR DESCRIPTION
## Summary

The `deployment run` cyclopts command had `alias="-jv"` on its `--job-variable` parameter, but cyclopts can't parse multi-char single-dash flags — it silently splits `-jv` into `-j` + `-v`. The alias was a no-op.

The global rewrite table added in #20783 (`_MULTICHAR_SHORT_FLAGS` in `_normalize_top_level_flags`) already handles `-jv` correctly for all subcommands, so the bogus alias is unnecessary and misleading.

## Test plan

- [x] `PREFECT_CLI_FAST=1 uv run pytest tests/cli/deployment/test_deployment_run.py::test_deployment_runs_with_job_variables` — 2 passed (both `-jv` and `--job-variable` parametrizations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)