### PR TITLE
Centralize work-pool result storage eligibility

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2508,7 +2508,7 @@ class InfrastructureBoundFlow(Flow[P, R]):
         )
         from prefect.context import FlowRunContext, TagsContext
         from prefect.results import (
-            _select_configured_flow_result_storage,
+            _result_storage_is_configured_for_remote_retrieval,
             get_result_store,
             resolve_result_storage,
         )
@@ -2532,26 +2532,32 @@ class InfrastructureBoundFlow(Flow[P, R]):
                 )
 
             current_result_store = get_result_store()
-            result_storage, source = _select_configured_flow_result_storage(
+            if not _result_storage_is_configured_for_remote_retrieval(
                 self.result_storage,
                 current_result_store.result_storage,
-                work_pool.storage_configuration.default_result_storage_block_id,
-                allow_local_current_storage=False,
-            )
-
-            if source == "work_pool" and result_storage is not None:
-                # Use the work pool's default result storage block for the flow run to ensure the caller can retrieve the result
-                flow = self.with_options(
-                    result_storage=resolve_result_storage(result_storage, _sync=True),
-                    persist_result=True,
-                )
-            else:
-                flow = self
-                if source is None:
+            ):
+                if (
+                    work_pool.storage_configuration.default_result_storage_block_id
+                    is None
+                ):
                     logger.warning(
                         f"Flow {self.name!r} has no result storage configured. Please configure "
                         "result storage for the flow if you want to retrieve the result for the flow run."
                     )
