### PR TITLE
Add PgBouncer support via NullPool configuration

### DIFF
--- a/docs/v3/advanced/database-maintenance.mdx
+++ b/docs/v3/advanced/database-maintenance.mdx
@@ -505,9 +505,41 @@ For example, you could run the retention flow daily at 2 AM to clean up old flow
 - Review query plans with `EXPLAIN ANALYZE`
 
 ### "Connection limit reached"
-- Implement connection pooling immediately
+- Implement connection pooling with PgBouncer (see below)
 - Check for connection leaks: connections in 'idle' state for hours
 - Reduce Prefect worker connection counts
+
+## Using PgBouncer for connection pooling
+
+For high-scale deployments with many Prefect servers or workers, using [PgBouncer](https://www.pgbouncer.org/) as an external connection pooler reduces database connection overhead. When multiple API servers each maintain their own connection pool, total connections can exceed PostgreSQL limits even if most are idle. PgBouncer consolidates these into a single, efficient pool.
+
+### Configure Prefect for PgBouncer
+
+Set `pool_size` to `null` to disable SQLAlchemy's internal connection pool (using `NullPool`) and let PgBouncer handle pooling:
+
+```bash
+# Point Prefect at PgBouncer (note port 6432)
+export PREFECT_SERVER_DATABASE_CONNECTION_URL="postgresql+asyncpg://prefect:prefect@localhost:6432/prefect"
+
+# Disable SQLAlchemy connection pooling — PgBouncer handles it
+export PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE=null
+
+# Required for PgBouncer transaction mode — prepared statements don't
+# persist across different backend connections
+export PREFECT_SERVER_DATABASE_SQLALCHEMY_CONNECT_ARGS_STATEMENT_CACHE_SIZE=0
+```
+
+<Note>
+Use PgBouncer in **transaction mode** for Prefect. This releases connections back to the pool after each transaction, providing the best connection reuse.
+</Note>
+
+### Troubleshooting PgBouncer
+
+| Symptom | Fix |
+|---------|-----|
+| "prepared statement does not exist" | Set `statement_cache_size=0` and verify PgBouncer is in `transaction` mode |
+| "too many clients" | Increase `max_client_conn` in PgBouncer config |
+| High `cl_waiting` in `SHOW POOLS` | Increase PgBouncer's `default_pool_size` or check for slow queries |
 
 ## Further reading
 
@@ -515,3 +547,4 @@ For example, you could run the retention flow daily at 2 AM to clean up old flow
 - [PostgreSQL routine maintenance](https://www.postgresql.org/docs/current/routine-vacuuming.html)
 - [Monitoring PostgreSQL](https://www.postgresql.org/docs/current/monitoring-stats.html)
 - [pg_repack extension](https://github.com/reorg/pg_repack)
+- [PgBouncer documentation](https://www.pgbouncer.org/)

--- a/docs/v3/advanced/database-maintenance.mdx
+++ b/docs/v3/advanced/database-maintenance.mdx
@@ -538,6 +538,7 @@ Use PgBouncer in **transaction mode** for Prefect. This releases connections bac
 | Symptom | Fix |
 |---------|-----|
 | "prepared statement does not exist" | Set `statement_cache_size=0` and verify PgBouncer is in `transaction` mode |
+| "wrong password type" / `ProtocolViolationError` | Set `AUTH_TYPE=scram-sha-256` in PgBouncer config (required for asyncpg with PostgreSQL 14+) |
 | "too many clients" | Increase `max_client_conn` in PgBouncer config |
 | High `cl_waiting` in `SHOW POOLS` | Increase PgBouncer's `default_pool_size` or check for slow queries |
 

--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1113,9 +1113,9 @@ Settings for controlling SQLAlchemy connection behavior
 **TOML dotted key path**: `server.database.sqlalchemy.connect_args`
 
 ### `pool_size`
-Controls connection pool size of database connection pools from the Prefect backend.
+Controls connection pool size of database connection pools from the Prefect backend. Set to None/null to use NullPool for external connection poolers like PgBouncer.
 
-**Type**: `integer`
+**Type**: `integer | None`
 
 **Default**: `5`
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -951,14 +951,21 @@
                     "supported_environment_variables": []
                 },
                 "pool_size": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
                     "default": 5,
-                    "description": "Controls connection pool size of database connection pools from the Prefect backend.",
+                    "description": "Controls connection pool size of database connection pools from the Prefect backend. Set to None/null to use NullPool for external connection poolers like PgBouncer.",
                     "supported_environment_variables": [
                         "PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE",
                         "PREFECT_SQLALCHEMY_POOL_SIZE"
                     ],
-                    "title": "Pool Size",
-                    "type": "integer"
+                    "title": "Pool Size"
                 },
                 "pool_recycle": {
                     "default": 3600,

--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -236,9 +236,9 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
         )
         if cache_key not in ENGINES:
             sqlalchemy_settings = get_current_settings().server.database.sqlalchemy
-            kwargs: dict[str, Any] = {
-                "pool_recycle": sqlalchemy_settings.pool_recycle,
-            }
+            kwargs: dict[str, Any] = sqlalchemy_settings.model_dump(
+                mode="json", exclude={"connect_args"}
+            )
             connect_args: dict[str, Any] = {}
 
             if self.timeout is not None:
@@ -317,13 +317,19 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
                 kwargs["connect_args"] = connect_args
 
             if self.sqlalchemy_pool_size is None:
-                # Use NullPool for external connection poolers like PgBouncer
-                from sqlalchemy.pool import NullPool
-
-                kwargs["poolclass"] = NullPool
+                # Use NullPool for external connection poolers like PgBouncer.
+                # NullPool doesn't accept pool-related parameters.
+                kwargs["poolclass"] = sa.pool.NullPool
+                for key in (
+                    "pool_size",
+                    "pool_timeout",
+                    "max_overflow",
+                    "pool_pre_ping",
+                    "pool_use_lifo",
+                ):
+                    kwargs.pop(key, None)
             else:
                 kwargs["pool_size"] = self.sqlalchemy_pool_size
-                kwargs["pool_timeout"] = sqlalchemy_settings.pool_timeout
                 if self.sqlalchemy_max_overflow is not None:
                     kwargs["max_overflow"] = self.sqlalchemy_max_overflow
                 # "pre-ping" connections upon checkout to ensure they have not been

--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -146,7 +146,8 @@ class BaseDatabaseConfiguration(ABC):
         )
         self.sqlalchemy_pool_size: Optional[int] = (
             sqlalchemy_pool_size
-            or get_current_settings().server.database.sqlalchemy.pool_size
+            if sqlalchemy_pool_size is not None
+            else get_current_settings().server.database.sqlalchemy.pool_size
         )
         self.sqlalchemy_max_overflow: Optional[int] = (
             sqlalchemy_max_overflow
@@ -234,11 +235,10 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
             self.timeout,
         )
         if cache_key not in ENGINES:
-            kwargs: dict[str, Any] = (
-                get_current_settings().server.database.sqlalchemy.model_dump(
-                    mode="json", exclude={"connect_args"}
-                )
-            )
+            sqlalchemy_settings = get_current_settings().server.database.sqlalchemy
+            kwargs: dict[str, Any] = {
+                "pool_recycle": sqlalchemy_settings.pool_recycle,
+            }
             connect_args: dict[str, Any] = {}
 
             if self.timeout is not None:
@@ -316,23 +316,28 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
             if connect_args:
                 kwargs["connect_args"] = connect_args
 
-            if self.sqlalchemy_pool_size is not None:
+            if self.sqlalchemy_pool_size is None:
+                # Use NullPool for external connection poolers like PgBouncer
+                from sqlalchemy.pool import NullPool
+
+                kwargs["poolclass"] = NullPool
+            else:
                 kwargs["pool_size"] = self.sqlalchemy_pool_size
-
-            if self.sqlalchemy_max_overflow is not None:
-                kwargs["max_overflow"] = self.sqlalchemy_max_overflow
-
-            engine = create_async_engine(
-                self.connection_url,
-                echo=self.echo,
+                kwargs["pool_timeout"] = sqlalchemy_settings.pool_timeout
+                if self.sqlalchemy_max_overflow is not None:
+                    kwargs["max_overflow"] = self.sqlalchemy_max_overflow
                 # "pre-ping" connections upon checkout to ensure they have not been
                 # closed on the server side
-                pool_pre_ping=True,
+                kwargs["pool_pre_ping"] = True
                 # Use connections in LIFO order to help reduce connections
                 # after spiky load and in general increase the likelihood
                 # that a given connection pulled from the pool will be
                 # usable.
-                pool_use_lifo=True,
+                kwargs["pool_use_lifo"] = True
+
+            engine = create_async_engine(
+                self.connection_url,
+                echo=self.echo,
                 **kwargs,
             )
 

--- a/src/prefect/settings/models/server/database.py
+++ b/src/prefect/settings/models/server/database.py
@@ -1,10 +1,11 @@
 import warnings
-from typing import Any, ClassVar, Optional
+from typing import Annotated, Any, ClassVar, Optional
 from urllib.parse import quote_plus
 
 from pydantic import (
     AliasChoices,
     AliasPath,
+    BeforeValidator,
     Field,
     SecretStr,
     model_validator,
@@ -111,9 +112,14 @@ class SQLAlchemySettings(PrefectBaseSettings):
         description="Settings for controlling SQLAlchemy connection behavior",
     )
 
-    pool_size: int = Field(
+    pool_size: Annotated[
+        Optional[int],
+        BeforeValidator(
+            lambda v: None if isinstance(v, str) and v.lower() == "null" else v
+        ),
+    ] = Field(
         default=5,
-        description="Controls connection pool size of database connection pools from the Prefect backend.",
+        description="Controls connection pool size of database connection pools from the Prefect backend. Set to None/null to use NullPool for external connection poolers like PgBouncer.",
         validation_alias=AliasChoices(
             AliasPath("pool_size"),
             "prefect_server_database_sqlalchemy_pool_size",

--- a/tests/server/database/test_dependencies.py
+++ b/tests/server/database/test_dependencies.py
@@ -215,3 +215,53 @@ class TestDBInject:
         else:
             assert inspect.iscoroutinefunction(coroutine_with_injected_db)
         assert asyncio.run(coroutine_with_injected_db(42)) is self.db
+
+
+class TestNullPoolConfiguration:
+    """Test NullPool configuration for PgBouncer support."""
+
+    async def test_null_pool_size_uses_nullpool(self):
+        """Test that setting pool_size to None uses NullPool."""
+        import uuid
+
+        import sqlalchemy as sa
+
+        from prefect.server.database.configurations import ENGINES
+        from prefect.settings import (
+            PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE,
+            temporary_settings,
+        )
+
+        with temporary_settings({PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE: None}):
+            ENGINES.clear()
+
+            unique_db = f"test_nullpool_{uuid.uuid4().hex[:8]}"
+            config = AsyncPostgresConfiguration(
+                connection_url=f"postgresql+asyncpg://user:pass@localhost:5433/{unique_db}",
+            )
+
+            engine = await config.engine()
+            assert isinstance(engine.pool, sa.pool.NullPool)
+
+            await engine.dispose()
+
+    async def test_integer_pool_size_uses_regular_pool(self):
+        """Test that setting pool_size to an integer uses regular pool."""
+        import uuid
+
+        import sqlalchemy as sa
+
+        from prefect.server.database.configurations import ENGINES
+
+        ENGINES.clear()
+
+        unique_db = f"test_pool_{uuid.uuid4().hex[:8]}"
+        config = AsyncPostgresConfiguration(
+            connection_url=f"postgresql+asyncpg://user:pass@localhost:5433/{unique_db}",
+            sqlalchemy_pool_size=5,
+        )
+
+        engine = await config.engine()
+        assert not isinstance(engine.pool, sa.pool.NullPool)
+
+        await engine.dispose()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1459,6 +1459,12 @@ class TestDatabaseSettings:
         assert Settings().server.database.sqlalchemy.pool_size == 128
         assert Settings().server.database.sqlalchemy.max_overflow == 9001
 
+    def test_sqlalchemy_pool_size_null_via_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE", "null")
+        assert Settings().server.database.sqlalchemy.pool_size is None
+
     def test_sqlalchemy_settings_migration_via_toml(
         self, temporary_toml_file: Callable[..., None]
     ):

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -9335,10 +9335,10 @@ export interface components {
             connect_args?: components["schemas"]["SQLAlchemyConnectArgsSettings"];
             /**
              * Pool Size
-             * @description Controls connection pool size of database connection pools from the Prefect backend.
+             * @description Controls connection pool size of database connection pools from the Prefect backend. Set to None/null to use NullPool for external connection poolers like PgBouncer.
              * @default 5
              */
-            pool_size: number;
+            pool_size: number | null;
             /**
              * Pool Recycle
              * @description This setting causes the pool to recycle connections after the given number of seconds has passed; set it to -1 to avoid recycling entirely.


### PR DESCRIPTION
closes #18616

## Summary

- Allow `PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE=null` to use SQLAlchemy's `NullPool`, disabling internal connection pooling for external poolers like PgBouncer
- When `pool_size` is `None`, pool-related kwargs (`pool_pre_ping`, `pool_use_lifo`, `pool_timeout`, `max_overflow`) are excluded since `NullPool` doesn't support them
- Adds PgBouncer setup docs to the database maintenance guide

<details>
<summary>revives #18643</summary>

The original PR was closed by the stale bot. This is a fresh implementation rebased on current main with the same approach — community members have been asking for this (see comments on the original PR).
</details>

## Test plan

- [x] `TestNullPoolConfiguration` verifies `NullPool` is used when `pool_size=None` and regular pool when `pool_size` is an integer
- [x] Settings test verifies `PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE=null` env var parses correctly
- [x] All existing database dependency and settings tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)