### PR TITLE
Preserve explicit result storage during ad-hoc submission

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2529,10 +2529,9 @@ class InfrastructureBoundFlow(Flow[P, R]):
 
             current_result_store = get_result_store()
             # Check result storage and use the work pool default if needed
-            if (
+            if self.result_storage is None and (
                 current_result_store.result_storage is None
                 or isinstance(current_result_store.result_storage, LocalFileSystem)
-                and self.result_storage is None
             ):
                 if (
                     work_pool.storage_configuration.default_result_storage_block_id

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -911,10 +911,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         current_result_store = get_result_store()
         # Check result storage and use the work pool default if needed
-        if (
+        if flow.result_storage is None and (
             current_result_store.result_storage is None
             or isinstance(current_result_store.result_storage, LocalFileSystem)
-            and flow.result_storage is None
         ):
             if (
                 self.work_pool.storage_configuration.default_result_storage_block_id

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -560,6 +560,31 @@ class TestInfrastructureBoundFlow:
         assert future.result() == "Here you go chief!"
 
     @pytest.mark.filterwarnings("ignore::FutureWarning")
+    def test_submit_to_work_pool_does_not_override_explicit_flow_result_storage(
+        self,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        resolve_storage_mock = MagicMock()
+        monkeypatch.setattr(
+            "prefect.results.resolve_result_storage", resolve_storage_mock
+        )
+
+        @flow(result_storage=tmp_path / "explicit-result-storage")
+        def prepared_flow():
+            print("I already know where my results should go.")
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=prepared_flow, work_pool=work_pool.name, worker_cls=ProcessWorker
+        )
+
+        future = infrastructure_bound_flow.submit_to_work_pool()
+
+        assert future.flow_run_id is not None
+        resolve_storage_mock.assert_not_called()
+
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     async def test_retry_existing_flow_run(
         self, work_pool: WorkPool, result_storage: LocalFileSystem
     ):

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -6,6 +6,7 @@ import logging
 import sys
 import uuid
 from datetime import timedelta
+from pathlib import Path
 from typing import Any, Dict, Optional, Type
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock
@@ -2767,6 +2768,29 @@ class TestSubmit:
 
         # Return value is hardcoded in the FakeResultStorage to ensure it is used as expected
         assert future.result() == "Here you go chief!"
+
+    @pytest.mark.usefixtures("mock_run_process")
+    async def test_submit_does_not_override_explicit_flow_result_storage(
+        self,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        resolve_storage_mock = AsyncMock()
+        monkeypatch.setattr(
+            "prefect.results.aresolve_result_storage", resolve_storage_mock
+        )
+
+        @flow(result_storage=tmp_path / "explicit-result-storage")
+        def prepared_flow():
+            print("I already know where my results should go.")
+
+        async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+            with pytest.warns(FutureWarning):
+                future = await worker.submit(prepared_flow)
+                assert isinstance(future, PrefectFlowRunFuture)
+
+        resolve_storage_mock.assert_not_awaited()
 
     @pytest.mark.usefixtures("mock_run_process")
     async def test_submit_calls_initiate_run_if_implemented(


### PR DESCRIPTION
this PR preserves a core Storage Defaults invariant: explicit flow-level result storage should remain higher precedence than lower-level defaults during ad-hoc submission.

why this matters for the project:
- the intended default hierarchy starts with `explicit flow/task setting > work pool > workspace > account > fallback`
- that hierarchy only works if the top rule is reliable before we add more lower-level defaults
- this is groundwork, not feature delivery: it makes the existing work-pool default behavior consistent with the precedence model the broader project depends on

this PR:
- narrows the work-pool default result-storage predicate in worker submission and `submit_to_work_pool()`
- prevents explicitly configured flows from being rewritten to the work-pool default branch outside a run context
- adds focused regression coverage for both submission entrypoints