### PR TITLE
Docs: remove unused catalog files

### DIFF
--- a/.claude/skills/write-docs/SKILL.md
+++ b/.claude/skills/write-docs/SKILL.md
@@ -45,7 +45,7 @@ In-depth pages for experienced users covering topics like transactions, interact
 
 ### Integrations (`integrations/`)
 
-Each integration (e.g., `prefect-aws`, `prefect-gcp`) has its own subdirectory. The `index.mdx` covers installation, credential setup (blocks), and key capabilities. Additional pages cover specific workers, tasks, or SDK reference. Integration metadata lives in `integrations/catalog/` as YAML files. Follow the existing pattern: "Why use it" section, prerequisites, install instructions, blocks setup, then per-service usage sections.
+Each integration (e.g., `prefect-aws`, `prefect-gcp`) has its own subdirectory. The `index.mdx` covers installation, credential setup (blocks), and key capabilities. Additional pages cover specific workers, tasks, or SDK reference. Follow the existing pattern: "Why use it" section, prerequisites, install instructions, blocks setup, then per-service usage sections.
 
 ### API Reference (`v3/api-ref/`)
 

--- a/docs/integrations/catalog/TEMPLATE.yaml
+++ b/docs/integrations/catalog/TEMPLATE.yaml
@@ -1,8 +1,0 @@
-integrationName: # Your collection name. Should match your PyPI package name. For example: prefect-collection
-author: Your Name
-authorUrl: # A link to information about the author. For example: Company URL, GitHub user profile, etc.
-documentation: # A link to the collection's documentation. For example, GitHub Pages.
-iconUrl: # Used as the src attribute of the collection's logo.
-# You can provide an external URL or add your logo under docs/latest/img/collections and provide a path
-# relative to docs/ For example: /images/integrations/my-logo.png
-tag: # A tag to help users search for your collection. Should correspond to the service that your collection integrates with. For example: "dbt", "AWS", "Databricks"

--- a/docs/integrations/catalog/prefect-alert.yaml
+++ b/docs/integrations/catalog/prefect-alert.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-alert
-author: Khuyen Tran
-authorUrl: https://github.com/khuyentran1401
-documentation: https://khuyentran1401.github.io/prefect-alert/
-iconUrl: /images/integrations/alert.png
-tag: Alert

--- a/docs/integrations/catalog/prefect-aws.yaml
+++ b/docs/integrations/catalog/prefect-aws.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-aws
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-aws
-iconUrl: /images/integrations/aws.png
-tag: AWS

--- a/docs/integrations/catalog/prefect-azure.yaml
+++ b/docs/integrations/catalog/prefect-azure.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-azure
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-azure
-iconUrl: /images/integrations/azure.png
-tag: Azure

--- a/docs/integrations/catalog/prefect-bitbucket.yaml
+++ b/docs/integrations/catalog/prefect-bitbucket.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-bitbucket
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-bitbucket
-iconUrl: /images/integrations/bitbucket.png
-tag: Bitbucket

--- a/docs/integrations/catalog/prefect-coiled.yaml
+++ b/docs/integrations/catalog/prefect-coiled.yaml
@@ -1,6 +1,0 @@
-integrationName: coiled
-author: Coiled
-authorUrl: https://www.coiled.io/
-documentation: https://docs.coiled.io/user_guide/labs/prefect.html?utm_source=prefect-docs&utm_medium=integrations
-iconUrl: /images/integrations/coiled.png
-tag: Coiled

--- a/docs/integrations/catalog/prefect-cubejs.yaml
+++ b/docs/integrations/catalog/prefect-cubejs.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-cubejs
-author: Alessandro Lollo
-authorUrl: https://github.com/AlessandroLollo
-documentation: https://alessandrolollo.github.io/prefect-cubejs/
-iconUrl: /images/integrations/cubejs.png
-tag: CubeJS

--- a/docs/integrations/catalog/prefect-dask.yaml
+++ b/docs/integrations/catalog/prefect-dask.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-dask
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-dask
-iconUrl: /images/integrations/dask.png
-tag: Dask

--- a/docs/integrations/catalog/prefect-databricks.yaml
+++ b/docs/integrations/catalog/prefect-databricks.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-databricks
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-databricks
-iconUrl: /images/integrations/databricks.png
-tag: Databricks

--- a/docs/integrations/catalog/prefect-dbt.yaml
+++ b/docs/integrations/catalog/prefect-dbt.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-dbt
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-dbt
-iconUrl: /images/integrations/dbt.png
-tag: dbt

