### PR TITLE
Harden GitRepository clone against transient network failures

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse, urlsplit, urlunparse
 from uuid import uuid4
 
 import fsspec  # pyright: ignore[reportMissingTypeStubs]
-from anyio import run_process
+from anyio import run_process, sleep
 from pydantic import SecretStr
 
 from prefect._internal.concurrency.api import create_call, from_async
@@ -26,6 +26,39 @@ from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
 from prefect.logging.loggers import get_logger
 from prefect.utilities.collections import visit_collection
+
+_TRANSIENT_GIT_CLONE_ERROR_MARKERS = (
+    "could not resolve host",
+    "connection timed out",
+    "connection reset by peer",
+    "failed to connect",
+    "network is unreachable",
+    "remote end hung up unexpectedly",
+    "http/2 stream",
+    "tls connection was non-properly terminated",
+    "gnutls recv error",
+)
+
+
+def _is_transient_git_clone_error(exc: subprocess.CalledProcessError) -> bool:
+    if exc.returncode != 128:
+        return False
+
+    stdout = (
+        exc.stdout.decode(errors="ignore")
+        if isinstance(exc.stdout, bytes)
+        else str(exc.stdout or "")
+    )
+    stderr = (
+        exc.stderr.decode(errors="ignore")
+        if isinstance(exc.stderr, bytes)
+        else str(exc.stderr or "")
+    )
+    combined_output = f"{stdout}\n{stderr}".lower()
+
+    return any(
+        marker in combined_output for marker in _TRANSIENT_GIT_CLONE_ERROR_MARKERS
+    )
 
 
 @runtime_checkable
@@ -449,20 +482,35 @@ class GitRepository:
         # Set path to clone to
         cmd += [str(self.destination)]
 
-        try:
-            await run_process(cmd)
-        except subprocess.CalledProcessError as exc:
-            # Hide the command used to avoid leaking the access token
-            parsed_url = urlparse(self._url)
-            exc_chain = (
-                None
-                if self._credentials or parsed_url.password or parsed_url.username
-                else exc
-            )
-            raise RuntimeError(
-                f"Failed to clone repository {strip_auth_from_url(self._url)!r} with exit code"
-                f" {exc.returncode}."
-            ) from exc_chain
+        max_clone_attempts = 3
+        for attempt in range(1, max_clone_attempts + 1):
+            try:
+                await run_process(cmd)
+                break
+            except subprocess.CalledProcessError as exc:
+                if attempt < max_clone_attempts and _is_transient_git_clone_error(exc):
+                    self._logger.warning(
+                        "Transient git clone failure for %r (attempt %d/%d); retrying in %ds.",
+                        strip_auth_from_url(self._url),
+                        attempt,
+                        max_clone_attempts,
+                        attempt,
+                    )
+                    shutil.rmtree(self.destination, ignore_errors=True)
+                    await sleep(attempt)
+                    continue
+
+                # Hide the command used to avoid leaking the access token
+                parsed_url = urlparse(self._url)
+                exc_chain = (
+                    None
+                    if self._credentials or parsed_url.password or parsed_url.username
+                    else exc
+                )
+                raise RuntimeError(
+                    f"Failed to clone repository {strip_auth_from_url(self._url)!r} with exit code"
+                    f" {exc.returncode}."
+                ) from exc_chain
 
         if self._commit_sha:
             # Fetch the commit

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -1,5 +1,6 @@
 import re
 import shutil
+import subprocess
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional
@@ -285,6 +286,59 @@ class TestGitRepository:
                 str(Path.cwd() / "repo"),
             ]
         )
+
+    async def test_pull_code_clone_repo_retries_transient_git_errors(
+        self, mock_run_process: AsyncMock, monkeypatch
+    ):
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("prefect.runner.storage.sleep", sleep_mock)
+
+        transient_clone_error = subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["git", "clone"],
+            stderr=b"fatal: unable to access 'https://github.com/org/repo.git/': Could not resolve host: github.com",
+        )
+        successful_clone = MagicMock(stdout=b"")
+        mock_run_process.side_effect = [transient_clone_error, successful_clone]
+
+        repo = GitRepository(url="https://github.com/org/repo.git")
+        await repo.pull_code()
+
+        expected_clone_cmd = [
+            "git",
+            "clone",
+            "https://github.com/org/repo.git",
+            "--depth",
+            "1",
+            str(Path.cwd() / "repo"),
+        ]
+        assert mock_run_process.await_args_list == [
+            call(expected_clone_cmd),
+            call(expected_clone_cmd),
+        ]
+        sleep_mock.assert_awaited_once_with(1)
+
+    async def test_pull_code_clone_repo_does_not_retry_non_transient_errors(
+        self, mock_run_process: AsyncMock, monkeypatch
+    ):
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("prefect.runner.storage.sleep", sleep_mock)
+
+        non_transient_clone_error = subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["git", "clone"],
+            stderr=b"fatal: Remote branch definitely-does-not-exist not found in upstream origin",
+        )
+        mock_run_process.side_effect = non_transient_clone_error
+
+        repo = GitRepository(url="https://github.com/org/repo.git")
+        with pytest.raises(RuntimeError):
+            await repo.pull_code()
+
+        assert mock_run_process.await_count == 1
+        sleep_mock.assert_not_awaited()
 
     async def test_clone_repo_sparse(self, mock_run_process: AsyncMock, monkeypatch):
         """


### PR DESCRIPTION
## Context
After merge commit `b5e9c4dc780` (#20930), the red checks on `main` were not from CLI lazy-loading behavior. The actionable failures were transient `git clone` errors (exit 128) in:
- Integration tests @main (`integration-tests/test_deploy.py::test_deploy`)
- Unit tests (`tests/deployment/test_steps.py::TestPipInstallRequirements::test_pip_install_reqs_with_directory_step_output_succeeds`)

Both failures were cloning public GitHub repos and appear to be network/transient Git transport issues.

## This PR
- Adds transient-error detection for `git clone` failures in `GitRepository._clone_repo`
- Retries clone up to 3 attempts for transient network signatures, with short backoff
- Cleans up partial clone directories before retrying
- Preserves existing secret-safe error behavior on final failure

## Tests
- Added retry behavior tests in `tests/runner/test_storage.py`:
  - retries transient clone errors and succeeds
  - does not retry non-transient clone errors
- Ran full `tests/runner/test_storage.py` locally
