### PR TITLE
Add --output json support to work-pool preview

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -716,12 +716,23 @@ async def preview(
             help="The number of hours to look ahead; defaults to 1 hour",
         ),
     ] = None,
+    output: Annotated[
+        Optional[str],
+        cyclopts.Parameter(
+            "--output",
+            alias="-o",
+            help="Specify an output format. Currently supports: json",
+        ),
+    ] = None,
 ):
     """Preview the work pool's scheduled work for all queues."""
     from prefect.client.orchestration import get_client
     from prefect.client.schemas.objects import FlowRun
     from prefect.exceptions import ObjectNotFound
     from prefect.types._datetime import now as now_fn
+
+    if output and output.lower() != "json":
+        exit_with_error("Only 'json' output format is supported.")
 
     if hours is None:
         hours = 1
@@ -750,7 +761,15 @@ async def preview(
         assert r.created is not None
         return now - r.created
 
-    for run in sorted(runs, key=sort_by_created_key):
+    sorted_runs = sorted(runs, key=sort_by_created_key)
+
+    if output and output.lower() == "json":
+        runs_json = [run.model_dump(mode="json") for run in sorted_runs]
+        json_output = orjson.dumps(runs_json, option=orjson.OPT_INDENT_2).decode()
+        _cli.console.print(json_output, soft_wrap=True)
+        return
+
+    for run in sorted_runs:
         table.add_row(
             (
                 f"{run.expected_start_time} [red](**)"
@@ -762,7 +781,7 @@ async def preview(
             str(run.deployment_id),
         )
 
-    if runs:
+    if sorted_runs:
         _cli.console.print(table)
     else:
         _cli.console.print(

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -832,6 +832,34 @@ class TestPreview:
         )
         assert res.exit_code == 0
 
+    async def test_preview_json_output(self, prefect_client, work_pool):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=["work-pool", "preview", work_pool.name, "--output", "json"],
+            expected_code=0,
+        )
+
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+
+    async def test_preview_json_output_short_flag(self, prefect_client, work_pool):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=["work-pool", "preview", work_pool.name, "-o", "json"],
+            expected_code=0,
+        )
+
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+
+    async def test_preview_invalid_output_format(self, prefect_client, work_pool):
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=["work-pool", "preview", work_pool.name, "--output", "xml"],
+            expected_code=1,
+            expected_output_contains="Only 'json' output format is supported.",
+        )
+
 
 class TestGetDefaultBaseJobTemplate:
     @pytest.mark.usefixtures("mock_collection_registry")


### PR DESCRIPTION
related to #19483

this PR adds `--output/-o json` support to `prefect work-pool preview`.

<details>
<summary>Implementation details</summary>

- validates output format and errors for non-json values
- serializes flow run results with `orjson.dumps(..., option=orjson.OPT_INDENT_2)`
- prints JSON with `soft_wrap=True` to avoid wrapped literal output issues
- preserves current table output when `--output` is not set
- adds tests for `--output`, `-o`, and invalid format behavior

</details>

## Testing
- `uv run ruff check src/prefect/cli/work_pool.py tests/cli/test_work_pool.py`
- `uv run pytest tests/cli/test_work_pool.py::TestPreview`
