### PR TITLE
Add pre-commit hook to prevent double backticks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: no-double-backticks
+        name: No double backticks
+        language: pygrep
+        entry: '(?<!`)``(?!`)'
+        types: [python]
       - id: check-ui-v2
         name: Check UI v2
         language: system

--- a/src/integrations/prefect-aws/prefect_aws/client_parameters.py
+++ b/src/integrations/prefect-aws/prefect_aws/client_parameters.py
@@ -36,7 +36,7 @@ class AwsClientParameters(BaseModel):
             appropriate URL to use when communicating with a service. You
             can specify a complete URL (including the "http/https" scheme)
             to override this behavior. If this value is provided,
-            then ``use_ssl`` is ignored.
+            then `use_ssl` is ignored.
         config: Advanced configuration for Botocore clients. See
             [botocore docs](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html)
             for more details.

--- a/src/integrations/prefect-azure/tests/test_aci_worker.py
+++ b/src/integrations/prefect-azure/tests/test_aci_worker.py
@@ -195,7 +195,7 @@ def job_configuration(aci_credentials, worker_flow_run):
 async def raw_job_configuration(aci_credentials, worker_flow_run):
     """
     Returns a basic job configuration suitable for use in a variety of tests.
-    ``prepare_for_flow_run`` has not called on the returned configuration, so you
+    `prepare_for_flow_run` has not called on the returned configuration, so you
     will need to call it yourself before using the job configuration.
     """
     return await create_job_configuration(

--- a/src/integrations/prefect-dbt/prefect_dbt/core/_artifacts.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/_artifacts.py
@@ -37,15 +37,15 @@ _UPSTREAM_ASSET_TYPES = frozenset(
 
 
 def create_summary_markdown(results: dict[str, Any]) -> str:
-    """Build a markdown summary of orchestrator ``run_build()`` results.
+    """Build a markdown summary of orchestrator `run_build()` results.
 
     Args:
         results: Dict mapping node unique_id to result dict with a
-            ``status`` key (``"success"``, ``"error"``, ``"skipped"``,
-            or ``"cached"``).
+            `status` key (`"success"`, `"error"`, `"skipped"`,
+            or `"cached"`).
 
     Returns:
-        Markdown string suitable for ``create_markdown_artifact()``.
+        Markdown string suitable for `create_markdown_artifact()`.
     """
     counts: dict[str, int] = {}
     errors: list[tuple[str, dict[str, Any]]] = []
@@ -129,10 +129,10 @@ def create_run_results_dict(
     results: dict[str, Any],
     elapsed_time: float,
 ) -> dict[str, Any]:
-    """Build a dbt-compatible ``run_results.json`` dict.
+    """Build a dbt-compatible `run_results.json` dict.
 
-    The output schema is compatible with dbt's ``run_results.json`` v6,
-    allowing downstream tools (e.g. ``dbt-artifacts``) to consume
+    The output schema is compatible with dbt's `run_results.json` v6,
+    allowing downstream tools (e.g. `dbt-artifacts`) to consume
     results produced by the orchestrator.
 
     Args:
@@ -194,7 +194,7 @@ def write_run_results_json(
     elapsed_time: float,
     target_dir: Path,
 ) -> Path:
-    """Write a dbt-compatible ``run_results.json`` to *target_dir*.
+    """Write a dbt-compatible `run_results.json` to *target_dir*.
 
     Args:
         results: Orchestrator results dict.
@@ -221,12 +221,12 @@ def create_asset_for_node(
     adapter_type: str,
     description_suffix: str = "",
 ) -> Asset:
-    """Create a Prefect ``Asset`` from a ``DbtNode``.
+    """Create a Prefect `Asset` from a `DbtNode`.
 
     Args:
         node: The DbtNode to create an asset for.  Must have a
-            ``relation_name``.
-        adapter_type: Database adapter type (e.g. ``"postgres"``).
+            `relation_name`.
+        adapter_type: Database adapter type (e.g. `"postgres"`).
         description_suffix: Optional suffix appended to the
             description (e.g. compiled SQL block).
 
@@ -234,7 +234,7 @@ def create_asset_for_node(
         Asset with key derived from *adapter_type* and *relation_name*.
 
     Raises:
-        ValueError: If the node has no ``relation_name``.
+        ValueError: If the node has no `relation_name`.
     """
     if not node.relation_name:
         raise ValueError(f"Node {node.unique_id} has no relation_name")
@@ -269,10 +269,10 @@ def get_upstream_assets_for_node(
     all_nodes: dict[str, DbtNode],
     adapter_type: str,
 ) -> list[Asset]:
-    """Get upstream ``Asset`` objects for lineage tracking.
+    """Get upstream `Asset` objects for lineage tracking.
 
     Returns assets for upstream nodes (models, seeds, snapshots,
-    sources) that have a ``relation_name``.  Ephemeral models are
+    sources) that have a `relation_name`.  Ephemeral models are
     traversed recursively so that sources or models behind them are
     still included.
 
@@ -282,7 +282,7 @@ def get_upstream_assets_for_node(
         adapter_type: Database adapter type.
 
     Returns:
-        List of upstream ``Asset`` objects.
+        List of upstream `Asset` objects.
     """
     # Collect asset-eligible dep IDs by walking through ephemerals.
     # The resolved node's depends_on may have had sources stripped
@@ -338,13 +338,13 @@ def get_compiled_code_for_node(
 ) -> str:
     """Get compiled SQL formatted for inclusion in an asset description.
 
-    Checks the node's ``compiled_code`` field first (populated by
-    ``dbt compile``), then falls back to reading from disk.
+    Checks the node's `compiled_code` field first (populated by
+    `dbt compile`), then falls back to reading from disk.
 
     Args:
         node: The DbtNode.
         project_dir: dbt project directory.
