### PR TITLE
Exclude styles folder from Mintlify deployments

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,1 +1,2 @@
 AGENTS.md
+styles/


### PR DESCRIPTION
Adds `styles/` to the `.mintignore` file to prevent this content from appearing on the docs site as it's only used in pre-commit and workflows.

Resolves #21357 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
