### PR TITLE
fix(prefect-shell): kill whole process tree on ShellOperation cleanup

### DIFF
--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 import tempfile
 import threading
-import time
 from contextlib import AsyncExitStack, ExitStack, contextmanager
 from contextvars import copy_context
 from typing import IO, Any, Generator, Optional, Union
@@ -26,6 +25,8 @@ from prefect.blocks.abstract import JobBlock, JobRun
 from prefect.logging import get_run_logger
 from prefect.utilities.processutils import open_process
 
+_SHELL_TERMINATE_GRACE_SECONDS = 5.0
+
 
 def _process_isolation_kwargs() -> dict[str, Any]:
     """Kwargs that place the spawned shell in its own process group/session.
@@ -40,17 +41,16 @@ def _process_isolation_kwargs() -> dict[str, Any]:
     return {"start_new_session": True}
 
 
-def _terminate_process_tree(
+def _signal_process_tree(
     process: Union[Process, subprocess.Popen[bytes]],
-    grace_seconds: float = 5.0,
+    sig: int,
 ) -> None:
-    """Terminate the process and any descendants it spawned.
+    """Send `sig` to the process and any descendants in its process group.
 
-    Uses `os.killpg` on POSIX so the whole process group established during
-    spawn with `start_new_session=True` receives the signal. On Windows, falls back
-    to the existing per-process `terminate`/`kill` behavior because the
-    subprocess is spawned with `CREATE_NEW_PROCESS_GROUP` and is cleaned up by
-    the shared `open_process` helper.
+    Non-blocking and idempotent. Silently ignores processes we can no longer
+    signal (already exited or zombies awaiting reap). On Windows, falls back
+    to per-process `terminate`/`kill` — the shared `open_process` helper
+    cleans up the `CREATE_NEW_PROCESS_GROUP` tree from there.
     """
     pid = process.pid
     if not isinstance(pid, int):
