### PR TITLE
fix: use scoped PAT for cluster-deployment workflow dispatch

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -148,12 +148,12 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Dispatch to cluster-deployment
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.PLATFORM_REPOS_WORKFLOWS_RW }}
-          repository: PrefectHQ/cluster-deployment
-          event-type: prefect-image-published
-          client-payload: '{"tag": "${{ github.ref_name }}"}'
+        env:
+          GH_TOKEN: ${{ secrets.CLUSTER_DEPLOYMENT_ACTIONS_RW }}
+        run: |
+          gh workflow run update-integration-test-image.yaml \
+            -R PrefectHQ/cluster-deployment \
+            --field tag=${{ github.ref_name }}
 
   get-prefect-aws-version:
     name: Get latest prefect-aws version


### PR DESCRIPTION
Switch the integration test worker image update trigger from `peter-evans/repository-dispatch` (which requires `contents:write`) to `gh workflow run` (which only needs `actions:read` + `actions:write`). This uses a new fine-grained `CLUSTER_DEPLOYMENT_ACTIONS_RW` token scoped to just the `cluster-deployment` repo, provisioned via [PrefectHQ/platform#10580](https://github.com/PrefectHQ/platform/pull/10580).

Follow-up to https://github.com/PrefectHQ/prefect/pull/21419.

Related to [PLA-2652](https://linear.app/prefect/issue/PLA-2652)

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.