### PR TITLE
Fix noisy 'I/O operation on closed file' during test teardown

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -324,7 +324,7 @@ class WorkerAPILogHandler(APILogHandler):
         return log
 
 
-class SafeStreamHandler(StreamHandler):
+class _SafeStreamHandler(StreamHandler):
     """A StreamHandler that gracefully handles closed streams during teardown.
 
     The stdlib StreamHandler.emit() catches ValueError internally and routes

--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -68,7 +68,7 @@ handlers:
 
   debug:
     level: 0
-    class: prefect.logging.handlers.SafeStreamHandler
+    class: prefect.logging.handlers._SafeStreamHandler
     formatter: debug
     stream: ext://sys.stderr
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -42,8 +42,8 @@ from prefect.logging.handlers import (
     APILogHandler,
     APILogWorker,
     PrefectConsoleHandler,
-    SafeStreamHandler,
     WorkerAPILogHandler,
+    _SafeStreamHandler,
     emit_api_log,
     set_api_log_sink,
 )
@@ -1565,7 +1565,7 @@ async def test_run_logger_in_task(
     }
 
 
-class TestSafeStreamHandler:
+class Test_SafeStreamHandler:
     """Regression tests for https://github.com/PrefectHQ/prefect/issues/16626"""
 
     def test_emit_with_closed_stream_does_not_raise(
@@ -1573,7 +1573,7 @@ class TestSafeStreamHandler:
     ):
         stream = StringIO()
         stream.close()
-        handler = SafeStreamHandler(stream=stream)
+        handler = _SafeStreamHandler(stream=stream)
         handler.setFormatter(logging.Formatter("%(message)s"))
 
         logger = logging.getLogger("test.safe_stream.closed")
@@ -1589,7 +1589,7 @@ class TestSafeStreamHandler:
 
     def test_emit_with_open_stream_works(self):
         stream = StringIO()
-        handler = SafeStreamHandler(stream=stream)
+        handler = _SafeStreamHandler(stream=stream)
         handler.setFormatter(logging.Formatter("%(message)s"))
 
         logger = logging.getLogger("test.safe_stream.open")


### PR DESCRIPTION
Closes #16626

## Summary

- Add `_SafeStreamHandler` to `src/prefect/logging/handlers.py` — suppresses `ValueError` from closed streams in `handleError()`
- Use it for the `debug` handler in `logging.yml` (only serves `prefect._internal`, no user-facing loggers affected)
- Add regression tests

This is a stdlib `logging.StreamHandler` + daemon thread race condition. When daemon threads from Prefect's concurrency layer log after pytest closes stderr, the stdlib's `handleError()` prints noisy `--- Logging error ---` tracebacks. `_SafeStreamHandler` silences that specific case.

<details>
<summary>Why a subclass?</summary>

The stdlib `StreamHandler.emit()` catches `ValueError` internally and routes it to `handleError()`, which prints the traceback. There's no configuration point to suppress this — subclassing is the only clean approach.

The subclass is scoped to the single `debug` handler used by `prefect._internal`. User-facing loggers (`prefect`, `prefect.flow_runs`, `prefect.task_runs`, etc.) use `PrefectConsoleHandler` or `APILogHandler` and are completely unaffected. It's underscore-prefixed to signal it's an internal implementation detail.

</details>

<details>
<summary>Root cause: stdlib reproduction (zero Prefect imports)</summary>

```python
"""
Minimal reproduction — pure stdlib, zero dependencies.

A daemon thread logs via a StreamHandler pointed at stderr. When the main
thread closes stderr (simulating pytest teardown), the daemon thread's next
log call hits "I/O operation on closed file" and the stdlib prints a noisy
"--- Logging error ---" traceback.
"""

import io
import logging
import sys
import threading
import time

logger = logging.getLogger("repro")
logger.setLevel(logging.DEBUG)
handler = logging.StreamHandler(sys.stderr)
handler.setFormatter(logging.Formatter("%(message)s"))
logger.addHandler(handler)


def daemon_work():
    time.sleep(0.1)
    logger.debug("Finished call %r", "get(<dropped>)")


capture = io.StringIO()
real_stderr = sys.stderr

t = threading.Thread(target=daemon_work, daemon=True)
t.start()

# simulate pytest teardown: close stderr while daemon is still alive
closed = io.StringIO()
closed.close()
handler.stream = closed
sys.stderr = capture

t.join()
sys.stderr = real_stderr

output = capture.getvalue()
if "I/O operation on closed file" in output:
    print("BUG REPRODUCED:")
    print(output)
else:
    print("bug not reproduced")
```
</details>

<details>
<summary>Why not graceful thread shutdown instead?</summary>

The concurrency layer's threads (global event loop, run-sync loop, service workers) are daemon threads by design — they're meant to die with the process without blocking exit. The race window is between pytest closing stderr and the interpreter killing daemon threads. We don't control that ordering.

The daemon threads *are* shutting down; they just sometimes get one last log call in after the stream is gone. `_SafeStreamHandler` handles that inherent timing gap.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)