### PR TITLE
ci: split database and orchestration tests into separate jobs

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -53,8 +53,10 @@ jobs:
         test-type:
           - name: Server Tests
             modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/orchestration/
-          - name: Database and Orchestration Tests
-            modules: tests/server/database/ tests/server/orchestration/
+          - name: Database Tests
+            modules: tests/server/database/
+          - name: Orchestration Tests
+            modules: tests/server/orchestration/
           - name: Client Tests
             modules: >-
               tests/


### PR DESCRIPTION
this PR splits the combined "Database and Orchestration Tests" matrix entry into two separate entries ("Database Tests" and "Orchestration Tests") so they run in parallel rather than sequentially.

<details>

The combined job was hitting the 15-minute CI timeout on SQLite. The orchestration suite alone is ~40k lines across 30+ test files, and running it back-to-back with the database/migration tests (which include some 120-second timeout guards) was too much for a single job.

Splitting them gives each its own 15-minute budget and lets them execute concurrently across the matrix.

</details>