### PR TITLE
refactor(cli): extract shared utils from typer command files

### DIFF
--- a/plans/2026-02-05-cli-cyclopts-migration.md
+++ b/plans/2026-02-05-cli-cyclopts-migration.md
@@ -220,30 +220,174 @@ Acceptance:
 
 ## Phase 3: Default Flip and Typer Retirement
 
-Problem: We need a clear path to make Cyclopts the default and retire Typer without breaking users.
+**Status:** Phase 2 complete. Full test suite passes under `PREFECT_CLI_FAST=1`:
+- `tests/cli/`: 1189 passed, 8 skipped (4 typer-specific, 1 windows, 1 TODO, 2 color)
+- `tests/events/client/cli/test_automations.py`: 46 passed
 
-Plan:
+### Current file layout
 
-1. Once all command groups are migrated and parity tests pass, flip the default to Cyclopts and keep a legacy opt-out toggle.
-2. Communicate the default flip and timeline for Typer removal.
-3. Remove Typer dependency and legacy code paths after a deprecation period.
+```
+src/prefect/cli/
+├── _cyclopts/                    ← 29 files, ~11,850 lines (new impl, becomes the CLI)
+│   ├── __init__.py               ← app, root callback, command registrations
+│   ├── _utilities.py             ← exit helpers, exception handling
+│   ├── deployment.py, deploy.py, server.py, ...  ← command modules
+│
+├── *.py                          ← ~20 typer command files, ~9,200 lines (to be deleted)
+│   ├── root.py                   ← typer app, root callback (to be deleted)
+│   ├── _typer_loader.py          ← typer registration (to be deleted)
+│   ├── _types.py                 ← typer-specific types (to be deleted)
+│   ├── _utilities.py             ← typer utilities (to be deleted)
+│
+├── _prompts.py                   ← SHARED (14 cyclopts files import from it)
+├── _server_utils.py              ← SHARED (cyclopts server.py imports from it)
+├── _cloud_utils.py               ← SHARED (cyclopts cloud.py imports from it)
+├── _worker_utils.py              ← SHARED (cyclopts worker.py imports from it)
+├── _transfer_utils.py            ← SHARED (cyclopts transfer.py imports from it)
+├── flow_runs_watching.py         ← SHARED (cyclopts deployment.py imports from it)
+├── deploy/                       ← SHARED business logic (_config, _core, _schedules, etc.)
+├── transfer/                     ← SHARED business logic (_dag, _exceptions, _migratable_resources/)
+│
+├── __init__.py                   ← toggle/routing logic (to be simplified)
+│
+├── cloud/                        ← typer cloud commands (to be deleted, cyclopts cloud.py replaces them)
+├── profile.py                    ← typer profile (to be deleted, BUT exports ConnectionStatus/check_server_connection used by cyclopts)
+├── shell.py                      ← typer shell (to be deleted, BUT exports run_shell_process used by cyclopts)
+```
 
-Acceptance:
+### Shared modules that survive
 
-1. Cyclopts is the default CLI and passes the full CLI test suite.
-2. Typer can be removed cleanly without functional regressions.
+These contain framework-agnostic business logic. Cyclopts commands already import from them. They stay in `src/prefect/cli/` unchanged:
 
