### PR TITLE
Add --output json support to server services ls

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Annotated, Optional
 
 import cyclopts
+import orjson
 from rich.table import Table
 from rich.text import Text
 
@@ -534,9 +535,44 @@ async def stamp(revision: str):
 
 @services_app.command(name="ls", alias="list")
 @with_cli_exception_handling
-def list_services():
+def list_services(
+    *,
+    output: Annotated[
+        Optional[str],
+        cyclopts.Parameter(
+            "--output",
+            alias="-o",
+            help="Specify an output format. Currently supports: json",
+        ),
+    ] = None,
+):
     """List all available services and their status."""
     from prefect.server.services.base import Service
+
+    if output is not None and output.lower() != "json":
+        exit_with_error("Only 'json' output format is supported.")
+
+    if output is not None:
+        payload: list[dict[str, object]] = []
+        for svc in Service.all_services():
+            name = svc.__name__
+            enabled = bool(svc.enabled())
+            environment_variable = svc.environment_variable_name()
+            doc = inspect.getdoc(svc) or ""
+            description = doc.split("\n", 1)[0].strip()
+            payload.append(
+                {
+                    "name": name,
+                    "enabled": enabled,
+                    "environment_variable": environment_variable,
+                    "description": description,
+                }
+            )
+        _cli.console.print(
+            orjson.dumps(payload, option=orjson.OPT_INDENT_2).decode(),
+            soft_wrap=True,
+        )
+        return
 
     table = Table(title="Available Services", expand=True)
     table.add_column("Name", no_wrap=True)

--- a/tests/cli/test_server_services.py
+++ b/tests/cli/test_server_services.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -129,4 +130,52 @@ class TestBackgroundServices:
                 "PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER",
             ],
             expected_code=0,
+        )
+
+    def test_list_services_json_output(self):
+        result = invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "ls",
+                "--output",
+                "json",
+            ],
+            expected_code=0,
+        )
+
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+        assert payload, "Expected non-empty JSON list"
+
+        required_keys = {"name", "enabled", "environment_variable", "description"}
+        for item in payload:
+            assert required_keys.issubset(item.keys())
+
+    def test_list_services_json_output_short_flag(self):
+        result = invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "ls",
+                "-o",
+                "json",
+            ],
+            expected_code=0,
+        )
+
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+
+    def test_list_services_invalid_output_format(self):
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "ls",
+                "--output",
+                "xml",
+            ],
+            expected_code=1,
+            expected_output_contains="Only 'json' output format is supported.",
         )


### PR DESCRIPTION
related to #19483

## Summary
This PR adds machine-readable output support to `prefect server services ls` via:

- `--output json`
- `-o json`

Behavior now matches the existing CLI output pattern:
- when `--output/-o json` is provided, command prints indented JSON
- default behavior remains the existing Rich table
- invalid output formats return a clear error (`Only 'json' output format is supported.`)

## Changes
- Updated `src/prefect/cli/server.py`
  - added `output` option to `server services ls`
  - added json serialization branch using `orjson.dumps(..., option=orjson.OPT_INDENT_2)`
  - preserved existing table output path
- Updated `tests/cli/test_server_services.py`
  - added test for `--output json`
  - added test for `-o json`
  - added test for invalid output format

## Testing
- `uv run pytest tests/cli/test_server_services.py`
