### PR TITLE
Fix UnicodeDecodeError when subprocess outputs non-UTF-8 bytes

### DIFF
--- a/src/prefect/deployments/steps/utility.py
+++ b/src/prefect/deployments/steps/utility.py
@@ -52,12 +52,12 @@ async def _stream_capture_process_output(
     async with create_task_group() as tg:
         tg.start_soon(
             stream_text,
-            TextReceiveStream(process.stdout),
+            TextReceiveStream(process.stdout, errors="replace"),
             *stdout_sinks,
         )
         tg.start_soon(
             stream_text,
-            TextReceiveStream(process.stderr),
+            TextReceiveStream(process.stderr, errors="replace"),
             *stderr_sinks,
         )
 
@@ -71,7 +71,7 @@ async def _read_stream(
         data = await stream.read(4096)
         if not data:
             break
-        text = data.decode()
+        text = data.decode(errors="replace")
         for sink in sinks:
             sink.write(text)
             if hasattr(sink, "flush"):

--- a/src/prefect/utilities/processutils.py
+++ b/src/prefect/utilities/processutils.py
@@ -338,13 +338,13 @@ async def consume_process_output(
         if process.stdout is not None:
             tg.start_soon(
                 stream_text,
-                TextReceiveStream(process.stdout),
+                TextReceiveStream(process.stdout, errors="replace"),
                 stdout_sink,
             )
         if process.stderr is not None:
             tg.start_soon(
                 stream_text,
-                TextReceiveStream(process.stderr),
+                TextReceiveStream(process.stderr, errors="replace"),
                 stderr_sink,
             )
 

--- a/tests/utilities/test_processutils.py
+++ b/tests/utilities/test_processutils.py
@@ -83,6 +83,26 @@ class TestRunProcess:
         assert process.returncode == 0
         assert (tmp_path / "output.txt").read_text().strip() == "hello world"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="printf with octal escapes not available on Windows",
+    )
+    async def test_run_process_handles_non_utf8_output(self, capsys):
+        """Subprocess output containing non-UTF-8 bytes should not crash the
+        process monitor. Instead, undecodable bytes are replaced with the
+        Unicode replacement character."""
+        # \xb2 is a lone continuation byte that is invalid in UTF-8
+        process = await run_process(
+            ["bash", "-c", r"printf 'hello\xb2world'"],
+            stream_output=True,
+        )
+        assert process.returncode == 0
+        out, _ = capsys.readouterr()
+        # The replacement character \ufffd should appear where the invalid byte was
+        assert "hello" in out
+        assert "world" in out
+        assert "\ufffd" in out
+
 
 class TestOpenProcess:
     str_cmd = "ls -a"


### PR DESCRIPTION
## Summary
- Fixes `UnicodeDecodeError` that crashes the process monitor when a subprocess emits non-UTF-8 bytes (e.g., on Windows with non-English locales or when subprocesses output binary data).
- Passes `errors="replace"` to `TextReceiveStream` in `consume_process_output` and `_stream_capture_process_output`, and to `bytes.decode()` in `_read_stream`, so undecodable bytes are replaced with the Unicode replacement character (`U+FFFD`) instead of raising an exception.
- The flow run completes normally and output remains readable; only truly undecodable bytes are substituted.

Closes #15330

## Changes
- `src/prefect/utilities/processutils.py`: Pass `errors="replace"` to `TextReceiveStream` in `consume_process_output`.
- `src/prefect/deployments/steps/utility.py`: Pass `errors="replace"` to `TextReceiveStream` in `_stream_capture_process_output` and to `bytes.decode()` in `_read_stream`.
- `tests/utilities/test_processutils.py`: Add test verifying that non-UTF-8 subprocess output is handled gracefully with replacement characters.

## Test plan
- [x] New test `test_run_process_handles_non_utf8_output` emits a raw `\xb2` byte via `printf` and verifies the output contains the Unicode replacement character without raising.
- [x] Existing process output tests continue to pass (standard UTF-8 output is unaffected by the change).