### PR TITLE
Improve CLI startup by deferring command imports

### DIFF
--- a/src/prefect/cli/_app.py
+++ b/src/prefect/cli/_app.py
@@ -63,7 +63,6 @@ def _setup_and_run(
 ) -> None:
     """Environment setup and command dispatch."""
     global console
-    import prefect.context
     from prefect.logging.configuration import setup_logging
     from prefect.settings import get_current_settings
 
@@ -93,17 +92,21 @@ def _setup_and_run(
 
         _app(tokens)
 
-    if profile and prefect.context.get_settings_context().profile.name != profile:
-        try:
-            with prefect.context.use_profile(
-                profile, override_environment_variables=True
-            ):
-                _run_with_settings()
-        except KeyError:
-            print(f"Unknown profile {profile!r}.", file=sys.stderr)
-            sys.exit(1)
-    else:
-        _run_with_settings()
+    if profile:
+        import prefect.context
+
+        if prefect.context.get_settings_context().profile.name != profile:
+            try:
+                with prefect.context.use_profile(
+                    profile, override_environment_variables=True
+                ):
+                    _run_with_settings()
+            except KeyError:
+                print(f"Unknown profile {profile!r}.", file=sys.stderr)
+                sys.exit(1)
+            return
+
+    _run_with_settings()
 
 
 # Short flags that need rewriting before cyclopts meta parses them.

--- a/src/prefect/cli/flow.py
+++ b/src/prefect/cli/flow.py
@@ -7,7 +7,6 @@ View and serve flows.
 from typing import Annotated, Optional
 
 import cyclopts
-import orjson
 from rich.table import Table
 
 import prefect.cli._app as _cli
@@ -15,14 +14,6 @@ from prefect.cli._utilities import (
     exit_with_error,
     with_cli_exception_handling,
 )
-from prefect.client.orchestration import get_client
-from prefect.client.schemas.actions import DeploymentScheduleCreate
-from prefect.client.schemas.schedules import construct_schedule
-from prefect.client.schemas.sorting import FlowSort
-from prefect.deployments.runner import RunnerDeployment
-from prefect.exceptions import MissingFlowError
-from prefect.runner import Runner
-from prefect.utilities import urls
 
 flow_app: cyclopts.App = cyclopts.App(
     name="flow",
@@ -51,6 +42,9 @@ async def ls(
     ] = None,
 ):
     """View flows."""
+    from prefect.client.orchestration import get_client
+    from prefect.client.schemas.sorting import FlowSort
+
     if output and output.lower() != "json":
         exit_with_error("Only 'json' output format is supported.")
 
@@ -68,6 +62,8 @@ async def ls(
         return
 
     if output and output.lower() == "json":
+        import orjson
+
         flows_json = [f.model_dump(mode="json") for f in flows]
         json_output = orjson.dumps(flows_json, option=orjson.OPT_INDENT_2).decode()
         _cli.console.print(json_output, soft_wrap=True)
@@ -198,6 +194,13 @@ async def serve(
     ] = None,
 ):
     """Serve a flow via an entrypoint."""
+    from prefect.client.schemas.actions import DeploymentScheduleCreate
+    from prefect.client.schemas.schedules import construct_schedule
+    from prefect.deployments.runner import RunnerDeployment
+    from prefect.exceptions import MissingFlowError
+    from prefect.runner import Runner
+    from prefect.utilities import urls
+
     runner = Runner(
         name=name,
         pause_on_shutdown=pause_on_shutdown,

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -10,20 +10,15 @@ import textwrap
 from typing import Annotated, Optional
 
 import cyclopts
-import orjson
-from rich.progress import Progress, SpinnerColumn, TextColumn
-from rich.prompt import Confirm
 from rich.table import Table
 
 import prefect.cli._app as _cli
-import prefect.context
 import prefect.settings
 from prefect.cli._utilities import (
     exit_with_error,
     exit_with_success,
     with_cli_exception_handling,
 )
-from prefect.context import use_profile
 from prefect.settings import ProfilesCollection
 from prefect.settings.profiles import _read_profiles_from, _write_profiles_to
 from prefect.utilities.collections import AutoEnum
@@ -39,8 +34,10 @@ def ls():
     """
     List profile names.
     """
+    from prefect import context as prefect_context
+
     profiles = prefect.settings.load_profiles(include_defaults=False)
-    current_profile = prefect.context.get_settings_context().profile
+    current_profile = prefect_context.get_settings_context().profile
     current_name = current_profile.name if current_profile is not None else None
 
     table = Table(caption="* active profile")
@@ -167,6 +164,10 @@ async def use(name: str):
     profiles.set_active(name)
     prefect.settings.save_profiles(profiles)
 
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+
+    from prefect.context import use_profile
+
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
@@ -195,7 +196,11 @@ def delete(name: str):
     if name not in profiles:
         exit_with_error(f"Profile {name!r} not found.")
 
-    current_profile = prefect.context.get_settings_context().profile
+    from rich.prompt import Confirm
+
+    from prefect import context as prefect_context
+
+    current_profile = prefect_context.get_settings_context().profile
     if current_profile.name == name:
         exit_with_error(
             f"Profile {name!r} is the active profile. You must switch profiles before"
@@ -230,7 +235,9 @@ def rename(name: str, new_name: str):
     profiles.add_profile(profiles[name].model_copy(update={"name": new_name}))
     profiles.remove_profile(name)
 
-    prefect.context.get_settings_context().profile
+    from prefect import context as prefect_context
+
+    prefect_context.get_settings_context().profile
     if profiles.active_name == name:
         profiles.set_active(new_name)
     if os.environ.get("PREFECT_PROFILE") == name:
@@ -269,7 +276,9 @@ def inspect(
 
     profiles = prefect.settings.load_profiles()
     if name is None:
-        current_profile = prefect.context.get_settings_context().profile
+        from prefect import context as prefect_context
+
+        current_profile = prefect_context.get_settings_context().profile
         if not current_profile:
             exit_with_error("No active profile set - please provide a name to inspect.")
         name = current_profile.name
@@ -285,6 +294,8 @@ def inspect(
         return
 
     if output and output.lower() == "json":
+        import orjson
+
         profile_data = {
             setting.name: value for setting, value in profiles[name].settings.items()
         }
@@ -312,6 +323,8 @@ def populate_defaults():
             return
 
         if _cli.is_interactive():
+            from rich.prompt import Confirm
+
             if Confirm.ask(
                 f"\nBack up existing profiles to {user_path}.bak?",
                 console=_cli.console,
@@ -326,6 +339,8 @@ def populate_defaults():
         _show_profile_changes(user_profiles, default_profiles)
 
     if _cli.is_interactive():
+        from rich.prompt import Confirm
+
         if not Confirm.ask(
             f"\nUpdate profiles at {user_path}?",
             console=_cli.console,


### PR DESCRIPTION
## Summary
This PR trims CLI import untangling to low-risk command-module changes only.

This PR:
- defers `prefect.context` import in `prefect.cli._app` until `--profile` is used
- defers heavy imports in `prefect.cli.flow` to command execution paths
- defers heavy imports in `prefect.cli.profile` to command execution paths

## Scope
- intentionally does **not** include settings/context plumbing changes from prior experiments
- keeps behavior changes minimal and focused on startup import cost

## Validation
- `uv run ruff check src/prefect/cli/_app.py src/prefect/cli/flow.py src/prefect/cli/profile.py`
- `uv run pytest tests/cli/test_flow.py tests/cli/test_flow_run.py`
- `uv run pytest tests/cli/test_profile.py::test_use_profile_unknown_key tests/cli/test_profile.py::test_inspect_profile_with_json_output tests/cli/test_profile.py::test_ls_additional_profiles tests/cli/test_profile.py::test_ls_respects_current_from_profile_flag tests/cli/test_profile.py::test_ls_respects_current_from_context`
- smoke: `prefect --help`, `prefect profile ls`, `prefect flow --help`

## Notes
I’m opening this as draft so we can evaluate the CI startup benchmarks before deciding whether to merge or further narrow/expand scope.