--- a/docs/integrations/catalog/prefect-docker.yaml
+++ b/docs/integrations/catalog/prefect-docker.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-docker
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-docker
-iconUrl: /images/integrations/docker.png
-tag: Docker

--- a/docs/integrations/catalog/prefect-earthdata.yaml
+++ b/docs/integrations/catalog/prefect-earthdata.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-earthdata
-author: Giorgio Basile
-authorUrl: https://github.com/giorgiobasile
-documentation: https://giorgiobasile.github.io/prefect-earthdata/
-iconUrl: /images/integrations/nasa.png
-tag: Earthdata

--- a/docs/integrations/catalog/prefect-email.yaml
+++ b/docs/integrations/catalog/prefect-email.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-email
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-email
-iconUrl: /images/integrations/email.png
-tag: Email

--- a/docs/integrations/catalog/prefect-fivetran.yaml
+++ b/docs/integrations/catalog/prefect-fivetran.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-fivetran
-author: Fivetran
-authorUrl: https://www.fivetran.com/
-documentation: https://fivetran.github.io/prefect-fivetran/
-iconUrl: /images/integrations/fivetran.png
-tag: Fivetran

--- a/docs/integrations/catalog/prefect-fugue.yaml
+++ b/docs/integrations/catalog/prefect-fugue.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-fugue
-author: The Fugue Development Team
-authorUrl: https://github.com/fugue-project/fugue
-documentation: https://fugue-project.github.io/prefect-fugue/
-iconUrl: https://avatars.githubusercontent.com/u/65140352?s=200&v=4
-tag: Fugue

--- a/docs/integrations/catalog/prefect-gcp.yaml
+++ b/docs/integrations/catalog/prefect-gcp.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-gcp
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-gcp
-iconUrl: /images/integrations/gcp.png
-tag: GCP

--- a/docs/integrations/catalog/prefect-github.yaml
+++ b/docs/integrations/catalog/prefect-github.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-github
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-github
-iconUrl: /images/integrations/github.png
-tag: GitHub

--- a/docs/integrations/catalog/prefect-gitlab.yaml
+++ b/docs/integrations/catalog/prefect-gitlab.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-gitlab
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-gitlab
-iconUrl: /images/integrations/gitlab.png
-tag: GitLab

--- a/docs/integrations/catalog/prefect-google-sheets.yaml
+++ b/docs/integrations/catalog/prefect-google-sheets.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-google-sheets
-author: Stefano Cascavilla
-authorUrl: https://github.com/stefanocascavilla
-documentation: https://stefanocascavilla.github.io/prefect-google-sheets/
-iconUrl: /images/integrations/gsheets.png
-tag: Google Sheets

--- a/docs/integrations/catalog/prefect-kubernetes.yaml
+++ b/docs/integrations/catalog/prefect-kubernetes.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-kubernetes
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-kubernetes
-iconUrl: /images/integrations/kubernetes.png
-tag: Kubernetes

--- a/docs/integrations/catalog/prefect-kv.yaml
+++ b/docs/integrations/catalog/prefect-kv.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-kv
-author: Zanie Blue
-authorUrl: https://github.com/zanieb
-documentation: https://github.com/zanieb/prefect-kv
-iconUrl: /images/integrations/prefect-kv.svg
-tag: "KV"

--- a/docs/integrations/catalog/prefect-metricflow.yaml
+++ b/docs/integrations/catalog/prefect-metricflow.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-metricflow
-author: Alessandro Lollo
-authorUrl: https://github.com/AlessandroLollo
-documentation: https://alessandrolollo.github.io/prefect-metricflow/
-iconUrl: /images/integrations/metricflow.png
-tag: MetricFlow

--- a/docs/integrations/catalog/prefect-planetary-computer.yaml
+++ b/docs/integrations/catalog/prefect-planetary-computer.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-planetary-computer
-author: Giorgio Basile
-authorUrl: https://github.com/giorgiobasile
-documentation: https://giorgiobasile.github.io/prefect-planetary-computer/
-iconUrl: /images/integrations/microsoft.png
-tag: Planetary Computer

--- a/docs/integrations/catalog/prefect-ray.yaml
+++ b/docs/integrations/catalog/prefect-ray.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-ray
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-ray
-iconUrl: /images/integrations/ray.png
-tag: Ray

--- a/docs/integrations/catalog/prefect-shell.yaml
+++ b/docs/integrations/catalog/prefect-shell.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-shell
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-shell
-iconUrl: /images/integrations/shell.png
-tag: Shell

