### PR TITLE
use cyclopts native lazy loading for CLI commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pytz>=2021.1,<2027",
     "readchar>=4.0.0,<5.0.0",
     "sqlalchemy[asyncio]>=2.0,<3.0.0",
-    "cyclopts>=3.0",
+    "cyclopts>=4.8.0",
     # Client dependencies
     # If you modify this list, make the same modification in client/pyproject.toml
     "amplitude-analytics>=1.2.1,<2.0.0",

--- a/src/prefect/cli/_app.py
+++ b/src/prefect/cli/_app.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import sys
-from importlib import import_module
 from typing import Annotated, Optional
 
 import cyclopts
@@ -163,98 +162,165 @@ def app() -> None:
 
 
 # =============================================================================
-# Command registrations
+# Lazy command registrations (cyclopts native lazy loading)
 # =============================================================================
+# Each string is resolved only when the command is actually invoked,
+# avoiding the cost of importing all 29 command modules at startup.
 
-
-def _load_target(target: str):
-    module_name, attribute_name = target.split(":", 1)
-    module = import_module(module_name)
-    return getattr(module, attribute_name)
-
-
-def _build_lazy_command_app(target: str, command_name: str) -> cyclopts.App:
-    """Create a thin command trampoline that defers importing real commands."""
-
-    def _dispatch(
-        *tokens: Annotated[
-            str, cyclopts.Parameter(show=False, allow_leading_hyphen=True)
-        ],
-    ) -> None:
-        resolved = _load_target(target)
-        if isinstance(resolved, cyclopts.App):
-            aliases = tuple(
-                alias
-                for alias in getattr(resolved, "alias", ())
-                if alias != command_name
-            )
-            command_app = cyclopts.App(name="prefect", help_flags=[], version_flags=[])
-            command_app.command(
-                resolved,
-                name=command_name,
-                alias=aliases if aliases else None,
-            )
-            command_app((command_name, *tokens))
-        else:
-            command_app = cyclopts.App(
-                default_command=resolved,
-                name=f"prefect {command_name}",
-                version_flags=[],
-            )
-            command_app(tokens)
-
-    return cyclopts.App(
-        default_command=_dispatch,
-        help_flags=[],
-        version_flags=[],
-    )
-
-
-# Register command entrypoints lazily to avoid importing every command module at
-# CLI startup. Each target is "module_path:object_name".
-_LAZY_COMMAND_SPECS: list[tuple[str, str, tuple[str, ...]]] = [
-    ("prefect.cli.deploy:deploy_app", "deploy", ()),
-    ("prefect.cli.deploy:init", "init", ()),
-    ("prefect.cli.flow:flow_app", "flow", ("flows",)),
-    ("prefect.cli.flow_run:flow_run_app", "flow-run", ("flow-runs",)),
-    ("prefect.cli.deployment:deployment_app", "deployment", ("deployments",)),
-    ("prefect.cli.server:server_app", "server", ()),
-    ("prefect.cli.worker:worker_app", "worker", ()),
-    ("prefect.cli.shell:shell_app", "shell", ()),
-    ("prefect.cli.config:config_app", "config", ()),
-    ("prefect.cli.profile:profile_app", "profile", ("profiles",)),
-    ("prefect.cli.cloud:cloud_app", "cloud", ()),
-    ("prefect.cli.work_pool:work_pool_app", "work-pool", ("work-pools",)),
-    ("prefect.cli.work_queue:work_queue_app", "work-queue", ("work-queues",)),
-    ("prefect.cli.variable:variable_app", "variable", ()),
-    ("prefect.cli.block:block_app", "block", ("blocks",)),
-    (
-        "prefect.cli.concurrency_limit:concurrency_limit_app",
-        "concurrency-limit",
-        ("concurrency-limits",),
-    ),
-    (
-        "prefect.cli.global_concurrency_limit:global_concurrency_limit_app",
-        "global-concurrency-limit",
-        ("gcl",),
-    ),
-    ("prefect.cli.artifact:artifact_app", "artifact", ()),
-    ("prefect.cli.experimental:experimental_app", "experimental", ()),
-    ("prefect.cli.automation:automation_app", "automation", ("automations",)),
-    ("prefect.cli.events:events_app", "events", ("event",)),
-    ("prefect.cli.task:task_app", "task", ()),
-    ("prefect.cli.task_run:task_run_app", "task-run", ("task-runs",)),
-    ("prefect.cli.api:api_app", "api", ()),
-    ("prefect.cli.dashboard:dashboard_app", "dashboard", ()),
-    ("prefect.cli.dev:dev_app", "dev", ()),
-    ("prefect.cli.sdk:sdk_app", "sdk", ()),
-    ("prefect.cli.transfer:transfer_app", "transfer", ()),
-    ("prefect.cli.version:version", "version", ()),
-]
-
-for target, name, aliases in _LAZY_COMMAND_SPECS:
-    _app.command(
-        _build_lazy_command_app(target, name),
-        name=name,
-        alias=aliases if aliases else None,
-    )
+_app.command(
+    "prefect.cli.deploy:deploy_app",
+    name="deploy",
+    help="Create and manage deployments.",
+)
+_app.command(
+    "prefect.cli.deploy:init",
+    name="init",
+    help="Initialize a Prefect project.",
+)
+_app.command(
+    "prefect.cli.flow:flow_app",
+    name="flow",
+    alias="flows",
+    help="View and serve flows.",
+)
+_app.command(
+    "prefect.cli.flow_run:flow_run_app",
+    name="flow-run",
+    alias="flow-runs",
+    help="Interact with flow runs.",
+)
+_app.command(
+    "prefect.cli.deployment:deployment_app",
+    name="deployment",
+    alias="deployments",
+    help="Manage deployments.",
+)
+_app.command(
+    "prefect.cli.server:server_app",
+    name="server",
+    help="Start a Prefect server instance and interact with the database.",
+)
+_app.command(
+    "prefect.cli.worker:worker_app",
+    name="worker",
+    help="Start and interact with workers.",
+)
+_app.command(
+    "prefect.cli.shell:shell_app",
+    name="shell",
+    help="Serve and watch shell commands as Prefect flows.",
+)
+_app.command(
+    "prefect.cli.config:config_app",
+    name="config",
+    help="View and set Prefect settings.",
+)
+_app.command(
+    "prefect.cli.profile:profile_app",
+    name="profile",
+    alias="profiles",
+    help="Select and manage Prefect profiles.",
+)
+_app.command(
+    "prefect.cli.cloud:cloud_app",
+    name="cloud",
+    help="Authenticate and interact with Prefect Cloud.",
+)
+_app.command(
+    "prefect.cli.work_pool:work_pool_app",
+    name="work-pool",
+    alias="work-pools",
+    help="Manage work pools.",
+)
+_app.command(
+    "prefect.cli.work_queue:work_queue_app",
+    name="work-queue",
+    alias="work-queues",
+    help="Manage work queues.",
+)
+_app.command(
+    "prefect.cli.variable:variable_app",
+    name="variable",
+    help="Manage variables.",
+)
+_app.command(
+    "prefect.cli.block:block_app",
+    name="block",
+    alias="blocks",
+    help="Manage blocks.",
+)
+_app.command(
+    "prefect.cli.concurrency_limit:concurrency_limit_app",
+    name="concurrency-limit",
+    alias="concurrency-limits",
+    help="Manage task-level concurrency limits.",
+)
+_app.command(
+    "prefect.cli.global_concurrency_limit:global_concurrency_limit_app",
+    name="global-concurrency-limit",
+    alias="gcl",
+    help="Manage global concurrency limits.",
+)
+_app.command(
+    "prefect.cli.artifact:artifact_app",
+    name="artifact",
+    help="Inspect and delete artifacts.",
+)
+_app.command(
+    "prefect.cli.experimental:experimental_app",
+    name="experimental",
+    help="Access experimental features (subject to change).",
+)
+_app.command(
+    "prefect.cli.automation:automation_app",
+    name="automation",
+    alias="automations",
+    help="Manage automations.",
+)
+_app.command(
+    "prefect.cli.events:events_app",
+    name="events",
+    alias="event",
+    help="Stream events.",
+)
+_app.command(
+    "prefect.cli.task:task_app",
+    name="task",
+    help="Work with task scheduling.",
+)
+_app.command(
+    "prefect.cli.task_run:task_run_app",
+    name="task-run",
+    alias="task-runs",
+    help="View and inspect task runs.",
+)
+_app.command(
+    "prefect.cli.api:api_app",
+    name="api",
+    help="Interact with the Prefect API.",
+)
+_app.command(
+    "prefect.cli.dashboard:dashboard_app",
+    name="dashboard",
+    help="Commands for interacting with the Prefect UI.",
+)
+_app.command(
+    "prefect.cli.dev:dev_app",
+    name="dev",
+    help="Internal Prefect development.",
+)
+_app.command(
+    "prefect.cli.sdk:sdk_app",
+    name="sdk",
+    help="Manage Prefect SDKs. (beta)",
+)
+_app.command(
+    "prefect.cli.transfer:transfer_app",
+    name="transfer",
+    help="Transfer resources from one Prefect profile to another.",
+)
+_app.command(
+    "prefect.cli.version:version",
+    name="version",
+    help="Get the current Prefect version and integration information.",
+)

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import watchfiles
 
 import prefect