+                    flow = self
+                else:
+                    result_storage = (
+                        work_pool.storage_configuration.default_result_storage_block_id
+                    )
+                    # Use the work pool's default result storage block for the flow run to ensure the caller can retrieve the result
+                    flow = self.with_options(
+                        result_storage=resolve_result_storage(
+                            result_storage, _sync=True
+                        ),
+                        persist_result=True,
+                    )
+            else:
+                flow = self
 
             bundle_key = str(uuid.uuid4())
             upload_command = convert_step_to_command(

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Literal,
     Optional,
     TypeVar,
     Union,
@@ -77,11 +76,6 @@ logger: "logging.Logger" = get_logger("results")
 P = ParamSpec("P")
 
 _default_storages: dict[tuple[str, str], WritableFileSystem] = {}
-_ConfiguredFlowResultStorageSource = Literal["explicit", "result_store", "work_pool"]
-_ConfiguredFlowResultStorageSelection = tuple[
-    ResultStorage | WritableFileSystem | UUID | Path | None,
-    _ConfiguredFlowResultStorageSource | None,
-]
 
 
 async def aget_default_result_storage() -> WritableFileSystem:
@@ -133,26 +127,14 @@ def get_default_result_storage() -> WritableFileSystem:
     return storage
 
 
-def _select_configured_flow_result_storage(
-    explicit_result_storage: ResultStorage | None,
+def _result_storage_is_configured_for_remote_retrieval(
+    flow_result_storage: ResultStorage | None,
     current_result_storage: WritableFileSystem | None,
-    work_pool_result_storage: ResultStorage | UUID | Path | None = None,
-    *,
-    allow_local_current_storage: bool = True,
-) -> _ConfiguredFlowResultStorageSelection:
-    if explicit_result_storage is not None:
-        return explicit_result_storage, "explicit"
-
-    if current_result_storage is not None and not (
-        not allow_local_current_storage
-        and isinstance(current_result_storage, LocalFileSystem)
-    ):
-        return current_result_storage, "result_store"
-
-    if work_pool_result_storage is not None:
-        return work_pool_result_storage, "work_pool"
-
-    return None, None
+) -> bool:
+    return flow_result_storage is not None or (
+        current_result_storage is not None
+        and not isinstance(current_result_storage, LocalFileSystem)
+    )
 
 
 async def aresolve_result_storage(
@@ -411,15 +393,10 @@ class ResultStore(BaseModel):
         """
         update: dict[str, Any] = {}
         update["cache_result_in_memory"] = flow.cache_result_in_memory
-        result_storage, source = _select_configured_flow_result_storage(
-            flow.result_storage,
-            self.result_storage,
-        )
-        if result_storage is not None:
-            if source == "result_store":
-                update["result_storage"] = result_storage
-            else:
-                update["result_storage"] = await aresolve_result_storage(result_storage)
+        if flow.result_storage is not None:
+            update["result_storage"] = await aresolve_result_storage(
+                flow.result_storage
+            )
         elif self.result_storage is None:
             update["result_storage"] = await aget_default_result_storage()
         if flow.result_serializer is not None:
@@ -440,17 +417,10 @@ class ResultStore(BaseModel):
         """
         update: dict[str, Any] = {}
         update["cache_result_in_memory"] = flow.cache_result_in_memory
-        result_storage, source = _select_configured_flow_result_storage(
-            flow.result_storage,
-            self.result_storage,
-        )
-        if result_storage is not None:
-            if source == "result_store":
-                update["result_storage"] = result_storage
-            else:
-                update["result_storage"] = resolve_result_storage(
-                    result_storage, _sync=True
-                )
+        if flow.result_storage is not None:
+            update["result_storage"] = resolve_result_storage(
+                flow.result_storage, _sync=True
+            )
         elif self.result_storage is None:
             update["result_storage"] = get_default_result_storage(_sync=True)
         if flow.result_serializer is not None:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -908,29 +908,33 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
 
         from prefect.results import (
-            _select_configured_flow_result_storage,
+            _result_storage_is_configured_for_remote_retrieval,
             aresolve_result_storage,
             get_result_store,
         )
 
         current_result_store = get_result_store()
-        result_storage, source = _select_configured_flow_result_storage(
+        if not _result_storage_is_configured_for_remote_retrieval(
             flow.result_storage,
             current_result_store.result_storage,
-            self.work_pool.storage_configuration.default_result_storage_block_id,
-            allow_local_current_storage=False,
-        )
-        if source == "work_pool" and result_storage is not None:
-            # Use the work pool's default result storage block for the flow run to ensure the caller can retrieve the result
-            flow = flow.with_options(
-                result_storage=await aresolve_result_storage(result_storage),
-                persist_result=True,
-            )
-        elif source is None:
-            self._logger.warning(
-                f"Flow {flow.name!r} has no result storage configured. Please configure "
-                "result storage for the flow if you want to retrieve the result for the flow run."
-            )
+        ):
+            if (
+                self.work_pool.storage_configuration.default_result_storage_block_id
+                is None
+            ):
+                self._logger.warning(
+                    f"Flow {flow.name!r} has no result storage configured. Please configure "
+                    "result storage for the flow if you want to retrieve the result for the flow run."
+                )
+            else:
+                result_storage = (
+                    self.work_pool.storage_configuration.default_result_storage_block_id
+                )
+                # Use the work pool's default result storage block for the flow run to ensure the caller can retrieve the result
+                flow = flow.with_options(
+                    result_storage=await aresolve_result_storage(result_storage),
+                    persist_result=True,
+                )
 
         bundle_key = str(uuid.uuid4())
         upload_command = convert_step_to_command(

--- a/tests/results/test_result_store.py
+++ b/tests/results/test_result_store.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -8,12 +9,12 @@ import prefect.results
 import prefect.types._datetime
 from prefect import flow, task
 from prefect.context import FlowRunContext, get_run_context
-from prefect.filesystems import LocalFileSystem
+from prefect.filesystems import LocalFileSystem, WritableFileSystem
 from prefect.locking.memory import MemoryLockManager
 from prefect.results import (
     ResultRecord,
     ResultStore,
-    _select_configured_flow_result_storage,
+    _result_storage_is_configured_for_remote_retrieval,
     should_persist_result,
 )
 from prefect.serializers import JSONSerializer, PickleSerializer
@@ -1056,60 +1057,40 @@ class TestAsyncDispatch:
         assert isinstance(result, ResultStore)
 
 
-class TestConfiguredFlowResultStorageSelection:
-    def test_select_prefers_explicit_flow_storage(self, tmp_path):
+class TestRemoteResultStorageConfiguration:
+    def test_returns_true_for_explicit_flow_storage(self, tmp_path):
         explicit_storage = tmp_path / "explicit"
         current_storage = LocalFileSystem(basepath=tmp_path / "current")
 
-        selected_storage, source = _select_configured_flow_result_storage(
+        is_configured = _result_storage_is_configured_for_remote_retrieval(
             explicit_storage,
             current_storage,
         )
 
-        assert source == "explicit"
-        assert selected_storage == explicit_storage
+        assert is_configured is True
 
-    def test_select_uses_current_result_store_storage(self, tmp_path):
+    def test_returns_true_for_non_local_current_result_store_storage(self, tmp_path):
+        explicit_storage = None
+        current_storage = MagicMock(spec=WritableFileSystem)
+
+        is_configured = _result_storage_is_configured_for_remote_retrieval(
+            explicit_storage,
+            current_storage,
+        )
+
+        assert is_configured is True
+
+    def test_returns_false_for_local_current_result_store_storage(self, tmp_path):
         current_storage = LocalFileSystem(basepath=tmp_path / "current")
 
-        selected_storage, source = _select_configured_flow_result_storage(
+        is_configured = _result_storage_is_configured_for_remote_retrieval(
             None,
             current_storage,
         )
 
-        assert source == "result_store"
-        assert selected_storage is current_storage
+        assert is_configured is False
 
-    def test_select_uses_work_pool_storage_when_no_higher_precedence_option(
-        self, tmp_path
-    ):
-        work_pool_storage = tmp_path / "work-pool"
+    def test_returns_false_when_no_result_storage_is_configured(self):
+        is_configured = _result_storage_is_configured_for_remote_retrieval(None, None)
 
-        selected_storage, source = _select_configured_flow_result_storage(
-            None,
-            None,
-            work_pool_storage,
-        )
-
-        assert source == "work_pool"
-        assert selected_storage == work_pool_storage
-
-    def test_select_can_skip_local_current_storage_for_work_pool(self, tmp_path):
-        current_storage = LocalFileSystem(basepath=tmp_path / "current")
-        work_pool_storage = tmp_path / "work-pool"
-
-        selected_storage, source = _select_configured_flow_result_storage(
-            None,
-            current_storage,
-            work_pool_storage,
-            allow_local_current_storage=False,
-        )
-
-        assert source == "work_pool"
-        assert selected_storage == work_pool_storage
-
-    def test_select_returns_none_when_no_configured_storage_exists(self):
-        selected_storage, source = _select_configured_flow_result_storage(None, None)
-
-        assert source is None
-        assert selected_storage is None
+        assert is_configured is False


### PR DESCRIPTION
this PR centralizes the rule that decides when a work-pool result storage default is allowed to apply for ad-hoc submission.

This is a small phase-1 Storage Defaults cleanup. Work-pool result storage is the only partial default layer we have today, and the project needs its precedence rule to be predictable before we add workspace or server defaults.

<details>
<summary>details</summary>

- adds a private helper in `prefect.results` for one shared question: does this flow already have result storage configured in a way that works for remote result retrieval?
- uses that helper from both ad-hoc submission paths: `InfrastructureBoundFlow.submit_to_work_pool()` and `BaseWorker._submit_adhoc_run()`
- keeps the actual work-pool override behavior explicit in those callsites instead of introducing a generic source-selection abstraction
- adds focused tests for the helper and preserves the existing behavior tests for both submission entrypoints

</details>

Why this matters for the project:
- explicit flow-level storage still wins
- the work-pool default remains the next lower-precedence option in these ad-hoc submission paths
- the rule for when work-pool storage is allowed to step in now lives in one place instead of two copies

Tests:
- `uv run pytest tests/results/test_result_store.py -k "RemoteResultStorageConfiguration or update_for_flow"`
- `uv run pytest tests/test_infrastructure_bound_flow.py -k "test_submit_uses_work_pool_result_storage_block or test_submit_to_work_pool_does_not_override_explicit_flow_result_storage"`
- `uv run pytest tests/workers/test_base_worker.py -k "test_submit_uses_work_pool_result_storage_block or test_submit_does_not_override_explicit_flow_result_storage"`
- `uv run ruff check src/prefect/results.py src/prefect/flows.py src/prefect/workers/base.py tests/results/test_result_store.py`