### PR TITLE
Add Unify tagging for contract-tier docs pages

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -32,6 +32,7 @@ const UNIFY_SCRIPT_SRC = 'https://tag.unifyintent.com/v1/Rj9KrQqMhyYcU5qfJtVszE/
 
 let unifyTagLoaded = false
 let currentUnifyPagePath = null
+let routeListenersInstalled = false
 
 function normalizePathname(pathname) {
     if (pathname === '/') return pathname
@@ -40,6 +41,24 @@ function normalizePathname(pathname) {
 
 function isUnifyPage(pathname) {
     return UNIFY_PAGE_PATHS.has(normalizePathname(pathname))
+}
+
+function getPathnameFromUrl(url) {
+    if (!url) return null
+
+    try {
+        if (typeof url === 'string') {
+            return normalizePathname(new URL(url, window.location.origin).pathname)
+        }
+
+        if (url instanceof URL) {
+            return normalizePathname(url.pathname)
+        }
+    } catch (error) {
+        return null
+    }
+
+    return null
 }
 
 function initializeUnifyQueue() {
@@ -74,6 +93,10 @@ function ensureUnifyTagLoaded() {
     script.id = UNIFY_SCRIPT_ID
     script.src = UNIFY_SCRIPT_SRC
     script.setAttribute('data-api-key', UNIFY_API_KEY)
+    script.addEventListener('load', () => {
+        observeRouteChanges(syncUnifyTag)
+        window.unify.stopAutoPage()
+    })
 
     ;(document.body || document.head).appendChild(script)
     unifyTagLoaded = true
@@ -93,6 +116,7 @@ function syncUnifyTag() {
     }
 
     ensureUnifyTagLoaded()
+    window.unify.stopAutoPage()
     window.unify.startAutoIdentify()
 
     if (currentUnifyPagePath !== pathname) {
@@ -102,26 +126,47 @@ function syncUnifyTag() {
 }
 
 function observeRouteChanges(callback) {
-    const onRouteChange = () => {
-        window.setTimeout(callback, 0)
+    const wrapHistoryMethod = (methodName) => {
+        const currentMethod = window.history[methodName]
+
+        if (currentMethod.__prefectUnifyWrapped) {
+            return
+        }
+
+        const wrappedMethod = function () {
+            const nextPathname = getPathnameFromUrl(arguments[2])
+
+            if (unifyTagLoaded) {
+                window.unify.stopAutoPage()
+
+                if (nextPathname && !isUnifyPage(nextPathname)) {
+                    window.unify.stopAutoIdentify()
+                    currentUnifyPagePath = null
+                }
+            }
+
+            const result = currentMethod.apply(this, arguments)
+            window.setTimeout(callback, 0)
+            return result
+        }
+
+        wrappedMethod.__prefectUnifyWrapped = true
+        window.history[methodName] = wrappedMethod
     }
 
-    const { pushState, replaceState } = window.history
+    wrapHistoryMethod('pushState')
+    wrapHistoryMethod('replaceState')
 
-    window.history.pushState = function () {
-        const result = pushState.apply(this, arguments)
-        onRouteChange()
-        return result
+    if (!routeListenersInstalled) {
+        const onRouteChange = () => {
+            window.setTimeout(callback, 0)
+        }
+
+        window.addEventListener('popstate', onRouteChange)
+        window.addEventListener('hashchange', onRouteChange)
+        routeListenersInstalled = true
     }
 
-    window.history.replaceState = function () {
-        const result = replaceState.apply(this, arguments)
-        onRouteChange()
-        return result
-    }
-
-    window.addEventListener('popstate', onRouteChange)
-    window.addEventListener('hashchange', onRouteChange)
     callback()
 }
 


### PR DESCRIPTION
this PR adds website tagging to the docs site for an explicit allowlist of contract-tier pages.

<details>
<summary>What changed</summary>

- add a route-aware Unify loader in `docs/script.js`
- scope tagging to the six docs URLs
- use manual page events so tagged visits stay limited to the allowlisted pages, even with Mintlify client-side navigation
- keep the rest of the docs site unchanged

</details>

<details>
<summary>Validation</summary>

- `node --check docs/script.js`
- `timeout 60s just -f docs/justfile docs` (preview came up on localhost:3000)
- local Playwright browser check against the preview confirmed:
  - the tagged SSO page loads the Unify script and attempts one `POST https://api.unifyintent.com/analytics/v1/page`
  - a non-tagged getting-started page loads no Unify script and makes no Unify requests
  - navigating from a tagged page to a non-tagged page does not emit an extra Unify page request
- Mintlify surfaced unrelated existing docs issues while booting: a parse error in `integrations/prefect-kubernetes/api-ref/prefect_kubernetes-flows.mdx`, a few missing navigation targets, and repeated `TypeError: controller[kState].transformAlgorithm is not a function` messages after startup

</details>