### PR TITLE
Fix non-deterministic flow scanning in prefect deploy

### DIFF
--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -102,7 +102,8 @@ async def search_for_flow_functions(
         logger.error(f"Error searching for flow functions: {e}")
         return []
 
-    return [fn for file_fns in await asyncio.gather(*coros) for fn in file_fns]
+    flows = [fn for file_fns in await asyncio.gather(*coros) for fn in file_fns]
+    return sorted(flows, key=lambda x: (x["filepath"], x["function_name"]))
 
 
 def prompt(message: str, **kwargs: Any) -> str:

--- a/tests/cli/test_prompts.py
+++ b/tests/cli/test_prompts.py
@@ -126,3 +126,24 @@ class TestDiscoverFlows:
             import prefect  # noqa: F401
 
         await run_sync_in_worker_thread(import_prefect)
+
+    async def test_search_for_flow_functions_returns_deterministic_order(
+        self, project_dir: Path
+    ):
+        """Regression test: search_for_flow_functions should return flows in a deterministic order across multiple invocations."""
+
+        results = []
+        for _ in range(5):
+            flows = await search_for_flow_functions(str(project_dir))
+            results.append(flows)
+
+        first_result = results[0]
+        assert first_result, (
+            "search_for_flow_functions did not discover any flows; "
+            "this may indicate a regression in flow discovery."
+        )
+        for result in results[1:]:
+            assert result == first_result, (
+                "search_for_flow_functions returned flows in different order. "
+                "Expected deterministic ordering."
+            )


### PR DESCRIPTION
- Add deterministic sorting by filepath and function_name in search_for_flow_functions
- Add regression test to verify consistent ordering across multiple invocations
- Fixes #20826

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
## Description
Fixes non-deterministic behavior when scanning for flows in `prefect deploy` command. Previously, flows were discovered in random order across multiple runs, making the CLI experience unpredictable.

## Changes
- Added deterministic sorting to `search_for_flow_functions()` in `src/prefect/cli/_prompts.py` by sorting flows on `(filepath, function_name)` tuple
- Added regression test `test_search_for_flow_functions_returns_deterministic_order` in `tests/cli/test_prompts.py` that verifies consistent ordering across 5 invocations

## Testing
- ✅ Added regression test that validates deterministic ordering
- ✅ All existing tests pass (6/6 in `tests/cli/test_prompts.py`)
- ✅ Verified locally using `uv run pytest tests/cli/test_prompts.py -v`

### Test Output
tests/cli/test_prompts.py::TestDiscoverFlows::test_search_for_flow_functions_returns_deterministic_order PASSED [100%]
====================================== 6 passed in 7.93s =======================================

## Related Issue
Closes #20826

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes #20826"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

