### PR TITLE
fix: replace bare `except:` with `except Exception:` in flow_engine

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -1798,7 +1798,7 @@ def run_flow(
             ret_val = run_flow_sync(**kwargs)
     except (Abort, Pause):
         raise
-    except:
+    except Exception:
         if error_logger:
             error_logger.error(
                 "Engine execution exited with unexpected exception", exc_info=True


### PR DESCRIPTION
## Summary

Replace a bare `except:` clause with `except Exception:` in `src/prefect/flow_engine.py`.

**Change:**
```python
# Before
except:
    if error_logger:
        error_logger.error(...)

# After
except Exception:
    if error_logger:
        error_logger.error(...)
```

Bare `except:` clauses catch `BaseException`, including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`, which are rarely intended to be caught. Using `except Exception:` is the correct pattern here since the surrounding code already handles `Abort` and `Pause` explicitly.

## Testing

No behavior change for normal exceptions. The fix prevents inadvertently swallowing `KeyboardInterrupt`/`SystemExit` signals.