### PR TITLE
Add --output json to flow ls, work-pool ls, task-run ls, concurrency-limit ls

### DIFF
--- a/tests/cli/test_concurrency_limit.py
+++ b/tests/cli/test_concurrency_limit.py
@@ -1,0 +1,98 @@
+import json
+from typing import Generator, List
+from unittest import mock
+from uuid import UUID
+
+import pytest
+
+from prefect.client.schemas.objects import ConcurrencyLimit
+from prefect.testing.cli import invoke_and_assert
+
+
+@pytest.fixture
+def read_concurrency_limits() -> Generator[mock.AsyncMock, None, None]:
+    with mock.patch(
+        "prefect.client.orchestration.PrefectClient.read_concurrency_limits",
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def various_concurrency_limits(
+    read_concurrency_limits: mock.AsyncMock,
+) -> List[ConcurrencyLimit]:
+    concurrency_limits = [
+        ConcurrencyLimit(
+            id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            created="2021-01-01T00:00:00Z",
+            updated="2021-01-02T00:00:00Z",
+            tag="tag-1",
+            concurrency_limit=5,
+            active_slots=[],
+        ),
+        ConcurrencyLimit(
+            id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            created="2021-01-01T00:00:00Z",
+            updated="2021-01-03T00:00:00Z",
+            tag="tag-2",
+            concurrency_limit=10,
+            active_slots=[],
+        ),
+    ]
+    read_concurrency_limits.return_value = concurrency_limits
+    return concurrency_limits
+
+
+def test_ls(various_concurrency_limits: List[ConcurrencyLimit]):
+    invoke_and_assert(
+        ["concurrency-limit", "ls"],
+        expected_output_contains=(
+            "tag-1",
+            "tag-2",
+        ),
+        expected_code=0,
+    )
+
+
+def test_ls_json_output(various_concurrency_limits: List[ConcurrencyLimit]):
+    """Test concurrency-limit ls command with JSON output flag."""
+    result = invoke_and_assert(
+        ["concurrency-limit", "ls", "-o", "json"],
+        expected_code=0,
+    )
+
+    output_data = json.loads(result.stdout.strip())
+    assert isinstance(output_data, list)
+    assert len(output_data) == 2
+
+    output_ids = {item["id"] for item in output_data}
+    assert str(various_concurrency_limits[0].id) in output_ids
+    assert str(various_concurrency_limits[1].id) in output_ids
+
+    # Verify key fields are present
+    for item in output_data:
+        assert "tag" in item
+        assert "concurrency_limit" in item
+        assert "active_slots" in item
+
+
+def test_ls_json_output_empty(read_concurrency_limits: mock.AsyncMock):
+    """Test concurrency-limit ls with JSON output when no limits exist."""
+    read_concurrency_limits.return_value = []
+
+    result = invoke_and_assert(
+        ["concurrency-limit", "ls", "-o", "json"],
+        expected_code=0,
+    )
+
+    output_data = json.loads(result.stdout.strip())
+    assert output_data == []
+
+
+def test_ls_invalid_output_format():
+    """Test concurrency-limit ls with invalid output format."""
+    invoke_and_assert(
+        ["concurrency-limit", "ls", "-o", "xml"],
+        expected_code=1,
+        expected_output_contains="Only 'json' output format is supported.",
+    )


### PR DESCRIPTION
## Summary

Related to #19483

Adds `--output json` / `-o json` support to four CLI list commands that were missing it:

- `flow ls`
- `work-pool ls`
- `task-run ls`
- `concurrency-limit ls`

Each follows the established pattern from `flow-run ls` and `deployment ls`:
- Add `--output` / `-o` option (accepts `"json"`)
- When `output == "json"`, serialize response objects with `orjson.dumps(..., option=orjson.OPT_INDENT_2)` and print
- When not set, render the existing Rich table as before
- Empty results return `[]` in JSON mode instead of a text message
- Invalid format values produce a clear error message

Also adds proper empty-list handling (`exit_with_success`) for `flow ls` and `task-run ls` where it was previously missing.

## Changes

| File | Change |
|------|--------|
| `src/prefect/cli/flow.py` | Add `--output json` to `flow ls` |
| `src/prefect/cli/work_pool.py` | Add `--output json` to `work-pool ls` |
| `src/prefect/cli/task_run.py` | Add `--output json` to `task-run ls` |
| `src/prefect/cli/concurrency_limit.py` | Add `--output json` to `concurrency-limit ls` |
| `tests/cli/test_flow.py` | Tests for `flow ls` JSON output |
| `tests/cli/test_task_run.py` | Tests for `task-run ls` JSON output |
| `tests/cli/test_work_pool.py` | Tests for `work-pool ls` JSON output |
| `tests/cli/test_concurrency_limit.py` | New test file for `concurrency-limit ls` JSON output |

## Test plan

- [x] JSON output returns valid JSON array for each command
- [x] Empty results return `[]` (not a text message) in JSON mode
- [x] Invalid format (e.g. `-o xml`) returns error with exit code 1
- [x] State/name filters work with JSON output (`task-run ls --state Running -o json`)
- [x] Existing table output is unchanged when `--output` is not specified