### PR TITLE
Add server default result storage config surface

### DIFF
--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -110,6 +110,7 @@ from prefect.client.schemas.objects import (
     FlowRunResult,
     Parameter,
     Constant,
+    ServerDefaultResultStorage,
     TaskRunPolicy,
     WorkQueue,
     WorkQueueStatusDetail,
@@ -1079,6 +1080,27 @@ class PrefectClient(
         res = await self._client.get("/admin/version")
         return res.json()
 
+    async def read_server_default_result_storage(
+        self,
+    ) -> ServerDefaultResultStorage:
+        response = await self._client.get("/admin/default-result-storage")
+        return ServerDefaultResultStorage.model_validate(response.json())
+
+    async def update_server_default_result_storage(
+        self,
+        default_result_storage_block_id: UUID,
+    ) -> ServerDefaultResultStorage:
+        response = await self._client.put(
+            "/admin/default-result-storage",
+            json=ServerDefaultResultStorage(
+                default_result_storage_block_id=default_result_storage_block_id
+            ).model_dump(mode="json"),
+        )
+        return ServerDefaultResultStorage.model_validate(response.json())
+
+    async def clear_server_default_result_storage(self) -> None:
+        await self._client.delete("/admin/default-result-storage")
+
     def client_version(self) -> str:
         return prefect.__version__
 
@@ -1450,6 +1472,25 @@ class SyncPrefectClient(
     def api_version(self) -> str:
         res = self._client.get("/admin/version")
         return res.json()
+
+    def read_server_default_result_storage(self) -> ServerDefaultResultStorage:
+        response = self._client.get("/admin/default-result-storage")
+        return ServerDefaultResultStorage.model_validate(response.json())
+
+    def update_server_default_result_storage(
+        self,
+        default_result_storage_block_id: UUID,
+    ) -> ServerDefaultResultStorage:
+        response = self._client.put(
+            "/admin/default-result-storage",
+            json=ServerDefaultResultStorage(
+                default_result_storage_block_id=default_result_storage_block_id
+            ).model_dump(mode="json"),
+        )
+        return ServerDefaultResultStorage.model_validate(response.json())
+
+    def clear_server_default_result_storage(self) -> None:
+        self._client.delete("/admin/default-result-storage")
 
     def client_version(self) -> str:
         return prefect.__version__

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -1083,7 +1083,7 @@ class PrefectClient(
     async def read_server_default_result_storage(
         self,
     ) -> ServerDefaultResultStorage:
-        response = await self._client.get("/admin/default-result-storage")
+        response = await self._client.get("/admin/storage")
         return ServerDefaultResultStorage.model_validate(response.json())
 
     async def update_server_default_result_storage(
@@ -1091,7 +1091,7 @@ class PrefectClient(
         default_result_storage_block_id: UUID,
     ) -> ServerDefaultResultStorage:
         response = await self._client.put(
-            "/admin/default-result-storage",
+            "/admin/storage",
             json=ServerDefaultResultStorage(
                 default_result_storage_block_id=default_result_storage_block_id
             ).model_dump(mode="json"),
@@ -1099,7 +1099,7 @@ class PrefectClient(
         return ServerDefaultResultStorage.model_validate(response.json())
 
     async def clear_server_default_result_storage(self) -> None:
-        await self._client.delete("/admin/default-result-storage")
+        await self._client.delete("/admin/storage")
 
     def client_version(self) -> str:
         return prefect.__version__
@@ -1474,7 +1474,7 @@ class SyncPrefectClient(
         return res.json()
 
     def read_server_default_result_storage(self) -> ServerDefaultResultStorage:
-        response = self._client.get("/admin/default-result-storage")
+        response = self._client.get("/admin/storage")
         return ServerDefaultResultStorage.model_validate(response.json())
 
     def update_server_default_result_storage(
@@ -1482,7 +1482,7 @@ class SyncPrefectClient(
         default_result_storage_block_id: UUID,
     ) -> ServerDefaultResultStorage:
         response = self._client.put(
-            "/admin/default-result-storage",
+            "/admin/storage",
             json=ServerDefaultResultStorage(
                 default_result_storage_block_id=default_result_storage_block_id
             ).model_dump(mode="json"),
@@ -1490,7 +1490,7 @@ class SyncPrefectClient(
         return ServerDefaultResultStorage.model_validate(response.json())
 
     def clear_server_default_result_storage(self) -> None:
-        self._client.delete("/admin/default-result-storage")
+        self._client.delete("/admin/storage")
 
     def client_version(self) -> str:
         return prefect.__version__

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -111,6 +111,7 @@ from prefect.client.schemas.objects import (
     Parameter,
     Constant,
     ServerDefaultResultStorage,
+    ServerDefaultResultStorageUpdate,
     TaskRunPolicy,
     WorkQueue,
     WorkQueueStatusDetail,
@@ -1092,7 +1093,7 @@ class PrefectClient(
     ) -> ServerDefaultResultStorage:
         response = await self._client.put(
             "/admin/storage",
-            json=ServerDefaultResultStorage(
+            json=ServerDefaultResultStorageUpdate(
                 default_result_storage_block_id=default_result_storage_block_id
             ).model_dump(mode="json"),
         )
@@ -1483,7 +1484,7 @@ class SyncPrefectClient(
     ) -> ServerDefaultResultStorage:
         response = self._client.put(
             "/admin/storage",
-            json=ServerDefaultResultStorage(
+            json=ServerDefaultResultStorageUpdate(
                 default_result_storage_block_id=default_result_storage_block_id
             ).model_dump(mode="json"),
         )

--- a/src/prefect/client/orchestration/routes.py
+++ b/src/prefect/client/orchestration/routes.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 ServerRoutes = Literal[
+    "/admin/default-result-storage",
     "/admin/settings",
     "/admin/version",
     "/artifacts/",

--- a/src/prefect/client/orchestration/routes.py
+++ b/src/prefect/client/orchestration/routes.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 ServerRoutes = Literal[
-    "/admin/default-result-storage",
+    "/admin/storage",
     "/admin/settings",
     "/admin/version",
     "/artifacts/",

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1559,6 +1559,15 @@ class ServerDefaultResultStorage(PrefectBaseModel):
     )
 
 
+class ServerDefaultResultStorageUpdate(PrefectBaseModel):
+    """Request payload for setting the server default result storage block."""
+
+    default_result_storage_block_id: UUID = Field(
+        default=...,
+        description="The block document ID of the server default result storage block.",
+    )
+
+
 class WorkPool(ObjectBaseModel):
     """An ORM representation of a work pool"""
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1550,6 +1550,15 @@ class WorkPoolStorageConfiguration(PrefectBaseModel):
     )
 
 
+class ServerDefaultResultStorage(PrefectBaseModel):
+    """Server-side default result storage configuration."""
+
+    default_result_storage_block_id: Optional[UUID] = Field(
+        default=None,
+        description="The block document ID of the server default result storage block.",
+    )
+
+
 class WorkPool(ObjectBaseModel):
     """An ORM representation of a work pool"""
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1547,6 +1547,15 @@ class ServerDefaultResultStorage(PrefectBaseModel):
     )
 
 
+class ServerDefaultResultStorageUpdate(PrefectBaseModel):
+    """Request payload for setting the server default result storage block."""
+
+    default_result_storage_block_id: UUID = Field(
+        default=...,
+        description="The block document ID of the server default result storage block.",
+    )
+
+
 class WorkPool(ObjectBaseModel):
     """An ORM representation of a work pool"""
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1538,6 +1538,15 @@ class WorkPoolStorageConfiguration(PrefectBaseModel):
     )
 
 
+class ServerDefaultResultStorage(PrefectBaseModel):
+    """Server-side default result storage configuration."""
+
+    default_result_storage_block_id: Optional[UUID] = Field(
+        default=None,
+        description="The block document ID of the server default result storage block.",
+    )
+
+
 class WorkPool(ObjectBaseModel):
     """An ORM representation of a work pool"""
 

--- a/src/prefect/server/api/admin.py
+++ b/src/prefect/server/api/admin.py
@@ -43,22 +43,23 @@ async def read_server_default_result_storage(
 
 @router.put("/storage")
 async def update_server_default_result_storage(
-    configuration: schemas.core.ServerDefaultResultStorage,
+    configuration: schemas.core.ServerDefaultResultStorageUpdate,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.ServerDefaultResultStorage:
     """Set the server default result storage block."""
     try:
         async with db.session_context(begin_transaction=True) as session:
             block_document_id = configuration.default_result_storage_block_id
-            if block_document_id is not None:
-                await models.storage_defaults.validate_server_default_result_storage_block(
-                    session=session,
-                    block_document_id=block_document_id,
-                )
+            await models.storage_defaults.validate_server_default_result_storage_block(
+                session=session,
+                block_document_id=block_document_id,
+            )
 
             await models.storage_defaults.write_server_default_result_storage(
                 session=session,
-                storage_default=configuration,
+                storage_default=schemas.core.ServerDefaultResultStorage(
+                    default_result_storage_block_id=block_document_id
+                ),
             )
 
             return await models.storage_defaults.read_server_default_result_storage(

--- a/src/prefect/server/api/admin.py
+++ b/src/prefect/server/api/admin.py
@@ -2,8 +2,12 @@
 Routes for admin-level interactions with the Prefect REST API.
 """
 
+from fastapi import Depends, HTTPException, status
+
 import prefect
 import prefect.settings
+from prefect.server import models, schemas
+from prefect.server.database import PrefectDBInterface, provide_database_interface
 from prefect.server.utilities.server import PrefectRouter
 
 router: PrefectRouter = PrefectRouter(prefix="/admin", tags=["Admin"])
@@ -23,3 +27,61 @@ async def read_settings() -> prefect.settings.Settings:
 async def read_version() -> str:
     """Returns the Prefect version number"""
     return prefect.__version__
+
+
+@router.get("/default-result-storage")
+async def read_server_default_result_storage(
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> schemas.core.ServerDefaultResultStorage:
+    """Get the configured server default result storage block."""
+    async with db.session_context() as session:
+        return await models.configuration.read_server_default_result_storage(
+            session=session
+        )
+
+
+@router.put("/default-result-storage")
+async def update_server_default_result_storage(
+    configuration: schemas.core.ServerDefaultResultStorage,
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> schemas.core.ServerDefaultResultStorage:
+    """Set the server default result storage block."""
+    async with db.session_context(begin_transaction=True) as session:
+        block_document_id = configuration.default_result_storage_block_id
+        if block_document_id is not None:
+            block_document = await models.block_documents.read_block_document_by_id(
+                session=session,
+                block_document_id=block_document_id,
+            )
+            if block_document is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Block document {block_document_id!s} not found.",
+                )
+            if (
+                block_document.block_schema is None
+                or "write-path" not in block_document.block_schema.capabilities
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail=(
+                        f"Block document {block_document_id!s} cannot be used for "
+                        "result storage."
+                    ),
+                )
+
+        await models.configuration.write_server_default_result_storage(
+            session=session,
+            configuration=configuration,
+        )
+
+    return configuration
+
+
+@router.delete("/default-result-storage", status_code=status.HTTP_204_NO_CONTENT)
+async def clear_server_default_result_storage(
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> None:
+    """Clear the configured server default result storage block."""
+    async with db.session_context(begin_transaction=True) as session:
+        await models.configuration.clear_server_default_result_storage(session=session)

--- a/src/prefect/server/api/admin.py
+++ b/src/prefect/server/api/admin.py
@@ -29,7 +29,7 @@ async def read_version() -> str:
     return prefect.__version__
 
 
-@router.get("/default-result-storage")
+@router.get("/storage")
 async def read_server_default_result_storage(
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.ServerDefaultResultStorage:
@@ -40,7 +40,7 @@ async def read_server_default_result_storage(
         )
 
 
-@router.put("/default-result-storage")
+@router.put("/storage")
 async def update_server_default_result_storage(
     configuration: schemas.core.ServerDefaultResultStorage,
     db: PrefectDBInterface = Depends(provide_database_interface),
@@ -78,7 +78,7 @@ async def update_server_default_result_storage(
     return configuration
 
 
-@router.delete("/default-result-storage", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/storage", status_code=status.HTTP_204_NO_CONTENT)
 async def clear_server_default_result_storage(
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> None:

--- a/src/prefect/server/api/admin.py
+++ b/src/prefect/server/api/admin.py
@@ -8,6 +8,7 @@ import prefect
 import prefect.settings
 from prefect.server import models, schemas
 from prefect.server.database import PrefectDBInterface, provide_database_interface
+from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.utilities.server import PrefectRouter
 
 router: PrefectRouter = PrefectRouter(prefix="/admin", tags=["Admin"])
@@ -35,7 +36,7 @@ async def read_server_default_result_storage(
 ) -> schemas.core.ServerDefaultResultStorage:
     """Get the configured server default result storage block."""
     async with db.session_context() as session:
-        return await models.configuration.read_server_default_result_storage(
+        return await models.storage_defaults.read_server_default_result_storage(
             session=session
         )
 
@@ -46,36 +47,30 @@ async def update_server_default_result_storage(
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.ServerDefaultResultStorage:
     """Set the server default result storage block."""
-    async with db.session_context(begin_transaction=True) as session:
-        block_document_id = configuration.default_result_storage_block_id
-        if block_document_id is not None:
-            block_document = await models.block_documents.read_block_document_by_id(
+    try:
+        async with db.session_context(begin_transaction=True) as session:
+            block_document_id = configuration.default_result_storage_block_id
+            if block_document_id is not None:
+                await models.storage_defaults.validate_server_default_result_storage_block(
+                    session=session,
+                    block_document_id=block_document_id,
+                )
+
+            await models.storage_defaults.write_server_default_result_storage(
                 session=session,
-                block_document_id=block_document_id,
+                storage_default=configuration,
             )
-            if block_document is None:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Block document {block_document_id!s} not found.",
-                )
-            if (
-                block_document.block_schema is None
-                or "write-path" not in block_document.block_schema.capabilities
-            ):
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail=(
-                        f"Block document {block_document_id!s} cannot be used for "
-                        "result storage."
-                    ),
-                )
 
-        await models.configuration.write_server_default_result_storage(
-            session=session,
-            configuration=configuration,
+            return await models.storage_defaults.read_server_default_result_storage(
+                session=session
+            )
+    except ObjectNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
         )
-
-    return configuration
 
 
 @router.delete("/storage", status_code=status.HTTP_204_NO_CONTENT)
@@ -84,4 +79,6 @@ async def clear_server_default_result_storage(
 ) -> None:
     """Clear the configured server default result storage block."""
     async with db.session_context(begin_transaction=True) as session:
-        await models.configuration.clear_server_default_result_storage(session=session)
+        await models.storage_defaults.clear_server_default_result_storage(
+            session=session
+        )

--- a/src/prefect/server/models/__init__.py
+++ b/src/prefect/server/models/__init__.py
@@ -15,6 +15,7 @@ from . import (
     flows,
     logs,
     saved_searches,
+    storage_defaults,
     task_run_states,
     task_runs,
     task_workers,

--- a/src/prefect/server/models/configuration.py
+++ b/src/prefect/server/models/configuration.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect.server import schemas
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
 
+SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY = "server-default-result-storage"
+
 
 @db_injector
 async def write_configuration(
@@ -35,6 +37,18 @@ async def write_configuration(
 
 
 @db_injector
+async def delete_configuration(
+    db: PrefectDBInterface,
+    session: AsyncSession,
+    key: str,
+) -> bool:
+    query = sa.delete(db.Configuration).where(db.Configuration.key == key)
+    result = await session.execute(query)
+    db.queries.clear_configuration_value_cache_for_key(key=key)
+    return result.rowcount > 0
+
+
+@db_injector
 async def read_configuration(
     db: PrefectDBInterface,
     session: AsyncSession,
@@ -43,4 +57,36 @@ async def read_configuration(
     value = await db.queries.read_configuration_value(session=session, key=key)
     return (
         schemas.core.Configuration(key=key, value=value) if value is not None else None
+    )
+
+
+async def write_server_default_result_storage(
+    session: AsyncSession,
+    configuration: schemas.core.ServerDefaultResultStorage,
+) -> orm_models.Configuration:
+    return await write_configuration(
+        session=session,
+        configuration=schemas.core.Configuration(
+            key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
+            value=configuration.model_dump(mode="json"),
+        ),
+    )
+
+
+async def read_server_default_result_storage(
+    session: AsyncSession,
+) -> schemas.core.ServerDefaultResultStorage:
+    configuration = await read_configuration(
+        session=session,
+        key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
+    )
+    if configuration is None:
+        return schemas.core.ServerDefaultResultStorage()
+    return schemas.core.ServerDefaultResultStorage.model_validate(configuration.value)
+
+
+async def clear_server_default_result_storage(session: AsyncSession) -> bool:
+    return await delete_configuration(
+        session=session,
+        key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
     )

--- a/src/prefect/server/models/configuration.py
+++ b/src/prefect/server/models/configuration.py
@@ -6,8 +6,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect.server import schemas
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
 
-SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY = "server-default-result-storage"
-
 
 @db_injector
 async def write_configuration(
@@ -57,36 +55,4 @@ async def read_configuration(
     value = await db.queries.read_configuration_value(session=session, key=key)
     return (
         schemas.core.Configuration(key=key, value=value) if value is not None else None
-    )
-
-
-async def write_server_default_result_storage(
-    session: AsyncSession,
-    configuration: schemas.core.ServerDefaultResultStorage,
-) -> orm_models.Configuration:
-    return await write_configuration(
-        session=session,
-        configuration=schemas.core.Configuration(
-            key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
-            value=configuration.model_dump(mode="json"),
-        ),
-    )
-
-
-async def read_server_default_result_storage(
-    session: AsyncSession,
-) -> schemas.core.ServerDefaultResultStorage:
-    configuration = await read_configuration(
-        session=session,
-        key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
-    )
-    if configuration is None:
-        return schemas.core.ServerDefaultResultStorage()
-    return schemas.core.ServerDefaultResultStorage.model_validate(configuration.value)
-
-
-async def clear_server_default_result_storage(session: AsyncSession) -> bool:
-    return await delete_configuration(
-        session=session,
-        key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
     )

--- a/src/prefect/server/models/storage_defaults.py
+++ b/src/prefect/server/models/storage_defaults.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import schemas
+from prefect.server.database import orm_models
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models import block_documents, configuration
 
@@ -30,7 +31,7 @@ async def validate_server_default_result_storage_block(
 async def write_server_default_result_storage(
     session: AsyncSession,
     storage_default: schemas.core.ServerDefaultResultStorage,
-):
+) -> orm_models.Configuration:
     return await configuration.write_configuration(
         session=session,
         configuration=schemas.core.Configuration(

--- a/src/prefect/server/models/storage_defaults.py
+++ b/src/prefect/server/models/storage_defaults.py
@@ -1,0 +1,62 @@
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server import schemas
+from prefect.server.exceptions import ObjectNotFoundError
+from prefect.server.models import block_documents, configuration
+
+SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY = "server-default-result-storage"
+
+
+async def validate_server_default_result_storage_block(
+    session: AsyncSession,
+    block_document_id: UUID,
+) -> None:
+    block_document = await block_documents.read_block_document_by_id(
+        session=session,
+        block_document_id=block_document_id,
+    )
+    if block_document is None:
+        raise ObjectNotFoundError(f"Block document {block_document_id!s} not found.")
+
+    block_schema = block_document.block_schema
+    if block_schema is None or "write-path" not in block_schema.capabilities:
+        raise ValueError(
+            f"Block document {block_document_id!s} cannot be used for result storage."
+        )
+
+
+async def write_server_default_result_storage(
+    session: AsyncSession,
+    storage_default: schemas.core.ServerDefaultResultStorage,
+):
+    return await configuration.write_configuration(
+        session=session,
+        configuration=schemas.core.Configuration(
+            key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
+            value=storage_default.model_dump(mode="json"),
+        ),
+    )
+
+
+async def read_server_default_result_storage(
+    session: AsyncSession,
+) -> schemas.core.ServerDefaultResultStorage:
+    configured_value = await configuration.read_configuration(
+        session=session,
+        key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
+    )
+    if configured_value is None:
+        return schemas.core.ServerDefaultResultStorage()
+
+    return schemas.core.ServerDefaultResultStorage.model_validate(
+        configured_value.value
+    )
+
+
+async def clear_server_default_result_storage(session: AsyncSession) -> bool:
+    return await configuration.delete_configuration(
+        session=session,
+        key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
+    )

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -926,6 +926,15 @@ class ServerDefaultResultStorage(PrefectBaseModel):
     )
 
 
+class ServerDefaultResultStorageUpdate(PrefectBaseModel):
+    """Request payload for setting the server default result storage block."""
+
+    default_result_storage_block_id: UUID = Field(
+        default=...,
+        description="The block document ID of the server default result storage block.",
+    )
+
+
 class SavedSearchFilter(PrefectBaseModel):
     """A filter for a saved search model. Intended for use by the Prefect UI."""
 

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -917,6 +917,15 @@ class Configuration(ORMBaseModel):
     value: Dict[str, Any] = Field(default=..., description="Account info")
 
 
+class ServerDefaultResultStorage(PrefectBaseModel):
+    """Server-side default result storage configuration."""
+
+    default_result_storage_block_id: Optional[UUID] = Field(
+        default=None,
+        description="The block document ID of the server default result storage block.",
+    )
+
+
 class SavedSearchFilter(PrefectBaseModel):
     """A filter for a saved search model. Intended for use by the Prefect UI."""
 

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -78,6 +78,7 @@ from prefect.client.schemas.responses import (
 from prefect.client.schemas.schedules import CronSchedule, IntervalSchedule
 from prefect.client.utilities import inject_client
 from prefect.events import AutomationCore, EventTrigger, Posture
+from prefect.filesystems import LocalFileSystem
 from prefect.server.api.server import create_app
 from prefect.server.database.orm_models import WorkPool
 from prefect.settings import (
@@ -642,6 +643,33 @@ async def test_client_api_url():
 async def test_hello(prefect_client):
     response = await prefect_client.hello()
     assert response.json() == "👋"
+
+
+async def test_read_server_default_result_storage(prefect_client):
+    configuration = await prefect_client.read_server_default_result_storage()
+    assert configuration.default_result_storage_block_id is None
+
+
+async def test_update_and_clear_server_default_result_storage(prefect_client):
+    block_document_id = await LocalFileSystem(
+        basepath="/tmp/prefect-client-server-default"
+    ).asave(
+        name=f"server-default-{uuid4()}",
+        client=prefect_client,
+    )
+
+    updated = await prefect_client.update_server_default_result_storage(
+        block_document_id
+    )
+    assert updated.default_result_storage_block_id == block_document_id
+
+    read_back = await prefect_client.read_server_default_result_storage()
+    assert read_back.default_result_storage_block_id == block_document_id
+
+    await prefect_client.clear_server_default_result_storage()
+
+    cleared = await prefect_client.read_server_default_result_storage()
+    assert cleared.default_result_storage_block_id is None
 
 
 async def test_healthcheck(prefect_client):
@@ -3339,6 +3367,31 @@ class TestSyncClient:
         version = sync_prefect_client.api_version()
         assert prefect.__version__
         assert version == prefect.__version__
+
+    def test_read_server_default_result_storage(self, sync_prefect_client):
+        configuration = sync_prefect_client.read_server_default_result_storage()
+        assert configuration.default_result_storage_block_id is None
+
+    def test_update_and_clear_server_default_result_storage(self, sync_prefect_client):
+        block_document_id = LocalFileSystem(
+            basepath="/tmp/prefect-client-server-default"
+        ).save(
+            name=f"server-default-{uuid4()}",
+            client=sync_prefect_client,
+        )
+
+        updated = sync_prefect_client.update_server_default_result_storage(
+            block_document_id
+        )
+        assert updated.default_result_storage_block_id == block_document_id
+
+        read_back = sync_prefect_client.read_server_default_result_storage()
+        assert read_back.default_result_storage_block_id == block_document_id
+
+        sync_prefect_client.clear_server_default_result_storage()
+
+        cleared = sync_prefect_client.read_server_default_result_storage()
+        assert cleared.default_result_storage_block_id is None
 
     def test_pause_and_resume_deployment(self, sync_prefect_client, flow):
         # Create deployment in unpaused state

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -1,11 +1,53 @@
 from uuid import uuid4
 
 import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 import prefect
+from prefect.blocks.core import Block
 from prefect.blocks.system import Secret
 from prefect.filesystems import LocalFileSystem
+from prefect.server import models, schemas
+from prefect.server.models.block_registration import (
+    register_block_schema,
+    register_block_type,
+)
+
+
+async def create_server_block_document(
+    session: AsyncSession,
+    block: Block,
+    name: str,
+) -> str:
+    block_type_id = await register_block_type(
+        session=session,
+        block_type=block._to_block_type(),
+    )
+    block_schema_id = await register_block_schema(
+        session=session,
+        block_schema=block._to_block_schema(block_type_id=block_type_id),
+    )
+    block_document = block._to_block_document(
+        name=name,
+        block_schema_id=block_schema_id,
+        block_type_id=block_type_id,
+        include_secrets=True,
+    )
+
+    created_block_document = await models.block_documents.create_block_document(
+        session=session,
+        block_document=schemas.actions.BlockDocumentCreate(
+            name=block_document.name,
+            data=block_document.data,
+            block_schema_id=block_document.block_schema_id,
+            block_type_id=block_document.block_type_id,
+            is_anonymous=block_document.is_anonymous,
+        ),
+    )
+    await session.commit()
+
+    return str(created_block_document.id)
 
 
 async def test_version(client: httpx.AsyncClient) -> None:
@@ -39,13 +81,13 @@ class TestServerDefaultResultStorage:
         assert response.json() == {"default_result_storage_block_id": None}
 
     async def test_update_and_clear_server_default_result_storage(
-        self, client: httpx.AsyncClient, prefect_client
+        self, client: httpx.AsyncClient, session: AsyncSession
     ) -> None:
-        block_document = await LocalFileSystem(basepath="/tmp").asave(
+        block_document_id = await create_server_block_document(
+            session=session,
+            block=LocalFileSystem(basepath="/tmp"),
             name=f"result-storage-{uuid4()}",
-            client=prefect_client,
         )
-        block_document_id = str(block_document)
 
         update_response = await client.put(
             "/admin/storage",
@@ -92,16 +134,17 @@ class TestServerDefaultResultStorage:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     async def test_update_server_default_result_storage_rejects_non_storage_block(
-        self, client: httpx.AsyncClient, prefect_client
+        self, client: httpx.AsyncClient, session: AsyncSession
     ) -> None:
-        block_document_id = await Secret(value="super-secret").asave(
+        block_document_id = await create_server_block_document(
+            session=session,
+            block=Secret(value="super-secret"),
             name=f"not-storage-{uuid4()}",
-            client=prefect_client,
         )
 
         response = await client.put(
             "/admin/storage",
-            json={"default_result_storage_block_id": str(block_document_id)},
+            json={"default_result_storage_block_id": block_document_id},
         )
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -84,6 +84,13 @@ class TestServerDefaultResultStorage:
             "detail": f"Block document {block_document_id} not found."
         }
 
+    async def test_update_server_default_result_storage_requires_block_document_id(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        response = await client.put("/admin/storage", json={})
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
     async def test_update_server_default_result_storage_rejects_non_storage_block(
         self, client: httpx.AsyncClient, prefect_client
     ) -> None:

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -1,7 +1,11 @@
+from uuid import uuid4
+
 import httpx
 from starlette import status
 
 import prefect
+from prefect.blocks.system import Secret
+from prefect.filesystems import LocalFileSystem
 
 
 async def test_version(client: httpx.AsyncClient) -> None:
@@ -23,3 +27,79 @@ class TestSettings:
         assert parsed_settings.model_dump(mode="json") == prefect_settings.model_dump(
             mode="json"
         )
+
+
+class TestServerDefaultResultStorage:
+    async def test_read_server_default_result_storage_when_unset(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        response = await client.get("/admin/default-result-storage")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"default_result_storage_block_id": None}
+
+    async def test_update_and_clear_server_default_result_storage(
+        self, client: httpx.AsyncClient, prefect_client
+    ) -> None:
+        block_document = await LocalFileSystem(basepath="/tmp").asave(
+            name=f"result-storage-{uuid4()}",
+            client=prefect_client,
+        )
+        block_document_id = str(block_document)
+
+        update_response = await client.put(
+            "/admin/default-result-storage",
+            json={"default_result_storage_block_id": block_document_id},
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+        assert update_response.json() == {
+            "default_result_storage_block_id": block_document_id
+        }
+
+        read_response = await client.get("/admin/default-result-storage")
+        assert read_response.status_code == status.HTTP_200_OK
+        assert read_response.json() == {
+            "default_result_storage_block_id": block_document_id
+        }
+
+        clear_response = await client.delete("/admin/default-result-storage")
+        assert clear_response.status_code == status.HTTP_204_NO_CONTENT
+
+        read_cleared_response = await client.get("/admin/default-result-storage")
+        assert read_cleared_response.status_code == status.HTTP_200_OK
+        assert read_cleared_response.json() == {"default_result_storage_block_id": None}
+
+    async def test_update_server_default_result_storage_rejects_missing_block_document(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        block_document_id = str(uuid4())
+
+        response = await client.put(
+            "/admin/default-result-storage",
+            json={"default_result_storage_block_id": block_document_id},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {
+            "detail": f"Block document {block_document_id} not found."
+        }
+
+    async def test_update_server_default_result_storage_rejects_non_storage_block(
+        self, client: httpx.AsyncClient, prefect_client
+    ) -> None:
+        block_document_id = await Secret(value="super-secret").asave(
+            name=f"not-storage-{uuid4()}",
+            client=prefect_client,
+        )
+
+        response = await client.put(
+            "/admin/default-result-storage",
+            json={"default_result_storage_block_id": str(block_document_id)},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json() == {
+            "detail": (
+                f"Block document {block_document_id} cannot be used for result storage."
+            )
+        }

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -33,7 +33,7 @@ class TestServerDefaultResultStorage:
     async def test_read_server_default_result_storage_when_unset(
         self, client: httpx.AsyncClient
     ) -> None:
-        response = await client.get("/admin/default-result-storage")
+        response = await client.get("/admin/storage")
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"default_result_storage_block_id": None}
@@ -48,7 +48,7 @@ class TestServerDefaultResultStorage:
         block_document_id = str(block_document)
 
         update_response = await client.put(
-            "/admin/default-result-storage",
+            "/admin/storage",
             json={"default_result_storage_block_id": block_document_id},
         )
         assert update_response.status_code == status.HTTP_200_OK
@@ -56,16 +56,16 @@ class TestServerDefaultResultStorage:
             "default_result_storage_block_id": block_document_id
         }
 
-        read_response = await client.get("/admin/default-result-storage")
+        read_response = await client.get("/admin/storage")
         assert read_response.status_code == status.HTTP_200_OK
         assert read_response.json() == {
             "default_result_storage_block_id": block_document_id
         }
 
-        clear_response = await client.delete("/admin/default-result-storage")
+        clear_response = await client.delete("/admin/storage")
         assert clear_response.status_code == status.HTTP_204_NO_CONTENT
 
-        read_cleared_response = await client.get("/admin/default-result-storage")
+        read_cleared_response = await client.get("/admin/storage")
         assert read_cleared_response.status_code == status.HTTP_200_OK
         assert read_cleared_response.json() == {"default_result_storage_block_id": None}
 
@@ -75,7 +75,7 @@ class TestServerDefaultResultStorage:
         block_document_id = str(uuid4())
 
         response = await client.put(
-            "/admin/default-result-storage",
+            "/admin/storage",
             json={"default_result_storage_block_id": block_document_id},
         )
 
@@ -93,7 +93,7 @@ class TestServerDefaultResultStorage:
         )
 
         response = await client.put(
-            "/admin/default-result-storage",
+            "/admin/storage",
             json={"default_result_storage_block_id": str(block_document_id)},
         )
 

--- a/tests/server/models/test_configuration.py
+++ b/tests/server/models/test_configuration.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from prefect.server import models, schemas
 
 
@@ -48,29 +46,3 @@ async def test_write_configuration_multiple_times(session):
     assert isinstance(read_config, schemas.core.Configuration)
     assert read_config.key == "foo"
     assert read_config.value == {"bar": "bar"}
-
-
-async def test_write_read_and_clear_server_default_result_storage(session):
-    block_document_id = UUID("7cc65eb7-a8e2-4e0a-96aa-9527130d412d")
-
-    await models.configuration.write_server_default_result_storage(
-        session=session,
-        configuration=schemas.core.ServerDefaultResultStorage(
-            default_result_storage_block_id=block_document_id
-        ),
-    )
-
-    read_config = await models.configuration.read_server_default_result_storage(
-        session=session
-    )
-    assert read_config.default_result_storage_block_id == block_document_id
-
-    cleared = await models.configuration.clear_server_default_result_storage(
-        session=session
-    )
-    assert cleared is True
-
-    empty_config = await models.configuration.read_server_default_result_storage(
-        session=session
-    )
-    assert empty_config.default_result_storage_block_id is None

--- a/tests/server/models/test_configuration.py
+++ b/tests/server/models/test_configuration.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from prefect.server import models, schemas
 
 
@@ -46,3 +48,29 @@ async def test_write_configuration_multiple_times(session):
     assert isinstance(read_config, schemas.core.Configuration)
     assert read_config.key == "foo"
     assert read_config.value == {"bar": "bar"}
+
+
+async def test_write_read_and_clear_server_default_result_storage(session):
+    block_document_id = UUID("7cc65eb7-a8e2-4e0a-96aa-9527130d412d")
+
+    await models.configuration.write_server_default_result_storage(
+        session=session,
+        configuration=schemas.core.ServerDefaultResultStorage(
+            default_result_storage_block_id=block_document_id
+        ),
+    )
+
+    read_config = await models.configuration.read_server_default_result_storage(
+        session=session
+    )
+    assert read_config.default_result_storage_block_id == block_document_id
+
+    cleared = await models.configuration.clear_server_default_result_storage(
+        session=session
+    )
+    assert cleared is True
+
+    empty_config = await models.configuration.read_server_default_result_storage(
+        session=session
+    )
+    assert empty_config.default_result_storage_block_id is None

--- a/tests/server/models/test_storage_defaults.py
+++ b/tests/server/models/test_storage_defaults.py
@@ -1,0 +1,29 @@
+from uuid import UUID
+
+from prefect.server import models, schemas
+
+
+async def test_write_read_and_clear_server_default_result_storage(session):
+    block_document_id = UUID("7cc65eb7-a8e2-4e0a-96aa-9527130d412d")
+
+    await models.storage_defaults.write_server_default_result_storage(
+        session=session,
+        storage_default=schemas.core.ServerDefaultResultStorage(
+            default_result_storage_block_id=block_document_id
+        ),
+    )
+
+    read_config = await models.storage_defaults.read_server_default_result_storage(
+        session=session
+    )
+    assert read_config.default_result_storage_block_id == block_document_id
+
+    cleared = await models.storage_defaults.clear_server_default_result_storage(
+        session=session
+    )
+    assert cleared is True
+
+    empty_config = await models.storage_defaults.read_server_default_result_storage(
+        session=session
+    )
+    assert empty_config.default_result_storage_block_id is None

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -9803,6 +9803,18 @@ export interface components {
              */
             default_result_storage_block_id?: string | null;
         };
+        /**
+         * ServerDefaultResultStorageUpdate
+         * @description Request payload for setting the server default result storage block.
+         */
+        ServerDefaultResultStorageUpdate: {
+            /**
+             * Default Result Storage Block Id
+             * Format: uuid
+             * @description The block document ID of the server default result storage block.
+             */
+            default_result_storage_block_id: string;
+        };
         /** ServerDeploymentsSettings */
         ServerDeploymentsSettings: {
             /**
@@ -19064,7 +19076,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ServerDefaultResultStorage"];
+                "application/json": components["schemas"]["ServerDefaultResultStorageUpdate"];
             };
         };
         responses: {

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -3043,6 +3043,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/default-result-storage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read Server Default Result Storage
+         * @description Get the configured server default result storage block.
+         */
+        get: operations["read_server_default_result_storage_admin_default_result_storage_get"];
+        /**
+         * Update Server Default Result Storage
+         * @description Set the server default result storage block.
+         */
+        put: operations["update_server_default_result_storage_admin_default_result_storage_put"];
+        post?: never;
+        /**
+         * Clear Server Default Result Storage
+         * @description Clear the configured server default result storage block.
+         */
+        delete: operations["clear_server_default_result_storage_admin_default_result_storage_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/hello": {
         parameters: {
             query?: never;
@@ -8444,7 +8472,7 @@ export interface components {
          */
         IntervalSchedule: {
             /** Interval */
-            interval: number;
+            interval: number | string;
             /**
              * Anchor Date
              * Format: date-time
@@ -9763,6 +9791,17 @@ export interface components {
              * @default 5
              */
             connection_timeout: number | null;
+        };
+        /**
+         * ServerDefaultResultStorage
+         * @description Server-side default result storage configuration.
+         */
+        ServerDefaultResultStorage: {
+            /**
+             * Default Result Storage Block Id
+             * @description The block document ID of the server default result storage block.
+             */
+            default_result_storage_block_id?: string | null;
         };
         /** ServerDeploymentsSettings */
         ServerDeploymentsSettings: {
@@ -18971,6 +19010,101 @@ export interface operations {
                 content: {
                     "application/json": string;
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_server_default_result_storage_admin_default_result_storage_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServerDefaultResultStorage"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_server_default_result_storage_admin_default_result_storage_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ServerDefaultResultStorage"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServerDefaultResultStorage"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_server_default_result_storage_admin_default_result_storage_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -3043,7 +3043,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/admin/default-result-storage": {
+    "/admin/storage": {
         parameters: {
             query?: never;
             header?: never;
@@ -3054,18 +3054,18 @@ export interface paths {
          * Read Server Default Result Storage
          * @description Get the configured server default result storage block.
          */
-        get: operations["read_server_default_result_storage_admin_default_result_storage_get"];
+        get: operations["read_server_default_result_storage_admin_storage_get"];
         /**
          * Update Server Default Result Storage
          * @description Set the server default result storage block.
          */
-        put: operations["update_server_default_result_storage_admin_default_result_storage_put"];
+        put: operations["update_server_default_result_storage_admin_storage_put"];
         post?: never;
         /**
          * Clear Server Default Result Storage
          * @description Clear the configured server default result storage block.
          */
-        delete: operations["clear_server_default_result_storage_admin_default_result_storage_delete"];
+        delete: operations["clear_server_default_result_storage_admin_storage_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -19022,7 +19022,7 @@ export interface operations {
             };
         };
     };
-    read_server_default_result_storage_admin_default_result_storage_get: {
+    read_server_default_result_storage_admin_storage_get: {
         parameters: {
             query?: never;
             header?: {
@@ -19053,7 +19053,7 @@ export interface operations {
             };
         };
     };
-    update_server_default_result_storage_admin_default_result_storage_put: {
+    update_server_default_result_storage_admin_storage_put: {
         parameters: {
             query?: never;
             header?: {
@@ -19088,7 +19088,7 @@ export interface operations {
             };
         };
     };
-    clear_server_default_result_storage_admin_default_result_storage_delete: {
+    clear_server_default_result_storage_admin_storage_delete: {
         parameters: {
             query?: never;
             header?: {


### PR DESCRIPTION
this PR adds the OSS config surface for a server-level default result storage setting.

<details>
<summary>What changed</summary>

- adds a `ServerDefaultResultStorage` schema for representing the configured block document id
- adds `/admin/storage` read, update, and clear endpoints
- adds client methods for reading, updating, and clearing the server default result storage setting
- validates that the configured block exists and supports `write-path`
- keeps storage-default-specific validation and persistence in a dedicated `server.models.storage_defaults` module instead of leaving that logic inline in the route
- syncs the generated `ui-v2` OpenAPI client for the new admin surface

</details>

<details>
<summary>Why this is a separate slice</summary>

This PR only adds the configuration surface for storing a server default result storage block. It does not change runtime result-storage resolution yet.

That separation keeps the persisted setting and API contract reviewable on their own before the follow-up runtime behavior work lands.

This still matches the Cloud backend split: Cloud has a separate `storage_defaults` model module too, but its propagation and materialization logic lives in later slices. OSS is intentionally stopping at the persisted setting and API contract in this first PR.

</details>

<details>
<summary>Generated client note</summary>

`ui-v2/src/api/prefect.ts` includes the expected `/admin/storage` additions for this feature.

It also still includes the unrelated `IntervalSchedule.interval` change from `number` to `number | string`. I reproduced that by running `npm run service-sync` on a clean `origin/main` worktree, so it appears to be existing generator drift rather than a storage-defaults-specific change.

</details>

<details>
<summary>Verification</summary>

- `uv run pyright --ignoreexternal --verifytypes prefect`
- `uv run pytest tests/server/api/test_admin.py tests/server/models/test_storage_defaults.py tests/client/test_prefect_client.py -k 'server_default_result_storage'`
- `uv run pytest tests/server/models/test_configuration.py tests/server/models/test_storage_defaults.py`
- `uv run ruff check src/prefect/server/api/admin.py src/prefect/server/models/__init__.py src/prefect/server/models/configuration.py src/prefect/server/models/storage_defaults.py tests/server/api/test_admin.py tests/server/models/test_configuration.py tests/server/models/test_storage_defaults.py tests/client/test_prefect_client.py`
- repo hooks passed during commit and push, including `mypy` and `Sync UI v2 OpenAPI`

</details>