@@ -58,6 +58,10 @@ def _terminate_process_tree(
         return
 
     if sys.platform == "win32":
+        # `Popen.kill` and `Popen.terminate` both map to `TerminateProcess` on
+        # Windows; the shared `open_process` helper cleans up the
+        # `CREATE_NEW_PROCESS_GROUP` tree. Escalation from SIGTERM to SIGKILL
+        # has no distinct meaning here.
         try:
             process.terminate()
         except (OSError, ProcessLookupError):
@@ -67,34 +71,36 @@ def _terminate_process_tree(
     try:
         pgid = os.getpgid(pid)
     except ProcessLookupError:
-        # The direct child has already exited. Because we spawn with
-        # `start_new_session=True` the process was the group leader, so its
-        # pgid equals its pid; descendants (still alive) remain in that group.
+        # Leader already gone; any remaining descendants still share this pgid
+        # because we spawned with `start_new_session=True`.
         pgid = pid
     except PermissionError:
         return
 
     try:
-        os.killpg(pgid, signal.SIGTERM)
+        os.killpg(pgid, sig)
     except (ProcessLookupError, PermissionError):
+        pass
+
+
+def _close_sync_process_tree(process: subprocess.Popen[bytes]) -> None:
+    """Synchronously terminate the process tree and wait for it to exit.
+
+    Sends SIGTERM to the group, waits up to `_SHELL_TERMINATE_GRACE_SECONDS`
+    for the direct process to exit, then escalates to SIGKILL if needed.
+    Suitable for sync cleanup paths (`run()` finally, `close()` callbacks).
+    Async paths should call `_signal_process_tree` directly and let the
+    async context manager handle the wait.
+    """
+    if process.returncode is not None:
         return
 
-    deadline = time.monotonic() + grace_seconds
-    while time.monotonic() < deadline:
-        try:
-            os.killpg(pgid, 0)
-        except ProcessLookupError:
-            return
-        except PermissionError:
-            # A process in the group has become a zombie awaiting reap.
-            # Treat this as the group being terminated.
-            return
-        time.sleep(0.05)
-
+    _signal_process_tree(process, signal.SIGTERM)
     try:
-        os.killpg(pgid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError):
-        return
+        process.wait(timeout=_SHELL_TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        _signal_process_tree(process, signal.SIGKILL)
+        process.wait()
 
 
 @task
@@ -556,9 +562,10 @@ class ShellOperation(JobBlock[list[str]]):
         process = await self._exit_stack.enter_async_context(
             open_process(**input_open_kwargs)
         )
-        # Register a process-group terminator that runs before `open_process`
-        # cleans up, so descendants of the shell are killed along with it.
-        self._exit_stack.callback(_terminate_process_tree, process)
+        # Signal the shell's descendants before `open_process` unwinds, so its
+        # `process.terminate()` + `aclose()` cleanup doesn't leave descendants
+        # behind. Registered LIFO so it runs before `open_process.__aexit__`.
+        self._exit_stack.callback(_signal_process_tree, process, signal.SIGTERM)
         num_commands = len(self.commands)
         self.logger.info(
             f"PID {process.pid} triggered with {num_commands} commands running "
@@ -595,6 +602,10 @@ class ShellOperation(JobBlock[list[str]]):
         """
         input_open_kwargs = self._compile_kwargs_sync(**open_kwargs)
         process = subprocess.Popen(**input_open_kwargs)
+        # Ensure `close()` (and the `__exit__` that calls it) reclaims the
+        # subprocess tree instead of leaking it when a user exits the context
+        # without `wait_for_completion()`.
+        self._sync_exit_stack.callback(_close_sync_process_tree, process)
         num_commands = len(self.commands)
         self.logger.info(
             f"PID {process.pid} triggered with {num_commands} commands running "
@@ -638,8 +649,10 @@ class ShellOperation(JobBlock[list[str]]):
                 await shell_process.await_for_completion()
                 result = await shell_process.afetch_result()
             finally:
-                # Ensure descendants of the shell are killed along with it.
-                _terminate_process_tree(process)
+                # Signal descendants of the shell to terminate. The enclosing
+                # `open_process` context manager handles the wait on the direct
+                # process during its own cleanup.
+                _signal_process_tree(process, signal.SIGTERM)
 
         return result
 
@@ -681,9 +694,7 @@ class ShellOperation(JobBlock[list[str]]):
             result = shell_process.fetch_result()
         finally:
             # Ensure the whole process tree is cleaned up, not just the shell.
-            if process.returncode is None:
-                _terminate_process_tree(process)
-                process.wait()
+            _close_sync_process_tree(process)
 
         return result
 

--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 from contextlib import AsyncExitStack, ExitStack, contextmanager
 from contextvars import copy_context
 from typing import IO, Any, Generator, Optional, Union
@@ -23,6 +25,76 @@ from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.blocks.abstract import JobBlock, JobRun
 from prefect.logging import get_run_logger
 from prefect.utilities.processutils import open_process
+
+
+def _process_isolation_kwargs() -> dict[str, Any]:
+    """Kwargs that place the spawned shell in its own process group/session.
+
+    Isolating the shell in a new process group lets us signal the entire
+    process tree (the shell plus any children it spawned) on cleanup, rather
+    than only the shell itself. Without this, long-running descendants like
+    `sleep 9999` get orphaned when the flow run is cancelled (see GH #20979).
+    """
+    if sys.platform == "win32":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _terminate_process_tree(
+    process: Union[Process, subprocess.Popen[bytes]],
+    grace_seconds: float = 5.0,
+) -> None:
+    """Terminate the process and any descendants it spawned.
+
+    Uses `os.killpg` on POSIX so the whole process group established during
+    spawn with `start_new_session=True` receives the signal. On Windows, falls back
+    to the existing per-process `terminate`/`kill` behavior because the
+    subprocess is spawned with `CREATE_NEW_PROCESS_GROUP` and is cleaned up by
+    the shared `open_process` helper.
+    """
+    pid = process.pid
+    if not isinstance(pid, int):
+        # Includes `None` and mocked processes used in tests.
+        return
+
+    if sys.platform == "win32":
+        try:
+            process.terminate()
+        except (OSError, ProcessLookupError):
+            pass
+        return
+
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        # The direct child has already exited. Because we spawn with
+        # `start_new_session=True` the process was the group leader, so its
+        # pgid equals its pid; descendants (still alive) remain in that group.
+        pgid = pid
+    except PermissionError:
+        return
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return
+
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            # A process in the group has become a zombie awaiting reap.
+            # Treat this as the group being terminated.
+            return
+        time.sleep(0.05)
+
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        return
 
 
 @task
@@ -429,6 +501,7 @@ class ShellOperation(JobBlock[list[str]]):
             stderr=subprocess.PIPE,
             env=input_env,
             cwd=self.working_dir,
+            **_process_isolation_kwargs(),
             **open_kwargs,
         )
         return input_open_kwargs
@@ -448,6 +521,7 @@ class ShellOperation(JobBlock[list[str]]):
             stderr=subprocess.PIPE,
             env=input_env,
             cwd=self.working_dir,
+            **_process_isolation_kwargs(),
             **open_kwargs,
         )
         return input_open_kwargs
@@ -482,6 +556,9 @@ class ShellOperation(JobBlock[list[str]]):
         process = await self._exit_stack.enter_async_context(
             open_process(**input_open_kwargs)
         )
+        # Register a process-group terminator that runs before `open_process`
+        # cleans up, so descendants of the shell are killed along with it.
+        self._exit_stack.callback(_terminate_process_tree, process)
         num_commands = len(self.commands)
         self.logger.info(
             f"PID {process.pid} triggered with {num_commands} commands running "
@@ -551,14 +628,18 @@ class ShellOperation(JobBlock[list[str]]):
         """
         input_open_kwargs = self._compile_kwargs(**open_kwargs)
         async with open_process(**input_open_kwargs) as process:
-            shell_process = ShellProcess(shell_operation=self, process=process)
-            num_commands = len(self.commands)
-            self.logger.info(
-                f"PID {process.pid} triggered with {num_commands} commands running "
-                f"inside the {(self.working_dir or '.')!r} directory."
-            )
-            await shell_process.await_for_completion()
-            result = await shell_process.afetch_result()
+            try:
+                shell_process = ShellProcess(shell_operation=self, process=process)
+                num_commands = len(self.commands)
+                self.logger.info(
+                    f"PID {process.pid} triggered with {num_commands} commands running "
+                    f"inside the {(self.working_dir or '.')!r} directory."
+                )
+                await shell_process.await_for_completion()
+                result = await shell_process.afetch_result()
+            finally:
+                # Ensure descendants of the shell are killed along with it.
+                _terminate_process_tree(process)
 
         return result
 
@@ -599,9 +680,9 @@ class ShellOperation(JobBlock[list[str]]):
             shell_process.wait_for_completion()
             result = shell_process.fetch_result()
         finally:
-            # Ensure process is cleaned up
+            # Ensure the whole process tree is cleaned up, not just the shell.
             if process.returncode is None:
-                process.kill()
+                _terminate_process_tree(process)
                 process.wait()
 
         return result

--- a/src/integrations/prefect-shell/tests/test_commands.py
+++ b/src/integrations/prefect-shell/tests/test_commands.py
@@ -464,37 +464,33 @@ class TestShellOperationProcessGroup:
         )
 
     def test_sync_close_terminates_descendant_processes(self, tmp_path: Path):
-        """Synchronous cleanup must terminate the shell's descendants, not just
-        the shell itself (regression for GH #20979)."""
+        """Exiting the sync context manager after `trigger()` must terminate the
+        shell's descendants, not just the shell itself (regression for GH #20979).
+        """
         import time as _time
-
-        from prefect_shell.commands import _terminate_process_tree
 
         pid_file = tmp_path / "child.pid"
         op = ShellOperation(
             commands=[f"sleep 120 & echo $! > {pid_file}; wait"],
         )
         with op:
-            proc = op.trigger()
-
+            op.trigger()
             for _ in range(50):
                 if pid_file.exists() and pid_file.read_text().strip():
                     break
                 _time.sleep(0.1)
             else:
-                proc._process.kill()
                 pytest.fail("inner sleep process did not start in time")
 
             child_pid = int(pid_file.read_text().strip())
             assert self._pid_alive(child_pid), "sleep process should be running"
 
-            _terminate_process_tree(proc._process)
-            proc._process.wait(timeout=5)
-
+        # After exiting the context manager, `close()` must have reclaimed the
+        # full process tree, not just the shell.
         for _ in range(50):
             if not self._pid_alive(child_pid):
                 break
             _time.sleep(0.1)
         assert not self._pid_alive(child_pid), (
-            f"inner sleep (pid={child_pid}) was orphaned after tree termination"
+            f"inner sleep (pid={child_pid}) was orphaned after context exit"
         )

--- a/src/integrations/prefect-shell/tests/test_commands.py
+++ b/src/integrations/prefect-shell/tests/test_commands.py
@@ -388,3 +388,113 @@ class TestShellOperation:
         assert any("PID" in message and "stderr:" in message for message in messages)
         assert any("err1" in message for message in messages)
         assert any("err2" in message for message in messages)
+
+
+class TestShellOperationProcessGroup:
+    """Tests that ShellOperation subprocesses are isolated in their own process
+    group so that cleanup kills the whole process tree, not just the shell
+    (see GH #20979)."""
+
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError):
+            return False
+        return True
+
+    async def test_async_subprocess_is_own_session_leader(self, tmp_path: Path):
+        """The spawned shell should be a session leader so its whole process
+        tree can be signalled together."""
+        op = ShellOperation(commands=["sleep 30"])
+        async with op:
+            proc = await op.atrigger()
+            try:
+                assert os.getsid(proc.pid) == proc.pid, (
+                    f"Expected subprocess {proc.pid} to be its own session leader; "
+                    f"got sid={os.getsid(proc.pid)}"
+                )
+            finally:
+                proc._process.terminate()
+                await proc._process.wait()
+
+    def test_sync_subprocess_is_own_session_leader(self):
+        """The sync `trigger()` path should also place the shell in a new session."""
+        op = ShellOperation(commands=["sleep 30"])
+        with op:
+            proc = op.trigger()
+            try:
+                assert os.getsid(proc.pid) == proc.pid, (
+                    f"Expected subprocess {proc.pid} to be its own session leader; "
+                    f"got sid={os.getsid(proc.pid)}"
+                )
+            finally:
+                proc._process.kill()
+                proc._process.wait()
+
+    async def test_aclose_terminates_descendant_processes(self, tmp_path: Path):
+        """Closing the operation must terminate any descendants the shell spawned,
+        not just the direct shell process (regression for GH #20979)."""
+        pid_file = tmp_path / "child.pid"
+        op = ShellOperation(
+            commands=[f"sleep 120 & echo $! > {pid_file}; wait"],
+        )
+        async with op:
+            proc = await op.atrigger()
+
+            # Wait for the inner `sleep` to spawn and record its PID.
+            for _ in range(50):
+                if pid_file.exists() and pid_file.read_text().strip():
+                    break
+                await asyncio.sleep(0.1)
+            else:
+                proc._process.terminate()
+                pytest.fail("inner sleep process did not start in time")
+
+            child_pid = int(pid_file.read_text().strip())
+            assert self._pid_alive(child_pid), "sleep process should be running"
+
+        # After exiting the context, the shell's descendants must be gone.
+        for _ in range(50):
+            if not self._pid_alive(child_pid):
+                break
+            await asyncio.sleep(0.1)
+        assert not self._pid_alive(child_pid), (
+            f"inner sleep (pid={child_pid}) was orphaned after aclose()"
+        )
+
+    def test_sync_close_terminates_descendant_processes(self, tmp_path: Path):
+        """Synchronous cleanup must terminate the shell's descendants, not just
+        the shell itself (regression for GH #20979)."""
+        import time as _time
+
+        from prefect_shell.commands import _terminate_process_tree
+
+        pid_file = tmp_path / "child.pid"
+        op = ShellOperation(
+            commands=[f"sleep 120 & echo $! > {pid_file}; wait"],
+        )
+        with op:
+            proc = op.trigger()
+
+            for _ in range(50):
+                if pid_file.exists() and pid_file.read_text().strip():
+                    break
+                _time.sleep(0.1)
+            else:
+                proc._process.kill()
+                pytest.fail("inner sleep process did not start in time")
+
+            child_pid = int(pid_file.read_text().strip())
+            assert self._pid_alive(child_pid), "sleep process should be running"
+
+            _terminate_process_tree(proc._process)
+            proc._process.wait(timeout=5)
+
+        for _ in range(50):
+            if not self._pid_alive(child_pid):
+                break
+            _time.sleep(0.1)
+        assert not self._pid_alive(child_pid), (
+            f"inner sleep (pid={child_pid}) was orphaned after tree termination"
+        )


### PR DESCRIPTION
closes #20979

## summary

`ShellOperation` spawned its subprocess in the same process group as the flow run. when the worker cancelled the flow run, `ProcessManager.kill()` signalled only the flow process's pid, and the shell's subprocess (and any child it spawned, like `sleep 9999`) outlived the flow, reparented to init.

## the fix

- spawn the shell in its own session / process group (`start_new_session=True` on posix, `CREATE_NEW_PROCESS_GROUP` on windows)
- on cleanup, signal the whole process group via `os.killpg` — not just the direct shell pid — so anything the shell spawned dies with it
- apply this to all three entry points: sync `run()` finally, async `arun()` finally, and the async context-manager path used by `atrigger()` via the exit stack

## repro

```python
from prefect import flow
from prefect_shell import ShellOperation

@flow
def sleepy():
    ShellOperation(commands=[\"sleep 9999\"]).run()
```

deploy to a process work pool, run, cancel via ui. before: `pgrep sleep` shows the 9999 still running after the flow transitions to `Cancelled`. after: the whole tree is gone.

## scope notes

this is a prefect-shell-only fix. the reporter also suggested the worker could kill the process group — that would also fix the broader class of \"user code spawns subprocess, flow cancels, subprocess orphans\" beyond just `ShellOperation`. keeping this pr small and surgical; the worker-side change is a reasonable follow-up.

## test plan

- [x] new tests (`TestShellOperationProcessGroup`, 4 cases) verify:
  - sync and async spawn paths make the shell a session leader
  - sync and async cleanup paths kill descendants, not just the shell
- [x] full prefect-shell suite passes (61 passed, 3 skipped, no regressions)
- [x] end-to-end with a real process worker: flow transitions to `Cancelled`, no orphan `sleep` / `bash` remains
- [x] mock tests in the existing suite still pass (the helper is guarded against non-int pids)