-Scope: Flip default, deprecation period, remove typer dependency.
+| module | consumers | what it provides |
+|---|---|---|
+| `_prompts.py` (887 lines) | 14 cyclopts files | `confirm`, `prompt_select_from_table`, `prompt` |
+| `_server_utils.py` (411 lines) | cyclopts `server.py` | `SERVER_PID_FILE_NAME`, `_run_in_background`, `_run_in_foreground`, `prestart_check`, `_run_all_services`, etc. |
+| `_cloud_utils.py` (431 lines) | cyclopts `cloud.py` | `login_with_browser`, `prompt_for_account_and_workspace`, `check_key_is_valid_for_login`, etc. |
+| `_worker_utils.py` (133 lines) | cyclopts `worker.py` | `_load_worker_class`, `_check_work_pool_paused`, etc. |
+| `_transfer_utils.py` (121 lines) | cyclopts `transfer.py` | `collect_resources`, `execute_transfer`, etc. |
+| `flow_runs_watching.py` (191 lines) | cyclopts `deployment.py` | `watch_flow_run` |
+| `deploy/` subpackage | cyclopts `deploy.py` | `_run_multi_deploy`, `_run_single_deploy`, `_config`, `_schedules`, etc. |
+| `transfer/` subpackage | cyclopts `transfer.py` | `TransferDAG`, `TransferSkipped`, `_migratable_resources/` |
+
+### Business logic to extract before deletion
+
+Two typer command files export non-CLI functions that cyclopts commands import. These need to be moved to shared modules before the typer files can be deleted:
+
+| typer file | exports used by cyclopts | move to |
+|---|---|---|
+| `profile.py` | `ConnectionStatus`, `check_server_connection` | `_profile_utils.py` (new, ~80 lines) |
+| `shell.py` | `run_shell_process` | `_shell_utils.py` (new, ~100 lines) |
+
+### PR breakdown
+
+**PR 1: flip the default** (~30 lines changed)
+
+Invert the toggle so cyclopts is the default and typer is the opt-in escape hatch.
+
+- `src/prefect/cli/__init__.py`: change `_USE_CYCLOPTS` to `_USE_TYPER`, default to cyclopts
+  - `_USE_TYPER = os.environ.get("PREFECT_CLI_TYPER", "").lower() in ("1", "true")`
+  - invert `_should_delegate_to_typer` → only used when `_USE_TYPER` is set
+  - when `_USE_TYPER` is not set, go straight to `_cyclopts_app()`
+- `src/prefect/testing/cli.py`: invert the runner selection logic
+- update env var references in CI, tests, benchmarks (`PREFECT_CLI_FAST` → removed, `PREFECT_CLI_TYPER` → opt-in)
+- files touched: `src/prefect/cli/__init__.py`, `src/prefect/testing/cli.py`, `.github/workflows/python-tests.yaml`, `benches/cli-bench.toml`, ~10 test files that reference `PREFECT_CLI_FAST` or `_USE_CYCLOPTS`
+
+Validation: `uv run pytest tests/cli/ -n4` passes (now running cyclopts by default). `PREFECT_CLI_TYPER=1 uv run pytest tests/cli/ -n4` also passes (typer fallback).
+
+Estimated: ~30 lines of logic changes + ~40 lines of env var renames across 16 files.
+
+**PR 2: extract shared business logic from typer files** (~200 lines moved)
+
+Move non-CLI functions out of typer command files so those files can be cleanly deleted.
+
+- create `src/prefect/cli/_profile_utils.py`: move `ConnectionStatus` enum and `check_server_connection()` from `profile.py`
+- create `src/prefect/cli/_shell_utils.py`: move `run_shell_process()` from `shell.py`
+- update imports in:
+  - `src/prefect/cli/_cyclopts/profile.py`: `from prefect.cli._profile_utils import ...`
+  - `src/prefect/cli/_cyclopts/shell.py`: `from prefect.cli._shell_utils import ...`
+  - `src/prefect/cli/profile.py`: `from prefect.cli._profile_utils import ...` (typer version still works while escape hatch exists)
+  - `src/prefect/cli/shell.py`: `from prefect.cli._shell_utils import ...`
+
+Estimated: ~200 lines moved, ~20 import fixups. Zero behavior change.
+
+**PR 3: move `_cyclopts/` contents up to `cli/`** (~800 lines of import path changes)
+
+Rename the cyclopts modules to become the primary CLI modules. This is the wholesale file path migration.
+
+Approach: `git mv` each file, then find-and-replace all import paths.
+
+- `src/prefect/cli/_cyclopts/__init__.py` → merge into `src/prefect/cli/__init__.py` (the app, root callback, and command registrations become the sole entrypoint)
+- `src/prefect/cli/_cyclopts/_utilities.py` → `src/prefect/cli/_utilities.py` (replaces the typer one)
+- `src/prefect/cli/_cyclopts/deployment.py` → `src/prefect/cli/deployment.py` (replaces the typer one)
+- ... same pattern for all 27 command modules
+
+Import paths to rewrite:
+- 84 occurrences of `prefect.cli._cyclopts` across 31 source files → `prefect.cli`
+- ~17 test files that monkeypatch `prefect.cli._cyclopts.*` → `prefect.cli.*`
+- `import prefect.cli._cyclopts as _cli` in every command file → `import prefect.cli as _cli`
+
+The `_cyclopts/` directory is deleted after all moves.
+
+Estimated: ~0 new lines of logic. ~800 lines of mechanical import path changes across ~50 files.
+
+**PR 4: delete typer command files and infrastructure** (~-11,000 lines)
+
+Remove all typer-only code now that cyclopts is the sole implementation.
+
+Delete:
+- typer command files: `root.py`, `server.py`, `worker.py`, `shell.py` (now just the extracted util), `config.py`, `profile.py` (now just the extracted util), `flow_run.py`, `flow.py`, `deployment.py`, `work_pool.py`, `work_queue.py`, `variable.py`, `block.py`, `concurrency_limit.py`, `global_concurrency_limit.py`, `artifact.py`, `experimental.py`, `events.py`, `task.py`, `task_run.py`, `api.py`, `dashboard.py`, `dev.py`, `sdk.py`
+- typer infrastructure: `_typer_loader.py`, `_types.py`
+- typer cloud commands: `cloud/__init__.py`, `cloud/webhook.py`, `cloud/asset.py`, `cloud/ip_allowlist.py`
+- typer automations: `src/prefect/events/cli/automations.py`
+- test-time migration scaffolding: `tests/cli/test_cyclopts_parity.py`, `tests/cli/test_cyclopts_runner.py`
+
+Simplify:
+- `src/prefect/cli/__init__.py`: remove `_USE_TYPER`, `_should_delegate_to_typer`, `_DELEGATE_FLAGS`, `_CYCLOPTS_COMMANDS`, `_FLAGS_WITH_VALUES`. The entrypoint just calls `app()` directly.
+- `src/prefect/testing/cli.py`: remove typer `CliRunner` branch from `invoke_and_assert`, remove `_USE_CYCLOPTS` checks. `CycloptsCliRunner` becomes the only runner (can be renamed to just `CliRunner`).
+- CI: remove `PREFECT_CLI_TYPER` matrix leg, remove typer-specific test skips
+
+Estimated: ~-11,000 lines deleted, ~-200 lines of routing/toggle logic removed, ~50 lines of test simplification.
+
+**PR 5: remove typer dependency** (~10 lines)
+
+- `pyproject.toml`: remove `typer` from dependencies
+- `client/pyproject.toml`: parallel change if typer is listed there
+- verify nothing else imports typer: `rg "import typer" src/prefect/`
+
+This is kept as a separate PR because it's the point of no return — if anything was missed, this is where it surfaces.
+
+Estimated: ~10 lines.
+
+### Summary
+
+| PR | description | lines changed (est.) | risk |
+|---|---|---|---|
+| 1 | flip default | +70 / -70 | low — tests already pass under cyclopts |
+| 2 | extract shared business logic | +220 / -20 | low — pure refactor, no behavior change |
+| 3 | move `_cyclopts/` up to `cli/` | +400 / -400 | medium — large rename, but mechanical |
+| 4 | delete typer code | +50 / -11,200 | low — everything already tested without typer |
+| 5 | remove typer dependency | +0 / -10 | low — final validation |
+
+**Total: ~-11,000 net lines removed.** ~750 lines of mechanical rename work. No new application logic.
+
+PRs 1-2 can be done independently (no ordering dependency between them). PR 3 depends on PR 2. PR 4 depends on PR 3. PR 5 depends on PR 4.
+
+### Acceptance criteria
+
+1. `uv run pytest tests/cli/ tests/events/client/cli/ -n4` passes with no `PREFECT_CLI_*` env vars set (cyclopts is the default).
+2. No references to `prefect.cli._cyclopts` remain in the codebase.
+3. No references to `PREFECT_CLI_FAST` or `PREFECT_CLI_TYPER` remain.
+4. `typer` is not in `pyproject.toml` dependencies.
+5. `rg "import typer" src/prefect/` returns zero matches.
 
 ## Testing Strategy
 
