### PR TITLE
fix process-worker-shutdown-crashed-state

### DIFF
--- a/src/prefect/runner/_flow_run_executor.py
+++ b/src/prefect/runner/_flow_run_executor.py
@@ -123,6 +123,14 @@ class FlowRunExecutor:
             # after this await runs only once the process is done.
             handle = await self._start_process(task_status)
 
+        except anyio.get_cancelled_exc_class():
+            if self._process_manager.get(self._flow_run.id) is not None:
+                with anyio.CancelScope(shield=True):
+                    await self._state_proposer.propose_crashed(
+                        self._flow_run,
+                        message="Flow run process exited due to worker shutdown.",
+                    )
+            raise
         except Exception as exc:
             self._logger.exception(
                 "Flow run '%s' could not start: %s",
@@ -136,7 +144,7 @@ class FlowRunExecutor:
             return
         finally:
             # Step 6: remove handle from process_manager
-            if handle is not None:
+            if handle is not None or self._process_manager.get(self._flow_run.id):
                 await self._process_manager.remove(self._flow_run.id)
 
         # Step 7: interpret exit code and propose terminal state

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1209,6 +1209,14 @@ class Runner:
                 flow_run_logger.info(
                     f"Process for flow run {flow_run.name!r} exited cleanly."
                 )
+        except anyio.get_cancelled_exc_class():
+            if self.stopping and task_status._future.done():  # type: ignore[attr-defined]
+                with anyio.CancelScope(shield=True):
+                    await self._propose_crashed_state(
+                        flow_run,
+                        "Flow run process exited due to worker shutdown.",
+                    )
+            raise
         except Exception as exc:
             if not task_status._future.done():  # type: ignore
                 # This flow run was being submitted and did not start successfully
@@ -1226,14 +1234,6 @@ class Runner:
                     "occurred."
                 )
             return exc
-        except anyio.get_cancelled_exc_class():
-            if self.stopping and task_status._future.done():  # type: ignore[attr-defined]
-                with anyio.CancelScope(shield=True):
-                    await self._propose_crashed_state(
-                        flow_run,
-                        "Flow run process exited due to worker shutdown.",
-                    )
-            raise
         finally:
             self._release_limit_slot(flow_run.id)
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1239,7 +1239,7 @@ class Runner:
 
             await self._remove_flow_run_process_map_entry(flow_run.id)
 
-        if exit_code != 0:
+        if exit_code != 0 and not self._rescheduling:
             await self._propose_crashed_state(
                 flow_run,
                 f"Flow run process exited with non-zero status code {exit_code}.",

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -114,9 +114,7 @@ from prefect.settings import (
     PREFECT_RUNNER_SERVER_ENABLE,
     get_current_settings,
 )
-from prefect.states import (
-    AwaitingRetry,
-)
+from prefect.states import AwaitingRetry
 from prefect.types.entrypoint import EntrypointType
 from prefect.utilities._engine import get_hook_name
 from prefect.utilities._infrastructure_exit_codes import get_infrastructure_exit_info
@@ -792,20 +790,24 @@ class Runner:
             )
             self._flow_run_bundle_map[flow_run.id] = bundle
 
-            await anyio.to_thread.run_sync(process.join)
-
-            await self._remove_flow_run_process_map_entry(flow_run.id)
-
             flow_run_logger = self._get_flow_run_logger(flow_run)
-            if process.exitcode is None:
+            try:
+                await anyio.to_thread.run_sync(process.join)
+            finally:
+                with anyio.CancelScope(shield=True):
+                    await self._remove_flow_run_process_map_entry(flow_run.id)
+                self._release_limit_slot(flow_run.id)
+
+            exit_code = process.exitcode
+            if exit_code is None:
                 raise RuntimeError("Process has no exit code")
 
-            if process.exitcode:
-                info = get_infrastructure_exit_info(process.exitcode)
+            if exit_code:
+                info = get_infrastructure_exit_info(exit_code)
                 flow_run_logger.log(
                     info.log_level,
                     f"Process for flow run {flow_run.name!r} exited with status code:"
-                    f" {process.exitcode}; {info.explanation}",
+                    f" {exit_code}; {info.explanation}",
                 )
                 if info.resolution:
                     flow_run_logger.info(info.resolution)
@@ -1224,12 +1226,20 @@ class Runner:
                     "occurred."
                 )
             return exc
+        except anyio.get_cancelled_exc_class():
+            if self.stopping and task_status._future.done():  # type: ignore[attr-defined]
+                with anyio.CancelScope(shield=True):
+                    await self._propose_crashed_state(
+                        flow_run,
+                        "Flow run process exited due to worker shutdown.",
+                    )
+            raise
         finally:
             self._release_limit_slot(flow_run.id)
 
             await self._remove_flow_run_process_map_entry(flow_run.id)
 
-        if exit_code != 0 and not self._rescheduling:
+        if exit_code != 0:
             await self._propose_crashed_state(
                 flow_run,
                 f"Flow run process exited with non-zero status code {exit_code}.",

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1472,6 +1472,14 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 task_status=task_status,
                 configuration=configuration,
             )
