### PR TITLE
Defer task worker import in CLI task command

### DIFF
--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -15,7 +15,6 @@ from prefect.cli._utilities import (
     with_cli_exception_handling,
 )
 from prefect.logging import get_logger
-from prefect.task_worker import serve as task_serve
 
 task_app: cyclopts.App = cyclopts.App(
     name="task",
@@ -25,6 +24,12 @@ task_app: cyclopts.App = cyclopts.App(
 )
 
 logger: logging.Logger = get_logger("prefect.cli.task")
+
+
+async def task_serve(*args: Any, **kwargs: Any) -> Any:
+    from prefect.task_worker import serve as _task_serve
+
+    return await _task_serve(*args, **kwargs)
 
 
 def _import_tasks_from_module(module: str) -> list[Any]:


### PR DESCRIPTION
## Summary
- defer importing `prefect.task_worker.serve` until `prefect task serve` is invoked
- keep a module-level `task_serve` symbol for patchability in tests
- reduce startup import surface for non-task CLI commands

## Validation
- `uv run pytest tests/cli/test_task.py -q`
- `uv run ruff check src/prefect/cli/task.py`

## Local benchmark signal (focused)
- isolated `cli-bench --project-root` A/B (10 runs) showed:
  - `prefect --help`: `1101 -> 973 ms`
  - `prefect --version`: `972 -> 886 ms`
  - `prefect task --help`: `1076 -> 843 ms`
  - `prefect cloud --help`: `1007 -> 876 ms`
