### PR TITLE
Eagerly rebuild task-run submission schemas

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -942,6 +942,18 @@ class TaskRun(TimeSeriesBaseModel, ObjectBaseModel):
         return get_or_create_run_name(name)
 
 
+# These models are instantiated while task runs are being created locally on the
+# concurrent submission path. Rebuild them eagerly so threadpool workers do not
+# trigger deferred first-use schema builds under contention.
+RunInput.model_rebuild()
+TaskRunPolicy.model_rebuild()
+TaskRunResult.model_rebuild()
+FlowRunResult.model_rebuild()
+Parameter.model_rebuild()
+Constant.model_rebuild()
+TaskRun.model_rebuild()
+
+
 class Workspace(PrefectBaseModel):
     """
     A Prefect Cloud workspace.

--- a/src/prefect/main.py
+++ b/src/prefect/main.py
@@ -41,13 +41,6 @@ prefect.context.FlowRunContext.model_rebuild(_types_namespace=_types)
 prefect.context.TaskRunContext.model_rebuild(_types_namespace=_types)
 prefect.client.schemas.State.model_rebuild(_types_namespace=_types)
 prefect.client.schemas.StateCreate.model_rebuild(_types_namespace=_types)
-# These models are instantiated during task submission on threadpool workers; if they
-# stay deferred, the first concurrent burst of `TaskRun(...)` creation can force
-# thread-unsafe first-use schema builds.
-prefect.client.schemas.TaskRunPolicy.model_rebuild(_types_namespace=_types)
-prefect.client.schemas.TaskRunResult.model_rebuild(_types_namespace=_types)
-prefect.client.schemas.FlowRunResult.model_rebuild(_types_namespace=_types)
-prefect.client.schemas.TaskRun.model_rebuild(_types_namespace=_types)
 prefect.client.schemas.OrchestrationResult.model_rebuild(_types_namespace=_types)
 Transaction.model_rebuild()
 

--- a/src/prefect/main.py
+++ b/src/prefect/main.py
@@ -41,6 +41,13 @@ prefect.context.FlowRunContext.model_rebuild(_types_namespace=_types)
 prefect.context.TaskRunContext.model_rebuild(_types_namespace=_types)
 prefect.client.schemas.State.model_rebuild(_types_namespace=_types)
 prefect.client.schemas.StateCreate.model_rebuild(_types_namespace=_types)
+# These models are instantiated during task submission on threadpool workers; if they
+# stay deferred, the first concurrent burst of `TaskRun(...)` creation can force
+# thread-unsafe first-use schema builds.
+prefect.client.schemas.TaskRunPolicy.model_rebuild(_types_namespace=_types)
+prefect.client.schemas.TaskRunResult.model_rebuild(_types_namespace=_types)
+prefect.client.schemas.FlowRunResult.model_rebuild(_types_namespace=_types)
+prefect.client.schemas.TaskRun.model_rebuild(_types_namespace=_types)
 prefect.client.schemas.OrchestrationResult.model_rebuild(_types_namespace=_types)
 Transaction.model_rebuild()
 

--- a/tests/client/test_state_serialization.py
+++ b/tests/client/test_state_serialization.py
@@ -161,27 +161,43 @@ except TypeError as e:
 
     def test_task_run_hot_path_models_are_prebuilt_in_fresh_process(self):
         """
-        Regression test: importing Prefect should eagerly rebuild the task-run
-        schemas used during concurrent threadpool submission.
+        Regression test: importing the task decorator module should eagerly rebuild
+        the task-run schemas used during concurrent threadpool submission.
 
         These models are instantiated by `Task.create_local_run()` before any
         task code runs, so leaving them deferred makes the first burst of task
         submission depend on thread-safe first-use schema construction.
+
+        This intentionally avoids `from prefect import ...` to prove the fix does
+        not rely on `prefect.main` being imported first.
         """
         code = """
 import sys
 
-from prefect import flow, task
 from prefect.client.schemas.objects import (
+    Constant,
     FlowRunResult,
+    Parameter,
+    RunInput,
     TaskRun,
     TaskRunPolicy,
     TaskRunResult,
 )
+from prefect.tasks import task
 
-_ = (flow, task)
+assert 'prefect.main' not in sys.modules
 