+        except anyio.get_cancelled_exc_class():
+            if task_status and getattr(task_status, "_future").done():
+                with anyio.CancelScope(shield=True):
+                    await self._propose_crashed_state(
+                        flow_run,
+                        "Flow run process exited due to worker shutdown.",
+                    )
+            raise
         except Exception as exc:
             if task_status and not getattr(task_status, "_future").done():
                 # This flow run was being submitted and did not start successfully

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -2,6 +2,7 @@ import os
 import signal
 import sys
 import tempfile
+import textwrap
 from pathlib import Path
 from unittest.mock import ANY, AsyncMock, MagicMock
 
@@ -1023,3 +1024,57 @@ class TestWorkerSignalForwarding:
             "When sending two SIGTERM shortly after each other, the main process should"
             f" first receive a SIGINT and then a SIGKILL. Output:\n{out}"
         )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Signal-based graceful shutdown assertions are Unix-specific",
+    )
+    async def test_graceful_shutdown_marks_active_flow_run_as_crashed(
+        self,
+        worker_process,
+        prefect_client: PrefectClient,
+        tmp_path: Path,
+    ):
+        flow_file = tmp_path / "slow_flow.py"
+        flow_file.write_text(
+            textwrap.dedent(
+                """
+                import time
+
+                from prefect import flow
+
+
+                @flow
+                def slow_flow():
+                    time.sleep(30)
+                """
+            )
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("slow_flow")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="slow-flow-deployment",
+            work_pool_name="my-pool",
+            path=str(tmp_path),
+            entrypoint="slow_flow.py:slow_flow",
+        )
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+        with anyio.fail_after(30):
+            while True:
+                flow_run = await prefect_client.read_flow_run(flow_run.id)
+                if flow_run.state and flow_run.state.is_running():
+                    break
+                await anyio.sleep(0.5)
+
+        worker_process.send_signal(signal.SIGTERM)
+        await safe_shutdown(worker_process)
+
+        with anyio.fail_after(30):
+            while True:
+                flow_run = await prefect_client.read_flow_run(flow_run.id)
+                if flow_run.state and flow_run.state.is_crashed():
+                    break
+                await anyio.sleep(0.5)

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -197,6 +197,23 @@ class TestFlowRunExecutorSubmit:
         assert m["flow_run"] == call_args[0][0]
         assert "1" in call_args[1]["message"]
 
+    async def test_submit_proposes_crashed_when_cancelled_after_start(self):
+        """Cancellation after the process has started should mark the run as crashed."""
+        executor, m = _make_executor()
+        cancelled_error = anyio.get_cancelled_exc_class()()
+        executor._start_process = AsyncMock(side_effect=cancelled_error)
+        m["process_manager"].get = MagicMock(return_value=m["handle"])
+
+        with pytest.raises(anyio.get_cancelled_exc_class()):
+            await executor.submit()
+
+        m["process_manager"].remove.assert_awaited_once_with(m["flow_run"].id)
+        m["state_proposer"].propose_crashed.assert_awaited_once_with(
+            m["flow_run"],
+            message="Flow run process exited due to worker shutdown.",
+        )
+        m["hook_runner"].run_crashed_hooks.assert_not_awaited()
+
     async def test_submit_crashed_message_includes_registry_explanation(self):
         """The crashed state message should include the explanation from
         the centralized exit code registry."""


### PR DESCRIPTION
related to #16746

this PR ensures that active flow runs executed by a `process` worker are marked as `Crashed` when the worker shuts down gracefully.

## Summary

When a process worker receives a graceful shutdown signal, the flow-run subprocess can be interrupted while the worker is tearing down. Before this change, that shutdown path could remove local tracking for the running subprocess without proposing a terminal state back to the API, leaving the flow run stuck in `Running`.

This PR updates the runner shutdown/cancellation path so that if a started process-backed flow run is interrupted during worker shutdown, Prefect proposes a `Crashed` state instead of leaving the run indefinitely `Running`.

## What changed

- updated the runner's flow-run monitoring path in `src/prefect/runner/runner.py`
- when a started process-backed flow run is interrupted during worker shutdown, the runner now proposes a `Crashed` state during shielded cleanup
- made bundle subprocess waiting cancellable so shutdown can enter the intended cleanup path
- preserved existing cancellation and crashed hook behavior for bundle execution paths

## Tests

Added regression coverage for both the worker-facing and runner-facing paths:

- `tests/cli/test_worker.py`
  - verifies that a real `process` worker receiving graceful shutdown while a flow run is active results in the flow run becoming `Crashed`
- `tests/runner/test_runner.py`
  - verifies the runner cancellation/crashed behavior does not regress existing bundle execution semantics

## Notes

This change is intentionally scoped to the `process` worker / runner shutdown path.

It does not attempt to solve:
- generic worker-health-to-run-health coupling
- failover to another worker
- zombie detection for hard termination scenarios like `SIGKILL` or host loss

This change is intentionally implemented at the Prefect layer rather than in AnyIO. While AnyIO and internal cancellation behavior can influence subprocess teardown timing, responsibility for reconciling flow-run state during worker shutdown belongs to the runner.
