### PR TITLE
fix: correct return type annotation for dbt_runner_freshness_success fixture

### DIFF
--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -256,7 +256,7 @@ def dbt_runner_freshness_error(
 @pytest.fixture
 def dbt_runner_freshness_success(
     monkeypatch: pytest.MonkeyPatch, mock_dbt_runner_freshness_success: dbtRunnerResult
-) -> None:
+) -> MagicMock:
     _mock_dbt_runner_freshness_success = MagicMock(
         return_value=mock_dbt_runner_freshness_success
     )


### PR DESCRIPTION
## Summary

Fixes #20732

The `dbt_runner_freshness_success` pytest fixture in `test_commands.py` returns a `MagicMock` instance but was annotated as `-> None`. This causes static type checkers (pyrefly, mypy, pyright) to flag:

1. The `return _mock_dbt_runner_freshness_success` statement as returning a value from a `None`-typed function
2. Any downstream usage such as `dbt_runner_freshness_success.assert_called_with(...)` as calling a method on `None`

## Change

- Changed return annotation from `-> None` to `-> MagicMock` on the `dbt_runner_freshness_success` fixture (line 259)

## Verification

- `MagicMock` is already imported at the top of the file (`from unittest.mock import MagicMock`)
- Other fixtures that only monkeypatch without returning (`dbt_runner_model_result`, `dbt_runner_ls_result`, `dbt_runner_freshness_error`, `dbt_runner_failed_result`) correctly use `-> None` and are left unchanged
- The fixture's return value is actively used in `test_trigger_dbt_cli_command_cli_argument_list` which calls `.assert_called_with()` on it