--- a/docs/integrations/catalog/prefect-sifflet.yaml
+++ b/docs/integrations/catalog/prefect-sifflet.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-sifflet
-author: Sifflet and Alessandro Lollo
-authorUrl: https://www.siffletdata.com/
-documentation: https://siffletapp.github.io/prefect-sifflet/
-iconUrl: /images/integrations/sifflet.png
-tag: Sifflet

--- a/docs/integrations/catalog/prefect-slack.yaml
+++ b/docs/integrations/catalog/prefect-slack.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-slack
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-slack
-iconUrl: /images/integrations/slack.png
-tag: Slack

--- a/docs/integrations/catalog/prefect-slurm.yaml
+++ b/docs/integrations/catalog/prefect-slurm.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-slurm
-author: EBI Metagenomics
-authorUrl: https://www.ebi.ac.uk/metagenomics/
-documentation: https://github.com/EBI-Metagenomics/prefect-slurm
-iconUrl: /images/integrations/slurm.png
-tag: Slurm

--- a/docs/integrations/catalog/prefect-snowflake.yaml
+++ b/docs/integrations/catalog/prefect-snowflake.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-snowflake
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-snowflake
-iconUrl: /images/integrations/snowflake.png
-tag: Snowflake

--- a/docs/integrations/catalog/prefect-soda-cloud.yaml
+++ b/docs/integrations/catalog/prefect-soda-cloud.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-soda-cloud
-author: Alessandro Lollo
-authorUrl: https://github.com/AlessandroLollo
-documentation: https://alessandrolollo.github.io/prefect-soda-cloud/
-iconUrl: /images/integrations/soda.png
-tag: Soda Cloud

--- a/docs/integrations/catalog/prefect-soda-core.yaml
+++ b/docs/integrations/catalog/prefect-soda-core.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-soda-core
-author: Soda and Alessandro Lollo
-authorUrl: https://github.com/sodadata
-documentation: https://sodadata.github.io/prefect-soda-core/
-iconUrl: /images/integrations/soda.png
-tag: Soda Core

--- a/docs/integrations/catalog/prefect-spark-on-k8s-operator.yaml
+++ b/docs/integrations/catalog/prefect-spark-on-k8s-operator.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-spark-on-k8s-operator
-author: Manoj Babu Katragadda
-authorUrl: https://github.com/tardunge
-documentation: https://tardunge.github.io/prefect-spark-on-k8s-operator/
-iconUrl: /images/integrations/spark-on-kubernetes.png
-tag: Spark on Kubernetes

--- a/docs/integrations/catalog/prefect-sqlalchemy.yaml
+++ b/docs/integrations/catalog/prefect-sqlalchemy.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-sqlalchemy
-author: Prefect
-authorUrl: https://prefect.io
-documentation: prefect-sqlalchemy
-iconUrl: /images/integrations/sqlalchemy.png
-tag: SQLAlchemy

--- a/docs/integrations/catalog/prefect-stitch.yaml
+++ b/docs/integrations/catalog/prefect-stitch.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-stitch
-author: Alessandro Lollo
-authorUrl: https://github.com/AlessandroLollo
-documentation: https://alessandrolollo.github.io/prefect-stitch/
-iconUrl: /images/integrations/stitch.png
-tag: Stitch

--- a/docs/integrations/catalog/prefect-transform.yaml
+++ b/docs/integrations/catalog/prefect-transform.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-transform
-author: Alessandro Lollo
-authorUrl: https://github.com/AlessandroLollo
-documentation: https://alessandrolollo.github.io/prefect-transform/
-iconUrl: /images/integrations/transform.png
-tag: Transform

--- a/docs/integrations/catalog/prefect-vault.yaml
+++ b/docs/integrations/catalog/prefect-vault.yaml
@@ -1,6 +1,0 @@
-integrationName: prefect-vault
-author: Pavel Chekin
-authorUrl: https://github.com/pbchekin
-documentation: https://github.com/pbchekin/prefect-vault
-iconUrl: /images/integrations/vault.png
-tag: HashiCorp Vault

--- a/src/integrations/AGENTS.md
+++ b/src/integrations/AGENTS.md
@@ -51,4 +51,3 @@ just prepare-integration-release <pkg>        # Generate release notes for an in
 ## Related
 
 - `docs/integrations/` → Integration-specific documentation pages
-- `docs/integrations/catalog/` → YAML metadata for each integration


### PR DESCRIPTION
I believe these catalog .yaml files were used to build the integrations page, before the switch to Mintlify.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
