### PR TITLE
Add create_pool_if_not_found flag to worker start command

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -100,6 +100,18 @@ async def start(
             help="Path to JSON file containing base job template.",
         ),
     ] = None,
+    create_pool_if_not_found: Annotated[
+        bool,
+        cyclopts.Parameter(
+            "--create-pool-if-not-found",
+            negative="--no-create-pool-if-not-found",
+            help=(
+                "Create the work pool if it does not exist. "
+                "Set to false when the work pool is managed externally "
+                "(e.g. via Terraform or another provisioning tool)."
+            ),
+        ),
+    ] = True,
 ):
     """Start a worker process to poll a work pool for flow runs."""
     from prefect.cli._prompts import confirm
@@ -215,6 +227,7 @@ async def start(
         prefetch_seconds=prefetch_seconds,
         heartbeat_interval_seconds=int(PREFECT_WORKER_HEARTBEAT_SECONDS.value()),
         base_job_template=template_contents,
+        create_pool_if_not_found=create_pool_if_not_found,
     )
     try:
         await worker.start(

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -216,6 +216,7 @@ def test_start_worker_with_work_queue_names(mock_worker, process_work_pool):
         limit=None,
         heartbeat_interval_seconds=30,
         base_job_template=None,
+        create_pool_if_not_found=True,
     )
     mock_worker.return_value.start.assert_awaited_once_with(
         run_once=True, with_healthcheck=False, printer=ANY
@@ -262,6 +263,7 @@ def test_start_worker_with_specified_work_queues_paused(mock_worker, process_wor
         limit=None,
         heartbeat_interval_seconds=30,
         base_job_template=None,
+        create_pool_if_not_found=True,
     )
     mock_worker.return_value.start.assert_awaited_once_with(
         run_once=True, with_healthcheck=False, printer=ANY
@@ -300,6 +302,7 @@ def test_start_worker_with_all_work_queues_paused(mock_worker, process_work_pool
         limit=None,
         heartbeat_interval_seconds=30,
         base_job_template=None,
+        create_pool_if_not_found=True,
     )
     mock_worker.return_value.start.assert_awaited_once_with(
         run_once=True, with_healthcheck=False, printer=ANY
@@ -330,6 +333,7 @@ def test_start_worker_with_prefetch_seconds(mock_worker):
         limit=None,
         heartbeat_interval_seconds=30,
         base_job_template=None,
+        create_pool_if_not_found=True,
     )
     mock_worker.return_value.start.assert_awaited_once_with(
         run_once=True, with_healthcheck=False, printer=ANY
@@ -359,6 +363,7 @@ def test_start_worker_with_prefetch_seconds_from_setting_by_default(mock_worker)
         limit=None,
         heartbeat_interval_seconds=30,
         base_job_template=None,
+        create_pool_if_not_found=True,
     )
     mock_worker.return_value.start.assert_awaited_once_with(
         run_once=True, with_healthcheck=False, printer=ANY
@@ -389,6 +394,66 @@ def test_start_worker_with_limit(mock_worker):
         limit=5,
         heartbeat_interval_seconds=30,
         base_job_template=None,
+        create_pool_if_not_found=True,
+    )
+    mock_worker.return_value.start.assert_awaited_once_with(
+        run_once=True, with_healthcheck=False, printer=ANY
+    )
+
+
+@pytest.mark.usefixtures("use_hosted_api_server")
+def test_start_worker_create_pool_if_not_found_default(mock_worker):
+    invoke_and_assert(
+        command=[
+            "worker",
+            "start",
+            "-p",
+            "test",
+            "--run-once",
+            "-t",
+            "process",
+        ],
+        expected_code=0,
+    )
+    mock_worker.assert_called_once_with(
+        name=None,
+        work_pool_name="test",
+        work_queues=None,
+        prefetch_seconds=ANY,
+        limit=None,
+        heartbeat_interval_seconds=30,
+        base_job_template=None,
+        create_pool_if_not_found=True,
+    )
+    mock_worker.return_value.start.assert_awaited_once_with(
+        run_once=True, with_healthcheck=False, printer=ANY
+    )
+
+
+@pytest.mark.usefixtures("use_hosted_api_server")
+def test_start_worker_no_create_pool_if_not_found(mock_worker):
+    invoke_and_assert(
+        command=[
+            "worker",
+            "start",
+            "-p",
+            "test",
+            "--run-once",
+            "-t",
+            "process",
+            "--no-create-pool-if-not-found",
+        ],
+        expected_code=0,
+    )
+    mock_worker.assert_called_once_with(
+        name=None,
+        work_pool_name="test",
+        work_queues=None,
+        prefetch_seconds=ANY,
+        limit=None,
+        heartbeat_interval_seconds=30,
+        base_job_template=None,
+        create_pool_if_not_found=False,
     )
     mock_worker.return_value.start.assert_awaited_once_with(
         run_once=True, with_healthcheck=False, printer=ANY


### PR DESCRIPTION
### Overview
This PR adds a new `--create-pool-if-not-found` flag to the `worker start` CLI command, allowing users to control whether the worker should automatically create a work pool if it doesn't exist. This is useful for environments where work pools are managed externally (e.g., via Terraform or other provisioning tools).

### Changes
- Added `create_pool_if_not_found` parameter to the `worker start` command with a default value of `True` to maintain backward compatibility
- The parameter supports both `--create-pool-if-not-found` and `--no-create-pool-if-not-found` flags
- Updated the worker initialization to pass this parameter through to the Worker class
- Added comprehensive test coverage including:
  - Tests verifying the default behavior (creates pool if not found)
  - Tests verifying the `--no-create-pool-if-not-found` flag disables pool creation
  - Updated existing tests to include the new parameter in assertions

### Checklist
- [x] This pull request includes unit tests that cover the changes
- [ ] This pull request references any related issue by including "closes `<link to issue>`"

https://claude.ai/code/session_01ENHt9FzX43ecFSrPTwA6Q9