### PR TITLE
Use hmac.compare_digest for auth token comparisons

### DIFF
--- a/src/prefect/server/api/middleware.py
+++ b/src/prefect/server/api/middleware.py
@@ -1,3 +1,4 @@
+import hmac
 from typing import Awaitable, Callable
 
 from fastapi import status
@@ -63,7 +64,9 @@ class CsrfMiddleware(BaseHTTPMiddleware):
                     session=session, client=incoming_client
                 )
 
-                if token is None or token.token != incoming_token:
+                if token is None or not hmac.compare_digest(
+                    token.token, incoming_token
+                ):
                     return JSONResponse(
                         {"detail": "Invalid CSRF token or client identifier."},
                         status_code=status.HTTP_403_FORBIDDEN,

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -9,6 +9,7 @@ import atexit
 import base64
 import contextlib
 import gc
+import hmac
 import logging
 import mimetypes
 import os
@@ -446,7 +447,7 @@ def create_api_app(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     content={"exception_message": "Unauthorized"},
                 )
-            if decoded != auth_string:
+            if not hmac.compare_digest(decoded, auth_string):
                 return JSONResponse(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     content={"exception_message": "Unauthorized"},

--- a/src/prefect/server/utilities/subscriptions.py
+++ b/src/prefect/server/utilities/subscriptions.py
@@ -1,4 +1,5 @@
 import asyncio
+import hmac
 from asyncio import IncompleteReadError as IOError
 from logging import Logger
 from typing import Optional
@@ -81,7 +82,7 @@ async def accept_prefect_socket(websocket: WebSocket) -> Optional[WebSocket]:
                     reason="Auth required but no token provided",
                 )
 
-            if received_token != auth_setting:
+            if not hmac.compare_digest(received_token, auth_setting):
                 logger.warning("WebSocket connection closed: Invalid token.")
                 return await websocket.close(
                     WS_1008_POLICY_VIOLATION, reason="Invalid token"


### PR DESCRIPTION
Closes #7747

## Summary
- Replace `!=` string comparison with `hmac.compare_digest()` in three auth token comparison sites
- `src/prefect/server/api/server.py` — Basic auth middleware
- `src/prefect/server/api/middleware.py` — CSRF token validation
- `src/prefect/server/utilities/subscriptions.py` — WebSocket auth token check

<details>
<summary>Details</summary>

Python's `!=` operator short-circuits on the first non-matching character, creating a timing side-channel that could theoretically allow an attacker to guess tokens character-by-character. `hmac.compare_digest()` is a stdlib constant-time comparison function designed for exactly this use case.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)