### PR TITLE
Add bounded queue for EventsWorker to prevent OOM during server outages

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -58,8 +58,14 @@ class _QueueServiceBase(abc.ABC, Generic[T]):
     _instances: dict[int, Self] = {}
     _instance_lock = threading.Lock()
 
+    # Maximum number of items in the queue. 0 means unbounded (default).
+    # Subclasses can override this to set a bound on the queue size.
+    _max_queue_size: int = 0
+
     def __init__(self, *args: Hashable) -> None:
-        self._queue: queue.Queue[Optional[T]] = queue.Queue()
+        self._queue: queue.Queue[Optional[T]] = queue.Queue(
+            maxsize=self._max_queue_size
+        )
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._done_event: Optional[asyncio.Event] = None
         self._task: Optional[asyncio.Task[None]] = None
@@ -85,7 +91,7 @@ class _QueueServiceBase(abc.ABC, Generic[T]):
         self._loop = None
         self._done_event = None
         self._task = None
-        self._queue = queue.Queue()
+        self._queue = queue.Queue(maxsize=self._max_queue_size)
         self._lock = threading.Lock()
 
     @classmethod
@@ -345,7 +351,14 @@ class QueueService(_QueueServiceBase[T]):
                 raise RuntimeError("Cannot put items in a stopped service instance.")
 
             logger.debug("Service %r enqueuing item %r", self, item)
