### PR TITLE
fix: guard concurrent execute_bundle auto-start

### DIFF
--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -47,13 +47,14 @@ import sys
 import tempfile
 import threading
 import uuid
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, asynccontextmanager
 from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncGenerator,
     Callable,
     Dict,
     Iterable,
@@ -232,6 +233,7 @@ class Runner:
         self._prefetch_seconds: float = prefetch_seconds
 
         self._exit_stack = AsyncExitStack()
+        self._startup_lock = asyncio.Lock()
         self._cancelling_observer: FlowRunCancellingObserver | None = None
         self._scheduled_task_scopes: set[anyio.abc.CancelScope] = set()
         self._flow_run_bundle_map: dict[UUID, SerializedBundle] = dict()
@@ -765,7 +767,6 @@ class Runner:
         from prefect.client.schemas.objects import FlowRun
 
         self.pause_on_shutdown = False
-        context = self if not self.started else asyncnullcontext()
 
         flow_run = FlowRun.model_validate(bundle["flow_run"])
 
@@ -774,7 +775,7 @@ class Runner:
             env = env or {}
             env["PREFECT_FLOWS_HEARTBEAT_FREQUENCY"] = str(int(self._heartbeat_seconds))
 
-        async with context:
+        async with self._bundle_execution_context():
             if not self._acquire_limit_slot(flow_run.id):
                 return
 
@@ -820,6 +821,19 @@ class Runner:
                 flow_run_logger.info(
                     f"Process for flow run {flow_run.name!r} exited cleanly."
                 )
+
+    @asynccontextmanager
+    async def _bundle_execution_context(self) -> AsyncGenerator[None, None]:
+        if self.started:
+            async with asyncnullcontext():
+                yield
+            return
+
+        # Only serialize the implicit execute_bundle auto-start path.
+        async with self._startup_lock:
+            context = asyncnullcontext() if self.started else self
+            async with context:
+                yield
 
     def _get_flow_run_logger(self, flow_run: "FlowRun") -> PrefectLogAdapter:
         return flow_run_logger(flow_run=flow_run).getChild(

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import itertools
 import os
 import re
 import signal
@@ -301,6 +302,49 @@ class TestInit:
         with temporary_settings({PREFECT_RUNNER_POLL_FREQUENCY: 100}):
             runner = Runner()
             assert runner.query_seconds == 100
+
+
+class TestRunnerConcurrentBundleStartup:
+    async def test_concurrent_execute_bundle_auto_start_does_not_error(
+        self, prefect_client: PrefectClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        runner = Runner(name="test-concurrent-execute-bundle", pause_on_shutdown=False)
+
+        @flow
+        def simple_flow():
+            return "ok"
+
+        class FakeProcess:
+            def __init__(self, pid: int):
+                self.pid = pid
+                self.exitcode = 0
+
+            def join(self):
+                sleep(0.05)
+
+        pid_counter = itertools.count(start=1000)
+
+        monkeypatch.setattr(
+            prefect.runner.runner,
+            "execute_bundle_in_subprocess",
+            lambda *args, **kwargs: FakeProcess(next(pid_counter)),
+        )
+
+        bundle_one = create_bundle_for_flow_run(
+            simple_flow, await prefect_client.create_flow_run(simple_flow)
+        )["bundle"]
+        bundle_two = create_bundle_for_flow_run(
+            simple_flow, await prefect_client.create_flow_run(simple_flow)
+        )["bundle"]
+
+        results = await asyncio.gather(
+            runner.execute_bundle(bundle_one),
+            runner.execute_bundle(bundle_two),
+            return_exceptions=True,
+        )
+
+        assert results == [None, None]
+        assert runner.started is False
 
 
 class TestServe:


### PR DESCRIPTION
## Summary
This PR is a follow-up to #21124.

Based on the review feedback, the original approach was too broad as it introduced additional lifecycle management (e.g. ownership tracking and reference counting).

This version narrows the scope to only address the `execute_bundle` implicit auto-start race using a lightweight startup lock, without modifying Runner lifecycle semantics.

This version only targets the residual `execute_bundle()` implicit auto-start race where concurrent callers can both observe `self.started` as false and try to enter the runner at the same time. It does not change the broader `Runner` lifecycle or `__aenter__` / `__aexit__` behavior.

## What changed:
- added a small private startup lock for the implicit `execute_bundle` auto-start path
- guarded `execute_bundle()` startup behind a helper that re-checks `self.started` after acquiring the lock
- left `execute_flow_run()` and the rest of the runner lifecycle untouched

## Validation:
- `uv run pytest tests/runner/test_runner.py -k "test_concurrent_execute_bundle_auto_start_does_not_error" -vv`
- `uv run pytest tests/runner/test_runner.py -k "execute_bundle" -vv`

Both pass locally.
