### PR TITLE
Add composite index on task_run(state_type, start_time)

### DIFF
--- a/src/prefect/server/database/_migrations/versions/postgresql/2026_03_03_000000_add_task_run_state_type_start_time_index.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2026_03_03_000000_add_task_run_state_type_start_time_index.py
@@ -1,0 +1,33 @@
+"""Add composite index on task_run(state_type, start_time)
+
+Revision ID: 09a9e091e578
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-03 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "09a9e091e578"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS
+            ix_task_run__state_type_start_time
+            ON task_run (state_type, start_time)
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_task_run__state_type_start_time"
+        )

--- a/src/prefect/server/database/_migrations/versions/sqlite/2026_03_03_000000_add_task_run_state_type_start_time_index.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2026_03_03_000000_add_task_run_state_type_start_time_index.py
@@ -1,0 +1,29 @@
+"""Add composite index on task_run(state_type, start_time)
+
+Revision ID: 4dfa692e02a7
+Revises: a1b2c3d4e5f7
+Create Date: 2026-03-03 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4dfa692e02a7"
+down_revision = "a1b2c3d4e5f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+        ix_task_run__state_type_start_time
+        ON task_run (state_type, start_time)
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_task_run__state_type_start_time")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -761,6 +761,11 @@ class TaskRun(Run):
                 cls.state_type,
             ),
             sa.Index(
+                "ix_task_run__state_type_start_time",
+                cls.state_type,
+                cls.start_time,
+            ),
+            sa.Index(
                 "ix_task_run__state_name",
                 cls.state_name,
             ),


### PR DESCRIPTION
Closes #17895

## Summary

- Adds a composite index `ix_task_run__state_type_start_time` on `task_run(state_type, start_time)` to speed up `POST /task_runs/count` queries filtered by state type and time range
- Users with large task_run tables (6M+ rows) experience very slow dashboard responses because the 4 count queries (total, completed, failed, running) can only use one of the individual indexes, forcing a heap scan for the remaining filter condition
- The composite index lets PostgreSQL seek by `state_type` then range-scan on `start_time`, dramatically reducing I/O

<details>
<summary>Changes</summary>

- **ORM model**: Added `sa.Index("ix_task_run__state_type_start_time", cls.state_type, cls.start_time)` to `TaskRun.__table_args__`
- **PostgreSQL migration**: Uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS` to avoid holding locks on large tables
- **SQLite migration**: Uses `CREATE INDEX IF NOT EXISTS`
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)