### PR TITLE
fix(db-vacuum): lower default batch_size from 1000 to 200

### DIFF
--- a/src/prefect/settings/models/server/services.py
+++ b/src/prefect/settings/models/server/services.py
@@ -72,9 +72,9 @@ class ServerServicesDBVacuumSettings(ServicesBaseSetting):
     )
 
     batch_size: int = Field(
-        default=1000,
+        default=200,
         gt=0,
-        description="The number of records to delete per database transaction. Defaults to `1000`.",
+        description="The number of records to delete per database transaction. Defaults to `200`.",
     )
 
 


### PR DESCRIPTION
## Summary
- Lowers the default `batch_size` for the DB vacuum service from 1000 to 200

The orphaned-row queries use `NOT EXISTS` subqueries that scan the full log/artifact table. At `batch_size=1000` on Postgres this takes ~9-11s, exceeding asyncpg's default command timeout and causing the vacuum tasks to fail with `TimeoutError`. At 200 the same query completes in ~1.6s.

<details>
<summary>testing details</summary>

Tested against a live Postgres instance (PG 15, 2.7M logs, 102K flow runs) on the OSS testbed cluster. The vacuum service was enabled via `PREFECT_SERVER_SERVICES_DB_VACUUM_ENABLED=true` and immediately hit timeouts on `vacuum_orphaned_logs`. Query timings at various batch sizes:

| batch_size | query time |
|---|---|
| 1000 | ~9-11s (timeout) |
| 200 | ~1.6s |
| 100 | ~0.3s |

</details>

## Test plan
- [x] Existing vacuum tests pass (43/43)
- [x] Validated against live Postgres on OSS testbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)