-### Existing test infrastructure: `invoke_and_assert`
+### Test infrastructure: `invoke_and_assert`
 
-The current CLI test suite uses `invoke_and_assert` (`src/prefect/testing/cli.py`), which wraps typer's `CliRunner` to test commands in-process. There are ~950 call sites across 35 test files.
+The CLI test suite uses `invoke_and_assert` (`src/prefect/testing/cli.py`), which wraps an internal `CycloptsCliRunner` to test commands in-process. There are ~950 call sites across 35 test files.
 
-**Key constraint (empirically verified):** `invoke_and_assert` cannot test cyclopts commands through typer's `CliRunner`. With `PREFECT_CLI_FAST=1`, `from prefect.cli import app` returns a plain function (the cyclopts entrypoint), not a `Typer` instance. Typer's `CliRunner` raises `AttributeError: 'function' object has no attribute '_add_completion'`.
-
-**During migration (Phases 0–2) and beyond:** `invoke_and_assert` now supports both frameworks via an internal `CycloptsCliRunner`. When `PREFECT_CLI_FAST=1`, it uses the cyclopts runner; otherwise it uses typer's `CliRunner`. The ~950 call sites do not need to change.
+**During the migration (Phases 0–2):** `invoke_and_assert` supported both frameworks — `CycloptsCliRunner` when `PREFECT_CLI_FAST=1`, typer's `CliRunner` otherwise. After Phase 3, the typer branch will be removed and `CycloptsCliRunner` becomes the sole runner.
 
 ### `CycloptsCliRunner` (`src/prefect/testing/cli.py`)
 
