### PR TITLE
Add PREFECT_CLIENT_EMIT_EVENTS setting to disable client-side event emission

### DIFF
--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -38,6 +38,10 @@ class ProcessPoolForwardingEventsClient(EventsClient):
 
 
 def should_emit_events() -> bool:
+    from prefect.settings import get_current_settings
+
+    if not get_current_settings().client.emit_events:
+        return False
     return (
         emit_events_to_cloud()
         or should_emit_events_to_running_server()

--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -108,6 +108,20 @@ class ClientSettings(PrefectBaseSettings):
         """,
     )
 
+    emit_events: bool = Field(
+        default=True,
+        description="""
+        Whether the client should emit events to the Prefect server.
+        When disabled, no events will be sent, which can reduce memory usage
+        for long-running flows that do not rely on event-driven features
+        (automations, triggers).
+        """,
+        validation_alias=AliasChoices(
+            AliasPath("emit_events"),
+            "prefect_client_emit_events",
+        ),
+    )
+
     metrics: ClientMetricsSettings = Field(
         default_factory=ClientMetricsSettings,
         description="Settings for controlling metrics reporting from the client",

--- a/tests/events/client/test_emit_events_setting.py
+++ b/tests/events/client/test_emit_events_setting.py
@@ -1,0 +1,53 @@
+"""Tests for PREFECT_CLIENT_EMIT_EVENTS setting."""
+
+from unittest import mock
+
+from prefect.events.worker import should_emit_events
+from prefect.settings import PREFECT_CLIENT_EMIT_EVENTS, temporary_settings
+
+
+class TestEmitEventsSetting:
+    """Tests for the client.emit_events setting."""
+
+    def test_default_is_true(self):
+        """The setting defaults to True so existing behavior is preserved."""
+        assert PREFECT_CLIENT_EMIT_EVENTS.default() is True
+
+    def test_should_emit_events_respects_setting_when_false(self):
+        """When emit_events is False, should_emit_events() returns False
+        regardless of API URL or key configuration."""
+        with temporary_settings(updates={PREFECT_CLIENT_EMIT_EVENTS: False}):
+            assert should_emit_events() is False
+
+    def test_should_emit_events_normal_when_true(self):
+        """When emit_events is True (default), should_emit_events() delegates
+        to the existing logic based on API URL/key."""
+        with (
+            temporary_settings(updates={PREFECT_CLIENT_EMIT_EVENTS: True}),
+            mock.patch(
+                "prefect.events.worker.emit_events_to_cloud", return_value=False
+            ),
+            mock.patch(
+                "prefect.events.worker.should_emit_events_to_running_server",
+                return_value=False,
+            ),
+            mock.patch(
+                "prefect.events.worker.should_emit_events_to_ephemeral_server",
+                return_value=False,
+            ),
+        ):
+            assert should_emit_events() is False
+
+    def test_should_emit_events_true_with_cloud(self):
+        """When emit_events is True and cloud is configured, returns True."""
+        with (
+            temporary_settings(updates={PREFECT_CLIENT_EMIT_EVENTS: True}),
+            mock.patch("prefect.events.worker.emit_events_to_cloud", return_value=True),
+        ):
+            assert should_emit_events() is True
+
+    def test_emit_events_false_overrides_cloud(self):
+        """Even with cloud configured, emit_events=False disables emission."""
+        with temporary_settings(updates={PREFECT_CLIENT_EMIT_EVENTS: False}):
+            # Even if cloud would return True, setting takes precedence
+            assert should_emit_events() is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -207,6 +207,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_API_TLS_INSECURE_SKIP_VERIFY": {"test_value": True},
     "PREFECT_API_URL": {"test_value": "https://api.prefect.io"},
     "PREFECT_CLIENT_CSRF_SUPPORT_ENABLED": {"test_value": True},
+    "PREFECT_CLIENT_EMIT_EVENTS": {"test_value": False},
     "PREFECT_CLIENT_CUSTOM_HEADERS": {"test_value": '{"X-CUSTOM": "foobar"}'},
     "PREFECT_CLIENT_ENABLE_METRICS": {"test_value": True, "legacy": True},
     "PREFECT_CLIENT_MAX_RETRIES": {"test_value": 3},


### PR DESCRIPTION
Closes #21030

## Summary

Adds a `PREFECT_CLIENT_EMIT_EVENTS` boolean setting that controls whether the client emits events to the Prefect server. Defaults to `True` (no behavior change).

Currently, `should_emit_events()` is hardcoded to return `True` whenever `PREFECT_API_URL` is set — there's no way to disable client-side event emission via configuration. This PR adds a clean opt-out for deployments that don't use event-driven features (automations, triggers).

### Changes

- **`src/prefect/settings/models/client.py`** — new `emit_events` field on `ClientSettings` with env var `PREFECT_CLIENT_EMIT_EVENTS`
- **`src/prefect/events/worker.py`** — `should_emit_events()` checks the setting first, short-circuiting before API URL/key checks
- **`tests/events/client/test_emit_events_setting.py`** — 5 tests covering default behavior, override, and interaction with cloud config
- **`tests/test_settings.py`** — added to parametrized settings validation

### Usage

```bash
export PREFECT_CLIENT_EMIT_EVENTS=false
```

Or in Python:
```python
from prefect.settings import temporary_settings, PREFECT_CLIENT_EMIT_EVENTS

with temporary_settings(updates={PREFECT_CLIENT_EMIT_EVENTS: False}):
    # Events are not emitted in this context
    ...
```

## Checklist

- [x] References #21030
- [x] Includes tests
- [x] No breaking changes (defaults to `True`)