-        target_path: dbt target path (e.g. ``Path("target")``).
+        target_path: dbt target path (e.g. `Path("target")`).
         project_name: dbt project name from manifest metadata.
 
     Returns:

--- a/src/integrations/prefect-dbt/prefect_dbt/core/_manifest.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/_manifest.py
@@ -156,7 +156,7 @@ class ManifestParser:
 
     @property
     def adapter_type(self) -> str | None:
-        """Database adapter type from manifest metadata (e.g. ``"postgres"``)."""
+        """Database adapter type from manifest metadata (e.g. `"postgres"`)."""
         metadata = self._manifest_data.get("metadata", {})
         return metadata.get("adapter_type")
 

--- a/src/integrations/prefect-dbt/prefect_dbt/core/_orchestrator.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/_orchestrator.py
@@ -274,8 +274,8 @@ _TEST_NODE_TYPES = frozenset(t for t in (NodeType.Test, _UNIT_TYPE) if t is not 
 class CacheConfig:
     """Configuration for cross-run caching in PER_NODE execution mode.
 
-    Pass an instance to ``PrefectDbtOrchestrator(cache=CacheConfig(...))``
-    to enable caching.  ``None`` (the default) disables caching entirely.
+    Pass an instance to `PrefectDbtOrchestrator(cache=CacheConfig(...))`
+    to enable caching.  `None` (the default) disables caching entirely.
     """
 
     expiration: timedelta | None = None
@@ -512,7 +512,7 @@ class PrefectDbtOrchestrator:
             Defaults to `ProcessPoolTaskRunner`.
         cache: A `CacheConfig` instance to enable cross-run caching for
             PER_NODE mode.  When not None, unchanged nodes are skipped on
-            subsequent runs.  ``None`` (default) disables caching entirely.
+            subsequent runs.  `None` (default) disables caching entirely.
             Only supported with `execution_mode=ExecutionMode.PER_NODE`.
         test_strategy: Controls when dbt test nodes execute.
             `TestStrategy.IMMEDIATE` (default) interleaves tests with
@@ -833,7 +833,7 @@ class PrefectDbtOrchestrator:
 
         Returns:
             A tuple of `(waves, phases, filtered_nodes, skipped_results,
-            freshness_results, parser)`.  ``phases`` is a list of
+            freshness_results, parser)`.  `phases` is a list of
             node-dicts for eager per-node scheduling.
         """
         if extra_cli_args:
@@ -1353,19 +1353,19 @@ class PrefectDbtOrchestrator:
 
     @staticmethod
     def _is_block_slug(value: str) -> bool:
-        """Return True if *value* looks like a block slug (e.g. ``type/name``)."""
+        """Return True if *value* looks like a block slug (e.g. `type/name`)."""
         return len(value.split("/")) == 2
 
     def _resolve_storage(self) -> tuple[Path | None, Any]:
-        """Resolve ``CacheConfig.key_storage`` into a local path or filesystem block.
+        """Resolve `CacheConfig.key_storage` into a local path or filesystem block.
 
-        Returns ``(path, None)`` for local paths and ``(None, block)`` for
-        ``WritableFileSystem`` instances or block-slug strings.  Returns
-        ``(None, None)`` when caching is disabled or both key storage and
+        Returns `(path, None)` for local paths and `(None, block)` for
+        `WritableFileSystem` instances or block-slug strings.  Returns
+        `(None, None)` when caching is disabled or both key storage and
         result storage are unconfigured.
 
-        When ``key_storage`` is ``None`` we fall back to
-        ``result_storage`` because Prefect co-locates cache metadata with
+        When `key_storage` is `None` we fall back to
+        `result_storage` because Prefect co-locates cache metadata with
         results by default, so execution state should live there too.
         """
         ks = self._cache.key_storage if self._cache else None
@@ -1388,7 +1388,7 @@ class PrefectDbtOrchestrator:
         return None, ks
 
     def _load_execution_state(self) -> dict[str, str]:
-        """Load ``{node_id: cache_key}`` from persisted execution state."""
+        """Load `{node_id: cache_key}` from persisted execution state."""
         try:
             path, block = self._resolve_storage()
             if path is not None:
@@ -1443,7 +1443,7 @@ class PrefectDbtOrchestrator:
         state matches its current precomputed key the warehouse is
         assumed current and the upstream key is used unsalted (same
         cache namespace as a full build).  Otherwise the key is salted
-        with ``":unexecuted"`` so independent upstream rebuilds
+        with `":unexecuted"` so independent upstream rebuilds
         invalidate the downstream cache entry.
         """
         precomputed = precomputed_cache_keys or {}
@@ -1526,12 +1526,12 @@ class PrefectDbtOrchestrator:
         Walks *all_executable_nodes* using Kahn's algorithm so that each
         node's upstream keys are available before its own key is computed.
         This ensures nodes whose upstream dependencies are outside the
-        current ``select=`` filter still get valid cache keys, since cache
+        current `select=` filter still get valid cache keys, since cache
         keys are pure functions of manifest metadata and file contents —
         they don't require execution.
 
         Returns:
-            Mapping of ``node.unique_id`` to its computed cache key string.
+            Mapping of `node.unique_id` to its computed cache key string.
             Nodes whose key could not be computed (e.g. missing file on
             disk) are omitted from the dict.
         """

--- a/src/integrations/prefect-dbt/tests/core/conftest.py
+++ b/src/integrations/prefect-dbt/tests/core/conftest.py
@@ -134,7 +134,7 @@ def write_manifest(tmp_path: Path, data: dict[str, Any]) -> Path:
 def write_sql_files(project_dir: Path, file_map: dict[str, str]) -> None:
     """Create SQL/CSV files relative to *project_dir* for cache tests.
 
-    ``file_map`` maps relative paths (e.g. ``"models/my_model.sql"``) to
+    `file_map` maps relative paths (e.g. `"models/my_model.sql"`) to
     file content strings.
     """
     for rel_path, content in file_map.items():

--- a/src/integrations/prefect-dbt/tests/core/test_executor.py
+++ b/src/integrations/prefect-dbt/tests/core/test_executor.py
@@ -93,7 +93,7 @@ def mock_dbt(monkeypatch):
     """Patch dbtRunner and return (mock_runner_cls, mock_runner) pair.
 
     The runner is pre-wired to return a successful result with no artifacts.
-    Tests can override via ``mock_runner.invoke.return_value = ...``.
+    Tests can override via `mock_runner.invoke.return_value = ...`.
     """
     mock_runner = MagicMock()
     mock_runner_cls = MagicMock(return_value=mock_runner)

--- a/src/integrations/prefect-dbt/tests/core/test_orchestrator_cache.py
+++ b/src/integrations/prefect-dbt/tests/core/test_orchestrator_cache.py
@@ -598,8 +598,8 @@ class TestOrchestratorCachingOutcomes:
 
     These tests validate real caching behavior by running builds multiple
     times and observing whether the executor is invoked (cache miss) or
-    skipped (cache hit).  No internals like ``with_options`` or
-    ``build_cache_policy_for_node`` are patched or inspected.
+    skipped (cache hit).  No internals like `with_options` or
+    `build_cache_policy_for_node` are patched or inspected.
     """
 
     def test_second_run_skips_unchanged_nodes(self, cache_orch):
@@ -1130,8 +1130,8 @@ class TestCachingWithIsolatedSelection:
     """Integration tests for caching when select= excludes upstream nodes.
 
     This is the core bug fix: previously, selecting a downstream node
-    without its upstream dependencies (e.g. ``select="leaf"`` instead
-    of ``select="+leaf"``) silently disabled caching because upstream
+    without its upstream dependencies (e.g. `select="leaf"` instead
+    of `select="+leaf"`) silently disabled caching because upstream
     cache keys were not available.  With pre-computation, cache keys
     for ALL executable nodes are computed upfront from manifest
     metadata, so caching works regardless of the select= filter.
@@ -1247,7 +1247,7 @@ class TestCachingWithIsolatedSelection:
         Scenario:
         1. Full build — all nodes execute, cache populated.
         2. root.sql changes.
-        3. ``select="leaf"`` — leaf re-executes (cache miss due to new
+        3. `select="leaf"` — leaf re-executes (cache miss due to new
            upstream key) against OLD root/mid warehouse tables.
         4. Full build — root and mid re-execute with new data; leaf must
            also re-execute because its prior result was computed against
@@ -1297,9 +1297,9 @@ class TestCachingWithIsolatedSelection:
 
         Scenario:
         1. root.sql changes.
-        2. ``select=leaf`` — leaf executes against OLD root/mid tables.
-        3. ``select="root mid"`` — root and mid rebuild in the warehouse.
-        4. ``select=leaf`` — must NOT cache-hit from step 2 because the
+        2. `select=leaf` — leaf executes against OLD root/mid tables.
+        3. `select="root mid"` — root and mid rebuild in the warehouse.
+        4. `select=leaf` — must NOT cache-hit from step 2 because the
            upstream warehouse data changed.
 
         This works because the execution state file tracks when each
@@ -1353,9 +1353,9 @@ class TestCachingWithIsolatedSelection:
         Scenario (A -> B -> C -> D chain):
         1. Run full build so all nodes have execution state.
         2. Change A's SQL.
-        3. ``select=C`` — C executes with salted upstream keys because
+        3. `select=C` — C executes with salted upstream keys because
            A and B weren't re-executed after the file change.
-        4. ``select=D`` — D should NOT cache-hit because C ran against
+        4. `select=D` — D should NOT cache-hit because C ran against
            stale upstream data.  If the execution state incorrectly
            recorded C's unsalted precomputed key (instead of the actual
            salted key used in step 3), D would see the state as

--- a/src/integrations/prefect-gcp/prefect_gcp/utilities.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/utilities.py
@@ -21,7 +21,7 @@ def sanitize_labels_for_gcp(labels: dict[str, str]) -> dict[str, str]:
     length of 63 characters. Values follow the same character rules but may
     start with any allowed character, and may also be empty.
 
-    Dots and slashes in keys (e.g. ``prefect.io/flow-run-id``) are replaced
+    Dots and slashes in keys (e.g. `prefect.io/flow-run-id`) are replaced
     with hyphens. Leading non-letter characters are stripped from keys.
     Labels whose keys are empty after sanitization are dropped.
     """

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
@@ -398,7 +398,7 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
 
         Labels are written to both the job metadata and the execution template
         metadata so that executions (which persist after the job is deleted
-        when ``keep_job=False``) also carry the Prefect metadata.
+        when `keep_job=False`) also carry the Prefect metadata.
         """
         # --- Job-level labels ---
         existing = {

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -259,7 +259,7 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
 
         Labels are written to both the job level and the execution template
         so that executions (which persist after the job is deleted when
-        ``keep_job=False``) also carry the Prefect metadata.
+        `keep_job=False`) also carry the Prefect metadata.
         """
         # --- Job-level labels ---
         existing = {

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -1127,7 +1127,7 @@ class TestFetchCrashedPodLogs:
     def mock_k8s_client(self):
         """Creates a mock Kubernetes client with CoreV1Api.
 
-        The primary container is named ``prefect-job``, matching the default
+        The primary container is named `prefect-job`, matching the default
         used by the Prefect Kubernetes worker.
         """
         client = AsyncMock()

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -609,7 +609,7 @@ class Block(BaseModel, ABC):
         # reported from https://github.com/PrefectHQ/prefect-dbt/issues/54
         data_keys = self.model_json_schema(by_alias=False)["properties"].keys()
 
-        # `block_document_data`` must return the aliased version for it to show in the UI
+        # `block_document_data` must return the aliased version for it to show in the UI
         block_document_data = self.model_dump(
             by_alias=True,
             include=data_keys,

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -7,7 +7,7 @@ __all__ = ["app"]
 
 
 def __getattr__(name: str) -> ModuleType:
-    # Preserve historical attribute-style access such as ``prefect.cli.dev``
+    # Preserve historical attribute-style access such as `prefect.cli.dev`
     # without reintroducing eager imports at package import time.
     module_name = f"{__name__}.{name}"
     try:

--- a/src/prefect/cli/_app.py
+++ b/src/prefect/cli/_app.py
@@ -126,7 +126,7 @@ def _normalize_top_level_flags(args: list[str]) -> list[str]:
 
     Only rewrites flags that appear before the first non-flag token (the
     command name).  After the command, all tokens pass through unchanged
-    so subcommand flags like ``worker start -p pool`` are not affected.
+    so subcommand flags like `worker start -p pool` are not affected.
     """
     result = []
     seen_command = False

--- a/src/prefect/cli/_server_utils.py
+++ b/src/prefect/cli/_server_utils.py
@@ -202,7 +202,7 @@ def _validate_multi_worker(workers: int, exit_fn: Callable[[str], object]) -> No
     Args:
         workers: Number of worker processes.
         exit_fn: Called with an error message when validation fails (e.g.
-            ``exit_with_error``).
+            `exit_with_error`).
     """
     from prefect.server.utilities.database import get_dialect
 

--- a/src/prefect/cli/variable.py
+++ b/src/prefect/cli/variable.py
@@ -208,5 +208,5 @@ async def unset(name: str):
         exit_with_success(f"Unset variable {name!r}.")
 
 
-# Alias: ``prefect variable delete`` → ``prefect variable unset``
+# Alias: `prefect variable delete` → `prefect variable unset`
 variable_app.command(unset, name="delete")

--- a/src/prefect/client/_version_checking.py
+++ b/src/prefect/client/_version_checking.py
@@ -81,20 +81,20 @@ async def check_server_version(
     """Perform a one-shot server version compatibility check.
 
     The check is skipped when:
-    * The ``server_version_check_enabled`` setting is ``False``.
+    * The `server_version_check_enabled` setting is `False`.
     * The *api_url* points at Prefect Cloud (Cloud is always compatible).
     * A check for this *(api_url, client_version)* pair has already passed.
 
-    On a major-version mismatch a ``RuntimeError`` is raised (regardless of
+    On a major-version mismatch a `RuntimeError` is raised (regardless of
     *raise_on_error*).  When the server is simply older than the client a
     warning is logged.
 
     Args:
-        api_url: The base Prefect API URL (e.g. ``http://localhost:4200/api``).
+        api_url: The base Prefect API URL (e.g. `http://localhost:4200/api`).
         logger: Logger used for warnings and debug messages.
-        raise_on_error: When ``True`` (the default, used by HTTP clients),
-            raise ``RuntimeError`` if the version endpoint cannot be reached.
-            When ``False`` (used by WebSocket clients), log a debug message
+        raise_on_error: When `True` (the default, used by HTTP clients),
+            raise `RuntimeError` if the version endpoint cannot be reached.
+            When `False` (used by WebSocket clients), log a debug message
             and return silently so that the caller can still attempt its
             connection.
     """

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -735,7 +735,7 @@ class Runner:
             task_status.started(process.pid)
 
             # Only add the process to the map if it is still running
-            # The process may be a multiprocessing.context.SpawnProcess, in which case it will have an `exitcode`` attribute
+            # The process may be a multiprocessing.context.SpawnProcess, in which case it will have an `exitcode` attribute
             # but no `returncode` attribute
             if (
                 getattr(process, "returncode", None)

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -86,9 +86,9 @@ class PrefectDBInterface(metaclass=DBSingleton):
         orphaned references exist).  Dropping tables directly is both faster
         and more robust.
 
-        Reflection is used instead of ``Base.metadata.drop_all()`` so that
+        Reflection is used instead of `Base.metadata.drop_all()` so that
         tables created by migrations but not tracked in the ORM (e.g.
-        ``deployment_version``, ``alembic_version``) are also removed.
+        `deployment_version`, `alembic_version`) are also removed.
         """
         engine = await self.engine()
         async with engine.begin() as conn:

--- a/src/prefect/server/models/logs.py
+++ b/src/prefect/server/models/logs.py
@@ -41,7 +41,7 @@ def _sanitize_log_strings(log: LogCreate) -> LogCreate:
     """Strip null bytes from log string fields.
 
     PostgreSQL rejects strings containing null bytes (0x00) with
-    ``CharacterNotInRepertoireError``.  Rather than letting the INSERT
+    `CharacterNotInRepertoireError`.  Rather than letting the INSERT
     fail, we replace them here so the rest of the log record is preserved.
     """
     sanitized_message = log.message.replace("\x00", "")

--- a/src/prefect/server/services/scheduler.py
+++ b/src/prefect/server/services/scheduler.py
@@ -52,17 +52,17 @@ def _get_select_deployments_to_schedule_query(
     re-evaluated even when other schedules on the same deployment still
     have runs far in the future.
 
-    Each schedule's runs are identified via the ``created_by`` JSON column
-    which stores ``{"id": "<schedule_id>", "type": "SCHEDULE", ...}`` on
+    Each schedule's runs are identified via the `created_by` JSON column
+    which stores `{"id": "<schedule_id>", "type": "SCHEDULE", ...}` on
     every auto-scheduled flow run.  An expression index on
-    ``(created_by->>'id')`` keeps these correlated subqueries fast.
+    `(created_by->>'id')` keeps these correlated subqueries fast.
     """
     right_now = now("UTC")
 
     # Use type_coerce to bypass the Pydantic TypeDecorator so SQLAlchemy
-    # emits a bare ``created_by->>'id'`` (Postgres) / ``json_extract(created_by, '$.id')``
+    # emits a bare `created_by->>'id'` (Postgres) / `json_extract(created_by, '$.id')`
     # (SQLite) without an extra CAST wrapper.  This is required for
-    # PostgreSQL to match the expression index on ``(created_by->>'id')``.
+    # PostgreSQL to match the expression index on `(created_by->>'id')`.
     schedule_id_match = sa.type_coerce(db.FlowRun.created_by, sa.JSON)[
         "id"
     ].as_string() == sa.cast(db.DeploymentSchedule.id, sa.String)

--- a/src/prefect/server/utilities/postgres_listener.py
+++ b/src/prefect/server/utilities/postgres_listener.py
@@ -22,7 +22,7 @@ def _normalize_asyncpg_dsn_query_params(dsn_string: str) -> str:
     """
     Normalize connection query params into asyncpg/libpq-compatible forms.
 
-    In particular, asyncpg parses the URI query string with ``parse_qs`` and keeps
+    In particular, asyncpg parses the URI query string with `parse_qs` and keeps
     only the last value for duplicate keys. Normalize repeated multihost params
     like `host=...&host=...` into the documented comma-separated forms so
     asyncpg still sees the full host list. While rewriting, also rename the

--- a/src/prefect/telemetry/_metrics.py
+++ b/src/prefect/telemetry/_metrics.py
@@ -20,7 +20,7 @@ def _resolve_metrics_endpoint(
     """Resolve the OTLP metrics endpoint.
 
     Returns:
-        A tuple of (endpoint_url, is_cloud). ``is_cloud`` is True only
+        A tuple of (endpoint_url, is_cloud). `is_cloud` is True only
         when the endpoint was auto-derived from a Prefect Cloud API URL,
         which signals that the Prefect API key should be sent as an auth
         header. User-specified endpoints (via env vars) never receive the

--- a/src/prefect/testing/cli.py
+++ b/src/prefect/testing/cli.py
@@ -57,7 +57,7 @@ class CycloptsResult:
         self.stdout = stdout
         self.stderr = stderr
         # Click's CliRunner merges stdout and stderr into one stream.
-        # Match that behavior so ``result.output`` always contains both.
+        # Match that behavior so `result.output` always contains both.
         self.output: str = stdout + stderr
         self.exit_code = exit_code
         self.exception = exception
@@ -72,7 +72,7 @@ class CycloptsCliRunner:
 
     Design principles:
     - Use a TTY-emulating StringIO as sys.stdout so that Rich Console
-      instances (which resolve sys.stdout dynamically via their ``file``
+      instances (which resolve sys.stdout dynamically via their `file`
       property) write to our capture buffer AND report is_interactive=True.
     - Redirect sys.stdin to a StringIO for prompt input.
     - Save and restore all mutated global state (sys.stdout/stderr/stdin,


### PR DESCRIPTION
## Summary

- Adds a `pygrep`-based pre-commit hook that catches double backticks (```` `` ````) while allowing single and triple backticks
- Fixes all 25 existing files with double backtick violations, converting RST-style ```` ``foo`` ```` to markdown-style `` `foo` ``

🤖 Generated with [Claude Code](https://claude.com/claude-code)