### PR TITLE
fix: default missing Content-Type to application/json for old client …

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -415,6 +415,23 @@ def create_api_app(
     if final:
         gc.collect()
 
+    @api_app.middleware("http")
+    async def default_content_type(request: Request, call_next: Any):  # type: ignore[reportUnusedFunction]
+        # Older Prefect clients (<3.6.19) sent JSON bodies via httpx's
+        # content= parameter, which omits the Content-Type header.
+        # FastAPI >=0.132.0 requires Content-Type: application/json to
+        # parse request bodies. Default it here for backward compat.
+        if (
+            request.method in {"POST", "PUT", "PATCH"}
+            and "content-type" not in request.headers
+            and int(request.headers.get("content-length", "0")) > 0
+        ):
+            request.scope["headers"] = [
+                *request.scope["headers"],
+                (b"content-type", b"application/json"),
+            ]
+        return await call_next(request)
+
     auth_string = prefect.settings.PREFECT_SERVER_API_AUTH_STRING.value()
 
     if auth_string is not None:

--- a/tests/server/orchestration/api/test_task_runs.py
+++ b/tests/server/orchestration/api/test_task_runs.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import json
 import uuid
 from uuid import uuid4
 
@@ -43,6 +44,33 @@ class TestCreateTaskRun:
         )
         assert task_run
         assert task_run.flow_run_id == flow_run.id
+
+    async def test_create_task_run_with_content_no_content_type(self, flow_run, client):
+        """Old clients (<3.6.19) sent JSON via httpx's content= parameter,
+        which omits the Content-Type header. The server should still accept it."""
+        task_run_data = {
+            "flow_run_id": str(flow_run.id),
+            "task_key": "my-task-key",
+            "name": "my-old-client-task-run",
+            "dynamic_key": "0",
+        }
+        response = await client.post(
+            "/task_runs/",
+            content=json.dumps(task_run_data),
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["name"] == "my-old-client-task-run"
+
+    async def test_create_task_run_empty_body_no_content_type(self, client):
+        """A POST with no body and no Content-Type should not be forced to
+        application/json — it should fail with a normal validation error,
+        not a JSON parse error."""
+        response = await client.post(
+            "/task_runs/",
+            content=b"",
+            headers={"content-length": "0"},
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     async def test_create_task_run_gracefully_upserts(self, flow_run, client):
         # create a task run


### PR DESCRIPTION
Old Prefect clients (<=3.5.0) sent JSON bodies via httpx's content= parameter, which omits the Content-Type header. FastAPI >=0.132.0 requires Content-Type: application/json to parse request bodies, so upgrading the server breaks older clients with a 422 on POST /task_runs/. This adds a lightweight middleware that defaults the header when missing.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

Closes https://github.com/PrefectHQ/prefect/issues/21301

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
