### PR TITLE
fix: prevent Rich console from word-wrapping CLI JSON output

### DIFF
--- a/src/prefect/cli/artifact.py
+++ b/src/prefect/cli/artifact.py
@@ -77,7 +77,7 @@ async def list_artifacts(
     if output and output.lower() == "json":
         artifacts_json = [artifact.model_dump(mode="json") for artifact in artifacts]
         json_output = orjson.dumps(artifacts_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Artifacts",
@@ -148,7 +148,7 @@ async def inspect(
             json_output = orjson.dumps(
                 artifacts_json, option=orjson.OPT_INDENT_2
             ).decode()
-            _cli.console.print(json_output)
+            _cli.console.print(json_output, soft_wrap=True)
         else:
             _cli.console.print(Pretty(artifacts_json))
 

--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -281,7 +281,7 @@ async def block_ls(
     if output and output.lower() == "json":
         blocks_json = [block.model_dump(mode="json") for block in blocks]
         json_output = orjson.dumps(blocks_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Blocks", caption="List Block Types using `prefect block type ls`"
@@ -477,7 +477,7 @@ async def list_types(
         json_output = orjson.dumps(
             block_types_json, option=orjson.OPT_INDENT_2
         ).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Block Types",

--- a/src/prefect/cli/cloud/asset.py
+++ b/src/prefect/cli/cloud/asset.py
@@ -85,7 +85,7 @@ async def asset_ls(
 
     if output and output.lower() == "json":
         json_output = orjson.dumps(assets, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         if not assets:
             _cli.console.print("No assets found in this workspace.")

--- a/src/prefect/cli/concurrency_limit.py
+++ b/src/prefect/cli/concurrency_limit.py
@@ -91,7 +91,7 @@ async def inspect(
     if output and output.lower() == "json":
         result_json = result.model_dump(mode="json")
         json_output = orjson.dumps(result_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         trid_table = Table()
         trid_table.add_column("Active Task Run IDs", style="cyan", no_wrap=True)

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -185,7 +185,7 @@ async def inspect(
 
     if output and output.lower() == "json":
         json_output = orjson.dumps(deployment_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         _cli.console.print(Pretty(deployment_json))
 
@@ -250,7 +250,7 @@ async def ls(
         json_output = orjson.dumps(
             deployments_json, option=orjson.OPT_INDENT_2
         ).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Deployments",
@@ -1090,7 +1090,7 @@ async def list_schedules(
             for schedule in deployment.schedules
         ]
         json_output = orjson.dumps(schedules_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Deployment Schedules",

--- a/src/prefect/cli/flow.py
+++ b/src/prefect/cli/flow.py
@@ -70,7 +70,7 @@ async def ls(
     if output and output.lower() == "json":
         flows_json = [f.model_dump(mode="json") for f in flows]
         json_output = orjson.dumps(flows_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(title="Flows")
         table.add_column("ID", justify="right", style="cyan", no_wrap=True)

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -144,7 +144,7 @@ async def inspect(
             json_output = orjson.dumps(
                 flow_run_json, option=orjson.OPT_INDENT_2
             ).decode()
-            _cli.console.print(json_output)
+            _cli.console.print(json_output, soft_wrap=True)
         else:
             _cli.console.print(Pretty(flow_run))
 
@@ -249,7 +249,7 @@ async def ls(
     if output and output.lower() == "json":
         flow_runs_json = [flow_run.model_dump(mode="json") for flow_run in flow_runs]
         json_output = orjson.dumps(flow_runs_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(title="Flow Runs")
         table.add_column("ID", justify="right", style="cyan", no_wrap=True)

--- a/src/prefect/cli/global_concurrency_limit.py
+++ b/src/prefect/cli/global_concurrency_limit.py
@@ -58,7 +58,7 @@ async def ls(
             gcl_limit.model_dump(mode="json") for gcl_limit in gcl_limits
         ]
         json_output = orjson.dumps(gcl_limits_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Global Concurrency Limits",
@@ -139,7 +139,7 @@ async def inspect(
         gcl_limit_json = gcl_limit.model_dump(mode="json")
         json_output = orjson.dumps(gcl_limit_json, option=orjson.OPT_INDENT_2).decode()
         if not file_path:
-            _cli.console.print(json_output)
+            _cli.console.print(json_output, soft_wrap=True)
         else:
             with open(file_path, "w") as f:
                 f.write(json_output)

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -289,7 +289,7 @@ def inspect(
             setting.name: value for setting, value in profiles[name].settings.items()
         }
         json_output = orjson.dumps(profile_data, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         for setting, value in profiles[name].settings.items():
             _cli.console.print(f"{setting.name}='{value}'")

--- a/src/prefect/cli/task_run.py
+++ b/src/prefect/cli/task_run.py
@@ -81,7 +81,7 @@ async def inspect(
             json_output = orjson.dumps(
                 task_run_json, option=orjson.OPT_INDENT_2
             ).decode()
-            _cli.console.print(json_output)
+            _cli.console.print(json_output, soft_wrap=True)
         else:
             _cli.console.print(Pretty(task_run))
 

--- a/src/prefect/cli/variable.py
+++ b/src/prefect/cli/variable.py
@@ -69,7 +69,7 @@ async def list_variables(
     if output and output.lower() == "json":
         variables_json = [variable.model_dump(mode="json") for variable in variables]
         json_output = orjson.dumps(variables_json, option=orjson.OPT_INDENT_2).decode()
-        _cli.console.print(json_output)
+        _cli.console.print(json_output, soft_wrap=True)
     else:
         table = Table(
             title="Variables",
@@ -128,7 +128,7 @@ async def inspect(
             json_output = orjson.dumps(
                 variable_json, option=orjson.OPT_INDENT_2
             ).decode()
-            _cli.console.print(json_output)
+            _cli.console.print(json_output, soft_wrap=True)
         else:
             _cli.console.print(Pretty(variable))
 

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -364,7 +364,7 @@ async def inspect(
                 json_output = orjson.dumps(
                     pool_json, option=orjson.OPT_INDENT_2
                 ).decode()
-                _cli.console.print(json_output)
+                _cli.console.print(json_output, soft_wrap=True)
             else:
                 _cli.console.print(Pretty(pool))
         except ObjectNotFound:
@@ -834,7 +834,7 @@ async def storage_inspect(
                 json_output = orjson.dumps(
                     storage_data, option=orjson.OPT_INDENT_2
                 ).decode()
-                _cli.console.print(json_output)
+                _cli.console.print(json_output, soft_wrap=True)
             else:
                 storage_table.add_row("type", storage_type)
 

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -387,7 +387,7 @@ async def inspect(
                     json_output = orjson.dumps(
                         result_json, option=orjson.OPT_INDENT_2
                     ).decode()
-                    _cli.console.print(json_output)
+                    _cli.console.print(json_output, soft_wrap=True)
                 else:
                     _cli.console.print(Pretty(result))
         except ObjectNotFound:

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -1496,6 +1496,34 @@ class TestDeploymentList:
             ],
         )
 
+    @pytest.fixture
+    async def deployment_with_multiline_description(
+        self, prefect_client: PrefectClient
+    ):
+        @flow
+        async def multiline_desc_flow():
+            pass
+
+        flow_id = await prefect_client.create_flow(multiline_desc_flow)
+        await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="multiline-test",
+            description="line one\nline two\nline three",
+        )
+
+    @pytest.mark.usefixtures("deployment_with_multiline_description")
+    def test_list_deployments_json_with_multiline_description(self):
+        """Regression test: console.print must not word-wrap JSON output,
+        which would insert literal newlines inside JSON string values and
+        produce invalid JSON."""
+        result = invoke_and_assert(
+            ["deployment", "ls", "-o", "json"],
+            expected_code=0,
+        )
+        parsed = json.loads(result.stdout.strip())
+        descriptions = [d["description"] for d in parsed if d.get("description")]
+        assert any("\n" in desc for desc in descriptions)
+
     @pytest.mark.usefixtures("setup_many_deployments")
     def test_list_deployments_output_is_not_json(self):
         invoke_and_assert(


### PR DESCRIPTION
## Summary
- `console.print(json_output)` word-wraps at terminal width, inserting literal newlines into JSON string values — producing invalid JSON that breaks `jq` and any downstream tooling
- adds `soft_wrap=True` to all 21 `console.print(json_output)` calls across 13 CLI files
- adds regression test with a multiline deployment description

<details>
<summary>root cause</summary>

Rich's `Console.print()` wraps text at the terminal width by default. When a JSON string value is longer than the terminal width (e.g. a multiline deployment description), Rich inserts real newlines mid-string, breaking JSON validity. `soft_wrap=True` disables this wrapping.
</details>

## Test plan
- [x] `TestDeploymentList::test_list_deployments_json_with_multiline_description` — creates a deployment with `\n` in description, asserts `json.loads()` succeeds on `-o json` output
- [x] existing `TestDeploymentList` tests pass
- [ ] verified fix against live oss testbed (`prefect deployment ls -o json | jq .` → valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)