### PR TITLE
Don't overwrite custom_headers Authorization with PREFECT_API_KEY in check_server_version

### DIFF
--- a/src/prefect/client/_version_checking.py
+++ b/src/prefect/client/_version_checking.py
@@ -142,7 +142,7 @@ async def check_server_version(
     if auth_string:
         token = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
         headers["Authorization"] = f"Basic {token}"
-    elif api_key:
+    elif api_key and "Authorization" not in headers:
         headers["Authorization"] = f"Bearer {api_key}"
     if headers:
         httpx_kwargs["headers"] = headers

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -3557,17 +3557,17 @@ class TestCheckServerVersionCustomHeaders:
                 assert request.headers["apikey"] == "my-secret-key"
                 assert request.headers["X-Custom"] == "value"
 
-    async def test_auth_headers_override_custom_headers(self):
-        """PREFECT_API_KEY auth should take precedence over a custom
-        Authorization header from PREFECT_CLIENT_CUSTOM_HEADERS."""
+    async def test_custom_headers_authorization_not_overwritten_by_api_key(self):
+        """Authorization from PREFECT_CLIENT_CUSTOM_HEADERS should not be
+        overwritten by PREFECT_API_KEY.  This matches the behavior of
+        PrefectHttpxAsyncClient, where custom_headers are applied after
+        api_key and therefore take precedence."""
         with temporary_settings(
             {
                 PREFECT_API_URL: "http://fake-server:4200/api",
                 PREFECT_API_KEY: "my-api-key",
                 PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True,
-                PREFECT_CLIENT_CUSTOM_HEADERS: {
-                    "Authorization": "Basic should-be-overridden"
-                },
+                PREFECT_CLIENT_CUSTOM_HEADERS: {"Authorization": "Bearer custom-token"},
             }
         ):
             with respx.mock:
@@ -3582,8 +3582,30 @@ class TestCheckServerVersionCustomHeaders:
 
                 assert route.called
                 request = route.calls[0].request
-                # PREFECT_API_KEY should win because it's applied after
-                # custom headers
+                assert request.headers["Authorization"] == "Bearer custom-token"
+
+    async def test_api_key_used_when_no_custom_authorization(self):
+        """PREFECT_API_KEY should be used when custom headers don't set Authorization."""
+        with temporary_settings(
+            {
+                PREFECT_API_URL: "http://fake-server:4200/api",
+                PREFECT_API_KEY: "my-api-key",
+                PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True,
+                PREFECT_CLIENT_CUSTOM_HEADERS: {"X-Custom": "value"},
+            }
+        ):
+            with respx.mock:
+                route = respx.get("http://fake-server:4200/api/admin/version").mock(
+                    return_value=httpx.Response(200, json=prefect.__version__)
+                )
+
+                await check_server_version(
+                    "http://fake-server:4200/api",
+                    logging.getLogger("test"),
+                )
+
+                assert route.called
+                request = route.calls[0].request
                 assert request.headers["Authorization"] == "Bearer my-api-key"
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

closes #21620

This PR fixes a regression introduced in #21053 where `check_server_version` would overwrite an `Authorization` header set via `PREFECT_CLIENT_CUSTOM_HEADERS` with `PREFECT_API_KEY`, causing a 401 on self-hosted servers that authenticate via custom headers when a Cloud API key is also present in the user's profile.                                                                                                   
The fix aligns `check_server_version` with `PrefectHttpxAsyncClient`:  `PREFECT_API_KEY` is only applied when `custom_headers` has not already set an `Authorization` header.  