### PR TITLE
Fix Docket URL for Redis instance

### DIFF
--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -168,7 +168,7 @@ export PREFECT_SERVER_DOCKET_URL="redis://username:password@redis-host:6379/0"
 For Redis instances that require SSL/TLS:
 
 ```bash
-export PREFECT_SERVER_DOCKET_URL="rediss://redis-host:6379/0"
+export PREFECT_SERVER_DOCKET_URL="redis://redis-host:6379/0"
 ```
 
 <Note>


### PR DESCRIPTION
Corrected the Docket URL from 'rediss' to 'redis'.