### PR TITLE
Add end_time filter support for flow & task runs

### DIFF
--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -218,6 +218,22 @@ class FlowRunFilterStartTime(PrefectBaseModel):
     )
 
 
+class FlowRunFilterEndTime(PrefectBaseModel):
+    """Filter by `FlowRun.end_time`."""
+
+    before_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include flow runs ending at or before this time",
+    )
+    after_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include flow runs ending at or after this time",
+    )
+    is_null_: Optional[bool] = Field(
+        default=None, description="If true, only return flow runs without an end time"
+    )
+
+
 class FlowRunFilterExpectedStartTime(PrefectBaseModel):
     """Filter by `FlowRun.expected_start_time`."""
 
@@ -328,6 +344,9 @@ class FlowRunFilter(PrefectBaseModel, OperatorMixin):
     )
     start_time: Optional[FlowRunFilterStartTime] = Field(
         default=None, description="Filter criteria for `FlowRun.start_time`"
+    )
+    end_time: Optional[FlowRunFilterEndTime] = Field(
+        default=None, description="Filter criteria for `FlowRun.end_time`"
     )
     expected_start_time: Optional[FlowRunFilterExpectedStartTime] = Field(
         default=None, description="Filter criteria for `FlowRun.expected_start_time`"
@@ -454,6 +473,22 @@ class TaskRunFilterStartTime(PrefectBaseModel):
     )
 
 
+class TaskRunFilterEndTime(PrefectBaseModel):
+    """Filter by `TaskRun.end_time`."""
+
+    before_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include task runs ending at or before this time",
+    )
+    after_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include task runs ending at or after this time",
+    )
+    is_null_: Optional[bool] = Field(
+        default=None, description="If true, only return task runs without an end time"
+    )
+
+
 class TaskRunFilter(PrefectBaseModel, OperatorMixin):
     """Filter task runs. Only task runs matching all criteria will be returned"""
 
@@ -471,6 +506,9 @@ class TaskRunFilter(PrefectBaseModel, OperatorMixin):
     )
     start_time: Optional[TaskRunFilterStartTime] = Field(
         default=None, description="Filter criteria for `TaskRun.start_time`"
+    )
+    end_time: Optional[TaskRunFilterEndTime] = Field(
+        default=None, description="Filter criteria for `TaskRun.end_time`"
     )
     subflow_runs: Optional[TaskRunFilterSubFlowRuns] = Field(
         default=None, description="Filter criteria for `TaskRun.subflow_run`"

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1008,6 +1008,38 @@ class TaskRunFilterStartTime(PrefectFilterBaseModel):
         return filters
 
 
+class TaskRunFilterEndTime(PrefectFilterBaseModel):
+    """Filter by `TaskRun.end_time`."""
+
+    before_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include task runs ending at or before this time",
+    )
+    after_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include task runs ending at or after this time",
+    )
+    is_null_: Optional[bool] = Field(
+        default=None, description="If true, only return task runs without an end time"
+    )
+
+    def _get_filter_list(
+        self, db: "PrefectDBInterface"
+    ) -> Iterable[sa.ColumnExpressionArgument[bool]]:
+        filters: list[sa.ColumnExpressionArgument[bool]] = []
+        if self.before_ is not None:
+            filters.append(db.TaskRun.end_time <= self.before_)
+        if self.after_ is not None:
+            filters.append(db.TaskRun.end_time >= self.after_)
+        if self.is_null_ is not None:
+            filters.append(
+                db.TaskRun.end_time.is_(None)
+                if self.is_null_
+                else db.TaskRun.end_time.is_not(None)
+            )
+        return filters
+
+
 class TaskRunFilterExpectedStartTime(PrefectFilterBaseModel):
     """Filter by `TaskRun.expected_start_time`."""
 
@@ -1049,6 +1081,9 @@ class TaskRunFilter(PrefectOperatorFilterBaseModel):
     start_time: Optional[TaskRunFilterStartTime] = Field(
         default=None, description="Filter criteria for `TaskRun.start_time`"
     )
+    end_time: Optional[TaskRunFilterEndTime] = Field(
+        default=None, description="Filter criteria for `TaskRun.end_time`"
+    )
     expected_start_time: Optional[TaskRunFilterExpectedStartTime] = Field(
         default=None, description="Filter criteria for `TaskRun.expected_start_time`"
     )
@@ -1074,6 +1109,8 @@ class TaskRunFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.state.as_sql_filter())
         if self.start_time is not None:
             filters.append(self.start_time.as_sql_filter())
+        if self.end_time is not None:
+            filters.append(self.end_time.as_sql_filter())
         if self.expected_start_time is not None:
             filters.append(self.expected_start_time.as_sql_filter())
         if self.subflow_runs is not None:

--- a/tests/server/models/test_filters.py
+++ b/tests/server/models/test_filters.py
@@ -775,6 +775,34 @@ class TestCountTaskRunsModels:
             ),
             0,
         ],
