### PR TITLE
Preserve selected deployment tab after quick run

### DIFF
--- a/ui-v2/src/components/deployments/deployment-details-page.tsx
+++ b/ui-v2/src/components/deployments/deployment-details-page.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { buildDeploymentDetailsQuery } from "@/api/deployments";
 import { DeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
@@ -19,7 +20,10 @@ type DeploymentDetailsPageProps = {
 	id: string;
 };
 
+const routeApi = getRouteApi("/deployments/deployment/$id");
+
 export const DeploymentDetailsPage = ({ id }: DeploymentDetailsPageProps) => {
+	const { tab } = routeApi.useSearch();
 	const [showScheduleDialog, setShowScheduleDialog] = useState({
 		open: false,
 		scheduleIdToEdit: "",
@@ -76,7 +80,7 @@ export const DeploymentDetailsPage = ({ id }: DeploymentDetailsPageProps) => {
 						<DeploymentLinks deployment={deployment} />
 					</div>
 					<div className="flex items-center gap-2">
-						<RunFlowButton deployment={deployment} />
+						<RunFlowButton deployment={deployment} activeTab={tab} />
 						<DeploymentActionMenu
 							id={id}
 							onDelete={() =>

--- a/ui-v2/src/components/deployments/run-flow-button/run-flow-button.tsx
+++ b/ui-v2/src/components/deployments/run-flow-button/run-flow-button.tsx
@@ -1,7 +1,8 @@
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import type { Deployment } from "@/api/deployments";
 import { useQuickRun } from "@/components/deployments/use-quick-run";
 import { Button } from "@/components/ui/button";
+import type { DeploymentDetailsTabOptions } from "@/routes/deployments/deployment.$id";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -13,10 +14,28 @@ import { Icon } from "@/components/ui/icons";
 
 export type RunFlowButtonProps = {
 	deployment: Deployment;
+	activeTab?: DeploymentDetailsTabOptions;
 };
 
-export const RunFlowButton = ({ deployment }: RunFlowButtonProps) => {
-	const { onQuickRun, isPending } = useQuickRun();
+export const RunFlowButton = ({ deployment, activeTab }: RunFlowButtonProps) => {
+	const navigate = useNavigate();
+	const { onQuickRun, isPending } = useQuickRun({
+		onSuccess: () => {
+			if (!activeTab) {
+				return;
+			}
+
+			void navigate({
+				to: "/deployments/deployment/$id",
+				params: { id: deployment.id },
+				search: (prev) => ({
+					...prev,
+					tab: activeTab,
+				}),
+				replace: true,
+			});
+		},
+	});
 
 	return (
 		<DropdownMenu>

--- a/ui-v2/src/components/deployments/use-quick-run.test.tsx
+++ b/ui-v2/src/components/deployments/use-quick-run.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuickRun } from "@/components/deployments/use-quick-run";
+
+const createDeploymentFlowRun = vi.fn();
+
+vi.mock("@/api/flow-runs", () => ({
+	useDeploymentCreateFlowRun: () => ({
+		createDeploymentFlowRun,
+		isPending: false,
+	}),
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+	},
+}));
+
+describe("useQuickRun", () => {
+	beforeEach(() => {
+		createDeploymentFlowRun.mockReset();
+		vi.mocked(toast.success).mockReset();
+	});
+
+	it("calls provided onSuccess callback with flow run id", () => {
+		const callback = vi.fn();
+		createDeploymentFlowRun.mockImplementation(
+			(
+				_payload: unknown,
+				options?: { onSuccess?: (res: { id: string; name: string }) => void },
+			) => {
+				options?.onSuccess?.({ id: "flow-run-id", name: "test-run" });
+			},
+		);
+
+		const { result } = renderHook(() => useQuickRun({ onSuccess: callback }));
+		result.current.onQuickRun("deployment-id");
+
+		expect(callback).toHaveBeenCalledWith("flow-run-id");
+		expect(toast.success).toHaveBeenCalledOnce();
+	});
+});

--- a/ui-v2/src/components/deployments/use-quick-run.tsx
+++ b/ui-v2/src/components/deployments/use-quick-run.tsx
@@ -15,11 +15,15 @@ const DEPLOYMENT_QUICK_RUN_PAYLOAD = {
 	},
 } as const;
 
+type UseQuickRunOptions = {
+	onSuccess?: (flowRunId: string) => void;
+};
+
 /**
  *
  * @returns a function that handles the mutation and UX when a deployment creates a quick run
  */
-export const useQuickRun = () => {
+export const useQuickRun = ({ onSuccess }: UseQuickRunOptions = {}) => {
 	const { createDeploymentFlowRun, isPending } = useDeploymentCreateFlowRun();
 	const onQuickRun = (id: string) => {
 		createDeploymentFlowRun(
@@ -29,6 +33,7 @@ export const useQuickRun = () => {
 			},
 			{
 				onSuccess: (res) => {
+					onSuccess?.(res.id);
 					toast.success("Flow run created", {
 						action: (
 							<Link to="/runs/flow-run/$id" params={{ id: res.id }}>


### PR DESCRIPTION
closes #20235

this PR preserves the currently selected deployment details tab when triggering quick run from the deployment page.

<details>
<summary>Changes</summary>

- add an optional `onSuccess` callback to `useQuickRun`
- wire deployment details page tab state into `RunFlowButton`
- after quick run succeeds on deployment details, navigate with `replace` while preserving the active `tab` search param
- add a unit test for `useQuickRun` callback behavior in `ui-v2/src/components/deployments/use-quick-run.test.tsx`

</details>

<details>
<summary>Testing</summary>

- attempted: `npm run test -- src/components/deployments/use-quick-run.test.tsx`
- local environment failure: Node dynamic library load error (`libsimdjson.31.dylib` missing)

</details>