### PR TITLE
fix: ProcessPoolTaskRunner should respect upstream task failures in wait_for

### DIFF
--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -28,7 +28,7 @@ from prefect._internal.uuid7 import uuid7
 from prefect.client.schemas.objects import RunInput
 from prefect.events.schemas.events import Event
 from prefect.events.worker import EventsWorker, ProcessPoolForwardingEventsClient
-from prefect.exceptions import MappingLengthMismatch, MappingMissingIterable
+from prefect.exceptions import MappingLengthMismatch, MappingMissingIterable, UpstreamTaskError
 from prefect.futures import (
     PrefectConcurrentFuture,
     PrefectDistributedFuture,
@@ -967,8 +967,9 @@ class ProcessPoolTaskRunner(TaskRunner[PrefectConcurrentFuture[Any]]):
         """
         Helper method that:
         1. Waits for all futures in wait_for to complete
-        2. Resolves any futures in parameters to their actual values
-        3. Submits the task to the ProcessPoolExecutor with resolved values
+        2. Checks if any upstream tasks failed (raises UpstreamTaskError if so)
+        3. Resolves any futures in parameters to their actual values
+        4. Submits the task to the ProcessPoolExecutor with resolved values
 
         This method runs in a background thread to keep submit() non-blocking.
         """
@@ -977,6 +978,15 @@ class ProcessPoolTaskRunner(TaskRunner[PrefectConcurrentFuture[Any]]):
         # Wait for all futures in wait_for to complete
         if wait_for:
             wait(list(wait_for))
+
+            # Check if any upstream tasks failed - matching ThreadPoolTaskRunner behavior
+            for future in wait_for:
+                state = future.state
+                if not state.is_completed():
+                    raise UpstreamTaskError(
+                        f"Upstream task run '{state.state_details.task_run_id}' did not reach a"
+                        " 'COMPLETED' state."
+                    )
 
         # Resolve any futures in parameters to their actual values
         resolved_parameters = resolve_inputs_sync(

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -1093,6 +1093,35 @@ class TestProcessPoolTaskRunner:
         assert runner._subprocess_message_queue is None
         assert runner._message_forwarding_thread is None
 
+    def test_submit_with_wait_for_upstream_failure(self):
+        """
+        Test for issue #21117: ProcessPoolTaskRunner should respect upstream task failures
+        in wait_for dependencies. When an upstream task fails, the downstream task should
+        be marked as NotReady and should not execute.
+        """
+
+        @task
+        def failing_task():
+            raise RuntimeError("I failed!")
+
+        @task
+        def downstream_task():
+            return "downstream completed"
+
+        @flow(task_runner=ProcessPoolTaskRunner(max_workers=2))
+        def test_flow():
+            upstream = failing_task.submit()
+            downstream = downstream_task.submit(wait_for=[upstream])
+            return upstream.state, downstream.state
+
+        upstream_state, downstream_state = test_flow()
+
+        # Upstream should be failed
+        assert upstream_state.is_failed()
+        # Downstream should be NotReady (not executed because upstream failed)
+        assert downstream_state.name == "NotReady"
+        assert "did not reach a 'COMPLETED' state" in downstream_state.message
+
 
 class TestPrefectTaskRunner:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Fixes #21117

When a task is submitted with `wait_for=[upstream_future]`, the `ProcessPoolTaskRunner` was not checking if the upstream task actually succeeded. It only waited for the future to complete, which meant downstream tasks would run even if upstream tasks failed.

In contrast, `ThreadPoolTaskRunner` passes `wait_for` to the task engine, which uses `resolve_to_final_result` to raise `UpstreamTaskError` if upstream tasks don't reach a COMPLETED state. This causes the downstream task to be marked as `NotReady`.

## Changes

- Import `UpstreamTaskError` from `prefect.exceptions`
- Add check in `_resolve_futures_and_submit` to verify all upstream tasks in `wait_for` reached a COMPLETED state
- If any upstream task failed, raise `UpstreamTaskError` to match `ThreadPoolTaskRunner` behavior
- Add test case for upstream failure scenario

## Testing

The fix ensures that `ProcessPoolTaskRunner` now behaves consistently with `ThreadPoolTaskRunner` when handling failed upstream dependencies:

- Before fix: Downstream tasks would execute even when upstream tasks failed
- After fix: Downstream tasks are marked as `NotReady` when upstream tasks fail

---

I have read and understood the CLA and agree to its terms.