### PR TITLE
Add --output json support to block inspect and block type inspect

### DIFF
--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -415,10 +415,21 @@ async def block_inspect(
         Optional[UUID],
         cyclopts.Parameter("--id", help="A Block id to search for if no slug is given"),
     ] = None,
+    output: Annotated[
+        Optional[str],
+        cyclopts.Parameter(
+            "--output",
+            alias="-o",
+            help="Specify an output format. Currently supports: json",
+        ),
+    ] = None,
 ):
     """Displays details about a configured block."""
     from prefect.client.orchestration import get_client
     from prefect.exceptions import ObjectNotFound
+
+    if output and output.lower() != "json":
+        exit_with_error("Only 'json' output format is supported.")
 
     async with get_client() as client:
         if slug is None and block_id is not None:
@@ -442,7 +453,13 @@ async def block_inspect(
                 exit_with_error(f"Block {slug!r} not found!")
         else:
             exit_with_error("Must provide a block slug or id")
-        _cli.console.print(_display_block(block_document))
+
+        if output and output.lower() == "json":
+            block_json = block_document.model_dump(mode="json")
+            json_output = orjson.dumps(block_json, option=orjson.OPT_INDENT_2).decode()
+            _cli.console.print(json_output, soft_wrap=True)
+        else:
+            _cli.console.print(_display_block(block_document))
 
 
 # =========================================================================
@@ -508,18 +525,28 @@ async def list_types(
 @with_cli_exception_handling
 async def blocktype_inspect(
     slug: Annotated[str, cyclopts.Parameter(help="A block type slug")],
+    *,
+    output: Annotated[
+        Optional[str],
+        cyclopts.Parameter(
+            "--output",
+            alias="-o",
+            help="Specify an output format. Currently supports: json",
+        ),
+    ] = None,
 ):
     """Display details about a block type."""
     from prefect.client.orchestration import get_client
     from prefect.exceptions import ObjectNotFound
+
+    if output and output.lower() != "json":
+        exit_with_error("Only 'json' output format is supported.")
 
     async with get_client() as client:
         try:
             block_type = await client.read_block_type_by_slug(slug)
         except ObjectNotFound:
             exit_with_error(f"Block type {slug!r} not found!")
-
-        _cli.console.print(_display_block_type(block_type))
 
         try:
             latest_schema = await client.get_most_recent_block_schema_for_block_type(
@@ -531,6 +558,17 @@ async def blocktype_inspect(
         if latest_schema is None:
             exit_with_error(f"No schema found for the {slug} block type")
 
+        if output and output.lower() == "json":
+            block_type_json = block_type.model_dump(mode="json")
+            schema_json = latest_schema.model_dump(mode="json")
+            json_output = orjson.dumps(
+                {"block_type": block_type_json, "schema": schema_json},
+                option=orjson.OPT_INDENT_2,
+            ).decode()
+            _cli.console.print(json_output, soft_wrap=True)
+            return
+
+        _cli.console.print(_display_block_type(block_type))
         _cli.console.print(_display_block_schema_properties(latest_schema.fields))
 
         latest_schema_extra_definitions = latest_schema.fields.get("definitions")

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -1,3 +1,4 @@
+import json
 import re
 import uuid
 
@@ -392,6 +393,29 @@ async def test_inspecting_a_block():
     )
 
 
+async def test_inspecting_a_block_json_output():
+    await system.Secret(value="sk-1234567890").save("secretblob")
+
+    result = await run_sync_in_worker_thread(
+        invoke_and_assert,
+        ["block", "inspect", "secret/secretblob", "-o", "json"],
+        expected_code=0,
+    )
+    output_data = json.loads(result.stdout.strip())
+
+    assert output_data["name"] == "secretblob"
+    assert output_data["block_type"]["slug"] == "secret"
+    assert output_data["data"]["value"] == "********"
+
+
+def test_inspecting_a_block_invalid_output_format():
+    invoke_and_assert(
+        ["block", "inspect", "secret/secretblob", "-o", "xml"],
+        expected_code=1,
+        expected_output_contains="Only 'json' output format is supported.",
+    )
+
+
 def test_inspecting_a_block_malformed_slug():
     invoke_and_assert(
         ["block", "inspect", "chonk-block"],
@@ -452,6 +476,36 @@ def test_inspecting_a_block_type(tmp_path):
         ["block", "type", "inspect", "testforfileregister"],
         expected_code=0,
         expected_output_contains=expected_output,
+    )
+
+
+def test_inspecting_a_block_type_json_output(tmp_path):
+    test_file_path = tmp_path / "test.py"
+
+    with open(test_file_path, "w") as f:
+        f.write(TEST_BLOCK_CODE)
+
+    invoke_and_assert(
+        ["block", "register", "-f", str(test_file_path)],
+        expected_code=0,
+        expected_output_contains="Successfully registered 1 block",
+    )
+
+    result = invoke_and_assert(
+        ["block", "type", "inspect", "testforfileregister", "-o", "json"],
+        expected_code=0,
+    )
+    output_data = json.loads(result.stdout.strip())
+
+    assert output_data["block_type"]["slug"] == "testforfileregister"
+    assert output_data["schema"]["fields"]["properties"]["message"]["type"] == "string"
+
+
+def test_inspecting_a_block_type_invalid_output_format():
+    invoke_and_assert(
+        ["block", "type", "inspect", "secret", "-o", "xml"],
+        expected_code=1,
+        expected_output_contains="Only 'json' output format is supported.",
     )
 
 


### PR DESCRIPTION
## Summary

Related to #19483

Adds `--output json` / `-o json` support to:

- `block inspect`
- `block type inspect`

Behavior follows the existing CLI JSON pattern:
- validate `--output` values (only `json` supported)
- print machine-readable JSON using `orjson.dumps(..., option=orjson.OPT_INDENT_2)`
- keep existing rich/table output unchanged when `--output` is not provided

For `block type inspect`, JSON output includes both block type and schema payload:
- `block_type`
- `schema`

## Changes

- `src/prefect/cli/block.py`
  - Add `output` option to `block_inspect` and `blocktype_inspect`
  - Add JSON-mode serialization and output branches
  - Preserve existing text/table behavior for default mode

- `tests/cli/test_block.py`
  - Add JSON-output tests for both commands
  - Add invalid output format tests for both commands

## Test plan

- `uv run pytest tests/cli/test_block.py -k "inspecting_a_block_json_output or inspecting_a_block_invalid_output_format or inspecting_a_block_type_json_output or inspecting_a_block_type_invalid_output_format or inspecting_a_block_type or inspecting_a_block"`
- `uv run ruff check src/prefect/cli/block.py tests/cli/test_block.py`