@@ -331,33 +475,33 @@ CLI startup benchmarks already run in CI via [python-cli-bench](https://github.c
 
 ## Risks and Mitigations
 
-1. Risk: Global flags and startup behavior drift between frameworks.
-   Mitigation: Shared entrypoint module and parity tests for `--profile`, `--prompt`, and `--version`.
-2. Risk: Command help text diverges.
-   Mitigation: Route help/version/completion to Typer until parity is guaranteed; treat differences as regressions unless explicitly approved and documented.
-3. Risk: Migration slows due to large surface area.
-   Mitigation: Per-group PRs with explicit scope and regression tests.
+### Phase 2 risks (resolved)
 
-## Edge Cases
+1. ~~Risk: Global flags and startup behavior drift between frameworks.~~
+   Resolved: Parity tests validated identical behavior; full test suite passes under cyclopts.
+2. ~~Risk: Command help text diverges.~~
+   Resolved: All commands migrated, help output validated through test suite.
+3. ~~Risk: Migration slows due to large surface area.~~
+   Resolved: All command groups migrated across waves 1–5.
 
-| Scenario | Behavior |
-|----------|----------|
-| Unknown command with toggle enabled | Delegate to Typer (error message remains Typer's) |
-| Cyclopts not installed, toggle enabled | Error with install hint |
-| `--help` / `--version` / completion with toggle enabled | Route to Typer until help parity is guaranteed |
-| Partially migrated command group | Delegated commands route to Typer; only migrated commands use cyclopts |
+### Phase 3 risks
+
+1. Risk: File rename PR (PR 3) breaks downstream forks or tools that import from `prefect.cli._cyclopts`.
+   Mitigation: `_cyclopts` is a private module (leading underscore), not public API. No external consumers expected.
+2. Risk: Monkeypatch targets in tests break after rename.
+   Mitigation: Systematic `rg` sweep for all `_cyclopts` references before and after rename.
+3. Risk: Removing typer reveals hidden imports we missed.
+   Mitigation: PR 5 (remove dependency) is a separate, small PR specifically to catch this.
 
 ## Verification Checklist
 
-### Automated
-- `uv run pytest tests/cli/` passes (existing tests via typer)
-- `uv run pytest tests/cli/test_cyclopts_parity.py` passes (parity tests via subprocess)
-- Type checker passes
-
-### Manual
-- `prefect --help` output matches current CLI
-- `prefect --version` output matches current CLI
-- `prefect --profile <name> ...` selects the correct profile
+### After Phase 3 completion
+- `uv run pytest tests/cli/ tests/events/client/cli/ -n4` passes with no env vars
+- `rg "prefect.cli._cyclopts" src/ tests/` returns zero matches
+- `rg "PREFECT_CLI_FAST|PREFECT_CLI_TYPER" src/ tests/ .github/` returns zero matches
+- `rg "import typer" src/prefect/` returns zero matches
+- `prefect --help`, `prefect --version`, `prefect config view` work correctly
+- `prefect --profile <name> config view` selects the correct profile
 
 ## References
 

--- a/src/prefect/cli/_cyclopts/profile.py
+++ b/src/prefect/cli/_cyclopts/profile.py
@@ -23,7 +23,7 @@ from prefect.cli._cyclopts._utilities import (
     exit_with_success,
     with_cli_exception_handling,
 )
-from prefect.cli.profile import ConnectionStatus, check_server_connection
+from prefect.cli._profile_utils import ConnectionStatus, check_server_connection
 from prefect.context import use_profile
 from prefect.settings import ProfilesCollection
 from prefect.settings.profiles import _read_profiles_from, _write_profiles_to

--- a/src/prefect/cli/_cyclopts/shell.py
+++ b/src/prefect/cli/_cyclopts/shell.py
@@ -52,7 +52,7 @@ async def watch(
     """
     Execute a shell command and observe it as a Prefect flow.
     """
-    from prefect.cli.shell import run_shell_process
+    from prefect.cli._shell_utils import run_shell_process
     from prefect.context import tags
 
     tag = (tag or []) + ["shell"]
@@ -116,7 +116,7 @@ async def serve(
     if concurrency_limit is not None and concurrency_limit < 1:
         exit_with_error("--concurrency-limit must be >= 1.")
 
-    from prefect.cli.shell import run_shell_process
+    from prefect.cli._shell_utils import run_shell_process
     from prefect.client.schemas.actions import DeploymentScheduleCreate
     from prefect.client.schemas.schedules import CronSchedule
     from prefect.runner import Runner

--- a/src/prefect/cli/_profile_utils.py
+++ b/src/prefect/cli/_profile_utils.py
@@ -1,0 +1,90 @@
+"""
+Shared utilities for profile connection checking.
+
+Extracted from prefect.cli.profile so both typer and cyclopts
+command modules can import without pulling in CLI framework deps.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from prefect.client.base import determine_server_type
+from prefect.client.orchestration import ServerType, get_client
+from prefect.utilities.collections import AutoEnum
+
+
+class ConnectionStatus(AutoEnum):
+    CLOUD_CONNECTED = AutoEnum.auto()
+    CLOUD_ERROR = AutoEnum.auto()
+    CLOUD_UNAUTHORIZED = AutoEnum.auto()
+    SERVER_CONNECTED = AutoEnum.auto()
+    SERVER_ERROR = AutoEnum.auto()
+    UNCONFIGURED = AutoEnum.auto()
+    EPHEMERAL = AutoEnum.auto()
+    INVALID_API = AutoEnum.auto()
+
+
+async def check_server_connection() -> ConnectionStatus:
+    httpx_settings = dict(timeout=3)
+    try:
+        # First determine the server type based on the URL
+        server_type = determine_server_type()
+
+        # Only try to connect to Cloud if the URL looks like a Cloud URL
+        if server_type == ServerType.CLOUD:
+            from prefect.client.cloud import CloudUnauthorizedError, get_cloud_client
+
+            try:
+                cloud_client = get_cloud_client(
+                    httpx_settings=httpx_settings, infer_cloud_url=True
+                )
+                async with cloud_client:
+                    await cloud_client.api_healthcheck()
+                return ConnectionStatus.CLOUD_CONNECTED
+            except CloudUnauthorizedError:
+                # if the Cloud API exists and fails to authenticate, notify the user
+                return ConnectionStatus.CLOUD_UNAUTHORIZED
+            except (httpx.HTTPStatusError, Exception):
+                return ConnectionStatus.CLOUD_ERROR
+
+        # For non-Cloud URLs, try to connect as a hosted Prefect instance
+        if server_type == ServerType.EPHEMERAL:
+            return ConnectionStatus.EPHEMERAL
+        elif server_type == ServerType.UNCONFIGURED:
+            return ConnectionStatus.UNCONFIGURED
+
+        # Try to connect to the server
+        try:
+            client = get_client(httpx_settings=httpx_settings)
+            async with client:
+                connect_error = await client.api_healthcheck()
+            if connect_error is not None:
+                return ConnectionStatus.SERVER_ERROR
+            else:
+                return ConnectionStatus.SERVER_CONNECTED
+        except Exception:
+            return ConnectionStatus.SERVER_ERROR
+    except TypeError:
+        # if no Prefect API URL has been set, httpx will throw a TypeError
+        try:
+            # try to connect with the client anyway, it will likely use an
+            # ephemeral Prefect instance
+            server_type = determine_server_type()
+            if server_type == ServerType.EPHEMERAL:
+                return ConnectionStatus.EPHEMERAL
+            elif server_type == ServerType.UNCONFIGURED:
+                return ConnectionStatus.UNCONFIGURED
+            client = get_client(httpx_settings=httpx_settings)
+            if client.server_type == ServerType.EPHEMERAL:
+                return ConnectionStatus.EPHEMERAL
+            async with client:
+                connect_error = await client.api_healthcheck()
+            if connect_error is not None:
+                return ConnectionStatus.SERVER_ERROR
+            else:
+                return ConnectionStatus.SERVER_CONNECTED
+        except Exception:
+            return ConnectionStatus.SERVER_ERROR
+    except (httpx.ConnectError, httpx.UnsupportedProtocol):
+        return ConnectionStatus.INVALID_API

--- a/src/prefect/cli/_shell_utils.py
+++ b/src/prefect/cli/_shell_utils.py
@@ -1,0 +1,119 @@
+"""
+Shared utilities for shell command execution.
+
+Extracted from prefect.cli.shell so both typer and cyclopts
+command modules can import without pulling in CLI framework deps.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+from typing import IO, Any, Callable, Dict, Optional
+
+from prefect import flow
+from prefect.exceptions import FailedRun
+from prefect.logging.loggers import get_run_logger
+
+
+def output_stream(pipe: IO[str], logger_function: Callable[[str], None]) -> None:
+    """
+    Read from a pipe line by line and log using the provided logging function.
+
+    Args:
+        pipe (IO): A file-like object for reading process output.
+        logger_function (function): A logging function from the logger.
+    """
+    with pipe:
+        for line in iter(pipe.readline, ""):
+            logger_function(line.strip())
+
+
+def output_collect(pipe: IO[str], container: list[str]) -> None:
+    """
+    Collects output from a subprocess pipe and stores it in a container list.
+
+    Args:
+        pipe: The output pipe of the subprocess, either stdout or stderr.
+        container: A list to store the collected output lines.
+    """
+    for line in iter(pipe.readline, ""):
+        container.append(line)
+
+
+@flow
+def run_shell_process(
+    command: str,
+    log_output: bool = True,
+    stream_stdout: bool = False,
+    log_stderr: bool = False,
+    popen_kwargs: Optional[Dict[str, Any]] = None,
+):
+    """
+    Asynchronously executes the specified shell command and logs its output.
+
+    This function is designed to be used within Prefect flows to run shell commands as part of task execution.
+    It handles both the execution of the command and the collection of its output for logging purposes.
+
+    Args:
+        command: The shell command to execute.
+        log_output: If True, the output of the command (both stdout and stderr) is logged to Prefect.
+        stream_stdout: If True, the stdout of the command is streamed to Prefect logs.
+        log_stderr: If True, the stderr of the command is logged to Prefect logs.
+        popen_kwargs: Additional keyword arguments to pass to the `subprocess.Popen` call.
+
+    """
+
+    logger = get_run_logger() if log_output else logging.getLogger("prefect")
+
+    # Default Popen kwargs that can be overridden
+    kwargs = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "shell": True,
+        "text": True,
+        "bufsize": 1,
+        "universal_newlines": True,
+    }
+
+    if popen_kwargs:
+        kwargs |= popen_kwargs
+
+    # Containers for log batching
+    stdout_container, stderr_container = [], []
+    with subprocess.Popen(command, **kwargs) as proc:
+        # Create threads for collecting stdout and stderr
+        if stream_stdout:
+            stdout_logger = logger.info
+            output = output_stream
+        else:
+            stdout_logger = stdout_container
+            output = output_collect
+
+        stdout_thread = threading.Thread(
+            target=output, args=(proc.stdout, stdout_logger)
+        )
+
+        stderr_thread = threading.Thread(
+            target=output_collect, args=(proc.stderr, stderr_container)
+        )
+
+        stdout_thread.start()
+        stderr_thread.start()
+
+        stdout_thread.join()
+        stderr_thread.join()
+
+        proc.wait()
+        if stdout_container:
+            logger.info("".join(stdout_container).strip())
+
+        if stderr_container and log_stderr:
+            logger.error("".join(stderr_container).strip())
+            # Suppress traceback
+        if proc.returncode != 0:
+            logger.error("".join(stderr_container).strip())
+            sys.tracebacklimit = 0
+            raise FailedRun(f"Command failed with exit code {proc.returncode}")

--- a/src/prefect/cli/shell.py
+++ b/src/prefect/cli/shell.py
@@ -4,23 +4,17 @@ Includes functionalities for running shell commands ad-hoc or serving them as Pr
 with options for logging output, scheduling, and deployment customization.
 """
 
-import logging
-import subprocess
-import sys
-import threading
-from typing import IO, Any, Callable, Dict, List, Optional
+from typing import List, Optional
 
 import typer
 from typing_extensions import Annotated
 
-from prefect import flow
+from prefect.cli._shell_utils import run_shell_process as run_shell_process
 from prefect.cli._types import PrefectTyper
 from prefect.cli.root import app
 from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.schedules import CronSchedule
 from prefect.context import tags
-from prefect.exceptions import FailedRun
-from prefect.logging.loggers import get_run_logger
 from prefect.runner import Runner
 from prefect.settings import get_current_settings
 from prefect.types.entrypoint import EntrypointType
@@ -29,107 +23,6 @@ shell_app: PrefectTyper = PrefectTyper(
     name="shell", help="Serve and watch shell commands as Prefect flows."
 )
 app.add_typer(shell_app)
-
-
-def output_stream(pipe: IO[str], logger_function: Callable[[str], None]) -> None:
-    """
-    Read from a pipe line by line and log using the provided logging function.
-
-    Args:
-        pipe (IO): A file-like object for reading process output.
-        logger_function (function): A logging function from the logger.
-    """
-    with pipe:
-        for line in iter(pipe.readline, ""):
-            logger_function(line.strip())
-
-
-def output_collect(pipe: IO[str], container: list[str]) -> None:
-    """
-    Collects output from a subprocess pipe and stores it in a container list.
-
-    Args:
-        pipe: The output pipe of the subprocess, either stdout or stderr.
-        container: A list to store the collected output lines.
-    """
-    for line in iter(pipe.readline, ""):
-        container.append(line)
-
-
-@flow
-def run_shell_process(
-    command: str,
-    log_output: bool = True,
-    stream_stdout: bool = False,
-    log_stderr: bool = False,
-    popen_kwargs: Optional[Dict[str, Any]] = None,
-):
-    """
-    Asynchronously executes the specified shell command and logs its output.
-
-    This function is designed to be used within Prefect flows to run shell commands as part of task execution.
-    It handles both the execution of the command and the collection of its output for logging purposes.
-
-    Args:
-        command: The shell command to execute.
-        log_output: If True, the output of the command (both stdout and stderr) is logged to Prefect.
-        stream_stdout: If True, the stdout of the command is streamed to Prefect logs.
-        log_stderr: If True, the stderr of the command is logged to Prefect logs.
-        popen_kwargs: Additional keyword arguments to pass to the `subprocess.Popen` call.
-
-    """
-
-    logger = get_run_logger() if log_output else logging.getLogger("prefect")
-
-    # Default Popen kwargs that can be overridden
-    kwargs = {
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
-        "shell": True,
-        "text": True,
-        "bufsize": 1,
-        "universal_newlines": True,
-    }
-
-    if popen_kwargs:
-        kwargs |= popen_kwargs
-
-    # Containers for log batching
-    stdout_container, stderr_container = [], []
-    with subprocess.Popen(command, **kwargs) as proc:
-        # Create threads for collecting stdout and stderr
-        if stream_stdout:
-            stdout_logger = logger.info
-            output = output_stream
-        else:
-            stdout_logger = stdout_container
-            output = output_collect
-
-        stdout_thread = threading.Thread(
-            target=output, args=(proc.stdout, stdout_logger)
-        )
-
-        stderr_thread = threading.Thread(
-            target=output_collect, args=(proc.stderr, stderr_container)
-        )
-
-        stdout_thread.start()
-        stderr_thread.start()
-
-        stdout_thread.join()
-        stderr_thread.join()
-
-        proc.wait()
-        if stdout_container:
-            logger.info("".join(stdout_container).strip())
-
-        if stderr_container and log_stderr:
-            logger.error("".join(stderr_container).strip())
-            # Suppress traceback
-        if proc.returncode != 0:
-            logger.error("".join(stderr_container).strip())
-            sys.tracebacklimit = 0
-            raise FailedRun(f"Command failed with exit code {proc.returncode}")
 
 
 @shell_app.command("watch")


### PR DESCRIPTION
phase 3 prep for the cyclopts migration ([plan](plans/2026-02-05-cli-cyclopts-migration.md))

this PR extracts shared business logic out of typer command files so they can be cleanly deleted when typer is retired.

- extract `ConnectionStatus` enum + `check_server_connection()` from `profile.py` → `_profile_utils.py`
- extract `run_shell_process()` flow + helpers from `shell.py` → `_shell_utils.py`
- update cyclopts commands to import from the new shared modules
- typer files re-export for backwards compatibility (zero behavior change)

<details>
<summary>why this matters</summary>

cyclopts `profile.py` imports `ConnectionStatus` and `check_server_connection` from the typer `profile.py`. cyclopts `shell.py` imports `run_shell_process` from the typer `shell.py`. when we delete the typer files, these imports would break. extracting to framework-agnostic utility modules decouples them.
</details>

<details>
<summary>test results</summary>

both typer and cyclopts modes pass the full CLI test suite:

```
# typer (default)
uv run pytest tests/cli/ -n4 -q → 1173 passed, 22 skipped

# cyclopts
PREFECT_CLI_FAST=1 uv run pytest tests/cli/ -n4 -q → 1187 passed, 8 skipped

# automations
PREFECT_CLI_FAST=1 uv run pytest tests/events/client/cli/test_automations.py -q → 46 passed
```

(2 pre-existing flaky artifact timestamp tests excluded from count)
</details>