### PR TITLE
Optimize ProcessPoolTaskRunner worker overhead

### DIFF
--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -602,8 +602,12 @@ def _run_task_in_subprocess(
 
 def _process_pool_worker_initializer(env: dict[str, str]) -> None:
     """Initialize worker process environment once at process start."""
+    from prefect.plugins import load_prefect_collections
+
     os.environ.update(env)
     _ensure_process_pool_worker_client_context()
+    # Warm collection entrypoint loading once per worker to avoid first-task import spikes.
+    load_prefect_collections()
 
 
 class _ChainedFuture(concurrent.futures.Future[bytes]):


### PR DESCRIPTION
## Summary
This PR optimizes `ProcessPoolTaskRunner` worker overhead for per-node subprocess workloads while keeping one process task submitted per orchestrated node (PER_NODE semantics).

Current changes in this PR:
- cache static serialized context in `ProcessPoolTaskRunner` and re-serialize only dynamic task/tag context per submit
- initialize worker process environment once via `ProcessPoolExecutor(initializer=...)`
- centralize process-pool submission path for resolved parameters
- reuse a worker-local sync Prefect client context across task invocations (default behavior)
- cache worker `SettingsContext` (keyed by serialized settings context identity) to avoid rebuilding settings on every task run
- lazy-start hydrated flow task runners in remote task contexts (start only on first nested `.submit()` / `.map()`)
- change `Block.get_block_class_from_key` to load collection entrypoints only on lookup miss
- warm `load_prefect_collections()` once in process worker initializer

## Validation
- `uv run ruff check src/prefect/context.py src/prefect/task_runners.py src/prefect/blocks/core.py tests/test_context.py tests/test_task_runners.py tests/blocks/test_core.py`
- `uv run pytest tests/blocks/test_core.py -k "block_load_does_not_load_collections_for_registered_block or get_block_class_from_key_loads_collections_on_lookup_miss or dunder_new_skips_collection_load_for_registered_block"`
  - result: `3 passed`
- `uv run pytest tests/test_context.py -k "task_runner_starts_lazily_when_hydrating_context"`
  - result: `1 passed`
- `uv run pytest tests/test_task_runners.py -k "ProcessPoolTaskRunner and not handles_recursively_submitted_tasks"`
  - result: `25 passed, 26 deselected`

## Profiling Highlights
### Worker profile (direct ProcessPool runner harness)
- before (pre-settings-cache): `30,601,378` calls in `10.390s`
- after settings-cache: `805,941` calls in `0.428s`

Notable reductions:
- `main.py:_settings_build_values` cumulative: `9.457s -> 0.055s`
- `utils.py:parse_env_vars` cumulative: `2.231s -> 0.014s`

### Worker profile (flow-based harness)
- before (pre lazy-load/lazy-start): `62,735,163` calls in `22.513s`
- after latest changes: `562,269` calls in `0.260s`

The previous first-task hotspot around:
- `Block.get_block_class_from_key`
- `plugins.load_prefect_collections`

is removed from task-execution profiles after lazy-on-miss loading + worker pre-warm.

## Benchmarks (vanilla tasks, no dbt)
Clean-worktree local-server benchmark comparison (`PREFECT_API_URL=http://127.0.0.1:4200/api`):
- `main` (`a9b2cfdac4`) vs PR (`a019f0253b`)
- `vanilla / layers=5 width=10 (all)`: **2.094s -> 2.137s (+2.0%)**
- `vanilla / layers=1 width=10 (subset)`: **1.816s -> 1.735s (-4.5%)**

## Notes
- No `prefect-dbt` source files are changed in this PR.
- On this machine, `tests/test_task_runners.py -k ProcessPoolTaskRunner` still includes one existing timeout in `test_handles_recursively_submitted_tasks` on both baseline and optimized code.
