### PR TITLE
examples: add RAG failure diagnostics flow example (#20795)

### DIFF
--- a/examples/rag_failure_diagnostics.py
+++ b/examples/rag_failure_diagnostics.py
@@ -29,7 +29,6 @@ from typing import Any
 from prefect import flow, get_run_logger, task
 from prefect.artifacts import create_markdown_artifact
 
-
 STOPWORDS = {
     "a",
     "an",
@@ -378,8 +377,12 @@ def build_batch_artifact(results: list[QueryResult], threshold: float) -> None:
     ]
 
     for result in results:
-        retrieved_ids = ", ".join(result.retrieved_ids) if result.retrieved_ids else "none"
-        matched_tokens = ", ".join(result.matched_tokens) if result.matched_tokens else "none"
+        retrieved_ids = (
+            ", ".join(result.retrieved_ids) if result.retrieved_ids else "none"
+        )
+        matched_tokens = (
+            ", ".join(result.matched_tokens) if result.matched_tokens else "none"
+        )
         lines.append(
             "| "
             f"{result.query} | "
@@ -440,7 +443,13 @@ def rag_failure_diagnostics_flow(
         )
 
     result_futures = []
-    for _, prepared_future, retrieved_future, evaluation_future, action_future in scheduled:
+    for (
+        _,
+        prepared_future,
+        retrieved_future,
+        evaluation_future,
+        action_future,
+    ) in scheduled:
         answer_future = generate_answer.submit(
             prepared=prepared_future,
             retrieved=retrieved_future,


### PR DESCRIPTION
Add a new example in `examples/rag_failure_diagnostics.py` that shows how to:

- instrument each stage of a simple RAG pipeline with Prefect tasks and logs
- surface signals that map incidents to common failure patterns (retrieval hallucination, retriever coverage issues, recall gaps, etc.)

This is a docs-only change that addresses the request in #20795.

<!-- 
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

### Overview

This PR introduces a self-contained example for users running RAG or LLM pipelines with Prefect.

The example constructs a tiny FAQ knowledge base, applies naive chunking, uses a toy keyword-based retriever, and simulates an incorrect model answer. The flow logs diagnostics such as retrieval coverage, retrieved chunk IDs, missing or forbidden keywords, and prints possible failure patterns to investigate.  

The goal is to give users a minimal, inspectable template for debugging RAG flows using Prefect’s task boundaries and logging.

### Checklist

- [x] This pull request references the related issue by including: closes #20795
- [ ] This pull request adds no new functionality and is a docs-only change, so no unit tests are required
- [x] No docs files are removed and no redirect settings are needed in `mint.json`
- [x] This pull request adds an example script; docstrings are included within the file where appropriate