### PR TITLE
fix 429 rate limit

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -57,6 +57,7 @@ from prefect.exceptions import (
     InfrastructureNotAvailable,
     InfrastructureNotFound,
     ObjectNotFound,
+    PrefectHTTPStatusError,
 )
 from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectFlowRunFuture
@@ -1407,15 +1408,25 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                     f"Flow run {flow_run.id} will not be submitted for"
                     " execution"
                 )
-                self._submitting_flow_run_ids.remove(flow_run.id)
-                if self._cancelling_observer is not None:
-                    self._cancelling_observer.remove_in_flight_flow_run_id(flow_run.id)
+                self._finalize_flow_run_submission(flow_run.id)
                 await self._mark_flow_run_as_cancelled(
                     flow_run,
                     state_updates=dict(
                         message=f"Deployment {flow_run.deployment_id} no longer exists, cancelled run."
                     ),
                 )
+                return
+            except PrefectHTTPStatusError as exc:
+                if exc.response is None or exc.response.status_code != 429:
+                    raise
+
+                run_logger.warning(
+                    "Deployment lookup for flow run '%s' remained rate limited after "
+                    "client retries. The flow run will be retried on the next poll.",
+                    flow_run.id,
+                )
+                self._release_limit_slot(flow_run.id)
+                self._finalize_flow_run_submission(flow_run.id)
                 return
 
         ready_to_submit = await self._propose_pending_state(flow_run)
@@ -1449,9 +1460,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 self._release_limit_slot(flow_run.id)
         else:
             self._release_limit_slot(flow_run.id)
-        self._submitting_flow_run_ids.remove(flow_run.id)
-        if self._cancelling_observer is not None:
-            self._cancelling_observer.remove_in_flight_flow_run_id(flow_run.id)
+        self._finalize_flow_run_submission(flow_run.id)
 
     async def _submit_run_and_capture_errors(
         self,
@@ -1540,6 +1549,11 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 self._logger.debug(
                     "Limit slot for flow run '%s' was already released", flow_run_id
                 )
+
+    def _finalize_flow_run_submission(self, flow_run_id: UUID) -> None:
+        self._submitting_flow_run_ids.discard(flow_run_id)
+        if self._cancelling_observer is not None:
+            self._cancelling_observer.remove_in_flight_flow_run_id(flow_run_id)
 
     def get_status(self) -> dict[str, Any]:
         """

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -44,6 +44,7 @@ from prefect.context import FlowRunContext, TagsContext
 from prefect.exceptions import (
     CrashedRun,
     ObjectNotFound,
+    PrefectHTTPStatusError,
 )
 from prefect.filesystems import WritableFileSystem
 from prefect.flows import flow
@@ -99,6 +100,17 @@ class FakeResultStorageBlock(WritableFileSystem):
 
     async def write_path(self, path: str, content: bytes) -> None:
         print("What do you expect me to do with this?")
+
+
+def make_prefect_http_status_error(status_code: int) -> PrefectHTTPStatusError:
+    request = httpx.Request("GET", "https://api.prefect.cloud/api/deployments/test")
+    response = httpx.Response(status_code=status_code, request=request)
+    http_error = httpx.HTTPStatusError(
+        f"Server error '{status_code}' for {request.url!s}",
+        request=request,
+        response=response,
+    )
+    return PrefectHTTPStatusError.from_httpx_error(http_error)
 
 
 @pytest.fixture(autouse=True)
@@ -2541,6 +2553,82 @@ async def test_worker_removes_flow_run_from_submitting_when_not_ready(
         await worker.get_and_submit_flow_runs()
         # Verify the flow run was removed from _submitting_flow_run_ids
         assert flow_run.id not in worker._submitting_flow_run_ids
+
+
+async def test_worker_defers_flow_run_submission_on_rate_limited_deployment_lookup(
+    prefect_client: PrefectClient,
+    worker_deployment_wq1: Deployment,
+    work_pool: WorkPool,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+        release_mock = Mock(wraps=worker._release_limit_slot)
+        worker._release_limit_slot = release_mock
+        worker._submit_run_and_capture_errors = AsyncMock()
+
+        assert worker._client is not None
+        worker._client.read_deployment = AsyncMock(
+            side_effect=make_prefect_http_status_error(429)
+        )
+
+        await worker.get_and_submit_flow_runs()
+        await anyio.sleep(0)
+
+        worker._submit_run_and_capture_errors.assert_not_called()
+        release_mock.assert_called_once_with(flow_run.id)
+        assert flow_run.id not in worker._submitting_flow_run_ids
+
+
+async def test_worker_cleans_up_cancellation_observer_on_rate_limited_deployment_lookup(
+    prefect_client: PrefectClient,
+    worker_deployment_wq1: Deployment,
+    work_pool: WorkPool,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+
+    with temporary_settings(updates={PREFECT_WORKER_ENABLE_CANCELLATION: True}):
+        async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+            assert worker._client is not None
+            worker._client.read_deployment = AsyncMock(
+                side_effect=make_prefect_http_status_error(429)
+            )
+
+            observer = worker._cancelling_observer
+            assert observer is not None
+
+            await worker.get_and_submit_flow_runs()
+            await anyio.sleep(0)
+
+            assert flow_run.id not in observer._in_flight_flow_run_ids
+
+
+async def test_worker_propagates_non_rate_limit_deployment_lookup_errors(
+    prefect_client: PrefectClient,
+    worker_deployment_wq1: Deployment,
+    work_pool: WorkPool,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+        assert worker._client is not None
+        worker._client.read_deployment = AsyncMock(
+            side_effect=make_prefect_http_status_error(500)
+        )
+
+        worker._submitting_flow_run_ids.add(flow_run.id)
+
+        with pytest.raises(PrefectHTTPStatusError):
+            await worker._submit_run(flow_run)
 
 
 async def test_worker_proposes_submitting_state_before_run(


### PR DESCRIPTION
related to #20488

this PR prevents workers from crashing when deployment lookup remains rate-limited after the client exhausts its built-in 429 retries.

<details>
<summary>Summary</summary>

When `BaseWorker._submit_run` calls `read_deployment()`, a persistent `429 Too Many Requests` from Prefect Cloud could bubble up as a `PrefectHTTPStatusError` and terminate the worker process.

This change keeps the fix scoped to worker submission behavior:
- catches exhausted `429` errors during deployment lookup
- logs that submission is being deferred until the next poll
- releases the worker's concurrency slot
- removes the flow run from in-flight submission tracking
- returns without crashing the worker

Non-429 HTTP errors still propagate as before, and the existing `ObjectNotFound` cancellation behavior is unchanged.

</details>

<details>
<summary>Tests</summary>

Added worker regression coverage for:
- deferring submission when deployment lookup ends in `429`
- cleaning up cancellation observer state on deferred submission
- preserving existing propagation for non-429 HTTP errors

Validated with targeted worker tests against `tests/workers/test_base_worker.py`.

</details>
