### PR TITLE
Disable heartbeats in tests to fix CI timeout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
+    PREFECT_FLOWS_HEARTBEAT_FREQUENCY,
     PREFECT_HOME,
     PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_LOGGING_INTERNAL_LEVEL,
@@ -424,6 +425,9 @@ def pytest_sessionstart(session: pytest.Session):
             PREFECT_API_SERVICES_TRIGGERS_ENABLED: False,
             # Disable the task run recorder service
             PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED: False,
+            # Disable heartbeats during tests to avoid spawning background
+            # threads/tasks that slow down the test suite
+            PREFECT_FLOWS_HEARTBEAT_FREQUENCY: None,
         },
         source=__file__,
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -685,7 +685,7 @@ class TestSettingsClass:
 
     @pytest.mark.usefixtures("disable_hosted_api_server")
     def test_settings_to_environment_includes_all_settings_with_non_null_values(self):
-        settings = Settings()
+        settings = get_current_settings()
         expected_names = {
             s.name
             for s in _get_settings_fields(Settings).values()
@@ -1209,7 +1209,7 @@ class TestSettingAccess:
 
     def test_deprecated_runner_heartbeat_frequency_access(self):
         """Test that accessing runner.heartbeat_frequency emits deprecation warning."""
-        settings = Settings()
+        settings = get_current_settings()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 


### PR DESCRIPTION
## Summary

- The heartbeat default change (ce087d5299) from `None` to `180s` caused every flow run in tests to spawn background heartbeat threads/tasks, nearly doubling test execution time and causing all Client Tests jobs to time out at ~65% on CI.
- Adds `PREFECT_FLOWS_HEARTBEAT_FREQUENCY: None` to the test session profile in `conftest.py`, disabling heartbeats during tests. Heartbeat-specific tests in `test_flow_engine.py` already mock the heartbeat functions directly, so they're unaffected.
- Fixes two settings tests that used `Settings()` (fresh instance with production defaults) instead of `get_current_settings()` (test profile context), causing mismatches now that the profile overrides heartbeat_frequency to None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)