### PR TITLE
[DRAFT] Add defensive try/except in PrefectWrappedFuture.add_done_callback

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -180,8 +180,13 @@ class PrefectWrappedFuture(PrefectTaskRunFuture[R], abc.ABC, Generic[R, F]):
         if not self._final_state:
 
             def call_with_self(future: F):
-                """Call the callback with self as the argument, this is necessary to ensure we remove the future from the pending set"""
-                fn(self)
+                try:
+                    fn(self)
+                except Exception:
+                    logger.exception(
+                        "Exception in done callback for task run %s",
+                        self._task_run_id,
+                    )
 
             self._wrapped_future.add_done_callback(call_with_self)
             return

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -710,6 +710,50 @@ class TestPrefectFlowRunFuture:
             future.result()
 
 
+class TestPrefectWrappedFutureCallbackSafety:
+    def test_add_done_callback_logs_exception_from_callback(self, caplog):
+        """
+        Regression test: if a done callback raises, call_with_self must catch
+        and log the exception rather than letting it propagate into
+        concurrent.futures.Future._invoke_callbacks where it would be silently
+        swallowed. This ensures errors are visible in logs instead of causing
+        silent hangs.
+        """
+        import logging
+
+        inner = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), inner)
+
+        def exploding_callback(f):
+            raise RuntimeError("callback explosion")
+
+        future.add_done_callback(exploding_callback)
+
+        with caplog.at_level(logging.ERROR, logger="prefect.futures"):
+            inner.set_result(Completed(data=42))
+
+        assert any(
+            "Exception in done callback" in record.message
+            and "callback explosion" in record.exc_text
+            for record in caplog.records
+        ), f"Expected logged exception, got: {[r.message for r in caplog.records]}"
+
+    def test_add_done_callback_invokes_normally_on_success(self):
+        inner = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), inner)
+
+        results = []
+
+        def on_done(f):
+            results.append(f)
+
+        future.add_done_callback(on_done)
+        inner.set_result(Completed(data=99))
+
+        assert len(results) == 1
+        assert results[0] is future
+
+
 class TestPrefectFutureList:
     def test_wait(self):
         mock_futures = [MockFuture(data=i) for i in range(5)]


### PR DESCRIPTION
## Summary

Closes #21615

Follow-up to #21612. If a done callback raises inside `PrefectWrappedFuture.add_done_callback`'s `call_with_self` wrapper, the exception propagates into `concurrent.futures.Future._invoke_callbacks`, which silently catches and logs it via the stdlib logger. This makes errors invisible to Prefect's logging and can leave `_final_state` unset, causing flow runs to hang as zombies.

This is a defense-in-depth measure — #21612 fixed the specific `_UnpicklingFuture` deserialization case, but the same silent-hang pattern could be triggered by any unexpected exception in the callback chain.

- Wrapped `fn(self)` in `call_with_self` with a try/except that logs via Prefect's logger

## Test plan

- [x] `test_add_done_callback_logs_exception_from_callback` — registers a callback that raises `RuntimeError`, asserts the exception is logged via `prefect.futures` logger. **Verified FAILS without fix** (exception goes to `concurrent.futures` logger, not captured) **and PASSES after**
- [x] `test_add_done_callback_invokes_normally_on_success` — verifies happy path is unaffected
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)