### PR TITLE
Docs: add note about server default limit for client queries

### DIFF
--- a/docs/v3/advanced/api-client.mdx
+++ b/docs/v3/advanced/api-client.mdx
@@ -43,6 +43,38 @@ with get_client(sync_client=True) as client:
 
 </CodeGroup>
 
+## Pagination and default query limits
+
+Client methods that accept `limit` and `offset` parameters - such as `read_flow_runs`, `read_deployments`,
+and `read_task_runs` — are subject to a server-side maximum.
+When `limit` is `None` (the default), the server applies `PREFECT_API_DEFAULT_LIMIT`, which defaults
+to `200`. To retrieve all matching records, paginate with `offset`:
+
+{/* pmd-metadata: notest */}
+```python
+from prefect import get_client
+
+
+async def read_all_deployments(page_size: int = 200):
+    all_deployments = []
+    offset = 0
+
+    async with get_client() as client:
+        while True:
+            page = await client.read_deployments(
+                limit=page_size, offset=offset
+            )
+            if not page:
+                break
+            all_deployments.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
+
+    return all_deployments
+```
+
+
 ## Configure custom headers
 
 You can configure custom HTTP headers to be sent with every API request by setting the `PREFECT_CLIENT_CUSTOM_HEADERS` setting. This is useful for adding authentication headers, API keys, or other custom headers required by proxies, CDNs, or security systems.

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -909,8 +909,9 @@ class PrefectClient(
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
             sort: sort criteria for the task runs
-            limit: a limit for the task run query
-            offset: an offset for the task run query
+            limit: maximum number of task runs to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the task run query.
 
         Returns:
             a list of Task Run model representations
@@ -1015,8 +1016,9 @@ class PrefectClient(
         Args:
             work_pool_name: Name of the work pool for which to get queues.
             work_queue_filter: Criteria by which to filter queues.
-            limit: Limit for the queue query.
-            offset: Limit for the queue query.
+            limit: maximum number of work queues to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the work queue query.
 
         Returns:
             List of queues for the specified work pool.
@@ -1600,8 +1602,9 @@ class SyncPrefectClient(
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
             sort: sort criteria for the task runs
-            limit: a limit for the task run query
-            offset: an offset for the task run query
+            limit: maximum number of task runs to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the task run query.
 
         Returns:
             a list of Task Run model representations
@@ -1971,8 +1974,9 @@ class SyncPrefectClient(
         Args:
             work_pool_name: Name of the work pool for which to get queues.
             work_queue_filter: Criteria by which to filter queues.
-            limit: Limit for the queue query.
-            offset: Limit for the queue query.
+            limit: maximum number of work queues to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the work queue query.
 
         Returns:
             List of queues for the specified work pool.

--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -398,8 +398,9 @@ class DeploymentClient(BaseClient):
             deployment_filter: filter criteria for deployments
             work_pool_filter: filter criteria for work pools
             work_queue_filter: filter criteria for work pool queues
-            limit: a limit for the deployment query
-            offset: an offset for the deployment query
+            limit: maximum number of deployments to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the deployment query.
 
         Returns:
             a list of Deployment model representations
@@ -1111,8 +1112,9 @@ class DeploymentAsyncClient(BaseAsyncClient):
             deployment_filter: filter criteria for deployments
             work_pool_filter: filter criteria for work pools
             work_queue_filter: filter criteria for work pool queues
-            limit: a limit for the deployment query
-            offset: an offset for the deployment query
+            limit: maximum number of deployments to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the deployment query.
 
         Returns:
             a list of Deployment model representations

--- a/src/prefect/client/orchestration/_flow_runs/client.py
+++ b/src/prefect/client/orchestration/_flow_runs/client.py
@@ -281,8 +281,9 @@ class FlowRunClient(BaseClient):
             work_pool_filter: filter criteria for work pools
             work_queue_filter: filter criteria for work pool queues
             sort: sort criteria for the flow runs
-            limit: limit for the flow run query
-            offset: offset for the flow run query
+            limit: maximum number of flow runs to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the flow run query.
 
         Returns:
             a list of Flow Run model representations
@@ -780,8 +781,9 @@ class FlowRunAsyncClient(BaseAsyncClient):
             work_pool_filter: filter criteria for work pools
             work_queue_filter: filter criteria for work pool queues
             sort: sort criteria for the flow runs
-            limit: limit for the flow run query
-            offset: offset for the flow run query
+            limit: maximum number of flow runs to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the flow run query.
 
         Returns:
             a list of Flow Run model representations

--- a/src/prefect/client/orchestration/_flows/client.py
+++ b/src/prefect/client/orchestration/_flows/client.py
@@ -128,8 +128,9 @@ class FlowClient(BaseClient):
             work_pool_filter: filter criteria for work pools
             work_queue_filter: filter criteria for work pool queues
             sort: sort criteria for the flows
-            limit: limit for the flow query
-            offset: offset for the flow query
+            limit: maximum number of flows to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the flow query.
 
         Returns:
             a list of Flow model representations of the flows
@@ -287,8 +288,9 @@ class FlowAsyncClient(BaseAsyncClient):
             work_pool_filter: filter criteria for work pools
             work_queue_filter: filter criteria for work pool queues
             sort: sort criteria for the flows
-            limit: limit for the flow query
-            offset: offset for the flow query
+            limit: maximum number of flows to return. When `None`, the server
+                applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).
+            offset: an offset for the flow query.
 
         Returns:
             a list of Flow model representations of the flows


### PR DESCRIPTION
## Bug Summary

Fixes #15963

This PR clarifies that client query methods with `limit` and `offset` are still constrained by the server default limit when `limit=None`.

## Version Info

Document issue, N/A

## Changes
Add a note and example in the API client docs explaining default limit behavior and pagination expectations.

Update `limit` docstrings in orchestration client methods (`task runs`, `deployments`, `flow runs`, `flows`).
- `limit`: Maximum number of records to return. When `None`, the server applies `PREFECT_API_DEFAULT_LIMIT` (200 by default).