+import prefect.cli.dev
 from prefect.testing.cli import invoke_and_assert
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -635,8 +635,13 @@ def reset_sys_modules():
     # cached.  Also remove stale references from parent packages so that
     # subsequent monkeypatch / import resolution doesn't find a stale module
     # object via getattr on the parent while sys.modules has no entry.
+    #
+    # Preserve prefect.cli.* modules: cyclopts lazy loading caches resolved
+    # command Apps internally.  Removing the module from sys.modules creates
+    # a stale-reference split where cyclopts holds the old module's objects
+    # but monkeypatch patches a freshly re-imported copy.
     for module in set(sys.modules.keys()):
-        if module not in original_modules:
+        if module not in original_modules and not module.startswith("prefect.cli."):
             parts = module.rsplit(".", 1)
             if len(parts) == 2:
                 parent = sys.modules.get(parts[0])

--- a/uv.lock
+++ b/uv.lock
@@ -1064,18 +1064,19 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "3.24.0"
+version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/ca/7782da3b03242d5f0a16c20371dff99d4bd1fedafe26bc48ff82e42be8c9/cyclopts-3.24.0.tar.gz", hash = "sha256:de6964a041dfb3c57bf043b41e68c43548227a17de1bad246e3a0bfc5c4b7417", size = 76131, upload-time = "2025-09-08T15:40:57.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/7a/3c3623755561c7f283dd769470e99ae36c46810bf3b3f264d69006f6c97a/cyclopts-4.8.0.tar.gz", hash = "sha256:92cc292d18d8be372e58d8bce1aa966d30f819a5fb3fee02bd2ad4a6bb403f29", size = 164066, upload-time = "2026-03-07T19:39:18.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/8b/2c95f0645c6f40211896375e6fa51f504b8ccb29c21f6ae661fe87ab044e/cyclopts-3.24.0-py3-none-any.whl", hash = "sha256:809d04cde9108617106091140c3964ee6fceb33cecdd537f7ffa360bde13ed71", size = 86154, upload-time = "2025-09-08T15:40:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl", hash = "sha256:ef353da05fec36587d4ebce7a6e4b27515d775d184a23bab4b01426f93ddc8d4", size = 201948, upload-time = "2026-03-07T19:39:19.307Z" },
 ]
 
 [[package]]
