### PR TITLE
fix(prefect-shell): kill whole process tree on ShellOperation cleanup

### DIFF
--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -51,9 +51,8 @@ def _signal_process_tree(
 
     No-op on Windows — the process-group isolation in
     `_process_isolation_kwargs` is POSIX-only, so there is no matching tree
-    to signal on Windows. Windows cleanup goes through the direct
-    `subprocess.Popen.kill` / `terminate` on the caller side and is
-    unchanged from pre-PR behavior.
+    to signal on Windows. Windows cleanup relies on the direct
+    `subprocess.Popen.kill` / `terminate` on the caller side.
     """
     if sys.platform == "win32":
         return
@@ -81,27 +80,28 @@ def _signal_process_tree(
 def _close_sync_process_tree(process: subprocess.Popen[bytes]) -> None:
     """Synchronously terminate the process (tree on POSIX) and wait for exit.
 
-    POSIX: signal the process group with SIGTERM, wait up to
-    `_SHELL_TERMINATE_GRACE_SECONDS`, then escalate to SIGKILL if the
-    direct process has not exited.
+    POSIX: signal the process group with SIGTERM regardless of whether the
+    shell itself has already exited — detached descendants (e.g. `sleep 120 &`)
+    can outlive the shell and still share its process group. If the shell is
+    still running, wait up to `_SHELL_TERMINATE_GRACE_SECONDS`, then escalate
+    to SIGKILL on the group if it has not exited.
 
-    Windows: `process.kill()` + `process.wait()`, matching the pre-PR
-    cleanup in `run()`.
+    Windows: `process.kill()` + `process.wait()` if the process is still
+    running; no-op otherwise.
     """
-    if process.returncode is not None:
-        return
-
     if sys.platform == "win32":
-        process.kill()
-        process.wait()
+        if process.returncode is None:
+            process.kill()
+            process.wait()
         return
 
     _signal_process_tree(process, signal.SIGTERM)
-    try:
-        process.wait(timeout=_SHELL_TERMINATE_GRACE_SECONDS)
-    except subprocess.TimeoutExpired:
-        _signal_process_tree(process, signal.SIGKILL)
-        process.wait()
+    if process.returncode is None:
+        try:
+            process.wait(timeout=_SHELL_TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            _signal_process_tree(process, signal.SIGKILL)
+            process.wait()
 
 
 @task

--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -23,6 +24,84 @@ from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.blocks.abstract import JobBlock, JobRun
 from prefect.logging import get_run_logger
 from prefect.utilities.processutils import open_process
+
+_SHELL_TERMINATE_GRACE_SECONDS = 5.0
+
+
+def _process_isolation_kwargs() -> dict[str, Any]:
+    """Kwargs that place the spawned shell in its own process group.
+
+    Isolating the shell in a new session lets us signal the whole process
+    tree on cleanup instead of only the shell, so descendants like
+    `sleep 9999` don't outlive a cancelled flow run (GH #20979).
+
+    POSIX-only; Windows has a different process model and is not affected
+    by the bug this guards against.
+    """
+    if sys.platform == "win32":
+        return {}
+    return {"start_new_session": True}
+
+
+def _signal_process_tree(
+    process: Union[Process, subprocess.Popen[bytes]],
+    sig: int,
+) -> None:
+    """Send `sig` to the process and any descendants in its POSIX process group.
+
+    No-op on Windows — the process-group isolation in
+    `_process_isolation_kwargs` is POSIX-only, so there is no matching tree
+    to signal on Windows. Windows cleanup goes through the direct
+    `subprocess.Popen.kill` / `terminate` on the caller side and is
+    unchanged from pre-PR behavior.
+    """
+    if sys.platform == "win32":
+        return
+
+    pid = process.pid
+    if not isinstance(pid, int):
+        # Includes `None` and mocked processes used in tests.
+        return
+
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        # Leader already gone; any remaining descendants still share this pgid
+        # because we spawned with `start_new_session=True`.
+        pgid = pid
+    except PermissionError:
+        return
+
+    try:
+        os.killpg(pgid, sig)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def _close_sync_process_tree(process: subprocess.Popen[bytes]) -> None:
+    """Synchronously terminate the process (tree on POSIX) and wait for exit.
+
+    POSIX: signal the process group with SIGTERM, wait up to
+    `_SHELL_TERMINATE_GRACE_SECONDS`, then escalate to SIGKILL if the
+    direct process has not exited.
+
+    Windows: `process.kill()` + `process.wait()`, matching the pre-PR
+    cleanup in `run()`.
+    """
+    if process.returncode is not None:
+        return
+
+    if sys.platform == "win32":
+        process.kill()
+        process.wait()
+        return
+
+    _signal_process_tree(process, signal.SIGTERM)
+    try:
+        process.wait(timeout=_SHELL_TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        _signal_process_tree(process, signal.SIGKILL)
+        process.wait()
 
 
 @task
@@ -429,6 +508,7 @@ class ShellOperation(JobBlock[list[str]]):
             stderr=subprocess.PIPE,
             env=input_env,
             cwd=self.working_dir,
+            **_process_isolation_kwargs(),
             **open_kwargs,
         )
         return input_open_kwargs
@@ -448,6 +528,7 @@ class ShellOperation(JobBlock[list[str]]):
             stderr=subprocess.PIPE,
             env=input_env,
             cwd=self.working_dir,
+            **_process_isolation_kwargs(),
             **open_kwargs,
         )
         return input_open_kwargs
@@ -482,6 +563,10 @@ class ShellOperation(JobBlock[list[str]]):
         process = await self._exit_stack.enter_async_context(
             open_process(**input_open_kwargs)
         )
+        # Signal the shell's descendants before `open_process` unwinds, so its
+        # `process.terminate()` + `aclose()` cleanup doesn't leave descendants
+        # behind. Registered LIFO so it runs before `open_process.__aexit__`.
+        self._exit_stack.callback(_signal_process_tree, process, signal.SIGTERM)
         num_commands = len(self.commands)
         self.logger.info(
             f"PID {process.pid} triggered with {num_commands} commands running "
@@ -518,6 +603,10 @@ class ShellOperation(JobBlock[list[str]]):
         """
         input_open_kwargs = self._compile_kwargs_sync(**open_kwargs)
         process = subprocess.Popen(**input_open_kwargs)
+        # Ensure `close()` (and the `__exit__` that calls it) reclaims the
+        # subprocess tree instead of leaking it when a user exits the context
+        # without `wait_for_completion()`.
+        self._sync_exit_stack.callback(_close_sync_process_tree, process)
         num_commands = len(self.commands)
         self.logger.info(
             f"PID {process.pid} triggered with {num_commands} commands running "
@@ -551,14 +640,20 @@ class ShellOperation(JobBlock[list[str]]):
         """
         input_open_kwargs = self._compile_kwargs(**open_kwargs)
         async with open_process(**input_open_kwargs) as process:
-            shell_process = ShellProcess(shell_operation=self, process=process)
-            num_commands = len(self.commands)
-            self.logger.info(
-                f"PID {process.pid} triggered with {num_commands} commands running "
-                f"inside the {(self.working_dir or '.')!r} directory."
-            )
-            await shell_process.await_for_completion()
-            result = await shell_process.afetch_result()
+            try:
+                shell_process = ShellProcess(shell_operation=self, process=process)
+                num_commands = len(self.commands)
+                self.logger.info(
+                    f"PID {process.pid} triggered with {num_commands} commands running "
+                    f"inside the {(self.working_dir or '.')!r} directory."
+                )
+                await shell_process.await_for_completion()
+                result = await shell_process.afetch_result()
+            finally:
+                # Signal descendants of the shell to terminate. The enclosing
+                # `open_process` context manager handles the wait on the direct
+                # process during its own cleanup.
+                _signal_process_tree(process, signal.SIGTERM)
 
         return result
 
@@ -599,10 +694,8 @@ class ShellOperation(JobBlock[list[str]]):
             shell_process.wait_for_completion()
             result = shell_process.fetch_result()
         finally:
-            # Ensure process is cleaned up
-            if process.returncode is None:
-                process.kill()
-                process.wait()
+            # Ensure the whole process tree is cleaned up, not just the shell.
+            _close_sync_process_tree(process)
 
         return result
 

--- a/src/integrations/prefect-shell/tests/test_commands.py
+++ b/src/integrations/prefect-shell/tests/test_commands.py
@@ -388,3 +388,109 @@ class TestShellOperation:
         assert any("PID" in message and "stderr:" in message for message in messages)
         assert any("err1" in message for message in messages)
         assert any("err2" in message for message in messages)
+
+
+class TestShellOperationProcessGroup:
+    """Tests that ShellOperation subprocesses are isolated in their own process
+    group so that cleanup kills the whole process tree, not just the shell
+    (see GH #20979)."""
+
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError):
+            return False
+        return True
+
+    async def test_async_subprocess_is_own_session_leader(self, tmp_path: Path):
+        """The spawned shell should be a session leader so its whole process
+        tree can be signalled together."""
+        op = ShellOperation(commands=["sleep 30"])
+        async with op:
+            proc = await op.atrigger()
+            try:
+                assert os.getsid(proc.pid) == proc.pid, (
+                    f"Expected subprocess {proc.pid} to be its own session leader; "
+                    f"got sid={os.getsid(proc.pid)}"
+                )
+            finally:
+                proc._process.terminate()
+                await proc._process.wait()
+
+    def test_sync_subprocess_is_own_session_leader(self):
+        """The sync `trigger()` path should also place the shell in a new session."""
+        op = ShellOperation(commands=["sleep 30"])
+        with op:
+            proc = op.trigger()
+            try:
+                assert os.getsid(proc.pid) == proc.pid, (
+                    f"Expected subprocess {proc.pid} to be its own session leader; "
+                    f"got sid={os.getsid(proc.pid)}"
+                )
+            finally:
+                proc._process.kill()
+                proc._process.wait()
+
+    async def test_aclose_terminates_descendant_processes(self, tmp_path: Path):
+        """Closing the operation must terminate any descendants the shell spawned,
+        not just the direct shell process (regression for GH #20979)."""
+        pid_file = tmp_path / "child.pid"
+        op = ShellOperation(
+            commands=[f"sleep 120 & echo $! > {pid_file}; wait"],
+        )
+        async with op:
+            proc = await op.atrigger()
+
+            # Wait for the inner `sleep` to spawn and record its PID.
+            for _ in range(50):
+                if pid_file.exists() and pid_file.read_text().strip():
+                    break
+                await asyncio.sleep(0.1)
+            else:
+                proc._process.terminate()
+                pytest.fail("inner sleep process did not start in time")
+
+            child_pid = int(pid_file.read_text().strip())
+            assert self._pid_alive(child_pid), "sleep process should be running"
+
+        # After exiting the context, the shell's descendants must be gone.
+        for _ in range(50):
+            if not self._pid_alive(child_pid):
+                break
+            await asyncio.sleep(0.1)
+        assert not self._pid_alive(child_pid), (
+            f"inner sleep (pid={child_pid}) was orphaned after aclose()"
+        )
+
+    def test_sync_close_terminates_descendant_processes(self, tmp_path: Path):
+        """Exiting the sync context manager after `trigger()` must terminate the
+        shell's descendants, not just the shell itself (regression for GH #20979).
+        """
+        import time as _time
+
+        pid_file = tmp_path / "child.pid"
+        op = ShellOperation(
+            commands=[f"sleep 120 & echo $! > {pid_file}; wait"],
+        )
+        with op:
+            op.trigger()
+            for _ in range(50):
+                if pid_file.exists() and pid_file.read_text().strip():
+                    break
+                _time.sleep(0.1)
+            else:
+                pytest.fail("inner sleep process did not start in time")
+
+            child_pid = int(pid_file.read_text().strip())
+            assert self._pid_alive(child_pid), "sleep process should be running"
+
+        # After exiting the context manager, `close()` must have reclaimed the
+        # full process tree, not just the shell.
+        for _ in range(50):
+            if not self._pid_alive(child_pid):
+                break
+            _time.sleep(0.1)
+        assert not self._pid_alive(child_pid), (
+            f"inner sleep (pid={child_pid}) was orphaned after context exit"
+        )

--- a/src/integrations/prefect-shell/tests/test_commands.py
+++ b/src/integrations/prefect-shell/tests/test_commands.py
@@ -494,3 +494,43 @@ class TestShellOperationProcessGroup:
         assert not self._pid_alive(child_pid), (
             f"inner sleep (pid={child_pid}) was orphaned after context exit"
         )
+
+    def test_sync_close_terminates_detached_child_after_shell_exits(
+        self, tmp_path: Path
+    ):
+        """Even if the shell itself has already exited (e.g. it backgrounded a
+        child and returned without `wait`), `close()` must still signal the
+        process group so that detached descendants are reclaimed.
+        """
+        import time as _time
+
+        pid_file = tmp_path / "child.pid"
+        # Shell spawns `sleep 120` in the background and exits immediately,
+        # leaving the sleep running in the same (new) process group.
+        op = ShellOperation(
+            commands=[f"sleep 120 & echo $! > {pid_file}; disown; exit 0"],
+        )
+        with op:
+            proc = op.trigger()
+            for _ in range(50):
+                if pid_file.exists() and pid_file.read_text().strip():
+                    break
+                _time.sleep(0.1)
+            else:
+                pytest.fail("inner sleep process did not start in time")
+
+            child_pid = int(pid_file.read_text().strip())
+            assert self._pid_alive(child_pid), "sleep process should be running"
+
+            # Wait for the shell itself to exit so `returncode` is populated
+            # before context exit runs the cleanup callback.
+            proc._process.wait(timeout=5)
+            assert proc._process.returncode is not None
+
+        for _ in range(50):
+            if not self._pid_alive(child_pid):
+                break
+            _time.sleep(0.1)
+        assert not self._pid_alive(child_pid), (
+            f"detached child (pid={child_pid}) was orphaned after context exit"
+        )


### PR DESCRIPTION
closes #20979

## summary

on posix, `ShellOperation` spawned its subprocess in the same process group as the flow run. when the worker cancelled the flow run, `ProcessManager.kill()` signalled only the flow process's pid, and the shell's subprocess (and any child it spawned, like `sleep 9999`) outlived the flow, reparented to init.

## scope

- **posix:** targeted fix. isolate the shell with `start_new_session=True` and signal the whole process group on cleanup so descendants die with it.
- **windows:** existing paths (`run()`, `arun()`, `atrigger()`) are intentionally unchanged — the bug as reported is a posix signal/process-group concept and i couldn't verify an equivalent on windows. the only windows-visible change is that sync `trigger()` + `close()` now calls `process.kill()` instead of leaking the subprocess. standard `subprocess` api, no new windows-specific logic.

## the fix

- `_process_isolation_kwargs()` → `start_new_session=True` on posix, `{}` on windows
- `_signal_process_tree(process, sig)` → sends `sig` to the process group on posix, no-op on windows
- `_close_sync_process_tree(process)` → sync cleanup. posix: SIGTERM to group → `subprocess.wait(timeout=5)` → SIGKILL to group if needed. windows: `process.kill()` + `process.wait()` (same as pre-PR `run()` finally)
- applied to sync `run()` finally, async `arun()` finally, async `atrigger()` via `_exit_stack`, and sync `trigger()` via `_sync_exit_stack`

no internal polling loop — `subprocess.wait(timeout=)` on the sync side and `open_process`'s `process.aclose()` on the async side handle the wait. mirrors the pattern in core `ProcessManager.kill`.

## repro (linux)

```python
from prefect import flow
from prefect_shell import ShellOperation

@flow
def sleepy():
    ShellOperation(commands=["sleep 9999"]).run()
```

deploy to a process work pool, run, cancel via ui.

<details>
<summary>end-to-end repro on <code>main</code> shell code (bug present)</summary>

```
$ TOKEN="unfixed-$RANDOM"
$ RUN_ID=$(prefect deployment run 'sleepy-20979/sleepy-20979' --param token=$TOKEN)
  flow run id: ffcf0306-7f90-4086-a562-f882f734c5aa

$ ps -Ao pid,ppid,pgid,command | awk '/sleep 9999$/'
  98942 98941 98774 sleep 9999

$ ps -o pgid= -p 98941   # bash pgid
  98774
$ pgrep -f 'python -m prefect.engine' | xargs -I {} ps -o pgid= -p {}
  98774                  # flow pgid — same group as bash/sleep

$ prefect flow-run cancel $RUN_ID
  Flow run was successfully scheduled for cancellation.

# wait 35s for the grace period
$ prefect flow-run inspect $RUN_ID | grep state_name
      state_name='Cancelled'

$ ps -p 98942 >/dev/null && echo "BUG REPRODUCED"
  BUG REPRODUCED: sleep 98942 still alive after cancel
```
</details>

<details>
<summary>end-to-end repro on this branch (fix present)</summary>

```
$ TOKEN="v2-$RANDOM"
$ RUN_ID=$(prefect deployment run 'sleepy-20979/sleepy-20979' --param token=$TOKEN)
  flow run id: 3223e2d6-09c8-4954-bddc-75b7b5c07e6a

$ ps -Ao pid,ppid,command | awk '/sleep 9999$/'
  21327 21326 sleep 9999

$ prefect flow-run cancel $RUN_ID
  Flow run was successfully scheduled for cancellation.

$ prefect flow-run inspect $RUN_ID | grep state_name
      state_name='Cancelled'

$ ps -p 21327 >/dev/null && echo "sleep alive" || echo "sleep cleaned up"
  sleep cleaned up
$ ps -p 21326 >/dev/null && echo "bash alive"  || echo "bash cleaned up"
  bash cleaned up
```
</details>

## verification

**posix (linux):**
- [x] reproduced the orphan bug on `main`'s shell code with a deployed flow + real process worker + cancel via cli — `sleep` orphaned after the flow transitions to `Cancelled`
- [x] fix eliminates the orphan in the same scenario
- [x] direct subprocess repro (simulates the worker's SIGTERM path): 3/3 pre-fix reproduces, 3/3 post-fix clean
- [x] 4 new tests in `TestShellOperationProcessGroup` cover sync/async spawn (own session leader) and sync/async context-manager exit (descendants reclaimed)
- [x] full prefect-shell suite: 61 passed, 3 skipped, no regressions

**windows:**
- [x] ran the prefect-shell suite on `windows-latest` via a temporary CI workflow on this branch; all 31 tests that exercise modified code paths pass. one unrelated test (`test_shell_run_command_error_windows`) fails on a stale log-count assertion that has nothing to do with `ShellOperation` — same failure reproduces with this PR's code reverted. note: no main-branch CI currently runs this test, so it has silently drifted.
- [ ] the bug itself was not reproduced or verified on windows. the reported symptom is a posix signal/process-group concept without a direct windows analog. this PR does not claim to fix an orphan-subprocess bug on windows; it preserves existing windows behavior on the affected paths and incidentally fixes a sync `trigger()` + `close()` leak using standard `subprocess` api.