### PR TITLE
docs: document uv run --with pattern for managing flow run dependencies

### DIFF
--- a/docs/v3/how-to-guides/deployments/customize-job-variables.mdx
+++ b/docs/v3/how-to-guides/deployments/customize-job-variables.mdx
@@ -196,13 +196,13 @@ The job variables should be visible in the UI under the `Configuration` tab.
 
 ## Manage dependencies with `uv run --with`
 
-On Kubernetes and Docker work pools, you can override the `command` job variable to install
-dependencies with [uv](https://docs.astral.sh/uv/) and create ephemeral environments per flow run.
+You can override the `command` job variable to install dependencies with
+[uv](https://docs.astral.sh/uv/) and create ephemeral environments per flow run.
 
 [Pull steps](/v3/deploy/infrastructure-concepts/prefect-yaml#the-pull-action) like `git_clone` run
-*after* the container process starts, so dependencies from your project's `pyproject.toml` or
+*after* the worker process starts, so dependencies from your project's `pyproject.toml` or
 `requirements.txt` aren't available yet. Overriding `command` with `uv run --with` installs your
-package as part of the container command itself:
+package as part of the command itself:
 
 ```yaml
 deployments:
@@ -218,8 +218,9 @@ deployments:
 ```
 
 <Note>
-    Prefect's Kubernetes images (`prefecthq/prefect:3-python3.14-kubernetes`, etc.) ship with
-    `uv` pre-installed. If you use a custom base image, ensure `uv` is available.
+    `uv` must be available in the execution environment. Prefect's official images ship with
+    `uv` pre-installed. For other environments, see the
+    [uv installation docs](https://docs.astral.sh/uv/getting-started/installation/).
 </Note>
 
 When multiple deployments share the same command, YAML anchors keep things DRY:


### PR DESCRIPTION
## Summary

Adds a section to the [Override Job Variables](https://docs.prefect.io/v3/how-to-guides/deployments/customize-job-variables) guide showing how to override the `command` job variable with `uv run --with` to create ephemeral per-flow-run environments.

The `command` job variable is defined on `BaseJobConfiguration`, so this works on any work pool type. Pull steps run after the worker process starts, so `uv run --with` solves the dependency ordering problem by installing packages as part of the command itself.

Covers:
- `uv run --with` as a `command` override
- YAML anchors for shared config across deployments
- Per-deployment Python version overrides
- The `.deploy()` method equivalent

## Context

Related discussions:
- [#21185](https://github.com/PrefectHQ/prefect/discussions/21185) — Using uv with Kubernetes work pools
- [#18223](https://github.com/PrefectHQ/prefect/discussions/18223) — Enhanced support for uv dynamic virtual environments

## Test plan

- [ ] Docs build and render correctly
- [ ] Examples are accurate (verified against a running self-hosted deployment)
- [ ] Links to existing docs are valid


🤖 Generated with [Claude Code](https://claude.com/claude-code)