@@ -4202,7 +4203,7 @@ requires-dist = [
     { name = "cloudpickle", specifier = ">=2.0,<4.0" },
     { name = "coolname", specifier = ">=1.0.4,<5.0.0" },
     { name = "cryptography", specifier = ">=36.0.1" },
-    { name = "cyclopts", specifier = ">=3.0" },
+    { name = "cyclopts", specifier = ">=4.8.0" },
     { name = "dateparser", specifier = ">=1.1.1,<2.0.0" },
     { name = "docker", specifier = ">=4.0,<8.0" },
     { name = "exceptiongroup", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- replace the home-rolled pattern (`_build_lazy_command_app`) with cyclopts 4.8.0's native lazy loading via import path strings
- bump cyclopts pin from `>=3.0` to `>=4.8.0`
- removes ~90 lines of dispatch scaffolding from `_app.py`

cyclopts 4.8.0 ([BrianPugh/cyclopts#761](https://github.com/BrianPugh/cyclopts/pull/761)) adds `help=`, `show=`, `group=`, and `sort_key=` fields to `CommandSpec`, so lazy commands appear in `--help` with their descriptions without resolving any import paths — zero CLI module imports during `prefect --help`.



## Test plan
- [x] `prefect --help` shows all 29 commands with help text
- [x] `prefect version` / `prefect flow --help` resolve on demand
- [x] zero `prefect.cli.*` module imports during `--help` (verified with import tracking)
- [x] CLI test suite passing (252 passed)
- [x] pre-commit hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)