### PR TITLE
Batch-acknowledge Redis stream messages to reduce round-trips

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -384,6 +384,8 @@ class Consumer(_Consumer):
             if not claimed_messages:
                 break
 
+            ids_to_ack: list[bytes] = []
+
             for message_id, message in claimed_messages:
                 if message is None:
                     msg_id_str = (
@@ -398,7 +400,21 @@ class Consumer(_Consumer):
                     )
                     await acker(message_id)
                     continue
-                await self._handle_message(message_id, message, handler, acker)
+                try:
+                    should_ack = await self._handle_message(
+                        message_id, message, handler, acker
+                    )
+                    if should_ack:
+                        ids_to_ack.append(message_id)
+                except StopConsumer as e:
+                    if e.ack:
+                        ids_to_ack.append(message_id)
+                    if self.automatically_acknowledge:
+                        await self._batch_ack(redis_client, ids_to_ack)
+                    raise
+
+            if self.automatically_acknowledge:
+                await self._batch_ack(redis_client, ids_to_ack)
 
             start_id = next_start_id
 
@@ -455,14 +471,21 @@ class Consumer(_Consumer):
                         continue
 
                     acker = partial(redis_client.xack, self.stream, self.group)
+                    ids_to_ack: list[bytes] = []
 
                     for _, messages in stream_entries:
                         for message_id, message in messages:
                             try:
-                                await self._handle_message(
+                                should_ack = await self._handle_message(
                                     message_id, message, handler, acker
                                 )
-                            except StopConsumer:
+                                if should_ack:
+                                    ids_to_ack.append(message_id)
+                            except StopConsumer as e:
+                                if e.ack:
+                                    ids_to_ack.append(message_id)
+                                if self.automatically_acknowledge:
+                                    await self._batch_ack(redis_client, ids_to_ack)
                                 return
                             except Exception:
                                 logger.exception(
@@ -471,6 +494,11 @@ class Consumer(_Consumer):
                                     message_id,
                                     self.name,
                                 )
+
+                    if self.automatically_acknowledge:
+                        await self._batch_ack(redis_client, ids_to_ack)
+
+                    await self._trim_stream_if_necessary()
 
             except RedisError as e:
                 # Connection lost or Redis error - log and retry with backoff
@@ -492,7 +520,9 @@ class Consumer(_Consumer):
         message: dict[str, Any],
         handler: MessageHandler,
         acker: Callable[..., Awaitable[int]],
-    ):
+    ) -> bool:
+        """Handle a single message. Returns True if the message should be
+        acknowledged, False if it failed and should stay pending for retry."""
         redis_stream_message = RedisStreamsMessage(
             data=message["data"],
             attributes=orjson.loads(message["attributes"]),
@@ -504,19 +534,19 @@ class Consumer(_Consumer):
 
         try:
             await handler(redis_stream_message)
-            if self.automatically_acknowledge:
-                await redis_stream_message.acknowledge()
+            return True
         except StopConsumer as e:
             if not e.ack:
                 await self._on_message_failure(redis_stream_message, msg_id_str)
-            else:
-                if self.automatically_acknowledge:
-                    await redis_stream_message.acknowledge()
             raise
         except Exception:
             await self._on_message_failure(redis_stream_message, msg_id_str)
-        finally:
-            await self._trim_stream_if_necessary()
+            return False
+
+    async def _batch_ack(self, redis_client: Redis, ids_to_ack: list[bytes]) -> None:
+        """Acknowledge message IDs in a single xack call."""
+        if ids_to_ack:
+            await redis_client.xack(self.stream, self.group, *ids_to_ack)
 
     async def _on_message_failure(self, msg: RedisStreamsMessage, msg_id_str: str):
         current_count = self._retry_counts.get(msg_id_str, 0) + 1

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -793,3 +793,95 @@ async def test_consumer_handles_orphan_pending_entries(
         "Should have received the real message after skipping orphan"
     )
     assert captured_messages[0].data == "real-message"
+
+
+async def test_batch_ack_excludes_failed_messages(
+    redis: Redis, broker: str, publisher: Publisher
+):
+    """Test that when multiple messages are read in a single batch, only
+    successfully handled messages are acknowledged. Failed messages should
+    remain pending for retry via xautoclaim."""
+    captured_messages: list[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        if message.data == "fail-me":
+            raise ValueError("Simulated failure")
+        if len(captured_messages) >= 3:
+            raise StopConsumer(ack=True)
+
+    consumer = create_consumer("message-tests", read_batch_size=10)
+
+    async with publisher as p:
+        await p.publish_data(b"good-1", {"id": "1"})
+        await p.publish_data(b"fail-me", {"id": "2"})
+        await p.publish_data(b"good-2", {"id": "3"})
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+    with anyio.move_on_after(5.0):
+        await consumer_task
+
+    assert any(m.data == "good-1" for m in captured_messages)
+    assert any(m.data == "good-2" for m in captured_messages)
+    assert any(m.data == "fail-me" for m in captured_messages)
+
+    # The failed message should still be pending (reclaimable)
+    test_consumer = create_consumer(
+        "message-tests", min_idle_time=timedelta(seconds=0.1)
+    )
+    await asyncio.sleep(0.2)
+    remaining = await drain_one(test_consumer)
+    assert remaining is not None, "Failed message should be reclaimable"
+    assert remaining.data == "fail-me"
+
+
+async def test_orphan_entries_acked_when_auto_ack_disabled(
+    redis: Redis, broker: str, publisher: Publisher
+):
+    """Orphan pending entries (stream entry deleted but PEL entry remains) must
+    be acknowledged even when automatically_acknowledge=False. Otherwise they
+    get reclaimed indefinitely."""
+    captured_messages: list[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    consumer = create_consumer(
+        "message-tests",
+        min_idle_time=timedelta(seconds=0),
+        automatically_acknowledge=False,
+    )
+
+    async with publisher as p:
+        await p.publish_data(b"real-message", {"id": "1"})
+
+    original_xautoclaim = Redis.xautoclaim
+    call_count = 0
+    orphan_id = b"9999999999999-0"
+
+    async def xautoclaim_with_orphan(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [b"0-0", [(orphan_id, None)], []]
+        return await original_xautoclaim(self, *args, **kwargs)
+
+    acked_ids: list[bytes] = []
+    original_xack = Redis.xack
+
+    async def tracking_xack(self, stream, group, *ids):
+        acked_ids.extend(ids)
+        return await original_xack(self, stream, group, *ids)
+
+    with (
+        patch.object(Redis, "xautoclaim", xautoclaim_with_orphan),
+        patch.object(Redis, "xack", tracking_xack),
+    ):
+        consumer_task = asyncio.create_task(consumer.run(handler))
+        with anyio.move_on_after(5.0):
+            await consumer_task
+
+    assert orphan_id in acked_ids, (
+        "Orphan entry should be acked even with automatically_acknowledge=False"
+    )


### PR DESCRIPTION
The Consumer was calling xack individually for each message after handling, requiring one Redis round-trip per message (~0.67ms each). With read_batch_size of 4096, this added ~2.7 seconds of pure ack overhead per batch.

Collect successfully handled message IDs and acknowledge them in a single xack call at the end of each batch. Failed messages are excluded and remain pending for retry via xautoclaim. Stream trimming is also moved from per-message to per-batch.

Measured end-to-end improvement: ~500 to ~780 messages/s per consumer (1.6x),
by eliminating ~2.7s of per-message xack overhead from each 4096-message batch.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
