### PR TITLE
feat(prefect-dbt): add PrefectDbtOrchestrator benchmarks and CI workflow

### DIFF
--- a/.github/workflows/dbt-benchmarks.yaml
+++ b/.github/workflows/dbt-benchmarks.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: src/integrations/prefect-dbt
-        run: uv sync --compile-bytecode
+        run: uv sync --group bench --compile-bytecode
 
       - name: Start Prefect server
         working-directory: src/integrations/prefect-dbt
@@ -88,7 +88,7 @@ jobs:
           BENCH_PG_DBNAME: bench
         run: |
           mkdir -p .benchmarks
-          uv run -s benches/bench_orchestrator.py \
+          uv run python benches/bench_orchestrator.py \
             --output .benchmarks/results.json \
             --baseline .benchmarks/baseline.json \
             --markdown-out .benchmarks/comment.md \

--- a/src/integrations/prefect-dbt/benches/bench_orchestrator.py
+++ b/src/integrations/prefect-dbt/benches/bench_orchestrator.py
@@ -1,13 +1,4 @@
 #!/usr/bin/env python
-# /// script
-# requires-python = ">=3.10"
-# dependencies = [
-#   "dbt-postgres>=1.7",
-#   "prefect-dbt",
-#   "psycopg2-binary",
-#   "pyyaml",
-# ]
-# ///
 """Benchmark PrefectDbtOrchestrator vs PrefectDbtRunner.
 
 Creates a 5-layer × 10-model synthetic dbt project backed by Postgres (50 nodes

--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -72,6 +72,10 @@ integration = [
     "dbt-postgres>=1.7",
     "psycopg2-binary",
 ]
+bench = [
+    "dbt-postgres>=1.7",
+    "psycopg2-binary",
+]
 
 [project.urls]
 Homepage = "https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-dbt"


### PR DESCRIPTION
This PR adds a benchmark suite comparing `PrefectDbtRunner` against `PrefectDbtOrchestrator` (PER_WAVE and PER_NODE), and a CI workflow that runs the benchmarks on every PR touching `src/integrations/prefect-dbt/`.

<details>
<summary>Details</summary>

**`src/integrations/prefect-dbt/benches/bench_orchestrator.py`**

A standalone Python script that runs real dbt execution against a synthetic 50-node project (5 layers × 10 models) backed by Postgres. Results reflect actual user-facing wall-clock time — dbt invocation overhead, network I/O, and Prefect task overhead — not mocked execution.

Six scenarios are timed:

| Benchmark | Description |
|---|---|
| `runner / select=None (all)` | `PrefectDbtRunner` — single `dbt build` for all 50 nodes |
| `runner / select=path:models/layer_0` | `PrefectDbtRunner` — single `dbt build` for 10 nodes |
| `orchestrator / select=None (all) / PER_WAVE` | One `dbt build` per topological wave (5 invocations) |
| `orchestrator / select=path:models/layer_0 / PER_WAVE` | One `dbt build` for the single wave in layer 0 |
| `orchestrator / select=None (all) / PER_NODE` | One `dbt build` per node (50 invocations, `concurrency=10`) |
| `orchestrator / select=path:models/layer_0 / PER_NODE` | One `dbt build` per node for layer 0 (10 invocations, `concurrency=10`) |

Postgres is used instead of DuckDB so that PER_NODE can run with real concurrency (`concurrency=WIDTH=10`, matching the dbt thread count). DuckDB's single-writer constraint would require `concurrency=1`, making PER_NODE an unfair comparison. Each execution group uses its own Postgres schema for isolation. Connection details are read from `BENCH_PG_*` environment variables with defaults matching the CI service.

Results are formatted as a plain-text table for CI logs, JSON for caching, and Markdown (with a collapsible comparison table against the `main` baseline) written to the job summary.

**`.github/workflows/dbt-benchmarks.yaml`**

- Triggers on PRs and pushes to `main` when `src/integrations/prefect-dbt/**` changes
- Spins up a `postgres:16` service container (health-checked before benchmarks run)
- Starts a Prefect server and waits for it with `prefect server status --wait`
- Restores the most recent `main`-branch baseline from the Actions cache
- On `main` pushes, saves the current results as the new baseline for future PRs to compare against
- Writes results to the job summary

**`src/integrations/prefect-dbt/pyproject.toml`**

- Added `bench` dependency group (`dbt-postgres`, `psycopg2-binary`)
- Added `[tool.setuptools.packages.find]` exclude to keep `benches/` out of the built wheel

</details>