+        # task runs with end_time set (completed or failed)
+        [
+            dict(task_run_filter=filters.TaskRunFilter(end_time=dict(is_null_=False))),
+            5,
+        ],
+        # task runs with null end_time (running or no state)
+        [
+            dict(task_run_filter=filters.TaskRunFilter(end_time=dict(is_null_=True))),
+            5,
+        ],
+        # task runs with end_time before now + 1 day (all completed/failed runs)
+        [
+            dict(
+                task_run_filter=filters.TaskRunFilter(
+                    end_time=dict(before_=now("UTC") + timedelta(days=1))
+                )
+            ),
+            5,
+        ],
+        # task runs with end_time after now + 1 day (none)
+        [
+            dict(
+                task_run_filter=filters.TaskRunFilter(
+                    end_time=dict(after_=now("UTC") + timedelta(days=1))
+                )
+            ),
+            0,
+        ],
         # empty filter
         [dict(flow_filter=filters.FlowFilter()), 10],
         # multiple empty filters

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -6,6 +6,7 @@ from prefect.server.schemas.filters import (
     FlowRunFilter,
     FlowRunFilterCreatedBy,
     LogFilter,
+    TaskRunFilter,
 )
 from prefect.types._datetime import now
 
@@ -124,3 +125,20 @@ class TestFlowRunFilters:
         )
         sql_filter = flow_run_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.FlowRun.created_by.is_not(None)))
+
+
+class TestTaskRunFilters:
+    def test_applies_task_run_end_time_filter_before(self, db):
+        task_run_filter = TaskRunFilter(end_time={"before_": NOW})
+        sql_filter = task_run_filter.as_sql_filter()
+        assert sql_filter.compare(sa.and_(db.TaskRun.end_time <= NOW))
+
+    def test_applies_task_run_end_time_filter_after(self, db):
+        task_run_filter = TaskRunFilter(end_time={"after_": NOW})
+        sql_filter = task_run_filter.as_sql_filter()
+        assert sql_filter.compare(sa.and_(db.TaskRun.end_time >= NOW))
+
+    def test_applies_task_run_end_time_filter_null(self, db):
+        task_run_filter = TaskRunFilter(end_time={"is_null_": True})
+        sql_filter = task_run_filter.as_sql_filter()
+        assert sql_filter.compare(sa.and_(db.TaskRun.end_time.is_(None)))

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -10927,12 +10927,35 @@ export interface components {
             state?: components["schemas"]["TaskRunFilterState"] | null;
             /** @description Filter criteria for `TaskRun.start_time` */
             start_time?: components["schemas"]["TaskRunFilterStartTime"] | null;
+            /** @description Filter criteria for `TaskRun.end_time` */
+            end_time?: components["schemas"]["TaskRunFilterEndTime"] | null;
             /** @description Filter criteria for `TaskRun.expected_start_time` */
             expected_start_time?: components["schemas"]["TaskRunFilterExpectedStartTime"] | null;
             /** @description Filter criteria for `TaskRun.subflow_run` */
             subflow_runs?: components["schemas"]["TaskRunFilterSubFlowRuns"] | null;
             /** @description Filter criteria for `TaskRun.flow_run_id` */
             flow_run_id?: components["schemas"]["TaskRunFilterFlowRunId"] | null;
+        };
+        /**
+         * TaskRunFilterEndTime
+         * @description Filter by `TaskRun.end_time`.
+         */
+        TaskRunFilterEndTime: {
+            /**
+             * Before
+             * @description Only include task runs ending at or before this time
+             */
+            before_?: string | null;
+            /**
+             * After
+             * @description Only include task runs ending at or after this time
+             */
+            after_?: string | null;
+            /**
+             * Is Null
+             * @description If true, only return task runs without an end time
+             */
+            is_null_?: boolean | null;
         };
         /**
          * TaskRunFilterExpectedStartTime


### PR DESCRIPTION
Related to #9698

This PR takes on the approach from the earlier attempt (#19107) but applies it minimally to the current codebase.

Adds `end_time` filtering support (`before_`, `after_`, `is_null_`) for flow run and task run filters, aligned with existing `start_time` behavior.

<details>
<summary>What changed</summary>

- Added client schema support in `src/prefect/client/schemas/filters.py`:
  - `FlowRunFilterEndTime`
  - `TaskRunFilterEndTime`
  - `end_time` field on `FlowRunFilter`
  - `end_time` field on `TaskRunFilter`
- Added server schema support in `src/prefect/server/schemas/filters.py`:
  - `TaskRunFilterEndTime` SQL filter model
  - `end_time` field on `TaskRunFilter`
  - `TaskRunFilter._get_filter_list` handling for `end_time`
- Added model-level behavioral coverage in `tests/server/models/test_filters.py` for task run `end_time` filters:
  - `is_null_`
  - `before_`
  - `after_`
- Added missing schema-level SQL generation coverage for task run `end_time` in `tests/server/schemas/test_filters.py`
- Regenerated API types in `ui-v2/src/api/prefect.ts` via `npm run service-sync` (no manual edits)

</details>

### Validation

- `uv run pytest tests/server/schemas/test_filters.py -k "TaskRun and end_time" -x`
- `uv run pytest tests/server/models/test_filters.py -k "TestCountTaskRunsModels" -x`
- `uv run ruff check src/prefect/client/schemas/filters.py src/prefect/server/schemas/filters.py tests/server/models/test_filters.py tests/server/schemas/test_filters.py`

