### PR TITLE
Remove expired docs banner

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,9 +9,6 @@
     "default": "light",
     "strict": false
   },
-  "banner": {
-    "content": "Join us at inaugural PyAI Conf in San Francisco on March 10th! [Learn more](https://pyai.events?utm_source=docs.prefect.io)"
-  },
   "colors": {
     "dark": "#2D6DF6",
     "light": "#5F92FF",


### PR DESCRIPTION
The PyAI Conf date has passed, so this removes the docs banner.