### PR TITLE
Replace bare `except:` with `except Exception:` in flow_engine.py

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -1798,7 +1798,7 @@ def run_flow(
             ret_val = run_flow_sync(**kwargs)
     except (Abort, Pause):
         raise
-    except:
+    except Exception:
         if error_logger:
             error_logger.error(
                 "Engine execution exited with unexpected exception", exc_info=True


### PR DESCRIPTION
## Summary

This PR replaces a bare `except:` clause with `except Exception:` in `src/prefect/flow_engine.py` (line 1801).

### Problem

A bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (which inherit from `BaseException`, not `Exception`). These are typically not "unexpected exceptions" and should be allowed to propagate normally without being logged as errors.

### Fix

Changed `except:` to `except Exception:` so that only standard exceptions are caught and logged, while `BaseException` subclasses propagate as intended.

This is consistent with Python best practices (PEP 8) which recommend against bare `except:` clauses.