### PR TITLE
Update rate limit docs to match unified limits

### DIFF
--- a/docs/v3/concepts/rate-limits.mdx
+++ b/docs/v3/concepts/rate-limits.mdx
@@ -23,10 +23,10 @@ Rate limits are organized into two buckets:
 
 | Plan | API Requests (per minute) | Logs + Events (per minute) |
 |------|---------------------------|----------------------------|
-| Hobby | 400 | 2,000 |
-| Starter | 2,000 | 5,000 |
-| Team | 3,500 | 10,000 |
-| Pro | 5,000 | 15,000 |
+| Hobby | 625 | 2,000 |
+| Starter | 1,250 | 2,800 |
+| Team | 2,500 | 8,000 |
+| Pro | 5,000 | 40,000 |
 | Enterprise | Custom | Custom |
 
 For Enterprise limits, [contact Prefect's sales team](https://www.prefect.io/pricing).


### PR DESCRIPTION
## Summary

- Updates the rate limit table in `docs/v3/concepts/rate-limits.mdx` to reflect the unified rate limits currently deployed in production
- API Requests: Hobby 625, Starter 1,250, Team 2,500, Pro 5,000
- Logs + Events: Hobby 2,000, Starter 2,800, Team 8,000, Pro 40,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary>Session context</summary>

Values were verified against production `auth.account_plan` table to ensure docs match what customers actually experience. The codebase defaults in nebula `plans.py` differ slightly for some tiers (e.g., Starter orchestration is 2,000 in code but 1,250 in prod), so production was used as the source of truth.
</details>