### PR TITLE
docs: add pull_with_block YAML example to Bitbucket integration docs

### DIFF
--- a/docs/integrations/prefect-bitbucket/index.mdx
+++ b/docs/integrations/prefect-bitbucket/index.mdx
@@ -98,6 +98,15 @@ pull:
         credentials: "{{ prefect.blocks.bitbucket-credentials.my-bitbucket-credentials-block }}"
 ```
 
+Or, use `pull_with_block` to pull code using a Bitbucket Repository block directly:
+
+```yaml
+pull:
+    - prefect.deployments.steps.pull_with_block:
+        block_type_slug: bitbucket-repository
+        block_document_name: my-bitbucket-block
+```
+
 ### Interact with a Bitbucket repository
 
 The code below shows how to reference a particular branch or tag of a Bitbucket repository.


### PR DESCRIPTION
## Summary

Adds a `prefect.yaml` example showing how to use `pull_with_block` to pull deployment code from a Bitbucket Repository block.

Closes #19418

## Changes

Added a YAML code block to `docs/integrations/prefect-bitbucket/index.mdx` demonstrating the `pull_with_block` deployment step alongside the existing `git_clone` example.

The existing docs only showed the Python API and the `git_clone` YAML approach. This adds the `pull_with_block` alternative that uses a pre-configured Bitbucket Repository block.