-            self._queue.put_nowait(self._prepare_item(item))
+            try:
+                self._queue.put_nowait(self._prepare_item(item))
+            except queue.Full:
+                logger.warning(
+                    "Service %r queue is full (%d items), dropping item",
+                    self,
+                    self._queue.qsize(),
+                )
 
     def _prepare_item(self, item: T) -> T:
         """

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -10,6 +10,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    get_current_settings,
 )
 from prefect.utilities.context import temporary_context
 
@@ -66,9 +67,17 @@ class EventsWorker(QueueService[Event]):
         Tuple[Type[EventsClient], Tuple[Tuple[str, Any], ...]]
     ] = None
 
+    @classmethod
+    def _get_max_queue_size(cls) -> int:
+        """Get the maximum queue size from settings."""
+        return get_current_settings().events.worker_queue_max_size
+
     def __init__(
         self, client_type: Type[EventsClient], client_options: Tuple[Tuple[str, Any]]
     ):
+        # Set the max queue size from settings before calling super().__init__,
+        # which creates the queue.
+        self._max_queue_size = self._get_max_queue_size()
         super().__init__(client_type, client_options)
         self.client_type = client_type
         self.client_options = client_options

--- a/src/prefect/settings/models/events.py
+++ b/src/prefect/settings/models/events.py
@@ -1,0 +1,32 @@
+from typing import ClassVar
+
+from pydantic import AliasChoices, AliasPath, Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import (
+    PrefectBaseSettings,
+    build_settings_config,
+)
+
+
+class EventsSettings(PrefectBaseSettings):
+    """
+    Settings for controlling client-side events behavior
+    """
+
+    model_config: ClassVar[SettingsConfigDict] = build_settings_config(("events",))
+
+    worker_queue_max_size: int = Field(
+        default=10000,
+        description=(
+            "Maximum number of events that can be queued for delivery to the "
+            "Prefect API. When the queue is full, new events are dropped with "
+            "a warning. Set to 0 for unbounded (default behavior before this "
+            "change). This prevents memory exhaustion when the API is "
+            "unreachable for extended periods."
+        ),
+        validation_alias=AliasChoices(
+            AliasPath("worker_queue_max_size"),
+            "prefect_events_worker_queue_max_size",
+        ),
+    )

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -32,6 +32,7 @@ from .cli import CLISettings
 from .client import ClientSettings
 from .cloud import CloudSettings
 from .deployments import DeploymentsSettings
+from .events import EventsSettings
 from .experiments import ExperimentsSettings
 from .flows import FlowsSettings
 from .internal import InternalSettings
@@ -95,6 +96,11 @@ class Settings(PrefectBaseSettings):
     deployments: DeploymentsSettings = Field(
         default_factory=DeploymentsSettings,
         description="Settings for configuring deployments defaults",
+    )
+
+    events: EventsSettings = Field(
+        default_factory=EventsSettings,
+        description="Settings for controlling client-side events behavior",
     )
 
     experiments: ExperimentsSettings = Field(

--- a/tests/events/client/test_bounded_queue.py
+++ b/tests/events/client/test_bounded_queue.py
@@ -1,0 +1,96 @@
+import logging
+import queue
+import uuid
+
+import pytest
+
+from prefect.events import Event
+from prefect.events.worker import EventsWorker
+from prefect.settings import Settings, temporary_settings
+from prefect.settings.legacy import _get_settings_fields
+
+
+def make_event() -> Event:
+    return Event(
+        event="vogon.poetry.read",
+        resource={"prefect.resource.id": f"poem.{uuid.uuid4()}"},
+    )
+
+
+class TestBoundedQueue:
+    """Tests for bounded queue behavior in QueueService and EventsWorker."""
+
+    def test_default_max_queue_size_is_10000(self):
+        """The default setting for worker_queue_max_size should be 10000."""
+        settings = Settings()
+        assert settings.events.worker_queue_max_size == 10000
+
+    def test_max_queue_size_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        """The setting can be configured via environment variable."""
+        monkeypatch.setenv("PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE", "500")
+        settings = Settings()
+        assert settings.events.worker_queue_max_size == 500
+
+    def test_max_queue_size_zero_means_unbounded(self, monkeypatch: pytest.MonkeyPatch):
+        """Setting worker_queue_max_size to 0 means unbounded queue."""
+        monkeypatch.setenv("PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE", "0")
+        settings = Settings()
+        assert settings.events.worker_queue_max_size == 0
+
+    def test_events_worker_uses_setting_for_queue_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """EventsWorker should read the max queue size from settings."""
+        max_size = EventsWorker._get_max_queue_size()
+        # Default is 10000
+        assert max_size == 10000
+
+    def test_queue_service_send_drops_when_full(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        asserting_events_worker: EventsWorker,
+    ):
+        """When the queue is full, new items should be dropped with a warning."""
+        # Manually set a small queue to test the full behavior
+        asserting_events_worker._queue = queue.Queue(maxsize=3)
+
+        # Fill the queue
+        for _ in range(3):
+            asserting_events_worker._queue.put_nowait(make_event())
+
+        # Now the queue is full; sending another should drop with warning
+        with caplog.at_level(logging.WARNING):
+            asserting_events_worker.send(make_event())
+
+        assert "queue is full" in caplog.text
+        assert asserting_events_worker._queue.qsize() == 3
+
+    def test_queue_service_send_succeeds_when_not_full(
+        self,
+        asserting_events_worker: EventsWorker,
+    ):
+        """Items should be enqueued normally when the queue is not full."""
+        # Manually set a small queue
+        asserting_events_worker._queue = queue.Queue(maxsize=3)
+
+        event = make_event()
+        asserting_events_worker.send(event)
+
+        assert asserting_events_worker._queue.qsize() == 1
+
+    def test_unbounded_queue_accepts_many_items(
+        self,
+        asserting_events_worker: EventsWorker,
+    ):
+        """With maxsize=0 (unbounded), the queue should accept many items."""
+        asserting_events_worker._queue = queue.Queue(maxsize=0)
+
+        for _ in range(1000):
+            asserting_events_worker.send(make_event())
+
+        assert asserting_events_worker._queue.qsize() == 1000
+
+    def test_setting_name_is_valid(self):
+        """The setting PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE should be discoverable."""
+        settings_fields = _get_settings_fields(Settings)
+        assert "PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE" in settings_fields


### PR DESCRIPTION
## Summary

Closes #21031

When the Prefect API server is unreachable for extended periods, the in-memory event queue in EventsWorker grows without bound, leading to OOM kills in long-running worker processes.

This PR adds a configurable bound on the QueueService event queue. When the queue is full, new events are dropped with a warning instead of accumulating indefinitely.

### Changes

1. New _max_queue_size class variable on _QueueServiceBase (default 0 = unbounded). Subclasses can override to set a queue bound.

2. QueueService.send() catches queue.Full and logs a warning, dropping the item gracefully.

3. New PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE setting (default 10000) via EventsSettings. EventsWorker reads this in __init__. Set to 0 for unbounded.

4. Fully backward compatible: other QueueService subclasses keep _max_queue_size=0.

### Configuration

export PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE=10000  # default
export PREFECT_EVENTS_WORKER_QUEUE_MAX_SIZE=0      # unbounded (previous behavior)

### Files changed

- src/prefect/settings/models/events.py - New EventsSettings model
- src/prefect/settings/models/root.py - Register EventsSettings
- src/prefect/_internal/concurrency/services.py - Add _max_queue_size, handle queue.Full
- src/prefect/events/worker.py - Override _max_queue_size from settings
- tests/events/client/test_bounded_queue.py - Tests for bounded queue behavior