### PR TITLE
clarify dask priority docs

### DIFF
--- a/docs/integrations/prefect-dask/index.mdx
+++ b/docs/integrations/prefect-dask/index.mdx
@@ -359,6 +359,11 @@ def my_flow():
         future = show.submit(2)  # high priority task
 ```
 
+`priority` is a soft scheduling hint for queued work. It does not preempt tasks
+that have already been assigned to a worker, so sequential `.submit()` calls may
+still start in submission order even when later tasks have a higher priority.
+Use `wait_for` or stage your submissions if you need strict ordering.
+
 Another common use case is [resource](http://distributed.dask.org/en/stable/resources.html) annotations:
 
 ```python


### PR DESCRIPTION
## Summary
This PR clarifies the `prefect-dask` docs around Dask task priorities.

## Why
The current example can be read as implying that a later high-priority `.submit()` call will reorder execution ahead of earlier low-priority submissions. In practice, Dask priority is a soft scheduling hint for queued work and does not preempt tasks that have already been assigned to a worker.

## Impact
Readers should have a more accurate expectation of how `dask.annotate(priority=...)` behaves when used with `DaskTaskRunner`.

## Root cause
The behavior discussed in PrefectHQ/prefect#21568 is not caused by Prefect overriding Dask annotations. A local repro against a real Prefect OSS server showed that the annotations reach Dask, while execution may still begin in submission order for already-assigned work.

## Validation
- `curl http://localhost:4200/api/health`
- `uv run prefect config view`
- `uv run --extra dask python repros/21568.py`
