### PR TITLE
Change heartbeat default from None to 180s

### DIFF
--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -258,6 +258,15 @@
                     "title": "Custom Headers",
                     "type": "object"
                 },
+                "server_version_check_enabled": {
+                    "default": true,
+                    "description": "\n        Whether the client should check the server's API version on startup.\n        When disabled, the client will skip the call to /admin/version that\n        normally runs once per client context entry.  This is useful for worker\n        subprocesses that inherit a known-compatible server configuration and\n        do not need to repeat the version handshake.\n        ",
+                    "supported_environment_variables": [
+                        "PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED"
+                    ],
+                    "title": "Server Version Check Enabled",
+                    "type": "boolean"
+                },
                 "metrics": {
                     "$ref": "#/$defs/ClientMetricsSettings",
                     "supported_environment_variables": []
@@ -396,7 +405,7 @@
                             "type": "null"
                         }
                     ],
-                    "default": null,
+                    "default": 180,
                     "description": "Number of seconds between flow run heartbeats. Heartbeats are used to detect crashed flow runs.",
                     "supported_environment_variables": [
                         "PREFECT_FLOWS_HEARTBEAT_FREQUENCY",
@@ -1710,13 +1719,29 @@
             "description": "Settings for controlling the database vacuum service",
             "properties": {
                 "enabled": {
-                    "default": false,
-                    "description": "Whether or not to start the database vacuum service in the server application. Disabled by default because it permanently deletes data.",
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "uniqueItems": true
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [
+                        "events"
+                    ],
+                    "description": "Comma-separated set of vacuum types to enable. Valid values: 'events', 'flow_runs'. Defaults to 'events'. For backward compatibility, 'true' maps to 'events,flow_runs' and 'false' maps to 'events'. Event vacuum also requires event_persister.enabled (the default).",
                     "supported_environment_variables": [
                         "PREFECT_SERVER_SERVICES_DB_VACUUM_ENABLED"
                     ],
-                    "title": "Enabled",
-                    "type": "boolean"
+                    "title": "Enabled"
                 },
                 "loop_seconds": {
                     "default": 3600,
@@ -1747,6 +1772,21 @@
                     ],
                     "title": "Batch Size",
                     "type": "integer"
+                },
+                "event_retention_overrides": {
+                    "additionalProperties": {
+                        "format": "duration",
+                        "type": "string"
+                    },
+                    "default": {
+                        "prefect.flow-run.heartbeat": "P7D"
+                    },
+                    "description": "Per-event-type retention period overrides. Keys are event type strings (e.g. 'prefect.flow-run.heartbeat'), values are retention periods in seconds. Event types not listed fall back to server.events.retention_period. Each override is capped by the global events retention period.",
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_SERVICES_DB_VACUUM_EVENT_RETENTION_OVERRIDES"
+                    ],
+                    "title": "Event Retention Overrides",
+                    "type": "object"
                 }
             },
             "title": "ServerServicesDBVacuumSettings",
@@ -1814,16 +1854,6 @@
                     ],
                     "title": "Flush Interval",
                     "type": "number"
-                },
-                "batch_size_delete": {
-                    "default": 10000,
-                    "description": "The number of expired events and event resources the event persister will attempt to delete in one batch.",
-                    "exclusiveMinimum": 0,
-                    "supported_environment_variables": [
-                        "PREFECT_SERVER_SERVICES_EVENT_PERSISTER_BATCH_SIZE_DELETE"
-                    ],
-                    "title": "Batch Size Delete",
-                    "type": "integer"
                 },
                 "queue_max_size": {
                     "default": 50000,

--- a/src/prefect/settings/models/flows.py
+++ b/src/prefect/settings/models/flows.py
@@ -14,7 +14,7 @@ class FlowsSettings(PrefectBaseSettings):
     model_config: ClassVar[SettingsConfigDict] = build_settings_config(("flows",))
 
     heartbeat_frequency: Optional[int] = Field(
-        default=None,
+        default=180,
         description="Number of seconds between flow run heartbeats. "
         "Heartbeats are used to detect crashed flow runs.",
         ge=30,


### PR DESCRIPTION
## Summary

- Changes the default `heartbeat_frequency` from `None` (disabled) to `180` seconds, enabling zombie/crashed flow run detection out of the box
- With the default 540s automation threshold, a zombie is detected within ~9 minutes (3 missed heartbeats)
- Users can still disable heartbeats by explicitly setting `PREFECT_FLOWS_HEARTBEAT_FREQUENCY` to `None`

<details>
<summary>Changes</summary>

- `src/prefect/settings/models/flows.py`: `default=None` → `default=180`
- `schemas/settings.schema.json`: regenerated via `scripts/generate_settings_schema.py`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)