### PR TITLE
Fix heartbeat starvation under CPU-bound workloads

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import logging
 import multiprocessing
 import multiprocessing.context
@@ -38,6 +39,7 @@ from opentelemetry import propagate, trace
 from typing_extensions import ParamSpec
 
 from prefect import Task, __version__
+from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.client.schemas.filters import FlowRunFilter
@@ -169,6 +171,7 @@ def load_flow_and_flow_run(flow_run_id: UUID) -> tuple[FlowRun, Flow[..., Any]]:
 @contextmanager
 def _send_heartbeats(
     engine: "BaseFlowRunEngine[Any, Any]",
+    join_on_exit: bool = True,
 ) -> Generator[None, None, None]:
     """Context manager that maintains heartbeats for a flow run using a daemon thread.
 
@@ -177,6 +180,8 @@ def _send_heartbeats(
 
     Args:
         engine: The flow run engine instance to emit heartbeats for.
+        join_on_exit: Whether to join the heartbeat thread on exit. Set to
+            `False` in async engines to avoid blocking the event loop.
 
     Yields:
         None
@@ -222,9 +227,33 @@ def _send_heartbeats(
         yield
     finally:
         stop_event.set()
-        # Don't join — the daemon thread will exit on its own within ~1s.
-        # Joining here would block the event loop when used in the async engine.
+        if join_on_exit:
+            thread.join(timeout=2)
         engine.logger.debug("Stopped flow run heartbeat context")
+
+
+@deprecated_callable(
+    start_date=datetime.datetime(2026, 3, 1),
+    help="Use `_send_heartbeats` instead.",
+)
+@contextmanager
+def send_heartbeats_sync(
+    engine: "FlowRunEngine[Any, Any]",
+) -> Generator[None, None, None]:
+    with _send_heartbeats(engine, join_on_exit=True):
+        yield
+
+
+@deprecated_callable(
+    start_date=datetime.datetime(2026, 3, 1),
+    help="Use `_send_heartbeats` instead.",
+)
+@asynccontextmanager
+async def send_heartbeats_async(
+    engine: "AsyncFlowRunEngine[Any, Any]",
+) -> AsyncGenerator[None, None]:
+    with _send_heartbeats(engine, join_on_exit=False):
+        yield
 
 
 @dataclass
@@ -1559,7 +1588,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     seconds=self.flow.timeout_seconds,
                     timeout_exc_type=FlowRunTimeoutError,
                 ):
-                    with _send_heartbeats(self):
+                    with _send_heartbeats(self, join_on_exit=False):
                         self.logger.debug(
                             f"Executing flow {self.flow.name!r} for flow run {self.flow_run.name!r}..."
                         )

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -2670,7 +2670,7 @@ class TestFlowRunEngineHeartbeat:
         context_exited = []
 
         @contextmanager
-        def mock__send_heartbeats(engine):
+        def mock__send_heartbeats(engine, **kwargs):
             context_entered.append(engine)
             try:
                 yield
@@ -2707,7 +2707,7 @@ class TestFlowRunEngineHeartbeat:
         context_exited = []
 
         @contextmanager
-        def mock__send_heartbeats(engine):
+        def mock__send_heartbeats(engine, **kwargs):
             context_entered.append(engine)
             try:
                 yield
@@ -2844,7 +2844,7 @@ class TestFlowRunEngineHeartbeat:
         context_exited = []
 
         @contextmanager
-        def mock__send_heartbeats(engine):
+        def mock__send_heartbeats(engine, **kwargs):
             context_entered.append(engine)
             try:
                 yield
@@ -2879,7 +2879,7 @@ class TestFlowRunEngineHeartbeat:
         context_exited = []
 
         @contextmanager
-        def mock__send_heartbeats(engine):
+        def mock__send_heartbeats(engine, **kwargs):
             context_entered.append(engine)
             try:
                 yield
@@ -2987,7 +2987,7 @@ class TestFlowRunEngineHeartbeat:
         original__send_heartbeats = _send_heartbeats
 
         @contextmanager
-        def tracking__send_heartbeats(engine):
+        def tracking__send_heartbeats(engine, **kwargs):
             # Record state when entering context
             heartbeat_state_checks.append(
                 ("enter", engine.flow_run.state.type if engine.flow_run else None)
@@ -3040,7 +3040,7 @@ class TestFlowRunEngineHeartbeat:
         original__send_heartbeats = _send_heartbeats
 
         @contextmanager
-        def tracking__send_heartbeats(engine):
+        def tracking__send_heartbeats(engine, **kwargs):
             # Record state when entering context
             heartbeat_state_checks.append(
                 ("enter", engine.flow_run.state.type if engine.flow_run else None)


### PR DESCRIPTION
closes #20887

## Summary

- Replaces the dual `send_heartbeats_sync`/`send_heartbeats_async` with a single thread-based `send_heartbeats` context manager that works for both sync and async flows
- The async implementation used `asyncio.create_task` which was starved when the event loop was blocked by CPU-bound work — the new daemon thread fires regardless of event loop state
- Pre-computes the heartbeat event template (`resource` dict + `related` list with `RelatedResource.model_validate()` calls) once before starting the heartbeat thread, minimizing per-tick GIL hold time

Draws inspiration from https://github.com/PrefectHQ/prefect/pull/21177, which I initially was apprehensive of, but I've realized is the best solution.

<details>
<summary>Details</summary>

**Two starvation vectors fixed:**

1. **Event loop starvation (async flows):** `send_heartbeats_async` used `asyncio.create_task` — if the event loop was blocked by CPU-bound work, the heartbeat coroutine never got scheduled. Now uses a daemon thread that runs independently.

2. **GIL contention (both sync and async):** Each heartbeat previously did multiple `RelatedResource.model_validate()` calls, `Event()` construction, and context capture. Under CPU saturation, the heartbeat thread couldn't acquire the GIL long enough to complete this work. Now pre-computes the template once, so the per-tick work is just an `emit_event()` call.

This matches OTel's pattern (which worked fine during the same workloads) of pre-building data and doing minimal work in the background thread.
</details>