### PR TITLE
fix: add error handling for UI static directory creation

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -528,20 +528,38 @@ def create_ui_app(ephemeral: bool) -> FastAPI:
 
     def create_ui_static_subpath() -> None:
         if not os.path.exists(static_dir):
-            os.makedirs(static_dir)
+            try:
+                os.makedirs(static_dir)
+            except PermissionError as e:
+                logger.warning(
+                    f"Failed to create UI static directory '{static_dir}': {e}. "
+                    "UI may not be served correctly. Consider setting PREFECT_UI_STATIC_DIRECTORY "
+                    "to a writable location."
+                )
+                return
 
-        copy_directory(str(source_static_path), str(static_dir))
-        replace_placeholder_string_in_files(
-            str(static_dir),
-            "/PREFECT_UI_SERVE_BASE_REPLACE_PLACEHOLDER",
-            stripped_base_url,
-        )
+        try:
+            copy_directory(str(source_static_path), str(static_dir))
+            replace_placeholder_string_in_files(
+                str(static_dir),
+                "/PREFECT_UI_SERVE_BASE_REPLACE_PLACEHOLDER",
+                stripped_base_url,
+            )
 
-        # Create a file to indicate that the static files have been copied
-        # This is used to determine if the static files need to be copied again
-        # when the server is restarted
-        with open(os.path.join(static_dir, reference_file_name), "w") as f:
-            f.write(cache_key)
+            # Create a file to indicate that the static files have been copied
+            # This is used to determine if the static files need to be copied again
+            # when the server is restarted
+            with open(os.path.join(static_dir, reference_file_name), "w") as f:
+                f.write(cache_key)
+        except PermissionError as e:
+            logger.warning(
+                f"Failed to write to UI static directory '{static_dir}': {e}. "
+                "UI may not be served correctly. Consider setting PREFECT_UI_STATIC_DIRECTORY "
+                "to a writable location."
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error setting up UI static files: {e}")
+            raise
 
     ui_app.add_middleware(GZipMiddleware)
 


### PR DESCRIPTION
## Summary
Add error handling for UI static directory creation and file copy operations.

## Problem
When `os.makedirs(static_dir)` fails due to permission errors, the exception is silently swallowed and users don't know why the UI is not working. This was reported in #19317.

## Solution
- Add try/except for `os.makedirs` with `PermissionError` handling
- Add try/except for file copy operations
- Log helpful warning messages suggesting users to check `PREFECT_UI_STATIC_DIRECTORY`
- Re-raise unexpected exceptions

## Changes
- `src/prefect/server/api/server.py`: Added error handling in `create_ui_static_subpath()`

## Test Plan
1. Set PREFECT_UI_STATIC_DIRECTORY to a non-writable location (e.g., `/root/prefect-ui`)
2. Start prefect server
3. Verify warning is logged instead of crash
4. UI gracefully fails with helpful error message

Fixes #19317

---

- [x] I confirm that this pull request is my own work and that I have the right to submit it under the project's license. I understand that my contribution may be included in the project under the terms of the project's license.