### PR TITLE
Update maximum, documented timeout for Cloud Run v2 workers

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -592,11 +592,11 @@ class CloudRunWorkerV2Variables(BaseVariables):
     timeout: int = Field(
         default=600,
         gt=0,
-        le=86400,
+        le=604800,
         title="Job Timeout",
         description=(
             "Max allowed time duration the Job may be active before Cloud Run will "
-            " actively try to mark it failed and kill associated containers (maximum of 86400 seconds, 1 day)."
+            " actively try to mark it failed and kill associated containers (maximum of 604800 seconds, 7 days)."
         ),
     )
     vpc_connector_name: Optional[str] = Field(

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
@@ -54,7 +54,7 @@ def cloud_run_worker_v2_job_config(service_account_info, job_body):
         job_body=job_body,
         credentials=GcpCredentials(service_account_info=service_account_info),
         region="us-central1",
-        timeout=86400,
+        timeout=604800,
         env={"ENV1": "VALUE1", "ENV2": "VALUE2"},
     )
 
@@ -66,7 +66,7 @@ def cloud_run_worker_v2_job_config_noncompliant_name(service_account_info, job_b
         job_body=job_body,
         credentials=GcpCredentials(service_account_info=service_account_info),
         region="us-central1",
-        timeout=86400,
+        timeout=604800,
         env={"ENV1": "VALUE1", "ENV2": "VALUE2"},
     )
 
@@ -100,7 +100,7 @@ class TestCloudRunWorkerJobV2Configuration:
             job_body=job_body,
             credentials=GcpCredentials(service_account_info=service_account_info),
             region="us-central1",
-            timeout=86400,
+            timeout=604800,
         )
         job_name = config.job_name
         assert len(job_name) <= 63
@@ -112,7 +112,7 @@ class TestCloudRunWorkerJobV2Configuration:
 
         assert (
             cloud_run_worker_v2_job_config.job_body["template"]["template"]["timeout"]
-            == "86400s"
+            == "604800s"
         )
 
     def test_populate_env(self, cloud_run_worker_v2_job_config):

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2_filtering.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2_filtering.py
@@ -50,7 +50,7 @@ def cloud_run_worker_v2_job_config(service_account_info, job_body):
         job_body=job_body,
         credentials=GcpCredentials(service_account_info=service_account_info),
         region="us-central1",
-        timeout=86400,
+        timeout=604800,
         env={"ENV1": "VALUE1", "ENV2": "VALUE2"},
     )
 

--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -1257,10 +1257,10 @@
             },
             "timeout": {
               "title": "Job Timeout",
-              "description": "The length of time that Prefect will wait for a Cloud Run Job to complete before raising an exception (maximum of 86400 seconds, 1 day).",
+              "description": "The length of time that Prefect will wait for a Cloud Run Job to complete before raising an exception (maximum of 604800 seconds, 7 days).",
               "default": 600,
               "exclusiveMinimum": 0,
-              "maximum": 86400,
+              "maximum": 604800,
               "type": "integer"
             },
             "vpc_connector_name": {

--- a/tests/infrastructure/provisioners/test_cloud_run_v2.py
+++ b/tests/infrastructure/provisioners/test_cloud_run_v2.py
@@ -144,10 +144,10 @@ default_cloud_run_v2_push_base_job_template = {
             },
             "timeout": {
                 "title": "Job Timeout",
-                "description": "The length of time that Prefect will wait for a Cloud Run Job to complete before raising an exception (maximum of 86400 seconds, 1 day).",
+                "description": "The length of time that Prefect will wait for a Cloud Run Job to complete before raising an exception (maximum of 604800 seconds, 7 days).",
                 "default": 600,
                 "exclusiveMinimum": 0,
-                "maximum": 86400,
+                "maximum": 604800,
                 "type": "integer",
             },
             "vpc_connector_name": {


### PR DESCRIPTION
At some point this was probably 24 hours. It seems to now be 168 hours.

From GCP:
<img width="832" height="125" alt="Screenshot 2026-03-16 at 10 35 03 AM" src="https://github.com/user-attachments/assets/37298755-baac-4506-b9a1-83b1c1105cdd" />


<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
