### PR TITLE
docs: Update rate limit docs for unified two-bucket system

### DIFF
--- a/docs/v3/concepts/rate-limits.mdx
+++ b/docs/v3/concepts/rate-limits.mdx
@@ -33,7 +33,7 @@ For Enterprise limits, [contact Prefect's sales team](https://www.prefect.io/pri
 
 ### Monitor your usage
 
-View your account's rate limit usage in the Prefect Cloud UI under **Account Settings > Rate Limits**. The dashboard shows current usage against your limits and highlights the top contributors to request volume, such as specific API keys, deployments, or workspaces.
+View your account's rate limit usage in the Prefect Cloud UI under **Account Settings > Rate Limits**. The dashboard shows current usage against your limits and highlights the top contributors to request volume, such as specific API keys, workspaces, or API routes.
 
 ### Reduce request volume
 


### PR DESCRIPTION
## Summary

Updates the public rate limit docs to reflect the new unified two-bucket model (API Requests + Logs & Events), replacing the old per-endpoint breakdown. Also adds sections on monitoring usage and reducing request volume.

Closes CLOUD-3237

<details>
<summary>Session context</summary>

Kicked off by CLOUD-3237 — the rate limit simplification project needed updated public docs. Cross-referenced the tier values in nebula's `plans.py` to get the exact numbers for each plan. Kept the page structure simple since the whole point of this project is making rate limits easier to understand.
</details>