### PR TITLE
Fix Flow Runs history chart not updating on polling

### DIFF
--- a/ui-v2/src/components/flows/detail/flow-stats-summary/flow-runs-history-card.tsx
+++ b/ui-v2/src/components/flows/detail/flow-stats-summary/flow-runs-history-card.tsx
@@ -75,16 +75,9 @@ export function FlowRunsHistoryCard({
 		[flowRuns, flow],
 	);
 
-	const { startDate, endDate } = useMemo((): {
-		startDate: Date;
-		endDate: Date;
-	} => {
-		const now = new Date();
-		return {
-			startDate: subDays(now, 7),
-			endDate: now,
-		};
-	}, [flowRuns]);
+	const now = new Date();
+	const startDate = subDays(now, 7);
+	const endDate = now;
 
 	return (
 		<Card className="flex-1">


### PR DESCRIPTION
## Summary
Fixes an issue where the Flow Runs history bar chart did not visually update when polling fetched new flow runs.

## Cause
The chart date range was memoized in a way that left the rendered time window stale until a full page refresh.

## Fix
Compute the chart date range on render so it stays in sync when polling causes the component to re-render with updated flow run data.

## Testing
- Ran Prefect locally with the UI and server
- Created multiple flow runs using a local test flow
- Verified the chart updated without a manual page refresh after new runs completed
- Verified the dashboard also updated on the normal polling delay