### PR TITLE
Add ECS worker submission error hints for inactive tasks, capacity, and network issues

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -874,14 +874,17 @@ class ECSWorker(BaseWorker[ECSJobConfiguration, ECSVariables, ECSWorkerResult]):
         """
         # AWS generates exception types at runtime so they must be captured a bit
         # differently than normal.
-        if "ClusterNotFoundException" in str(exc):
+        exc_str = str(exc)
+        exc_str_lower = exc_str.lower()
+
+        if "ClusterNotFoundException" in exc_str:
             cluster = task_run.get("cluster", "default")
             raise RuntimeError(
                 f"Failed to run ECS task, cluster {cluster!r} not found. "
                 "Confirm that the cluster is configured in your region."
             ) from exc
         elif (
-            "No Container Instances" in str(exc) and task_run.get("launchType") == "EC2"
+            "No Container Instances" in exc_str and task_run.get("launchType") == "EC2"
         ):
             cluster = task_run.get("cluster", "default")
             raise RuntimeError(
@@ -890,8 +893,8 @@ class ECSWorker(BaseWorker[ECSJobConfiguration, ECSVariables, ECSWorkerResult]):
                 "have EC2 container instances available."
             ) from exc
         elif (
-            "failed to validate logger args" in str(exc)
-            and "AccessDeniedException" in str(exc)
+            "failed to validate logger args" in exc_str
+            and "AccessDeniedException" in exc_str
             and configuration.configure_cloudwatch_logs
         ):
             raise RuntimeError(
@@ -900,6 +903,29 @@ class ECSWorker(BaseWorker[ECSJobConfiguration, ECSVariables, ECSWorkerResult]):
                 f" {configuration.execution_role!r} has permissions"
                 " logs:CreateLogStream, logs:CreateLogGroup, and logs:PutLogEvents."
             )
+        elif "TaskDefinition is inactive" in exc_str:
+            raise RuntimeError(
+                "Failed to run ECS task, the task definition is inactive. "
+                "Re-register the task definition or remove the "
+                "`task_definition_arn` from your work pool configuration to "
+                "allow Prefect to register a new task definition automatically."
+            ) from exc
+        elif "no capacity" in exc_str_lower or "capacity provider" in exc_str_lower:
+            raise RuntimeError(
+                "Failed to run ECS task due to a capacity provider error. "
+                "Verify that your Fargate or EC2 capacity providers are "
+                "correctly configured for the cluster and that the requested "
+                "capacity is available."
+            ) from exc
+        elif "InvalidParameterException" in exc_str and any(
+            keyword in exc_str_lower
+            for keyword in ("subnet", "security group", "network")
+        ):
+            raise RuntimeError(
+                "Failed to run ECS task due to a network configuration error. "
+                "Verify the subnets and security groups in your work pool's "
+                "network configuration are valid and belong to the expected VPC."
+            ) from exc
         else:
             raise
 

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -2964,3 +2964,45 @@ async def test_kill_infrastructure_raises_not_found(aws_credentials, flow_run):
                     configuration=configuration,
                     grace_seconds=30,
                 )
+
+
+class TestReportTaskRunCreationFailure:
+    """Tests for _report_task_run_creation_failure error handling."""
+
+    @staticmethod
+    def _call(configuration, task_run, exc):
+        worker = ECSWorker.__new__(ECSWorker)
+        try:
+            raise exc
+        except Exception:
+            worker._report_task_run_creation_failure(configuration, task_run, exc)
+
+    @pytest.mark.parametrize(
+        "message,expected_match",
+        [
+            ("TaskDefinition is inactive", "task definition is inactive"),
+            ("No capacity is available", "capacity provider error"),
+            ("The Capacity Provider strategy is invalid", "capacity provider error"),
+            (
+                "InvalidParameterException: The subnet ID 'subnet-xxx' does not exist",
+                "network configuration error",
+            ),
+            (
+                "InvalidParameterException: The security group 'sg-xxx' does not exist",
+                "network configuration error",
+            ),
+            (
+                "InvalidParameterException: The network configuration is invalid",
+                "network configuration error",
+            ),
+        ],
+    )
+    def test_known_error_messages(self, message, expected_match):
+        exc = Exception(message)
+        with pytest.raises(RuntimeError, match=expected_match):
+            self._call(MagicMock(), {}, exc)
+
+    def test_unknown_error_reraised(self):
+        exc = Exception("Something completely unexpected")
+        with pytest.raises(Exception, match="Something completely unexpected"):
+            self._call(MagicMock(), {}, exc)


### PR DESCRIPTION
## Summary

- Adds three new error cases to `_report_task_run_creation_failure` in the ECS worker with actionable resolution hints:
  - **Inactive task definition** → suggests re-registering or removing `task_definition_arn` from config
  - **Capacity provider errors** → points to Fargate/EC2 capacity provider configuration
  - **Network configuration errors** (subnet/security group/network `InvalidParameterException`) → points to work pool network settings
- Refactors the method to compute `str(exc)` once instead of repeatedly across all branches
- Adds parametrized tests covering all new error cases

Closes OSS-7693

🤖 Generated with [Claude Code](https://claude.com/claude-code)