### PR TITLE
Log exception before sending message to DLQ in Redis messaging

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -43,6 +43,7 @@ from prefect_redis.client import clear_cached_clients, get_async_redis_client
 
 logger = get_logger(__name__)
 
+
 M = TypeVar("M", bound=Message)
 
 
@@ -513,6 +514,9 @@ class Consumer(_Consumer):
                     await redis_stream_message.acknowledge()
             raise
         except Exception:
+            logger.exception(
+                "Error while processing Redis stream message before sending to DLQ"
+            )
             await self._on_message_failure(redis_stream_message, msg_id_str)
         finally:
             await self._trim_stream_if_necessary()


### PR DESCRIPTION
## Description

Fixes #19317

Logs the underlying exception when Redis stream message processing fails before sending it to the DLQ.

Previously, exceptions were silently swallowed, making it difficult to debug failures (e.g., PermissionError during UI static directory creation).

## Changes

* Added exception logging in message processing before calling `_on_message_failure`

## Impact

No functional changes. Improves observability and debugging of automation failures.