-models = (TaskRunPolicy, TaskRunResult, FlowRunResult, TaskRun)
+_ = task
+
+models = (
+    RunInput,
+    TaskRunPolicy,
+    TaskRunResult,
+    FlowRunResult,
+    Parameter,
+    Constant,
+    TaskRun,
+)
 incomplete = [model.__name__ for model in models if not model.__pydantic_complete__]
 
 if incomplete:

--- a/tests/client/test_state_serialization.py
+++ b/tests/client/test_state_serialization.py
@@ -158,3 +158,49 @@ except TypeError as e:
         assert result["type"] == "CANCELLED"
         assert result["name"] == "Cancelled"
         assert "state_details" in result
+
+    def test_task_run_hot_path_models_are_prebuilt_in_fresh_process(self):
+        """
+        Regression test: importing Prefect should eagerly rebuild the task-run
+        schemas used during concurrent threadpool submission.
+
+        These models are instantiated by `Task.create_local_run()` before any
+        task code runs, so leaving them deferred makes the first burst of task
+        submission depend on thread-safe first-use schema construction.
+        """
+        code = """
+import sys
+
+from prefect import flow, task
+from prefect.client.schemas.objects import (
+    FlowRunResult,
+    TaskRun,
+    TaskRunPolicy,
+    TaskRunResult,
+)
+
+_ = (flow, task)
+
+models = (TaskRunPolicy, TaskRunResult, FlowRunResult, TaskRun)
+incomplete = [model.__name__ for model in models if not model.__pydantic_complete__]
+
+if incomplete:
+    print(f"INCOMPLETE_MODELS: {','.join(incomplete)}")
+    sys.exit(1)
+
+print("SUCCESS")
+"""
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            pytest.fail(
+                "Task-run submission schemas remained deferred after importing "
+                f"Prefect. stdout: {result.stdout}, stderr: {result.stderr}"
+            )
+
+        assert "SUCCESS" in result.stdout


### PR DESCRIPTION
closes #18151

this PR moves the eager task-run schema rebuilds onto the schema import path used during task submission, so worker threads do not depend on `prefect.main` or trigger deferred first-use Pydantic builds while creating local task runs.

<details>
<summary>details</summary>

### root cause

`PrefectBaseModel` enables `defer_build=True`, but the concurrent task submission path does not necessarily import `prefect.main` first. A direct import like `from prefect.tasks import task` bypasses `prefect.main` entirely while still importing the task-run schemas used by `Task.create_local_run()`.

Before this change, the hot-path task-run models could still be incomplete when local task runs were being created concurrently. In practice, that meant a burst of `TaskRun(...)` construction in threadpool workers could still depend on thread-safe first-use Pydantic schema construction, which matches the intermittent `AttributeError: TaskRun object has no attribute state` reports in #18151.

### what changed

- eagerly rebuild the task-run submission models in `src/prefect/client/schemas/objects.py`
- rebuild the exact models used on the local task-run creation path: `RunInput`, `TaskRunPolicy`, `TaskRunResult`, `FlowRunResult`, `Parameter`, `Constant`, and `TaskRun`
- add a fresh-process regression test that imports `prefect.tasks`, asserts `prefect.main` is still not loaded, and verifies those hot-path models are already complete

### alternatives considered

- move the rebuild closer to task submission or task-engine startup: not chosen because that pushes the work back onto a concurrent hot path. To be safe there, we would need a process-wide once-and-lock guard around rebuilds, which adds complexity and still scopes the fix to one caller path instead of fixing the model module itself.
- remove forward references across the client models: not chosen because forward references are not the core trigger here. With `defer_build=True`, even simple models without meaningful forward-reference resolution can remain incomplete until first use, so removing forward references alone would not guarantee that these task-run models are built before concurrent submission.
- disable `defer_build` on all client `PrefectBaseModel` subclasses: not chosen because it is a much broader behavior and performance change than needed for this bug. `defer_build=True` was added for import-time performance, and turning it off globally should be evaluated separately with import benchmarks instead of folded into a targeted correctness fix.
- disable `defer_build` only on these task-run models: possible, but not chosen because eager rebuild at the shared schema import site makes the guarantee explicit in one place while preserving the existing default for the rest of the client models.

### impact

This removes deferred schema construction from concurrent local task-run creation regardless of whether callers import through `prefect.main` or directly through `prefect.tasks`.

### validation

- fresh interpreter sanity check confirming that after `from prefect.tasks import task`, `prefect.main` is absent and the task-run submission models are complete

</details>
