### PR TITLE
fix: remove Panel border from `work-pool create` sample code output

### DIFF
--- a/src/prefect/infrastructure/provisioners/cloud_run.py
+++ b/src/prefect/infrastructure/provisioners/cloud_run.py
@@ -405,10 +405,10 @@ class CloudRunPushProvisioner:
                     Use any image name to build and push to this registry by default:
                     """
                 ),
-                Panel(
-                    Syntax(
-                        dedent(
-                            f"""\
+                Syntax(
+                    dedent(
+                        f"""\
+                        # example_deploy_script.py
                         from prefect import flow
                         from prefect.docker import DockerImage
 
@@ -427,12 +427,9 @@ class CloudRunPushProvisioner:
                                     platform="linux/amd64",
                                 )
                             )"""
-                        ),
-                        "python",
-                        background_color="default",
                     ),
-                    title="example_deploy_script.py",
-                    expand=False,
+                    "python",
+                    background_color="default",
                 ),
             )
 

--- a/src/prefect/infrastructure/provisioners/container_instance.py
+++ b/src/prefect/infrastructure/provisioners/container_instance.py
@@ -1044,10 +1044,10 @@ class ContainerInstancePushProvisioner:
                     Use any image name to build and push to this registry by default:
                     """
             ),
-            Panel(
-                Syntax(
-                    dedent(
-                        f"""\
+            Syntax(
+                dedent(
+                    f"""\
+                        # example_deploy_script.py
                         from prefect import flow
                         from prefect.docker import DockerImage
 
@@ -1066,12 +1066,9 @@ class ContainerInstancePushProvisioner:
                                     platform="linux/amd64",
                                 )
                             )"""
-                    ),
-                    "python",
-                    background_color="default",
                 ),
-                title="example_deploy_script.py",
-                expand=False,
+                "python",
+                background_color="default",
             ),
         )
 

--- a/src/prefect/infrastructure/provisioners/ecs.py
+++ b/src/prefect/infrastructure/provisioners/ecs.py
@@ -848,7 +848,7 @@ class ContainerRepositoryResource:
         self._repository_name = repository_name
         self._requires_provisioning = None
         self._work_pool_name = work_pool_name
-        self._next_steps: list[str | Panel] = []
+        self._next_steps: list[str | Syntax] = []
 
     async def get_task_count(self) -> int:
         """
@@ -955,40 +955,37 @@ class ContainerRepositoryResource:
                     To build and push a Docker image to your newly created repository, use [blue]{self._repository_name!r}[/] as your image name:
                     """
                 ),
-                Panel(
-                    Syntax(
-                        dedent(
-                            f"""\
-                                from prefect import flow
-                                from prefect.docker import DockerImage
+                Syntax(
+                    dedent(
+                        f"""\
+                            # example_deploy_script.py
+                            from prefect import flow
+                            from prefect.docker import DockerImage
 
 
-                                @flow(log_prints=True)
-                                def my_flow(name: str = "world"):
-                                    print(f"Hello {{name}}! I'm a flow running on ECS!")
+                            @flow(log_prints=True)
+                            def my_flow(name: str = "world"):
+                                print(f"Hello {{name}}! I'm a flow running on ECS!")
 
 
-                                if __name__ == "__main__":
-                                    my_flow.deploy(
-                                        name="my-deployment",
-                                        work_pool_name="{self._work_pool_name}",
-                                        image=DockerImage(
-                                            name="{self._repository_name}:latest",
-                                            platform="linux/amd64",
-                                        )
-                                    )"""
-                        ),
-                        "python",
-                        background_color="default",
+                            if __name__ == "__main__":
+                                my_flow.deploy(
+                                    name="my-deployment",
+                                    work_pool_name="{self._work_pool_name}",
+                                    image=DockerImage(
+                                        name="{self._repository_name}:latest",
+                                        platform="linux/amd64",
+                                    )
+                                )"""
                     ),
-                    title="example_deploy_script.py",
-                    expand=False,
+                    "python",
+                    background_color="default",
                 ),
             ]
         )
 
     @property
-    def next_steps(self) -> list[str | Panel]:
+    def next_steps(self) -> list[str | Syntax]:
         return self._next_steps
 
 
@@ -1326,7 +1323,7 @@ class ElasticContainerServicePushProvisioner:
                 # provision calls will be no-ops, but update the base job template
 
             base_job_template_copy = deepcopy(base_job_template)
-            next_steps: list[str | Panel] = []
+            next_steps: list[str | Syntax] = []
             with Progress(console=self._console, disable=num_tasks == 0) as progress:
                 task = progress.add_task(
                     "Provisioning Infrastructure",

--- a/tests/infrastructure/provisioners/test_ecs.py
+++ b/tests/infrastructure/provisioners/test_ecs.py
@@ -1338,8 +1338,9 @@ class TestContainerRepositoryResource:
             To build and push a Docker image to your newly created repository, use [blue]'prefect-flows'[/] as your image name:
             """
         )
-        assert container_repository_resource.next_steps[1].renderable.code == dedent(
+        assert container_repository_resource.next_steps[1].code == dedent(
             """\
+                # example_deploy_script.py
                 from prefect import flow
                 from prefect.docker import DockerImage
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
-->

Remove the `rich.Panel` border that wraps the example deploy script printed by `prefect work-pool create --provision-infra`. The bordered output (`│` bars on every line) makes the sample code difficult to copy-paste from the terminal.

The `Syntax` block is now rendered directly (still syntax-highlighted, just without the box). The filename is preserved as a `# example_deploy_script.py` comment at the top of the code block. Applied consistently across ECS, Cloud Run, and Azure Container Instance provisioners.

Closes #20228

### Checklist

- [x] This pull request references any related issue by including "closes `#20228`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.