### PR TITLE
chore(docs): Update callout for deploy CLI options with multiple targets

### DIFF
--- a/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
+++ b/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
@@ -688,11 +688,14 @@ prefect --no-prompt deploy --name my-deployment
 This prevents the command from hanging on prompts and will fail clearly if required information is missing.
 
 <Note>
-**CLI Options When deploying multiple deployments**
+    **CLI options when deploying multiple deployments**
 
-    When deploying more than one deployment with a single `prefect deploy` command, any additional attributes provided are ignored.
+    When `prefect deploy` targets multiple entries in a `prefect.yaml` file, 
+    explicit CLI options are ignored. To apply CLI overrides, target a single entry.
 
-    To provide overrides to a deployment through the CLI, you must deploy that deployment individually.
+    However, the [default work pool environment variable, 
+    `PREFECT_DEFAULT_WORK_POOL_NAME`](/v3/api-ref/settings-ref#default_work_pool_name), is still applied to deployments whose `prefect.yaml` entry
+    does not set `work_pool.name`, even when multiple entries are targeted.
 </Note>
 
 ### Reuse configuration across deployments


### PR DESCRIPTION
Related to #21258

Clarifies that CLI options are ignored when prefect deploy targets multiple prefect.yaml entries, and notes that PREFECT_DEFAULT_WORK_POOL_NAME still applies to entries without an explicit work_pool.name.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
