### PR TITLE
fix(docs): correct PrivateLink scope — API only, not UI

### DIFF
--- a/docs/v3/how-to-guides/cloud/manage-users/secure-access-by-private-link.mdx
+++ b/docs/v3/how-to-guides/cloud/manage-users/secure-access-by-private-link.mdx
@@ -5,7 +5,7 @@ description: Manage network access to Prefect Cloud accounts over PrivateLink.
 ---
 
 PrivateLink is an available upgrade to certain Enterprise plans.  
-[PrivateLink](https://aws.amazon.com/privatelink/) enables account administrators to restrict access to Prefect Cloud APIs and the UI at the network level, by routing all network traffic through AWS and GCP.  
+[PrivateLink](https://aws.amazon.com/privatelink/) enables account administrators to restrict access to Prefect Cloud APIs at the network level, by routing API traffic through AWS and GCP. PrivateLink does not secure access to the Prefect Cloud UI.  
 Traffic between your network and Prefect Cloud is encrypted, and does not traverse the public internet.  
 
 To learn more, please contact your account manager or the Prefect team at sales@prefect.io.


### PR DESCRIPTION
## Summary
- PrivateLink secures access to the Prefect Cloud API, not the UI. The docs incorrectly stated it covers both.

## Test plan
- [ ] Verify the page renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)