### PR TITLE
Fix serve not clearing work pool config on existing deployments

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -576,13 +576,6 @@ class RunnerDeployment(BaseModel):
         else:
             update_payload["pull_steps"] = None
 
-        # Include work pool fields only when explicitly set, so that partial
-        # updates (e.g. apply() with just a new image) preserve existing config.
-        if "work_pool_name" in self.model_fields_set:
-            update_payload["work_pool_name"] = self.work_pool_name
-        if "work_queue_name" in self.model_fields_set:
-            update_payload["work_queue_name"] = self.work_queue_name
-
         if self.schedules:
             update_payload["schedules"] = [
                 schedule.model_dump(mode="json", exclude_unset=True)
@@ -634,13 +627,6 @@ class RunnerDeployment(BaseModel):
             update_payload["pull_steps"] = pull_steps
         else:
             update_payload["pull_steps"] = None
-
-        # Include work pool fields only when explicitly set, so that partial
-        # updates (e.g. apply() with just a new image) preserve existing config.
-        if "work_pool_name" in self.model_fields_set:
-            update_payload["work_pool_name"] = self.work_pool_name
-        if "work_queue_name" in self.model_fields_set:
-            update_payload["work_queue_name"] = self.work_queue_name
 
         if self.schedules:
             update_payload["schedules"] = [

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -576,6 +576,13 @@ class RunnerDeployment(BaseModel):
         else:
             update_payload["pull_steps"] = None
 
+        # Include work pool fields only when explicitly set, so that partial
+        # updates (e.g. apply() with just a new image) preserve existing config.
+        if "work_pool_name" in self.model_fields_set:
+            update_payload["work_pool_name"] = self.work_pool_name
+        if "work_queue_name" in self.model_fields_set:
+            update_payload["work_queue_name"] = self.work_queue_name
+
         if self.schedules:
             update_payload["schedules"] = [
                 schedule.model_dump(mode="json", exclude_unset=True)
@@ -627,6 +634,13 @@ class RunnerDeployment(BaseModel):
             update_payload["pull_steps"] = pull_steps
         else:
             update_payload["pull_steps"] = None
+
+        # Include work pool fields only when explicitly set, so that partial
+        # updates (e.g. apply() with just a new image) preserve existing config.
+        if "work_pool_name" in self.model_fields_set:
+            update_payload["work_pool_name"] = self.work_pool_name
+        if "work_queue_name" in self.model_fields_set:
+            update_payload["work_queue_name"] = self.work_queue_name
 
         if self.schedules:
             update_payload["schedules"] = [
@@ -963,7 +977,7 @@ class RunnerDeployment(BaseModel):
             concurrency_limit
         )
 
-        deployment = cls(
+        kwargs: dict[str, Any] = dict(
             name=name,
             flow_name=flow.name,
             schedules=constructed_schedules,
@@ -977,10 +991,14 @@ class RunnerDeployment(BaseModel):
             version=version,
             version_type=version_type,
             enforce_parameter_schema=enforce_parameter_schema,
-            work_pool_name=work_pool_name,
-            work_queue_name=work_queue_name,
             job_variables=job_variables,
         )
+        if work_pool_name is not None:
+            kwargs["work_pool_name"] = work_pool_name
+        if work_queue_name is not None:
+            kwargs["work_queue_name"] = work_queue_name
+
+        deployment = cls(**kwargs)
         deployment._sla = _sla
 
         if not deployment.entrypoint:
@@ -1110,7 +1128,7 @@ class RunnerDeployment(BaseModel):
             concurrency_limit
         )
 
-        deployment = cls(
+        kwargs: dict[str, Any] = dict(
             name=name,
             flow_name=flow_name or flow.name,
             schedules=constructed_schedules,
@@ -1124,10 +1142,14 @@ class RunnerDeployment(BaseModel):
             version=version,
             entrypoint=entrypoint,
             enforce_parameter_schema=enforce_parameter_schema,
-            work_pool_name=work_pool_name,
-            work_queue_name=work_queue_name,
             job_variables=job_variables,
         )
+        if work_pool_name is not None:
+            kwargs["work_pool_name"] = work_pool_name
+        if work_queue_name is not None:
+            kwargs["work_queue_name"] = work_queue_name
+
+        deployment = cls(**kwargs)
         deployment._sla = _sla
         deployment._path = str(Path.cwd())
 
@@ -1237,7 +1259,7 @@ class RunnerDeployment(BaseModel):
                 if ":" not in entrypoint:
                     sys.path.remove(str(storage.destination))
 
-        deployment = cls(
+        kwargs: dict[str, Any] = dict(
             name=name,
             flow_name=flow_name or flow.name,
             schedules=constructed_schedules,
@@ -1253,10 +1275,14 @@ class RunnerDeployment(BaseModel):
             entrypoint=entrypoint,
             enforce_parameter_schema=enforce_parameter_schema,
             storage=storage,
-            work_pool_name=work_pool_name,
-            work_queue_name=work_queue_name,
             job_variables=job_variables,
         )
+        if work_pool_name is not None:
+            kwargs["work_pool_name"] = work_pool_name
+        if work_queue_name is not None:
+            kwargs["work_queue_name"] = work_queue_name
+
+        deployment = cls(**kwargs)
         deployment._sla = _sla
         deployment._entrypoint_type = (
             EntrypointType.FILE_PATH
@@ -1372,7 +1398,7 @@ class RunnerDeployment(BaseModel):
                 if ":" not in entrypoint:
                     sys.path.remove(str(storage.destination))
 
-        deployment = cls(
+        kwargs: dict[str, Any] = dict(
             name=name,
             flow_name=flow_name or flow.name,
             schedules=constructed_schedules,
@@ -1388,10 +1414,14 @@ class RunnerDeployment(BaseModel):
             entrypoint=entrypoint,
             enforce_parameter_schema=enforce_parameter_schema,
             storage=storage,
-            work_pool_name=work_pool_name,
-            work_queue_name=work_queue_name,
             job_variables=job_variables,
         )
+        if work_pool_name is not None:
+            kwargs["work_pool_name"] = work_pool_name
+        if work_queue_name is not None:
+            kwargs["work_queue_name"] = work_queue_name
+
+        deployment = cls(**kwargs)
         deployment._sla = _sla
         deployment._entrypoint_type = (
             EntrypointType.FILE_PATH

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -439,6 +439,12 @@ class Runner:
             concurrency_limit=concurrency_limit,
         )
 
+        # Explicitly mark work pool fields as set so _update() includes them
+        # in the payload. This clears any existing work pool config on the
+        # server, ensuring runs execute locally instead of on a remote worker.
+        deployment.work_pool_name = None
+        deployment.work_queue_name = None
+
         deployment_id = await self.aadd_deployment(deployment)
 
         # Only add the flow to the map if it is not loaded from storage

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -351,6 +351,13 @@ async def update_deployment(
             session=session,
             work_pool_name=deployment.work_pool_name,
         )
+    elif (
+        deployment.work_pool_name is None
+        and "work_pool_name" in deployment.model_fields_set
+    ):
+        # work_pool_name was explicitly set to None — clear the work queue so
+        # runs are no longer routed to a work pool (e.g. switching to serve).
+        update_data["work_queue_id"] = None
     elif deployment.work_queue_name:
         # If just a queue name was provided, ensure the queue exists and
         # get its ID.

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -700,6 +700,33 @@ class TestRunner:
         # Verify pull steps were cleared
         assert api_deployment.pull_steps is None
 
+    async def test_runner_add_flow_clears_work_pool_on_existing_deployment(
+        self, prefect_client: PrefectClient, work_pool
+    ):
+        """When a deployment previously assigned to a work pool is served
+        locally via Runner.add_flow, the work pool config should be cleared
+        so that runs execute locally."""
+
+        @flow
+        def test_flow_clear_wp():
+            pass
+
+        deployment_with_pool = RunnerDeployment(
+            name="test-clear-work-pool",
+            flow_name="test-flow-clear-wp",
+            work_pool_name=work_pool.name,
+        )
+        deployment_id = await deployment_with_pool.apply()
+        api_deployment = await prefect_client.read_deployment(deployment_id)
+        assert api_deployment.work_pool_name == work_pool.name
+
+        runner = Runner()
+        await runner.add_flow(test_flow_clear_wp, name="test-clear-work-pool")
+
+        api_deployment = await prefect_client.read_deployment(deployment_id)
+        assert api_deployment.work_pool_name is None
+        assert api_deployment.work_queue_name is None
+
     @pytest.mark.parametrize(
         "kwargs",
         [


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.


Closes: #21527

## Summary                                                                            
                                                                                        
 When serving a deployment that was previously deployed to a work pool, the work pool configuration was not being cleared. This caused runs to  be picked up by remote workers (e.g. K8s) instead of executing locally.               
                                                                                        
  The fix ensures that the serve path explicitly sends `work_pool_name=None` to the server, which clears the `work_queue_id` association. Factory methods are updated to only include work pool fields in Pydantic's `model_fields_set` when explicitly provided, so that partial updates (e.g. changing just the image) don't accidentally clear existing work pool config.                                   
                                                                                        
## Test plan                                                                          
                                                                                        
  - Added `test_runner_add_flow_clears_work_pool_on_existing_deployment`                
  - Existing `test_apply_with_image` confirms partial updates preserve work pool config