### PR TITLE
Relax work-pool storage CLI to allow ambient cloud credentials

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -1252,7 +1252,7 @@ async def storage_inspect(
             exit_with_error(f"Work pool {work_pool_name!r} does not exist.")
 
 
-async def _create_or_update_result_storage_block(
+async def _create_or_update_block_document(
     client: Any,
     block_document_name: str,
     block_document_data: dict[str, Any],
@@ -1341,13 +1341,18 @@ async def storage_configure_s3(
             exit_with_error("--bucket is required in non-interactive mode.")
         bucket = _cli.console.input("Enter the name of the S3 bucket to use: ")
 
-    if credentials_block_name is None:
-        if not _cli.is_interactive():
-            exit_with_error(
-                "--aws-credentials-block-name is required in non-interactive mode."
+    # In interactive mode, prompt so an operator re-running to tweak another
+    # flag doesn't silently swap a configured credentials block for ambient
+    # auth. Pressing Enter at the prompt is an explicit opt-in to ambient
+    # auth. In non-interactive mode the omitted flag means ambient auth
+    # (the IaC / Helm use case).
+    if credentials_block_name is None and _cli.is_interactive():
+        credentials_block_name = (
+            _cli.console.input(
+                "Enter the name of the AWS credentials block to use"
+                " (press Enter to use default credentials): "
             )
-        credentials_block_name = _cli.console.input(
-            "Enter the name of the AWS credentials block to use: "
+            or None
         )
 
     resolved_upload_launcher, resolved_execution_launcher = _resolve_launcher_flags(
@@ -1360,26 +1365,37 @@ async def storage_configure_s3(
     )
 
     async with get_client() as client:
-        try:
-            credentials_block_document = await client.read_block_document_by_name(
-                name=credentials_block_name, block_type_slug="aws-credentials"
-            )
-        except ObjectNotFound:
-            exit_with_error(
-                f"AWS credentials block {credentials_block_name!r} does not exist."
-                " Please create one using `prefect block create aws-credentials`."
-            )
+        credentials_block_document = None
+        if credentials_block_name is not None:
+            try:
+                credentials_block_document = await client.read_block_document_by_name(
+                    name=credentials_block_name, block_type_slug="aws-credentials"
+                )
+            except ObjectNotFound:
+                exit_with_error(
+                    f"AWS credentials block {credentials_block_name!r} does not"
+                    " exist. Please create one using"
+                    " `prefect block create aws-credentials`, or omit"
+                    " --aws-credentials-block-name to use default credentials."
+                )
 
         result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
-        block_data = {
+        # Always set `credentials` explicitly (a $ref for a named block, or
+        # an empty dict for ambient auth). Setting it on every run clears any
+        # stale credential reference from a prior --aws-credentials-block-name
+        # invocation, while the merge-update behavior preserves user-managed
+        # fields like `base_folder` that the CLI does not send.
+        block_data: dict[str, Any] = {
             "bucket_name": bucket,
             "bucket_folder": "results",
-            "credentials": {
-                "$ref": {"block_document_id": credentials_block_document.id}
-            },
+            "credentials": (
+                {"$ref": {"block_document_id": credentials_block_document.id}}
+                if credentials_block_document is not None
+                else {}
+            ),
         }
 
-        block_document = await _create_or_update_result_storage_block(
+        block_document = await _create_or_update_block_document(
             client=client,
             block_document_name=result_storage_block_document_name,
             block_document_data=block_data,
@@ -1391,6 +1407,10 @@ async def storage_configure_s3(
             ),
         )
 
+        bundle_step_config: dict[str, Any] = {"bucket": bucket}
+        if credentials_block_name is not None:
+            bundle_step_config["aws_credentials_block_name"] = credentials_block_name
+
         try:
             await client.update_work_pool(
                 work_pool_name=work_pool_name,
@@ -1398,19 +1418,13 @@ async def storage_configure_s3(
                     storage_configuration=WorkPoolStorageConfiguration(
                         bundle_upload_step=_build_bundle_step(
                             "prefect_aws.experimental.bundles.upload",
-                            {
-                                "bucket": bucket,
-                                "aws_credentials_block_name": credentials_block_name,
-                            },
+                            bundle_step_config,
                             "prefect-aws",
                             resolved_upload_launcher,
                         ),
                         bundle_execution_step=_build_bundle_step(
                             "prefect_aws.experimental.bundles.execute",
-                            {
-                                "bucket": bucket,
-                                "aws_credentials_block_name": credentials_block_name,
-                            },
+                            bundle_step_config,
                             "prefect-aws",
                             resolved_execution_launcher,
                         ),
@@ -1466,13 +1480,18 @@ async def storage_configure_gcs(
             "Enter the name of the Google Cloud Storage bucket to use: "
         )
 
-    if credentials_block_name is None:
-        if not _cli.is_interactive():
-            exit_with_error(
-                "--gcp-credentials-block-name is required in non-interactive mode."
+    # In interactive mode, prompt so an operator re-running to tweak another
+    # flag doesn't silently swap a configured credentials block for ADC.
+    # Pressing Enter at the prompt is an explicit opt-in to ambient auth.
+    # In non-interactive mode the omitted flag means ambient auth (the IaC /
+    # Helm use case).
+    if credentials_block_name is None and _cli.is_interactive():
+        credentials_block_name = (
+            _cli.console.input(
+                "Enter the name of the Google Cloud credentials block to use"
+                " (press Enter to use default credentials): "
             )
-        credentials_block_name = _cli.console.input(
-            "Enter the name of the Google Cloud credentials block to use: "
+            or None
         )
 
     resolved_upload_launcher, resolved_execution_launcher = _resolve_launcher_flags(
@@ -1485,26 +1504,38 @@ async def storage_configure_gcs(
     )
 
     async with get_client() as client:
-        try:
-            credentials_block_document = await client.read_block_document_by_name(
-                name=credentials_block_name, block_type_slug="gcp-credentials"
-            )
-        except ObjectNotFound:
-            exit_with_error(
-                f"GCS credentials block {credentials_block_name!r} does not exist."
-                " Please create one using `prefect block create gcp-credentials`."
-            )
+        credentials_block_document = None
+        if credentials_block_name is not None:
+            try:
+                credentials_block_document = await client.read_block_document_by_name(
+                    name=credentials_block_name, block_type_slug="gcp-credentials"
+                )
+            except ObjectNotFound:
+                exit_with_error(
+                    f"GCS credentials block {credentials_block_name!r} does not"
+                    " exist. Please create one using"
+                    " `prefect block create gcp-credentials`, or omit"
+                    " --gcp-credentials-block-name to use default credentials."
+                )
 
         result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
-        block_data = {
+        # Always set `gcp_credentials` explicitly (a $ref for a named block,
+        # or an empty dict for ambient auth). Setting it on every run clears
+        # any stale credential reference from a prior
+        # --gcp-credentials-block-name invocation, while the merge-update
+        # behavior preserves user-managed fields like `bucket_folder`
+        # overrides that the CLI does not send.
+        block_data: dict[str, Any] = {
             "bucket": bucket,
             "bucket_folder": "results",
-            "gcp_credentials": {
-                "$ref": {"block_document_id": credentials_block_document.id}
-            },
+            "gcp_credentials": (
+                {"$ref": {"block_document_id": credentials_block_document.id}}
+                if credentials_block_document is not None
+                else {}
+            ),
         }
 
-        block_document = await _create_or_update_result_storage_block(
+        block_document = await _create_or_update_block_document(
             client=client,
             block_document_name=result_storage_block_document_name,
             block_document_data=block_data,
@@ -1516,6 +1547,10 @@ async def storage_configure_gcs(
             ),
         )
 
+        bundle_step_config: dict[str, Any] = {"bucket": bucket}
+        if credentials_block_name is not None:
+            bundle_step_config["gcp_credentials_block_name"] = credentials_block_name
+
         try:
             await client.update_work_pool(
                 work_pool_name=work_pool_name,
@@ -1523,19 +1558,13 @@ async def storage_configure_gcs(
                     storage_configuration=WorkPoolStorageConfiguration(
                         bundle_upload_step=_build_bundle_step(
                             "prefect_gcp.experimental.bundles.upload",
-                            {
-                                "bucket": bucket,
-                                "gcp_credentials_block_name": credentials_block_name,
-                            },
+                            bundle_step_config,
                             "prefect-gcp",
                             resolved_upload_launcher,
                         ),
                         bundle_execution_step=_build_bundle_step(
                             "prefect_gcp.experimental.bundles.execute",
-                            {
-                                "bucket": bucket,
-                                "gcp_credentials_block_name": credentials_block_name,
-                            },
+                            bundle_step_config,
                             "prefect-gcp",
                             resolved_execution_launcher,
                         ),
@@ -1631,7 +1660,7 @@ async def storage_configure_azure_blob_storage(
             },
         }
 
-        block_document = await _create_or_update_result_storage_block(
+        block_document = await _create_or_update_block_document(
             client=client,
             block_document_name=result_storage_block_document_name,
             block_document_data=block_data,

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -24,7 +24,7 @@ from prefect.client.schemas.objects import BlockDocument, WorkPool
 from prefect.context import get_settings_context
 from prefect.exceptions import ObjectNotFound, PrefectHTTPStatusError
 from prefect.infrastructure import provisioners
-from prefect.server.schemas.actions import BlockDocumentCreate
+from prefect.server.schemas.actions import BlockDocumentCreate, BlockDocumentUpdate
 from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_UI_URL,
@@ -1631,10 +1631,211 @@ class TestStorageConfigure:
                 ],
                 expected_code=1,
                 expected_output_contains=[
-                    "AWS credentials block 'nonexistent-credentials' does not exist"
+                    "AWS credentials block 'nonexistent-credentials' does not exist",
+                    "or omit --aws-credentials-block-name",
                 ],
             )
             assert res.exit_code == 1
+
+        @pytest.mark.usefixtures("s3_bucket_block_definition")
+        async def test_storage_configure_without_credentials_block(
+            self, prefect_client: PrefectClient, work_pool: WorkPool
+        ):
+            """Omitting --aws-credentials-block-name wires the bundle's ambient-auth path.
+
+            No credentials block document is created or referenced. The bundle
+            step config omits aws_credentials_block_name so the upload/execute
+            functions hit their `else: AwsCredentials()` branch, and the
+            result-storage block omits `credentials` so S3Bucket's
+            default_factory supplies an empty AwsCredentials on load.
+            """
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                expected_code=0,
+                expected_output_contains=[
+                    f"Configured S3 storage for work pool {work_pool.name!r}"
+                ],
+            )
+
+            # No auto-created credentials block exists.
+            with pytest.raises(ObjectNotFound):
+                await prefect_client.read_block_document_by_name(
+                    name=f"default-{work_pool.name}-aws-credentials",
+                    block_type_slug="aws-credentials",
+                )
+
+            client_res = await prefect_client.read_work_pool(work_pool.name)
+            assert client_res.storage_configuration.bundle_upload_step == {
+                "prefect_aws.experimental.bundles.upload": {
+                    "requires": "prefect-aws",
+                    "bucket": "test-bucket",
+                }
+            }
+            assert client_res.storage_configuration.bundle_execution_step == {
+                "prefect_aws.experimental.bundles.execute": {
+                    "requires": "prefect-aws",
+                    "bucket": "test-bucket",
+                }
+            }
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="s3-bucket",
+            )
+            assert storage.data == {
+                "bucket_name": "test-bucket",
+                "bucket_folder": "results",
+                "credentials": {},
+            }
+
+        @pytest.mark.usefixtures("s3_bucket_block_definition")
+        async def test_storage_configure_migrates_from_named_to_ambient_credentials(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+            aws_credentials: BlockDocument,
+        ):
+            """Reconfiguring without the flag must clear the prior credential ref.
+
+            Otherwise the bundle steps move to ambient auth while the result-
+            storage block keeps pointing at the old aws-credentials block.
+            """
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                    "--aws-credentials-block-name",
+                    aws_credentials.name,
+                ],
+                expected_code=0,
+            )
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="s3-bucket",
+            )
+            assert storage.data["credentials"] == aws_credentials.data
+
+            # Reconfigure without the flag — credential reference must be cleared.
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                expected_code=0,
+            )
+
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="s3-bucket",
+            )
+            assert storage.data["credentials"] == {}
+
+            client_res = await prefect_client.read_work_pool(work_pool.name)
+            assert (
+                "aws_credentials_block_name"
+                not in client_res.storage_configuration.bundle_upload_step[
+                    "prefect_aws.experimental.bundles.upload"
+                ]
+            )
+            assert (
+                "aws_credentials_block_name"
+                not in client_res.storage_configuration.bundle_execution_step[
+                    "prefect_aws.experimental.bundles.execute"
+                ]
+            )
+
+        @pytest.mark.usefixtures(
+            "interactive_console",
+            "s3_bucket_block_definition",
+        )
+        async def test_storage_configure_interactive_prompts_for_credentials_block(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+            aws_credentials: BlockDocument,
+        ):
+            """Interactive mode prompts for a credentials block when the flag is omitted.
+
+            Typing an existing block name at the prompt uses that block (the
+            pre-relaxation behavior, preserved so an operator re-running the
+            command interactively does not silently clear configured auth).
+            """
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                user_input=f"{aws_credentials.name}\n",
+                expected_code=0,
+                expected_output_contains=[
+                    "Enter the name of the AWS credentials block to use",
+                    f"Configured S3 storage for work pool {work_pool.name!r}",
+                ],
+            )
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="s3-bucket",
+            )
+            assert storage.data["credentials"] == aws_credentials.data
+
+        @pytest.mark.usefixtures(
+            "interactive_console",
+            "s3_bucket_block_definition",
+        )
+        async def test_storage_configure_interactive_enter_selects_ambient_auth(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+        ):
+            """Pressing Enter at the interactive prompt opts into ambient auth."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                user_input="\n",
+                expected_code=0,
+                expected_output_contains=[
+                    "press Enter to use default credentials",
+                ],
+            )
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="s3-bucket",
+            )
+            assert storage.data["credentials"] == {}
 
     class TestGCS:
         @pytest.mark.usefixtures("gcs_bucket_block_definition")
@@ -1733,9 +1934,210 @@ class TestStorageConfigure:
                 ],
                 expected_code=1,
                 expected_output_contains=[
-                    "GCS credentials block 'nonexistent-credentials' does not exist"
+                    "GCS credentials block 'nonexistent-credentials' does not exist",
+                    "or omit --gcp-credentials-block-name",
                 ],
             )
+
+        @pytest.mark.usefixtures("gcs_bucket_block_definition")
+        async def test_storage_configure_without_credentials_block(
+            self, prefect_client: PrefectClient, work_pool: WorkPool
+        ):
+            """Omitting --gcp-credentials-block-name wires the bundle's ambient-auth path.
+
+            No credentials block document is created or referenced. The bundle
+            step config omits gcp_credentials_block_name so the upload/execute
+            functions hit their `else: GcpCredentials()` branch, and the
+            result-storage block omits `gcp_credentials` so GcsBucket's
+            default_factory supplies an empty GcpCredentials on load.
+            """
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                expected_code=0,
+                expected_output_contains=[
+                    f"Configured GCS storage for work pool {work_pool.name!r}"
+                ],
+            )
+
+            # No auto-created credentials block exists.
+            with pytest.raises(ObjectNotFound):
+                await prefect_client.read_block_document_by_name(
+                    name=f"default-{work_pool.name}-gcp-credentials",
+                    block_type_slug="gcp-credentials",
+                )
+
+            client_res = await prefect_client.read_work_pool(work_pool.name)
+            assert client_res.storage_configuration.bundle_upload_step == {
+                "prefect_gcp.experimental.bundles.upload": {
+                    "requires": "prefect-gcp",
+                    "bucket": "test-bucket",
+                }
+            }
+            assert client_res.storage_configuration.bundle_execution_step == {
+                "prefect_gcp.experimental.bundles.execute": {
+                    "requires": "prefect-gcp",
+                    "bucket": "test-bucket",
+                }
+            }
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="gcs-bucket",
+            )
+            assert storage.data == {
+                "bucket": "test-bucket",
+                "bucket_folder": "results",
+                "gcp_credentials": {},
+            }
+
+        @pytest.mark.usefixtures("gcs_bucket_block_definition")
+        async def test_storage_configure_migrates_from_named_to_ambient_credentials(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+            gcs_credentials: BlockDocument,
+        ):
+            """Reconfiguring without the flag must clear the prior credential ref.
+
+            Otherwise the bundle steps move to ADC while the result-storage
+            block keeps pointing at the old gcp-credentials block.
+            """
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                    "--gcp-credentials-block-name",
+                    gcs_credentials.name,
+                ],
+                expected_code=0,
+            )
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="gcs-bucket",
+            )
+            assert storage.data["gcp_credentials"] == gcs_credentials.data
+
+            # Reconfigure without the flag — credential reference must be cleared.
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                expected_code=0,
+            )
+
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="gcs-bucket",
+            )
+            assert storage.data["gcp_credentials"] == {}
+
+            client_res = await prefect_client.read_work_pool(work_pool.name)
+            assert (
+                "gcp_credentials_block_name"
+                not in client_res.storage_configuration.bundle_upload_step[
+                    "prefect_gcp.experimental.bundles.upload"
+                ]
+            )
+            assert (
+                "gcp_credentials_block_name"
+                not in client_res.storage_configuration.bundle_execution_step[
+                    "prefect_gcp.experimental.bundles.execute"
+                ]
+            )
+
+        @pytest.mark.usefixtures(
+            "interactive_console",
+            "gcs_bucket_block_definition",
+        )
+        async def test_storage_configure_interactive_prompts_for_credentials_block(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+            gcs_credentials: BlockDocument,
+        ):
+            """Interactive mode prompts for a credentials block when the flag is omitted.
+
+            Typing an existing block name at the prompt uses that block (the
+            pre-relaxation behavior, preserved so an operator re-running the
+            command interactively does not silently clear configured auth).
+            """
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                user_input=f"{gcs_credentials.name}\n",
+                expected_code=0,
+                expected_output_contains=[
+                    "Enter the name of the Google Cloud credentials block",
+                    f"Configured GCS storage for work pool {work_pool.name!r}",
+                ],
+            )
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="gcs-bucket",
+            )
+            assert storage.data["gcp_credentials"] == gcs_credentials.data
+
+        @pytest.mark.usefixtures(
+            "interactive_console",
+            "gcs_bucket_block_definition",
+        )
+        async def test_storage_configure_interactive_enter_selects_ambient_auth(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+        ):
+            """Pressing Enter at the interactive prompt opts into ambient auth."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                ],
+                user_input="\n",
+                expected_code=0,
+                expected_output_contains=[
+                    "press Enter to use default credentials",
+                ],
+            )
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="gcs-bucket",
+            )
+            assert storage.data["gcp_credentials"] == {}
 
     class TestAzureBlobStorage:
         @pytest.mark.usefixtures("azure_blob_storage_container_block_definition")
@@ -1836,6 +2238,59 @@ class TestStorageConfigure:
                     "Azure Blob Storage credentials block 'nonexistent-credentials' does not exist"
                 ],
             )
+
+        @pytest.mark.usefixtures("azure_blob_storage_container_block_definition")
+        async def test_storage_configure_preserves_existing_result_storage_fields(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+            azure_blob_storage_credentials: BlockDocument,
+        ):
+            """Reconfiguring must not drop fields the CLI does not resend.
+
+            The Azure CLI only sends container_name and credentials, so any
+            fields the user has added to the auto-created result-storage block
+            (e.g. base_folder) must be preserved on re-run.
+            """
+            base_command = [
+                "work-pool",
+                "storage",
+                "configure",
+                "azure-blob-storage",
+                work_pool.name,
+                "--container",
+                "test-container",
+                "--azure-blob-storage-credentials-block-name",
+                azure_blob_storage_credentials.name,
+            ]
+            await run_sync_in_worker_thread(
+                invoke_and_assert, command=base_command, expected_code=0
+            )
+
+            # Simulate a user adding base_folder to the auto-created block.
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="azure-blob-storage-container",
+            )
+            await prefect_client.update_block_document(
+                block_document_id=storage.id,
+                block_document=BlockDocumentUpdate(
+                    data={"base_folder": "custom/prefix"},
+                    merge_existing_data=True,
+                ),
+            )
+
+            # Reconfigure; base_folder must survive.
+            await run_sync_in_worker_thread(
+                invoke_and_assert, command=base_command, expected_code=0
+            )
+
+            storage = await prefect_client.read_block_document_by_name(
+                name=f"default-{work_pool.name}-result-storage",
+                block_type_slug="azure-blob-storage-container",
+            )
+            assert storage.data["base_folder"] == "custom/prefix"
+            assert storage.data["container_name"] == "test-container"
 
 
 class TestFormatDuration:


### PR DESCRIPTION
## Summary

`prefect work-pool storage configure s3`/`gcs` no longer require a credentials block. When `--*-credentials-block-name` is omitted, the CLI wires the bundle upload/execute steps and the result-storage block to the cloud SDK's default credential chain (boto3 / Google ADC). This matches the behavior already documented in `docs/v3/advanced/submit-flows-directly-to-dynamic-infrastructure.mdx` and unblocks Helm / IaC setups where the work pool should use an IAM role or instance service account rather than a stored block.

## Motivation

User report: running `prefect work-pool storage configure gcs default --bucket ...` from a Helm chart fails because it prompts for a credentials block name in non-interactive mode. The documentation already promises ambient credentials as a fallback, but the CLI contradicted it.

## Behavior by mode

- **Non-interactive + no flag**: ambient auth silently (Helm / IaC).
- **Interactive + no flag**: prompt "Enter the name of the AWS/GCP credentials block to use (press Enter to use default credentials):". Pressing Enter opts into ambient auth; typing a name uses that block. This prevents an operator re-running the command to tweak an unrelated flag from silently swapping configured auth.
- **Any mode + flag given**: unchanged lookup; error message now hints that the flag can be omitted.

## Design notes

- **No auto-generated credentials block.** Earlier review iterations tried creating an empty `default-{pool}-{slug}` credentials block; this was unsafe (block names are unique per type, so a pre-existing block with that name would be clobbered) and unnecessary (it forced the bundle runtime into the `Block.load()` path, adding a Prefect API dependency that custom launchers may not satisfy). The current design skips block creation entirely — the bundle's `else: AwsCredentials() / GcpCredentials()` branch handles ambient auth natively.
- **`credentials` / `gcp_credentials` is always set explicitly** on the result-storage block (a `$ref` for a named block, or `{}` for ambient). This is what lets an operator reliably migrate a pool from named to ambient auth: the explicit write clears the stale reference while the merge-update behavior still preserves user-managed fields like `base_folder`.
- **Azure is intentionally excluded.** `AzureBlobStorageCredentials` has a model validator that raises when both `connection_string` and `account_url` are missing, so ambient auth has no viable path. Azure still requires the flag; adding an Azure-specific `--account-url` flag is a larger follow-up.