### PR TITLE
feat(snowflake): SPCS worker improvements — crash diagnostics, pending state, partner ID

### DIFF
--- a/src/integrations/prefect-snowflake/prefect_snowflake/__init__.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/__init__.py
@@ -1,5 +1,6 @@
 from . import _version
 from prefect_snowflake.credentials import SnowflakeCredentials  # noqa
 from prefect_snowflake.database import SnowflakeConnector  # noqa
+import prefect_snowflake.experimental.workers.spcs  # noqa
 
 __version__ = _version.__version__

--- a/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
@@ -466,18 +466,12 @@ class SPCSWorker(BaseWorker):
     job_configuration_variables = SPCSServiceTemplateVariables
     _description = "Execute flow runs within containers on Snowflake's Snowpark Container Services. Requires a Snowflake account."
 
-    async def _start_service_and_build_identifier(
+    async def _start_service(
         self,
         flow_run: FlowRun,
         configuration: SPCSWorkerConfiguration,
-    ) -> tuple[str, str]:
-        """Start a SPCS job service and build its infrastructure identifier.
-
-        Returns:
-            A tuple of (job_service_name, identifier).
-        """
-        [database, schema, _] = configuration.compute_pool.split(".")
-
+    ) -> str:
+        """Start a SPCS job service and return its infrastructure identifier."""
         try:
             job_service_name = await run_sync_in_worker_thread(
                 self._create_and_start_service,
@@ -488,8 +482,7 @@ class SPCSWorker(BaseWorker):
             self._report_service_creation_failure(configuration, exc)
             raise
 
-        identifier = f"{database}.{schema}::{job_service_name}"
-        return job_service_name, identifier
+        return job_service_name
 
     async def _initiate_run(
         self,
@@ -500,11 +493,9 @@ class SPCSWorker(BaseWorker):
 
         Returns the infrastructure identifier for cancellation support.
         """
-        _, identifier = await self._start_service_and_build_identifier(
-            flow_run, configuration
-        )
-        self._logger.info(f"Initiated SPCS job service: {identifier}")
-        return identifier
+        job_service_name = await self._start_service(flow_run, configuration)
+        self._logger.info(f"Initiated SPCS job service: {job_service_name}")
+        return job_service_name
 
     async def run(
         self,
@@ -524,10 +515,8 @@ class SPCSWorker(BaseWorker):
             The result of the flow run.
 
         """
-        job_service_name, identifier = await self._start_service_and_build_identifier(
-            flow_run, configuration
-        )
-        self._logger.info(f"Created SPCS job service: {identifier}")
+        job_service_name = await self._start_service(flow_run, configuration)
+        self._logger.info(f"Created SPCS job service: {job_service_name}")
 
         try:
             async with prefect.get_client() as client:
@@ -547,7 +536,7 @@ class SPCSWorker(BaseWorker):
             )
 
         if task_status:
-            task_status.started(identifier)
+            task_status.started(job_service_name)
 
         job_status = await run_sync_in_worker_thread(
             self._watch_service,
@@ -559,7 +548,7 @@ class SPCSWorker(BaseWorker):
 
         return SPCSWorkerResult(
             status_code=exit_code,
-            identifier=identifier,
+            identifier=job_service_name,
         )
 
     async def kill_infrastructure(
@@ -568,13 +557,8 @@ class SPCSWorker(BaseWorker):
         configuration: SPCSWorkerConfiguration,
         grace_seconds: int = 30,
     ) -> None:
-        if "::" in infrastructure_pid:
-            database, schema, service_name = self._parse_infrastructure_pid(
-                infrastructure_pid
-            )
-        else:
-            database, schema, _ = configuration.compute_pool.split(".")
-            service_name = infrastructure_pid
+        database, schema, _ = configuration.compute_pool.split(".")
+        service_name = infrastructure_pid
 
         if grace_seconds != 30:
             self._logger.info(
@@ -614,22 +598,6 @@ class SPCSWorker(BaseWorker):
                     f"Service {database}.{schema}.{service_name} not found. "
                     "It may have already completed or been deleted."
                 )
-
-    @staticmethod
-    def _parse_infrastructure_pid(infrastructure_pid: str) -> tuple[str, str, str]:
-        if "::" not in infrastructure_pid:
-            raise ValueError(
-                f"Invalid infrastructure PID format: {infrastructure_pid!r}. "
-                "Expected 'database.schema::service_name'."
-            )
-        location, service_name = infrastructure_pid.split("::", 1)
-        parts = location.split(".", 1)
-        if len(parts) != 2:
-            raise ValueError(
-                f"Invalid location in infrastructure PID: {location!r}. "
-                "Expected 'database.schema'."
-            )
-        return parts[0], parts[1], service_name
 
     def _report_service_creation_failure(
         self, configuration: SPCSWorkerConfiguration, exc: Exception

--- a/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
@@ -568,9 +568,13 @@ class SPCSWorker(BaseWorker):
         configuration: SPCSWorkerConfiguration,
         grace_seconds: int = 30,
     ) -> None:
-        database, schema, service_name = self._parse_infrastructure_pid(
-            infrastructure_pid
-        )
+        if "::" in infrastructure_pid:
+            database, schema, service_name = self._parse_infrastructure_pid(
+                infrastructure_pid
+            )
+        else:
+            database, schema, _ = configuration.compute_pool.split(".")
+            service_name = infrastructure_pid
 
         if grace_seconds != 30:
             self._logger.info(

--- a/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import os
 import shlex
 import sys
@@ -24,10 +25,20 @@ from snowflake.core.service import (
     ServiceContainer,
     ServiceResource,
 )
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_fixed,
+    wait_random,
+)
 
+import prefect
 from prefect.client.schemas.objects import FlowRun
+from prefect.states import InfrastructurePending
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
+from prefect.utilities.engine import propose_state
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,
@@ -39,12 +50,37 @@ if TYPE_CHECKING:
     from prefect.server.schemas.core import Flow
     from prefect.server.schemas.responses import DeploymentResponse
 
+SUSPENDED_POOL_STATES = frozenset({"SUSPENDED"})
+TERMINAL_POOL_FAILURE_STATES = frozenset({"SUSPENDED"})
+
 SPCS_DEFAULT_CPU_REQUEST = "1"
 SPCS_DEFAULT_MEMORY_REQUEST = "1G"
 SPCS_DEFAULT_CPU_LIMIT = None
 SPCS_DEFAULT_MEMORY_LIMIT = None
 
 DEFAULT_CONTAINER_ENTRYPOINT = "/opt/prefect/entrypoint.sh"
+
+MAX_CREATE_SERVICE_ATTEMPTS = 3
+CREATE_SERVICE_MIN_DELAY_SECONDS = 1
+CREATE_SERVICE_MIN_DELAY_JITTER_SECONDS = 0
+CREATE_SERVICE_MAX_DELAY_JITTER_SECONDS = 3
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """Classify whether a Snowflake error is transient and worth retrying.
+
+    Transient: connection resets, timeouts, network blips, operational errors.
+    Permanent: auth failures, SQL syntax errors, object-not-found, privilege errors.
+    """
+    if isinstance(exc, snowflake.connector.errors.OperationalError):
+        return True
+    if isinstance(exc, snowflake.connector.errors.InterfaceError):
+        return True
+    if isinstance(exc, snowflake.connector.errors.DatabaseError):
+        msg = str(exc).lower()
+        if any(term in msg for term in ("connection", "timeout", "reset", "network")):
+            return True
+    return False
 
 
 def _get_default_job_manifest_template() -> dict[str, Any]:
@@ -57,7 +93,7 @@ def _get_default_job_manifest_template() -> dict[str, Any]:
                     "name": "{{ name }}",
                     "image": "{{ image }}",
                     "command": "{{ entrypoint }}",
-                    "args": " {{ command }}",
+                    "args": "{{ command }}",
                     "env": "{{ env }}",
                     "secrets": "{{ secrets }}",
                     "volumeMounts": "{{ volume_mounts }}",
@@ -122,7 +158,7 @@ class SPCSWorkerConfiguration(BaseJobConfiguration):
         default_factory=SnowflakeCredentials,
         description="Snowflake credentials to use when creating job services.",
     )
-    secrets: list[dict[str, str]] = Field(
+    secrets: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Snowflake secrets to inject into the container as env variables or files.",
     )
@@ -252,6 +288,9 @@ class SPCSWorkerConfiguration(BaseJobConfiguration):
         # There's only one container.
         container = self.job_manifest["spec"]["containers"][0]
 
+        # Set the container name (may be None from template if no name was configured)
+        container["name"] = self.name
+
         # Ensure an image is set.
         container["image"] = self.image
 
@@ -286,6 +325,13 @@ class SPCSWorkerConfiguration(BaseJobConfiguration):
         # Set memory_limit to the same value as memory_request, if not specified.
         if not self.memory_limit:
             container["resources"]["limits"]["memory"] = self.memory_request
+
+        if not self.cpu_limit:
+            container["resources"]["limits"].pop("cpu", None)
+
+        if not self.gpu_count:
+            container["resources"]["requests"].pop("nvidia.com/gpu", None)
+            container["resources"]["limits"].pop("nvidia.com/gpu", None)
 
         # Remove the platformMonitor section if there are no metrics groups.
         if not self.metrics_groups:
@@ -331,7 +377,7 @@ class SPCSServiceTemplateVariables(BaseVariables):
         default_factory=SnowflakeCredentials,
         description="Snowflake credentials to use when creating job services.",
     )
-    secrets: list[dict[str, str]] = Field(
+    secrets: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Snowflake secrets to inject into the container as env variables or files.",
     )
@@ -420,24 +466,45 @@ class SPCSWorker(BaseWorker):
     job_configuration_variables = SPCSServiceTemplateVariables
     _description = "Execute flow runs within containers on Snowflake's Snowpark Container Services. Requires a Snowflake account."
 
+    async def _start_service_and_build_identifier(
+        self,
+        flow_run: FlowRun,
+        configuration: SPCSWorkerConfiguration,
+    ) -> tuple[str, str]:
+        """Start a SPCS job service and build its infrastructure identifier.
+
+        Returns:
+            A tuple of (job_service_name, identifier).
+        """
+        [database, schema, _] = configuration.compute_pool.split(".")
+
+        try:
+            job_service_name = await run_sync_in_worker_thread(
+                self._create_and_start_service,
+                flow_run,
+                configuration,
+            )
+        except Exception as exc:
+            self._report_service_creation_failure(configuration, exc)
+            raise
+
+        identifier = f"{database}.{schema}::{job_service_name}"
+        return job_service_name, identifier
+
     async def _initiate_run(
         self,
         flow_run: FlowRun,
         configuration: SPCSWorkerConfiguration,
-    ) -> None:
-        """Initiates a flow run as a service job in Snowpark Container Services. This method does not wait for the flow run to complete.
+    ) -> str:
+        """Initiates a flow run as a service job in Snowpark Container Services.
 
-        Args:
-            flow_run: The flow run to run.
-            configuration: The configuration for the flow run.
-
+        Returns the infrastructure identifier for cancellation support.
         """
-        # Create the execution environment and start execution
-        await run_sync_in_worker_thread(
-            self._create_and_start_service,
-            flow_run,
-            configuration,
+        _, identifier = await self._start_service_and_build_identifier(
+            flow_run, configuration
         )
+        self._logger.info(f"Initiated SPCS job service: {identifier}")
+        return identifier
 
     async def run(
         self,
@@ -457,34 +524,152 @@ class SPCSWorker(BaseWorker):
             The result of the flow run.
 
         """
-        # Create the execution environment and start execution
-        job_service_name = await run_sync_in_worker_thread(
-            self._create_and_start_service,
-            flow_run,
-            configuration,
+        job_service_name, identifier = await self._start_service_and_build_identifier(
+            flow_run, configuration
         )
+        self._logger.info(f"Created SPCS job service: {identifier}")
+
+        try:
+            async with prefect.get_client() as client:
+                with anyio.move_on_after(5):
+                    await propose_state(
+                        client=client,
+                        state=InfrastructurePending(
+                            message="SPCS service is provisioning."
+                        ),
+                        flow_run_id=flow_run.id,
+                    )
+        except Exception:
+            self._logger.debug(
+                "Failed to propose InfrastructurePending for flow run %s",
+                flow_run.id,
+                exc_info=True,
+            )
 
         if task_status:
-            # Use a unique ID to mark the run as started.
-            # This ID is later used to tear down infrastructure, if the flow run is cancelled.
-            task_status.started(job_service_name)
+            task_status.started(identifier)
 
-        # Monitor the execution
         job_status = await run_sync_in_worker_thread(
             self._watch_service,
             job_service_name,
             configuration,
         )
 
-        exit_code = (
-            job_status if job_status is not None else -1
-        )  # Get the result of the execution for reporting
+        exit_code = job_status if job_status is not None else -1
 
         return SPCSWorkerResult(
             status_code=exit_code,
-            identifier=job_service_name,
+            identifier=identifier,
         )
 
+    async def kill_infrastructure(
+        self,
+        infrastructure_pid: str,
+        configuration: SPCSWorkerConfiguration,
+        grace_seconds: int = 30,
+    ) -> None:
+        database, schema, service_name = self._parse_infrastructure_pid(
+            infrastructure_pid
+        )
+
+        if grace_seconds != 30:
+            self._logger.info(
+                f"grace_seconds={grace_seconds} ignored; SPCS enforces a "
+                "built-in 30-second SIGTERM grace period."
+            )
+        self._logger.info(f"Dropping job service {service_name}...")
+
+        connection_parameters = self._get_snowflake_connection_parameters(configuration)
+
+        await run_sync_in_worker_thread(
+            self._drop_service,
+            database,
+            schema,
+            service_name,
+            connection_parameters,
+        )
+
+    def _drop_service(
+        self,
+        database: str,
+        schema: str,
+        service_name: str,
+        connection_parameters: dict[str, Any],
+    ) -> None:
+        from prefect.exceptions import InfrastructureNotFound
+
+        with snowflake.connector.connect(**connection_parameters) as session:
+            root = Root(session)
+            try:
+                service = (
+                    root.databases[database].schemas[schema].services[service_name]
+                )
+                service.drop()
+            except NotFoundError:
+                raise InfrastructureNotFound(
+                    f"Service {database}.{schema}.{service_name} not found. "
+                    "It may have already completed or been deleted."
+                )
+
+    @staticmethod
+    def _parse_infrastructure_pid(infrastructure_pid: str) -> tuple[str, str, str]:
+        if "::" not in infrastructure_pid:
+            raise ValueError(
+                f"Invalid infrastructure PID format: {infrastructure_pid!r}. "
+                "Expected 'database.schema::service_name'."
+            )
+        location, service_name = infrastructure_pid.split("::", 1)
+        parts = location.split(".", 1)
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid location in infrastructure PID: {location!r}. "
+                "Expected 'database.schema'."
+            )
+        return parts[0], parts[1], service_name
+
+    def _report_service_creation_failure(
+        self, configuration: SPCSWorkerConfiguration, exc: Exception
+    ) -> None:
+        """Wrap common Snowflake errors with actionable messages."""
+        msg = str(exc)
+        error_kind = "transient" if _is_transient_error(exc) else "permanent"
+        self._logger.debug(
+            f"Service creation failed ({error_kind}): {type(exc).__name__}: {msg}"
+        )
+
+        if isinstance(exc, snowflake.connector.errors.ProgrammingError):
+            if "does not exist" in msg.lower():
+                raise RuntimeError(
+                    f"Failed to create SPCS job service: {msg}. "
+                    "Verify that the compute pool, database, and schema exist "
+                    "and that the configured role has access. "
+                    f"Compute pool: {configuration.compute_pool}"
+                ) from exc
+            if "insufficient privileges" in msg.lower():
+                raise RuntimeError(
+                    "Failed to create SPCS job service: insufficient privileges. "
+                    "Ensure the configured role has USAGE on the compute pool "
+                    "and CREATE SERVICE on the schema. "
+                    f"Compute pool: {configuration.compute_pool}"
+                ) from exc
+        elif isinstance(exc, snowflake.connector.errors.DatabaseError):
+            if "connection" in msg.lower() or "timeout" in msg.lower():
+                raise RuntimeError(
+                    f"Failed to connect to Snowflake: {msg}. "
+                    "Check your network connectivity and Snowflake account credentials."
+                ) from exc
+        raise
+
+    @retry(
+        stop=stop_after_attempt(MAX_CREATE_SERVICE_ATTEMPTS),
+        wait=wait_fixed(CREATE_SERVICE_MIN_DELAY_SECONDS)
+        + wait_random(
+            CREATE_SERVICE_MIN_DELAY_JITTER_SECONDS,
+            CREATE_SERVICE_MAX_DELAY_JITTER_SECONDS,
+        ),
+        retry=retry_if_exception(_is_transient_error),
+        reraise=True,
+    )
     def _create_and_start_service(
         self,
         flow_run: FlowRun,
@@ -498,8 +683,17 @@ class SPCSWorker(BaseWorker):
         self._logger.info(
             f"Starting job service {job_service_name} in compute pool {compute_pool}..."
         )
+        self._logger.debug(
+            f"Job manifest: {json.dumps(configuration.job_manifest, indent=2, default=str)}"
+        )
 
         connection_parameters = self._get_snowflake_connection_parameters(configuration)
+        auth_method = (
+            "in-Snowflake OAuth"
+            if os.getenv("SNOWFLAKE_HOST")
+            else "external credentials"
+        )
+        self._logger.info(f"Connecting to Snowflake using {auth_method}")
 
         with snowflake.connector.connect(**connection_parameters) as session:
             # The Snowflake Python SDK currently doesn't support creating a service and
@@ -575,19 +769,24 @@ class SPCSWorker(BaseWorker):
             while True:
                 pool_state = pool.fetch().state
 
-                # Wait until the compute pool is active. It might be idle, resizing, etc.
-                if pool_state == "ACTIVE":
+                if pool_state in TERMINAL_POOL_FAILURE_STATES:
+                    raise RuntimeError(
+                        f"Compute pool {compute_pool} is in state {pool_state}. "
+                        "Resume it with ALTER COMPUTE POOL ... RESUME before running flows."
+                    )
+
+                if pool_state in ("ACTIVE", "IDLE"):
                     break
 
                 elapsed_time = time.time() - pool_start_time_seconds
 
                 if pool_timeout and elapsed_time > pool_timeout:
                     raise RuntimeError(
-                        f"Timed out after {elapsed_time} s while waiting for compute pool start."
+                        f"Timed out after {elapsed_time} s while waiting for compute pool to become ready."
                     )
 
                 self._logger.info(
-                    f"Compute pool {compute_pool} is in state {pool_state}, checking for ACTIVE state again in {configuration.service_watch_poll_interval} seconds."
+                    f"Compute pool {compute_pool} is {pool_state}, waiting for ready state (polling in {configuration.service_watch_poll_interval}s)."
                 )
                 time.sleep(configuration.service_watch_poll_interval)
 
@@ -599,6 +798,7 @@ class SPCSWorker(BaseWorker):
                 root.databases[database].schemas[schema].services[job_service_name]
             )
             last_log_time = service_start_datetime
+            service_status: str | None = None
 
             while True:
                 # Sleep first, give the job service a chance to start.
@@ -609,17 +809,32 @@ class SPCSWorker(BaseWorker):
                     container = next(service.get_containers())
                     service_status = container.service_status
 
-                    # If status == PENDING or similar, we'll get an exception if we try to retrieve logs.
-                    if configuration.stream_output and service_status in (
+                    # Stream logs during execution if configured, and always
+                    # forward final logs on failure (matches K8s/ECS behavior).
+                    should_stream = configuration.stream_output and service_status in (
                         "RUNNING",
                         "DONE",
                         "FAILED",
-                    ):
-                        last_log_time = self._get_and_stream_output(
-                            service=service,
-                            container=container,
-                            last_log_time=last_log_time,
-                        )
+                    )
+                    should_forward_crash_logs = (
+                        not configuration.stream_output
+                        and service_status in ("FAILED", "INTERNAL_ERROR")
+                    )
+                    if should_stream or should_forward_crash_logs:
+                        try:
+                            last_log_time = self._get_and_stream_output(
+                                service=service,
+                                container=container,
+                                last_log_time=last_log_time,
+                            )
+                        except Exception:
+                            if should_forward_crash_logs:
+                                self._logger.debug(
+                                    f"Failed to retrieve crash logs for {job_service_name}",
+                                    exc_info=True,
+                                )
+                            else:
+                                raise
 
                     # If status in one of these, the container is no longer running.
                     if service_status in (
@@ -644,7 +859,68 @@ class SPCSWorker(BaseWorker):
                         f"Service {job_service_name} isn't running yet, polling for status again in {configuration.service_watch_poll_interval} seconds."
                     )
 
-        return 0
+        if service_status is None:
+            self._logger.warning(
+                f"Service {job_service_name} loop exited without determining status"
+            )
+            return -1
+
+        if service_status == "DONE":
+            self._logger.info(f"Service {job_service_name} completed successfully.")
+            return 0
+
+        self._log_service_failure_diagnostic(job_service_name, service_status)
+        return 1
+
+    def _log_service_failure_diagnostic(
+        self,
+        job_service_name: str,
+        service_status: str,
+    ) -> None:
+        _DIAGNOSTICS: dict[str, tuple[str, str]] = {
+            "FAILED": (
+                "error",
+                "Container exited with an error. Check the Snowflake event "
+                "table for detailed logs: "
+                "SELECT * FROM <event_table> WHERE RESOURCE_ATTRIBUTES['snow.service.name'] = "
+                f"'{job_service_name}' ORDER BY TIMESTAMP DESC LIMIT 50;",
+            ),
+            "INTERNAL_ERROR": (
+                "error",
+                "Snowflake encountered an internal platform error. This is "
+                "typically transient — retry the flow run. Contact Snowflake "
+                "support if it persists.",
+            ),
+            "SUSPENDING": (
+                "warning",
+                "Service is being suspended. The compute pool may have been "
+                "suspended or auto-suspended due to inactivity. Resume with: "
+                "ALTER COMPUTE POOL <pool> RESUME;",
+            ),
+            "SUSPENDED": (
+                "warning",
+                "Service was suspended. The compute pool may have been "
+                "suspended or auto-suspended due to inactivity. Resume with: "
+                "ALTER COMPUTE POOL <pool> RESUME;",
+            ),
+            "DELETING": (
+                "warning",
+                "Service is being deleted. This may indicate manual "
+                "cancellation or automatic cleanup.",
+            ),
+            "DELETED": (
+                "warning",
+                "Service was deleted externally. This may indicate manual "
+                "cancellation or automatic cleanup.",
+            ),
+        }
+
+        level, message = _DIAGNOSTICS.get(
+            service_status,
+            ("warning", f"ended with unexpected status {service_status}"),
+        )
+        log_fn = self._logger.error if level == "error" else self._logger.warning
+        log_fn(f"Service {job_service_name}: {message}")
 
     @staticmethod
     def _get_snowflake_connection_parameters(
@@ -667,14 +943,21 @@ class SPCSWorker(BaseWorker):
                 "account": os.getenv("SNOWFLAKE_ACCOUNT"),
                 "token": Path("/snowflake/session/token").read_text(),
                 "authenticator": "oauth",
+                "application": "Prefect_Snowflake_Collection",
             }
         else:
-            connection_parameters = {
-                "account": configuration.snowflake_credentials.account,
-                "user": configuration.snowflake_credentials.user,
-                "private_key": configuration.snowflake_credentials.resolve_private_key(),
-                "role": configuration.snowflake_credentials.role,
+            creds = configuration.snowflake_credentials
+            connection_parameters: dict[str, Any] = {
+                "account": creds.account,
+                "user": creds.user,
+                "role": creds.role,
+                "application": "Prefect_Snowflake_Collection",
             }
+            private_key = creds.resolve_private_key()
+            if private_key is not None:
+                connection_parameters["private_key"] = private_key
+            elif creds.password is not None:
+                connection_parameters["password"] = creds.password.get_secret_value()
 
         return connection_parameters
 

--- a/src/integrations/prefect-snowflake/pyproject.toml
+++ b/src/integrations/prefect-snowflake/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "snowflake>=1.5.0",
   "snowflake-connector-python>=3.17.2",
   "prefect>=3.0.0",
+  "tenacity>=8.0.0",
 ]
 dynamic = ["version"]
 description = "Prefect integrations for interacting with Snowflake"

--- a/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
+++ b/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
@@ -16,6 +16,7 @@ from prefect_snowflake.experimental.workers.spcs import (
 from prefect.client.schemas import FlowRun
 from prefect.server.schemas.core import Flow
 from prefect.utilities.dockerutils import get_prefect_image_name
+from prefect.workers.base import BaseWorker
 
 
 def create_mock_snowflake_connection():
@@ -207,6 +208,13 @@ def worker_flow_run(worker_flow):
 
 
 # Tests
+def test_spcs_worker_registered_for_cli_discovery():
+    assert (
+        BaseWorker.get_worker_class_from_type("snowpark-container-service")
+        is SPCSWorker
+    )
+
+
 async def test_worker_valid_command_validation(snowflake_credentials, worker_flow_run):
     # ensure the validator allows valid commands to pass through
     command = "command arg1 arg2"
@@ -1168,6 +1176,29 @@ async def test_kill_infrastructure_drops_service(
     async with SPCSWorker(work_pool_name="test-pool") as worker:
         await worker.kill_infrastructure(
             infrastructure_pid="mydb.myschema::test_service",
+            configuration=config,
+        )
+
+    mock_service.drop.assert_called_once()
+
+
+async def test_kill_infrastructure_drops_legacy_service_name_pid(
+    snowflake_credentials,
+    worker_flow_run,
+    mock_snowflake_root,
+):
+    config = await create_job_configuration(
+        snowflake_credentials,
+        worker_flow_run,
+        {"compute_pool": "mydb.myschema.test_pool"},
+    )
+
+    mock_schema = mock_snowflake_root.databases["mydb"].schemas["myschema"]
+    mock_service = mock_schema.services["test_service"]
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        await worker.kill_infrastructure(
+            infrastructure_pid="test_service",
             configuration=config,
         )
 

--- a/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
+++ b/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
@@ -388,8 +388,6 @@ async def test_worker_run_with_task_status(
     mock_task_status.started.assert_called_once()
     identifier = mock_task_status.started.call_args.args[0]
     assert identifier is not None
-    assert "::" in identifier
-    assert identifier.startswith("common.compute::")
     assert "test_flow_run" in identifier
 
 
@@ -1175,29 +1173,6 @@ async def test_kill_infrastructure_drops_service(
 
     async with SPCSWorker(work_pool_name="test-pool") as worker:
         await worker.kill_infrastructure(
-            infrastructure_pid="mydb.myschema::test_service",
-            configuration=config,
-        )
-
-    mock_service.drop.assert_called_once()
-
-
-async def test_kill_infrastructure_drops_legacy_service_name_pid(
-    snowflake_credentials,
-    worker_flow_run,
-    mock_snowflake_root,
-):
-    config = await create_job_configuration(
-        snowflake_credentials,
-        worker_flow_run,
-        {"compute_pool": "mydb.myschema.test_pool"},
-    )
-
-    mock_schema = mock_snowflake_root.databases["mydb"].schemas["myschema"]
-    mock_service = mock_schema.services["test_service"]
-
-    async with SPCSWorker(work_pool_name="test-pool") as worker:
-        await worker.kill_infrastructure(
             infrastructure_pid="test_service",
             configuration=config,
         )
@@ -1223,28 +1198,9 @@ async def test_kill_infrastructure_raises_not_found(
     async with SPCSWorker(work_pool_name="test-pool") as worker:
         with pytest.raises(InfrastructureNotFound, match="not found"):
             await worker.kill_infrastructure(
-                infrastructure_pid="mydb.myschema::gone_service",
+                infrastructure_pid="gone_service",
                 configuration=config,
             )
-
-
-def test_parse_infrastructure_pid_valid():
-    db, schema, name = SPCSWorker._parse_infrastructure_pid(
-        "my_database.my_schema::my_service_name"
-    )
-    assert db == "my_database"
-    assert schema == "my_schema"
-    assert name == "my_service_name"
-
-
-def test_parse_infrastructure_pid_invalid_no_separator():
-    with pytest.raises(ValueError, match="Invalid infrastructure PID format"):
-        SPCSWorker._parse_infrastructure_pid("just_a_service_name")
-
-
-def test_parse_infrastructure_pid_invalid_no_dot():
-    with pytest.raises(ValueError, match="Invalid location"):
-        SPCSWorker._parse_infrastructure_pid("nodot::service_name")
 
 
 # Retry and error wrapping tests
@@ -1338,8 +1294,7 @@ async def test_initiate_run_returns_identifier(snowflake_credentials, worker_flo
         )
 
     assert identifier is not None
-    assert "::" in identifier
-    assert identifier.startswith("common.compute::")
+    assert "test_flow_run" in identifier
 
 
 async def test_initiate_run_wraps_errors(
@@ -1596,7 +1551,7 @@ class TestGraceSeconds:
 
         async with SPCSWorker(work_pool_name="test-pool") as worker:
             await worker.kill_infrastructure(
-                infrastructure_pid="mydb.myschema::test_service",
+                infrastructure_pid="test_service",
                 configuration=config,
                 grace_seconds=30,
             )
@@ -1618,7 +1573,7 @@ class TestGraceSeconds:
         with caplog.at_level(logging.INFO):
             async with SPCSWorker(work_pool_name="test-pool") as worker:
                 await worker.kill_infrastructure(
-                    infrastructure_pid="mydb.myschema::test_service",
+                    infrastructure_pid="test_service",
                     configuration=config,
                     grace_seconds=60,
                 )
@@ -2208,12 +2163,12 @@ class TestWorkerMetadata:
         assert "variables" in template
 
     def test_worker_result_type(self):
-        result = SPCSWorkerResult(status_code=0, identifier="db.schema::svc")
+        result = SPCSWorkerResult(status_code=0, identifier="svc")
         assert result.status_code == 0
-        assert result.identifier == "db.schema::svc"
+        assert result.identifier == "svc"
 
     def test_worker_result_failure(self):
-        result = SPCSWorkerResult(status_code=1, identifier="db.schema::svc")
+        result = SPCSWorkerResult(status_code=1, identifier="svc")
         assert result.status_code == 1
 
 

--- a/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
+++ b/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
@@ -10,6 +10,7 @@ from prefect_snowflake.experimental.workers.spcs import (
     SPCSWorker,
     SPCSWorkerConfiguration,
     SPCSWorkerResult,
+    _is_transient_error,
 )
 
 from prefect.client.schemas import FlowRun
@@ -377,9 +378,11 @@ async def test_worker_run_with_task_status(
         )
 
     mock_task_status.started.assert_called_once()
-    service_name = mock_task_status.started.call_args.args[0]
-    assert service_name is not None
-    assert "test_flow_run" in service_name
+    identifier = mock_task_status.started.call_args.args[0]
+    assert identifier is not None
+    assert "::" in identifier
+    assert identifier.startswith("common.compute::")
+    assert "test_flow_run" in identifier
 
 
 async def test_create_and_start_service_sql_generation(
@@ -435,7 +438,7 @@ async def test_watch_service_waits_for_pool_activation(
         nonlocal call_count
         call_count += 1
         mock_pool_state = MagicMock()
-        mock_pool_state.state = "ACTIVE" if call_count > 2 else "IDLE"
+        mock_pool_state.state = "ACTIVE" if call_count > 2 else "STARTING"
         return mock_pool_state
 
     mock_pool.fetch.side_effect = pool_fetch_side_effect
@@ -475,7 +478,7 @@ async def test_watch_service_pool_timeout(
     mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
     mock_pool = mock_schema.compute_pools["test_pool"]
     mock_pool_state = MagicMock()
-    mock_pool_state.state = "IDLE"
+    mock_pool_state.state = "STARTING"
     mock_pool.fetch.return_value = mock_pool_state
 
     config = await create_job_configuration(
@@ -486,7 +489,7 @@ async def test_watch_service_pool_timeout(
 
     async with SPCSWorker(work_pool_name="test-pool") as worker:
         with pytest.raises(
-            RuntimeError, match="Timed out.*while waiting for compute pool start"
+            RuntimeError, match="Timed out.*while waiting for compute pool"
         ):
             worker._watch_service("test_service", config)
 
@@ -505,14 +508,16 @@ async def test_watch_service_handles_different_states(
     )
 
     for state in ["DONE", "FAILED", "SUSPENDED", "DELETED", "INTERNAL_ERROR"]:
-        exit_code_val = 0 if state == "DONE" else 1
-        mock_service.get_containers.side_effect = lambda s=state, ec=exit_code_val: (
-            iter([create_mock_service_container(s, exit_code=ec)])
+        expected_exit_code = 0 if state == "DONE" else 1
+        mock_service.get_containers.side_effect = lambda s=state: iter(
+            [create_mock_service_container(s)]
         )
 
         async with SPCSWorker(work_pool_name="test-pool") as worker:
             exit_code = worker._watch_service(service_name, config)
-            assert exit_code == 0
+            assert exit_code == expected_exit_code, (
+                f"Expected exit code {expected_exit_code} for state {state}, got {exit_code}"
+            )
 
 
 async def test_watch_service_timeout_on_start(
@@ -563,8 +568,45 @@ async def test_get_snowflake_connection_parameters_external():
 
     assert params["account"] == "test_account"
     assert params["user"] == "test_user"
+    assert params["password"] == "test_password"
+    assert params["role"] == "test_role"
+    assert params["application"] == "Prefect_Snowflake_Collection"
+    assert "private_key" not in params
+
+
+async def test_get_snowflake_connection_parameters_external_private_key():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    credentials = SnowflakeCredentials(
+        account="test_account",
+        user="test_user",
+        private_key=pem,
+        role="test_role",
+        authenticator="snowflake_jwt",
+    )
+
+    config = SPCSWorkerConfiguration(
+        snowflake_credentials=credentials,
+        compute_pool="common.compute.test_pool",
+        image_registry="common.compute.test_registry",
+        job_manifest={"spec": {"containers": []}},
+    )
+
+    params = SPCSWorker._get_snowflake_connection_parameters(config)
+
+    assert params["account"] == "test_account"
+    assert params["user"] == "test_user"
     assert "private_key" in params
     assert params["role"] == "test_role"
+    assert "password" not in params
 
 
 async def test_get_snowflake_connection_parameters_in_snowflake(monkeypatch, tmp_path):
@@ -597,6 +639,7 @@ async def test_get_snowflake_connection_parameters_in_snowflake(monkeypatch, tmp
     assert params["account"] == "test-account"
     assert params["token"] == "test-token"
     assert params["authenticator"] == "oauth"
+    assert params["application"] == "Prefect_Snowflake_Collection"
 
 
 async def test_get_and_stream_output(snowflake_credentials, worker_flow_run):
@@ -708,6 +751,31 @@ async def test_job_manifest_memory_limit_defaults(
     assert container["resources"]["limits"]["memory"] == "2G"
 
 
+async def test_job_manifest_omits_empty_resource_values(
+    snowflake_credentials, worker_flow_run
+):
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    container = config.job_manifest["spec"]["containers"][0]
+
+    assert "cpu" not in container["resources"]["limits"]
+    assert "nvidia.com/gpu" not in container["resources"]["requests"]
+    assert "nvidia.com/gpu" not in container["resources"]["limits"]
+
+
+async def test_job_manifest_includes_gpu_count_when_positive(
+    snowflake_credentials, worker_flow_run
+):
+    config = await create_job_configuration(
+        snowflake_credentials, worker_flow_run, {"gpu_count": 1}
+    )
+
+    container = config.job_manifest["spec"]["containers"][0]
+
+    assert container["resources"]["requests"]["nvidia.com/gpu"] == 1
+    assert container["resources"]["limits"]["nvidia.com/gpu"] == 1
+
+
 async def test_job_manifest_removes_platform_monitor_without_metrics(
     snowflake_credentials, worker_flow_run
 ):
@@ -767,6 +835,8 @@ async def test_validation_errors(
 async def test_handle_snowflake_connection_error(
     snowflake_credentials, worker_flow_run, monkeypatch
 ):
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
     def raise_connection_error(*args, **kwargs):
         raise snowflake.connector.errors.DatabaseError("Connection failed")
 
@@ -775,15 +845,14 @@ async def test_handle_snowflake_connection_error(
     config = await create_job_configuration(snowflake_credentials, worker_flow_run)
 
     async with SPCSWorker(work_pool_name="test-pool") as worker:
-        with pytest.raises(
-            snowflake.connector.errors.DatabaseError, match="Connection failed"
-        ):
+        with pytest.raises(RuntimeError, match="Failed to connect to Snowflake"):
             await worker.run(flow_run=worker_flow_run, configuration=config)
 
 
 async def test_handle_service_creation_sql_error(
-    snowflake_credentials, worker_flow_run, mock_snowflake_connection
+    snowflake_credentials, worker_flow_run, mock_snowflake_connection, monkeypatch
 ):
+    monkeypatch.setattr("time.sleep", lambda _: None)
     mock_connect, mock_connection, mock_cursor = mock_snowflake_connection
 
     mock_cursor.execute.side_effect = snowflake.connector.errors.ProgrammingError(
@@ -793,7 +862,7 @@ async def test_handle_service_creation_sql_error(
     config = await create_job_configuration(snowflake_credentials, worker_flow_run)
 
     async with SPCSWorker(work_pool_name="test-pool") as worker:
-        with pytest.raises(snowflake.connector.errors.ProgrammingError):
+        with pytest.raises(RuntimeError, match="Verify that the compute pool"):
             await worker.run(flow_run=worker_flow_run, configuration=config)
 
 
@@ -817,8 +886,7 @@ async def test_service_enters_failed_state(
     async with SPCSWorker(work_pool_name="test-pool") as worker:
         result = await worker.run(flow_run=worker_flow_run, configuration=config)
 
-    # Worker should still return successfully, letting Prefect handle the failure
-    assert result.status_code == 0
+    assert result.status_code == 1
 
 
 async def test_service_enters_internal_error_state(
@@ -841,8 +909,7 @@ async def test_service_enters_internal_error_state(
     async with SPCSWorker(work_pool_name="test-pool") as worker:
         result = await worker.run(flow_run=worker_flow_run, configuration=config)
 
-    # Worker returns 0, Prefect handles the actual failure
-    assert result.status_code == 0
+    assert result.status_code == 1
 
 
 async def test_connection_lost_during_monitoring(
@@ -1083,3 +1150,1380 @@ async def test_sql_uses_bind_parameters_for_all_user_inputs(
     assert "eai1" in params
     assert "eai2" in params
     assert "eai3" in params
+
+
+# kill_infrastructure / cancellation tests
+
+
+async def test_kill_infrastructure_drops_service(
+    snowflake_credentials,
+    worker_flow_run,
+    mock_snowflake_root,
+):
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    mock_schema = mock_snowflake_root.databases["mydb"].schemas["myschema"]
+    mock_service = mock_schema.services["test_service"]
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        await worker.kill_infrastructure(
+            infrastructure_pid="mydb.myschema::test_service",
+            configuration=config,
+        )
+
+    mock_service.drop.assert_called_once()
+
+
+async def test_kill_infrastructure_raises_not_found(
+    snowflake_credentials,
+    worker_flow_run,
+    mock_snowflake_root,
+):
+    from snowflake.core.exceptions import NotFoundError
+
+    from prefect.exceptions import InfrastructureNotFound
+
+    mock_schema = mock_snowflake_root.databases["mydb"].schemas["myschema"]
+    mock_service = mock_schema.services["gone_service"]
+    mock_service.drop.side_effect = NotFoundError("not found")
+
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        with pytest.raises(InfrastructureNotFound, match="not found"):
+            await worker.kill_infrastructure(
+                infrastructure_pid="mydb.myschema::gone_service",
+                configuration=config,
+            )
+
+
+def test_parse_infrastructure_pid_valid():
+    db, schema, name = SPCSWorker._parse_infrastructure_pid(
+        "my_database.my_schema::my_service_name"
+    )
+    assert db == "my_database"
+    assert schema == "my_schema"
+    assert name == "my_service_name"
+
+
+def test_parse_infrastructure_pid_invalid_no_separator():
+    with pytest.raises(ValueError, match="Invalid infrastructure PID format"):
+        SPCSWorker._parse_infrastructure_pid("just_a_service_name")
+
+
+def test_parse_infrastructure_pid_invalid_no_dot():
+    with pytest.raises(ValueError, match="Invalid location"):
+        SPCSWorker._parse_infrastructure_pid("nodot::service_name")
+
+
+# Retry and error wrapping tests
+
+
+async def test_create_service_retries_on_transient_failure(
+    snowflake_credentials, worker_flow_run, mock_snowflake_connection, monkeypatch
+):
+    """Test that service creation retries on transient Snowflake errors."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    _, _, mock_cursor = mock_snowflake_connection
+
+    call_count = [0]
+
+    def execute_with_transient_failure(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise snowflake.connector.errors.OperationalError("Connection reset")
+
+    mock_cursor.execute.side_effect = execute_with_transient_failure
+
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        service_name = worker._create_and_start_service(
+            flow_run=worker_flow_run, configuration=config
+        )
+
+    assert call_count[0] == 2
+    assert service_name is not None
+
+
+async def test_run_wraps_object_not_found_error(
+    snowflake_credentials, worker_flow_run, mock_snowflake_connection, monkeypatch
+):
+    """Test that ProgrammingError with 'does not exist' is wrapped with actionable message."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    _, _, mock_cursor = mock_snowflake_connection
+    mock_cursor.execute.side_effect = snowflake.connector.errors.ProgrammingError(
+        "SQL compilation error: Object 'BAD_POOL' does not exist"
+    )
+
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        with pytest.raises(RuntimeError, match="Verify that the compute pool"):
+            await worker.run(flow_run=worker_flow_run, configuration=config)
+
+
+async def test_run_wraps_insufficient_privileges_error(
+    snowflake_credentials, worker_flow_run, mock_snowflake_connection, monkeypatch
+):
+    """Test that ProgrammingError with 'insufficient privileges' is wrapped."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    _, _, mock_cursor = mock_snowflake_connection
+    mock_cursor.execute.side_effect = snowflake.connector.errors.ProgrammingError(
+        "Insufficient privileges to operate on compute pool"
+    )
+
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        with pytest.raises(RuntimeError, match="insufficient privileges"):
+            await worker.run(flow_run=worker_flow_run, configuration=config)
+
+
+async def test_run_wraps_connection_error_with_context(
+    snowflake_credentials, worker_flow_run, mock_snowflake_connection, monkeypatch
+):
+    """Test that DatabaseError with connection issues is wrapped."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    _, _, mock_cursor = mock_snowflake_connection
+    mock_cursor.execute.side_effect = snowflake.connector.errors.DatabaseError(
+        "Connection timeout after 30 seconds"
+    )
+
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        with pytest.raises(RuntimeError, match="Check your network connectivity"):
+            await worker.run(flow_run=worker_flow_run, configuration=config)
+
+
+async def test_initiate_run_returns_identifier(snowflake_credentials, worker_flow_run):
+    """Test that _initiate_run returns the infrastructure identifier."""
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        identifier = await worker._initiate_run(
+            flow_run=worker_flow_run, configuration=config
+        )
+
+    assert identifier is not None
+    assert "::" in identifier
+    assert identifier.startswith("common.compute::")
+
+
+async def test_initiate_run_wraps_errors(
+    snowflake_credentials, worker_flow_run, mock_snowflake_connection, monkeypatch
+):
+    """Test that _initiate_run wraps errors like run() does."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    _, _, mock_cursor = mock_snowflake_connection
+    mock_cursor.execute.side_effect = snowflake.connector.errors.ProgrammingError(
+        "Object 'MISSING' does not exist"
+    )
+
+    config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+    async with SPCSWorker(work_pool_name="test-pool") as worker:
+        with pytest.raises(RuntimeError, match="Verify that the compute pool"):
+            await worker._initiate_run(flow_run=worker_flow_run, configuration=config)
+
+
+# ---- Error classification tests ----
+
+
+class TestErrorClassification:
+    """Tests for _is_transient_error and structured error handling."""
+
+    def test_operational_error_is_transient(self):
+        exc = snowflake.connector.errors.OperationalError("Connection reset by peer")
+        assert _is_transient_error(exc) is True
+
+    def test_interface_error_is_transient(self):
+        exc = snowflake.connector.errors.InterfaceError("Failed to connect")
+        assert _is_transient_error(exc) is True
+
+    def test_database_error_with_connection_keyword_is_transient(self):
+        exc = snowflake.connector.errors.DatabaseError("Connection lost during query")
+        assert _is_transient_error(exc) is True
+
+    def test_database_error_with_timeout_keyword_is_transient(self):
+        exc = snowflake.connector.errors.DatabaseError("Timeout after 30 seconds")
+        assert _is_transient_error(exc) is True
+
+    def test_database_error_with_reset_keyword_is_transient(self):
+        exc = snowflake.connector.errors.DatabaseError("Connection reset")
+        assert _is_transient_error(exc) is True
+
+    def test_database_error_with_network_keyword_is_transient(self):
+        exc = snowflake.connector.errors.DatabaseError("Network is unreachable")
+        assert _is_transient_error(exc) is True
+
+    def test_programming_error_is_permanent(self):
+        exc = snowflake.connector.errors.ProgrammingError("SQL compilation error")
+        assert _is_transient_error(exc) is False
+
+    def test_database_error_without_transient_keywords_is_permanent(self):
+        exc = snowflake.connector.errors.DatabaseError(
+            "Insufficient privileges to execute"
+        )
+        assert _is_transient_error(exc) is False
+
+    def test_generic_exception_is_permanent(self):
+        exc = ValueError("Something went wrong")
+        assert _is_transient_error(exc) is False
+
+    def test_runtime_error_is_permanent(self):
+        exc = RuntimeError("Unexpected failure")
+        assert _is_transient_error(exc) is False
+
+
+class TestRetryBehavior:
+    """Tests for retry decorator with error classification."""
+
+    async def test_permanent_error_not_retried(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_connection,
+        monkeypatch,
+    ):
+        """Permanent errors should fail immediately without retrying."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _, _, mock_cursor = mock_snowflake_connection
+
+        mock_cursor.execute.side_effect = snowflake.connector.errors.ProgrammingError(
+            "SQL compilation error: Object does not exist"
+        )
+
+        config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            with pytest.raises(RuntimeError, match="Verify that the compute pool"):
+                await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        # Permanent error: should be called exactly once (no retries)
+        assert mock_cursor.execute.call_count == 1
+
+    async def test_transient_error_retried_then_succeeds(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_connection,
+        monkeypatch,
+    ):
+        """Transient errors should be retried up to MAX_CREATE_SERVICE_ATTEMPTS."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _, _, mock_cursor = mock_snowflake_connection
+
+        call_count = [0]
+
+        def execute_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise snowflake.connector.errors.OperationalError(
+                    "Connection reset by peer"
+                )
+
+        mock_cursor.execute.side_effect = execute_side_effect
+
+        config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            result = await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        assert result.status_code == 0
+        assert call_count[0] == 2  # First call fails, second succeeds
+
+    async def test_transient_error_exhausts_retries(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_connection,
+        monkeypatch,
+    ):
+        """Transient errors that persist should exhaust all retry attempts."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _, _, mock_cursor = mock_snowflake_connection
+
+        mock_cursor.execute.side_effect = snowflake.connector.errors.OperationalError(
+            "Connection reset by peer"
+        )
+
+        config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            # OperationalError is a DatabaseError subclass with "connection" in the message,
+            # so _report_service_creation_failure wraps it as RuntimeError
+            with pytest.raises(RuntimeError, match="Check your network connectivity"):
+                await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        # Should have been called MAX_CREATE_SERVICE_ATTEMPTS times
+        assert mock_cursor.execute.call_count == 3
+
+
+# ---- Compute pool validation tests ----
+
+
+class TestComputePoolValidation:
+    """Tests for pre-run compute pool state validation."""
+
+    async def test_suspended_pool_fails_fast(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """A SUSPENDED compute pool should fail immediately, not wait for timeout."""
+        mock_pool = mock_snowflake_root.compute_pools["test_pool"]
+        mock_pool_state = MagicMock()
+        mock_pool_state.state = "SUSPENDED"
+        mock_pool.fetch.return_value = mock_pool_state
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            with pytest.raises(RuntimeError, match="SUSPENDED.*Resume it"):
+                worker._watch_service("test_service", config)
+
+        # Should fail after a single check, not loop until timeout
+        assert mock_pool.fetch.call_count == 1
+
+    async def test_idle_pool_is_ready(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """An IDLE pool is ready — the worker should not wait for ACTIVE."""
+        mock_pool = mock_snowflake_root.compute_pools["test_pool"]
+
+        mock_state = MagicMock()
+        mock_state.state = "IDLE"
+        mock_pool.fetch.return_value = mock_state
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service("test_service", config)
+
+        assert exit_code == 0
+        assert mock_pool.fetch.call_count == 1
+
+    async def test_resizing_pool_waits_for_active(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """A RESIZING pool should be waited on until it becomes ACTIVE."""
+        mock_pool = mock_snowflake_root.compute_pools["test_pool"]
+
+        states = iter(["RESIZING", "ACTIVE"])
+
+        def fetch_side_effect():
+            state = MagicMock()
+            state.state = next(states)
+            return state
+
+        mock_pool.fetch.side_effect = fetch_side_effect
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service("test_service", config)
+
+        assert exit_code == 0
+
+
+# ---- Grace seconds tests ----
+
+
+class TestGraceSeconds:
+    """Tests for kill_infrastructure grace_seconds handling."""
+
+    async def test_default_grace_seconds_no_warning(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+        caplog,
+    ):
+        """Default grace_seconds (30) should not produce a warning."""
+        config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            await worker.kill_infrastructure(
+                infrastructure_pid="mydb.myschema::test_service",
+                configuration=config,
+                grace_seconds=30,
+            )
+
+        assert "grace_seconds=" not in caplog.text
+
+    async def test_custom_grace_seconds_logs_info(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+        caplog,
+    ):
+        """Non-default grace_seconds should log an info message."""
+        import logging
+
+        config = await create_job_configuration(snowflake_credentials, worker_flow_run)
+
+        with caplog.at_level(logging.INFO):
+            async with SPCSWorker(work_pool_name="test-pool") as worker:
+                await worker.kill_infrastructure(
+                    infrastructure_pid="mydb.myschema::test_service",
+                    configuration=config,
+                    grace_seconds=60,
+                )
+
+        assert "grace_seconds=60 ignored" in caplog.text
+        assert "built-in 30-second SIGTERM" in caplog.text
+
+
+# ---- Environment variable tests ----
+
+
+class TestEnvironmentVariables:
+    """Tests for environment variable handling and inheritance."""
+
+    async def test_base_environment_variables_present(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """Base Prefect environment variables should always be set."""
+        config = await create_job_configuration(
+            snowflake_credentials, worker_flow_run, {"env": {}}
+        )
+        container = config.job_manifest["spec"]["containers"][0]
+
+        assert "PREFECT__FLOW_RUN_ID" in container["env"]
+        assert container["env"]["PREFECT__FLOW_RUN_ID"] == str(worker_flow_run.id)
+
+    async def test_custom_env_merged_with_base(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """Custom environment variables should be merged with base variables."""
+        custom_env = {"MY_VAR": "my_value", "ANOTHER": "value2"}
+        config = await create_job_configuration(
+            snowflake_credentials, worker_flow_run, {"env": custom_env}
+        )
+        container = config.job_manifest["spec"]["containers"][0]
+
+        # Custom vars present
+        assert container["env"]["MY_VAR"] == "my_value"
+        assert container["env"]["ANOTHER"] == "value2"
+        # Base vars also present
+        assert "PREFECT__FLOW_RUN_ID" in container["env"]
+
+    async def test_custom_env_overrides_base(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """Custom env vars should override base vars with the same key."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"env": {"PREFECT__FLOW_RUN_ID": "custom-override"}},
+        )
+        container = config.job_manifest["spec"]["containers"][0]
+
+        assert container["env"]["PREFECT__FLOW_RUN_ID"] == "custom-override"
+
+    async def test_api_auth_string_removed_with_secret(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """PREFECT_API_AUTH_STRING should be removed from env when a matching secret exists."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {
+                "secrets": [
+                    {
+                        "envVarName": "PREFECT_API_AUTH_STRING",
+                        "snowflakeSecret": "auth_secret",
+                    }
+                ],
+                "env": {"PREFECT_API_AUTH_STRING": "should-be-removed"},
+            },
+        )
+        container = config.job_manifest["spec"]["containers"][0]
+        assert "PREFECT_API_AUTH_STRING" not in container["env"]
+
+    async def test_api_key_kept_without_matching_secret(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """PREFECT_API_KEY should be kept if no matching secret is configured."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {
+                "secrets": [{"envVarName": "OTHER_SECRET", "snowflakeSecret": "other"}],
+                "env": {"PREFECT_API_KEY": "keep-this"},
+            },
+        )
+        container = config.job_manifest["spec"]["containers"][0]
+        assert container["env"]["PREFECT_API_KEY"] == "keep-this"
+
+
+# ---- Log streaming tests ----
+
+
+class TestLogStreaming:
+    """Tests for log streaming edge cases."""
+
+    async def test_stream_output_empty_string(self):
+        """Empty log content should return the original last_log_time."""
+        worker = SPCSWorker(work_pool_name="test-pool")
+        last_time = datetime.datetime(
+            2025, 10, 27, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        result = worker._stream_output("", last_time)
+        assert result == last_time
+
+    async def test_stream_output_only_whitespace(self):
+        """Whitespace-only lines should be skipped."""
+        worker = SPCSWorker(work_pool_name="test-pool")
+        last_time = datetime.datetime(
+            2025, 10, 27, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        result = worker._stream_output("   \n\n  \n", last_time)
+        assert result == last_time
+
+    async def test_stream_output_malformed_timestamp(self):
+        """Lines with unparsable timestamps should be skipped gracefully."""
+        worker = SPCSWorker(work_pool_name="test-pool")
+        last_time = datetime.datetime(
+            2025, 10, 27, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        result = worker._stream_output("not-a-timestamp Some log message", last_time)
+        assert result == last_time
+
+    async def test_stream_output_filters_old_and_keeps_new(self, capsys):
+        """Only lines newer than last_log_time should be streamed."""
+        worker = SPCSWorker(work_pool_name="test-pool")
+        last_time = datetime.datetime(
+            2025, 10, 27, 10, 0, 2, tzinfo=datetime.timezone.utc
+        )
+
+        log_content = (
+            "2025-10-27T10:00:00.000Z Old log line\n"
+            "2025-10-27T10:00:01.000Z Also old\n"
+            "2025-10-27T10:00:05.000Z New log line\n"
+            "2025-10-27T10:00:10.000Z Also new"
+        )
+
+        result = worker._stream_output(log_content, last_time)
+
+        captured = capsys.readouterr()
+        assert "Old log line" not in captured.err
+        assert "Also old" not in captured.err
+        assert "New log line" in captured.err
+        assert "Also new" in captured.err
+        assert result == datetime.datetime(
+            2025, 10, 27, 10, 0, 10, tzinfo=datetime.timezone.utc
+        )
+
+    async def test_stream_output_during_running_state(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """Log streaming should work when service is in RUNNING state."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        call_count = [0]
+
+        def get_containers_side_effect():
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return iter([create_mock_service_container("RUNNING")])
+            return iter([create_mock_service_container("DONE")])
+
+        mock_service.get_containers.side_effect = get_containers_side_effect
+        mock_service.get_service_logs.return_value = (
+            "2025-10-27T10:00:05.000Z Running flow..."
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": True},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service(service_name, config)
+
+        assert exit_code == 0
+        assert mock_service.get_service_logs.call_count >= 1
+
+
+# ---- Service lifecycle tests ----
+
+
+class TestServiceLifecycle:
+    """Tests for full service lifecycle: create → monitor → complete."""
+
+    async def test_running_then_done_returns_zero(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """Service that transitions RUNNING → DONE should return exit code 0."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        call_count = [0]
+
+        def get_containers_side_effect():
+            call_count[0] += 1
+            if call_count[0] <= 3:
+                return iter([create_mock_service_container("RUNNING")])
+            return iter([create_mock_service_container("DONE")])
+
+        mock_service.get_containers.side_effect = get_containers_side_effect
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            result = await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        assert result.status_code == 0
+        assert call_count[0] > 1
+
+    async def test_pending_then_running_then_done(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """Service that goes PENDING → RUNNING → DONE should succeed."""
+        from snowflake.core.exceptions import NotFoundError
+
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        call_count = [0]
+
+        def get_containers_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise NotFoundError("Not ready yet")
+            elif call_count[0] <= 3:
+                return iter([create_mock_service_container("RUNNING")])
+            return iter([create_mock_service_container("DONE")])
+
+        mock_service.get_containers.side_effect = get_containers_side_effect
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            result = await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        assert result.status_code == 0
+
+    async def test_suspending_returns_failure(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """Service that enters SUSPENDING state should return non-zero."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("SUSPENDING")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            result = await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        assert result.status_code == 1
+
+    async def test_deleting_returns_failure(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """Service that enters DELETING state should return non-zero."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("DELETING")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            result = await worker.run(flow_run=worker_flow_run, configuration=config)
+
+        assert result.status_code == 1
+
+
+# ---- Slugify edge case tests ----
+
+
+class TestSlugify:
+    """Tests for service name slugification edge cases."""
+
+    def test_empty_service_name_returns_none(self):
+        result = SPCSWorker._slugify_service_name("", uuid.uuid4())
+        assert result is None
+
+    def test_none_service_name_returns_none(self):
+        result = SPCSWorker._slugify_service_name(None, uuid.uuid4())
+        assert result is None
+
+    def test_special_characters_cleaned(self):
+        flow_run_id = uuid.uuid4()
+        result = SPCSWorker._slugify_service_name("My Flow! @#$% Name", flow_run_id)
+        assert result is not None
+        assert "@" not in result
+        assert "#" not in result
+        assert "$" not in result
+        assert "%" not in result
+        assert result.endswith(str(flow_run_id).replace("-", "_"))
+
+    def test_unicode_characters_cleaned(self):
+        flow_run_id = uuid.uuid4()
+        result = SPCSWorker._slugify_service_name("Fluß Wörk", flow_run_id)
+        assert result is not None
+        assert all(c.isalnum() or c in ("-", "_") for c in result)
+
+    def test_very_long_name_truncated_to_63(self):
+        flow_run_id = uuid.uuid4()
+        long_name = "A" * 200
+        result = SPCSWorker._slugify_service_name(long_name, flow_run_id)
+        assert len(result) <= 63
+
+    def test_underscores_in_name_preserved(self):
+        flow_run_id = uuid.uuid4()
+        result = SPCSWorker._slugify_service_name("my_flow_name", flow_run_id)
+        assert result is not None
+        assert "my_flow_name" in result
+
+
+# ---- Concurrent run isolation tests ----
+
+
+class TestConcurrentRunIsolation:
+    """Tests for concurrent runs producing unique service names."""
+
+    async def test_unique_service_names_per_flow_run(
+        self,
+        snowflake_credentials,
+        worker_flow,
+    ):
+        """Each flow run should get a unique service name."""
+        flow_runs = [
+            FlowRun(
+                id=uuid.uuid4(),
+                flow_id=worker_flow.id,
+                name=f"test-flow-run-{i}",
+            )
+            for i in range(5)
+        ]
+
+        names = set()
+        for fr in flow_runs:
+            name = SPCSWorker._slugify_service_name("test-flow", fr.id)
+            names.add(name)
+
+        assert len(names) == 5
+
+    async def test_same_flow_different_runs_get_different_names(
+        self,
+        snowflake_credentials,
+        worker_flow,
+    ):
+        """Same flow name but different run IDs should produce different service names."""
+        id1 = uuid.uuid4()
+        id2 = uuid.uuid4()
+
+        name1 = SPCSWorker._slugify_service_name("identical-flow", id1)
+        name2 = SPCSWorker._slugify_service_name("identical-flow", id2)
+
+        assert name1 != name2
+        assert name1.startswith("identical_flow_")
+        assert name2.startswith("identical_flow_")
+
+
+# ---- Configuration edge case tests ----
+
+
+class TestConfigurationEdgeCases:
+    """Tests for configuration validation edge cases."""
+
+    async def test_compute_pool_missing_raises(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """Missing compute_pool should raise during prepare_for_flow_run."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"compute_pool": None},
+            run_prep=False,
+        )
+        with pytest.raises(ValueError, match="compute_pool is required"):
+            config.prepare_for_flow_run(worker_flow_run)
+
+    async def test_cpu_limit_empty_string_raises(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """Empty string cpu_limit should raise."""
+        with pytest.raises(ValueError, match="cpu_limit cannot be empty"):
+            await create_job_configuration(
+                snowflake_credentials,
+                worker_flow_run,
+                {"cpu_limit": "  "},
+            )
+
+    async def test_memory_limit_empty_string_raises(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """Empty string memory_limit should raise."""
+        with pytest.raises(ValueError, match="memory_limit cannot be empty"):
+            await create_job_configuration(
+                snowflake_credentials,
+                worker_flow_run,
+                {"memory_limit": "  "},
+            )
+
+    async def test_gpu_count_zero_is_valid(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """gpu_count=0 should be valid (explicitly no GPUs)."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"gpu_count": 0},
+        )
+        assert config.gpu_count == 0
+
+    async def test_explicit_memory_limit_used(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """When memory_limit is explicitly set, it should be used instead of memory_request."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"memory_request": "2G", "memory_limit": "4G"},
+        )
+        container = config.job_manifest["spec"]["containers"][0]
+        assert container["resources"]["requests"]["memory"] == "2G"
+        assert container["resources"]["limits"]["memory"] == "4G"
+
+    async def test_metrics_groups_present_keeps_platform_monitor(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+    ):
+        """When metrics_groups is non-empty, platformMonitor should be kept."""
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"metrics_groups": ["system.all"]},
+        )
+        assert "platformMonitor" in config.job_manifest["spec"]
+
+    async def test_no_external_access_integrations_omits_clause(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_connection,
+    ):
+        """When no EAIs are configured, the SQL should not include the clause."""
+        _, _, mock_cursor = mock_snowflake_connection
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"external_access_integrations": []},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            worker._create_and_start_service(
+                flow_run=worker_flow_run, configuration=config
+            )
+
+        sql_cmd = mock_cursor.execute.call_args[0][0]
+        assert "EXTERNAL_ACCESS_INTEGRATIONS" not in sql_cmd
+
+    async def test_no_query_warehouse_omits_clause(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_connection,
+    ):
+        """When no query_warehouse is configured, the SQL should not include it."""
+        _, _, mock_cursor = mock_snowflake_connection
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"query_warehouse": None},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            worker._create_and_start_service(
+                flow_run=worker_flow_run, configuration=config
+            )
+
+        sql_cmd = mock_cursor.execute.call_args[0][0]
+        assert "QUERY_WAREHOUSE" not in sql_cmd
+
+    async def test_no_service_comment_omits_clause(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_connection,
+    ):
+        """When no service_comment is configured, the SQL should not include it."""
+        _, _, mock_cursor = mock_snowflake_connection
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_comment": None},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            worker._create_and_start_service(
+                flow_run=worker_flow_run, configuration=config
+            )
+
+        sql_cmd = mock_cursor.execute.call_args[0][0]
+        assert "COMMENT" not in sql_cmd
+
+
+# ---- Worker type and metadata tests ----
+
+
+class TestWorkerMetadata:
+    """Tests for worker type, description, and configuration metadata."""
+
+    def test_worker_type(self):
+        assert SPCSWorker.type == "snowpark-container-service"
+
+    def test_worker_has_description(self):
+        assert SPCSWorker._description is not None
+        assert len(SPCSWorker._description) > 0
+
+    def test_default_base_job_template_structure(self):
+        template = SPCSWorker.get_default_base_job_template()
+        assert "job_configuration" in template
+        assert "variables" in template
+
+    def test_worker_result_type(self):
+        result = SPCSWorkerResult(status_code=0, identifier="db.schema::svc")
+        assert result.status_code == 0
+        assert result.identifier == "db.schema::svc"
+
+    def test_worker_result_failure(self):
+        result = SPCSWorkerResult(status_code=1, identifier="db.schema::svc")
+        assert result.status_code == 1
+
+
+# ---- Crash log forwarding and diagnostics tests ----
+
+
+class TestCrashLogForwarding:
+    """Tests for crash log forwarding when stream_output=False."""
+
+    async def test_crash_logs_forwarded_on_failure_without_stream_output(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """When stream_output=False and service FAILED, logs should still be fetched."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("FAILED")]
+        )
+        mock_service.get_service_logs.return_value = (
+            "2025-10-27T10:00:05.000Z Error: container crashed"
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service(service_name, config)
+
+        assert exit_code == 1
+        assert mock_service.get_service_logs.call_count >= 1
+
+    async def test_crash_logs_forwarded_on_internal_error_without_stream_output(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """When stream_output=False and service hits INTERNAL_ERROR, logs should still be fetched."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("INTERNAL_ERROR")]
+        )
+        mock_service.get_service_logs.return_value = (
+            "2025-10-27T10:00:05.000Z Internal error occurred"
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service(service_name, config)
+
+        assert exit_code == 1
+        assert mock_service.get_service_logs.call_count >= 1
+
+    async def test_crash_log_retrieval_failure_does_not_raise(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """If crash log retrieval fails, it should be swallowed (not crash the worker)."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("FAILED")]
+        )
+        mock_service.get_service_logs.side_effect = Exception("Log retrieval failed")
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service(service_name, config)
+
+        assert exit_code == 1
+
+    async def test_no_crash_logs_for_non_failure_states(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """DONE state without stream_output should NOT fetch logs."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("DONE")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            exit_code = worker._watch_service(service_name, config)
+
+        assert exit_code == 0
+        assert mock_service.get_service_logs.call_count == 0
+
+
+class TestFailureDiagnostics:
+    """Tests for structured failure diagnostic messages."""
+
+    async def test_failed_service_logs_error_with_event_table_hint(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+        caplog,
+    ):
+        """FAILED status should log an error with event table query hint."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("FAILED")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            import logging
+
+            with caplog.at_level(logging.ERROR):
+                worker._watch_service(service_name, config)
+
+        assert (
+            "event table" in caplog.text.lower() or "event_table" in caplog.text.lower()
+        )
+
+    async def test_internal_error_logs_retry_guidance(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+        caplog,
+    ):
+        """INTERNAL_ERROR should log guidance about retrying."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("INTERNAL_ERROR")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            import logging
+
+            with caplog.at_level(logging.ERROR):
+                worker._watch_service(service_name, config)
+
+        assert "transient" in caplog.text.lower() or "retry" in caplog.text.lower()
+
+    async def test_suspended_service_logs_resume_guidance(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+        caplog,
+    ):
+        """SUSPENDED status should log guidance about resuming the compute pool."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("SUSPENDED")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            import logging
+
+            with caplog.at_level(logging.WARNING):
+                worker._watch_service(service_name, config)
+
+        assert "resume" in caplog.text.lower()
+
+    async def test_deleted_service_logs_cancellation_hint(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+        caplog,
+    ):
+        """DELETED status should log a hint about external cancellation."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+
+        mock_service.get_containers.side_effect = lambda: iter(
+            [create_mock_service_container("DELETED")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1, "stream_output": False},
+        )
+
+        async with SPCSWorker(work_pool_name="test-pool") as worker:
+            import logging
+
+            with caplog.at_level(logging.WARNING):
+                worker._watch_service(service_name, config)
+
+        assert "cancel" in caplog.text.lower() or "deleted" in caplog.text.lower()
+
+
+class TestInfrastructurePending:
+    """Tests for InfrastructurePending state proposal during run()."""
+
+    async def test_run_proposes_infrastructure_pending(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """run() should propose InfrastructurePending after creating the service."""
+
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+        mock_service.get_containers.return_value = iter(
+            [create_mock_service_container("DONE")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        mock_client = AsyncMock()
+        mock_client.set_flow_run_state = AsyncMock(
+            return_value=MagicMock(status=MagicMock(value="ACCEPT"))
+        )
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "prefect_snowflake.experimental.workers.spcs.prefect"
+        ) as mock_prefect:
+            mock_prefect.get_client.return_value = mock_ctx
+            with patch(
+                "prefect_snowflake.experimental.workers.spcs.propose_state",
+                new_callable=AsyncMock,
+            ) as mock_propose:
+                async with SPCSWorker(work_pool_name="test-pool") as worker:
+                    result = await worker.run(
+                        flow_run=worker_flow_run, configuration=config
+                    )
+
+        assert result.status_code == 0
+        mock_propose.assert_called_once()
+        call_kwargs = mock_propose.call_args
+        proposed_state = call_kwargs.kwargs.get("state") or call_kwargs[1].get(
+            "state", call_kwargs[0][1] if len(call_kwargs[0]) > 1 else None
+        )
+        assert proposed_state is not None
+        assert proposed_state.name == "InfrastructurePending"
+        proposed_flow_run_id = call_kwargs.kwargs.get("flow_run_id") or call_kwargs[
+            1
+        ].get("flow_run_id")
+        assert proposed_flow_run_id == worker_flow_run.id
+
+    async def test_run_continues_if_pending_proposal_fails(
+        self,
+        snowflake_credentials,
+        worker_flow_run,
+        mock_snowflake_root,
+    ):
+        """run() should still complete even if InfrastructurePending proposal fails."""
+        service_name = "test_service"
+        mock_schema = mock_snowflake_root.databases["common"].schemas["compute"]
+        mock_service = mock_schema.services[service_name]
+        mock_service.get_containers.return_value = iter(
+            [create_mock_service_container("DONE")]
+        )
+
+        config = await create_job_configuration(
+            snowflake_credentials,
+            worker_flow_run,
+            {"service_watch_poll_interval": 1},
+        )
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=ConnectionError("No server"))
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "prefect_snowflake.experimental.workers.spcs.prefect"
+        ) as mock_prefect:
+            mock_prefect.get_client.return_value = mock_ctx
+
+            async with SPCSWorker(work_pool_name="test-pool") as worker:
+                result = await worker.run(
+                    flow_run=worker_flow_run, configuration=config
+                )
+
+        assert result.status_code == 0


### PR DESCRIPTION
## Summary

This PR improves the existing **experimental** Snowflake Snowpark Container Services worker. It should be reviewed as an iteration on `prefect_snowflake.experimental.workers.spcs`, not as a promotion to a stable public API.

George's work builds on the experimental worker that was already in `main`. That worker could create async SPCS job services, render a Snowflake service spec from work pool variables, wait for the compute pool/service lifecycle, and optionally stream container logs.

This PR adds:

- service creation retries for transient Snowflake connector failures
- clearer diagnostics for missing Snowflake objects and privilege errors
- `InfrastructurePending` state proposal while the SPCS service is provisioning
- cancellation support via `kill_infrastructure`, while preserving the existing service-name infrastructure PID format
- password-based Snowflake credentials in addition to private key credentials
- Snowflake partner/application metadata on worker connections
- crash diagnostics and final log forwarding for failed containers
- CLI discovery for the experimental worker type without adding a stable top-level `SPCSWorker` export
- broader unit coverage for service lifecycle, cancellation, auth, and failure paths

Additional live validation found that Snowflake rejects empty resource values in SPCS specs, so this branch omits unset CPU limit and GPU fields from the rendered manifest.

## Why this remains experimental

This PR intentionally keeps the worker under:

```python
prefect_snowflake.experimental.workers.spcs
```

It is not GA-ready yet because the user-facing contract and operational behavior still need decisions:

- The worker does not yet have an observer like the Kubernetes and ECS workers. It proposes `InfrastructurePending` directly and watches the service in the run loop, but it does not independently reconcile SPCS services back to Prefect flow runs.
- Completed job services remain visible in Snowflake until dropped. We need to decide whether to drop them automatically, retain them for diagnostics, or expose this as a worker option.
- `image_registry` is currently required by validation, but the service spec uses `image` directly. We should either make `image_registry` meaningful, document the expected fully qualified `image`, or remove the redundant field while the API is still experimental.
- End-to-end coverage still depends on manual Snowflake credentials and account resources. Unit coverage is broad, but live coverage is not automated.

These should be review discussion points, not blockers for reviewing this as an experimental worker improvement.

## Live validation

Tested against a real Prefect Cloud workspace and a real Snowflake account using the CLI path:

1. `prefect work-pool create spcs-e2e --type snowpark-container-service ...`
2. `prefect deploy repros/spcs-e2e/spcs_e2e_flow.py:spcs_e2e_flow --pool spcs-e2e ...`
3. `prefect deployment run 'spcs-e2e-flow/spcs-e2e' ...`
4. `prefect worker start --pool spcs-e2e --type snowpark-container-service --run-once ...`

The worker discovered the Cloud deployment run, submitted it to Snowflake as an SPCS job service, and the flow run completed successfully in Cloud. The run logs included the flow's logger and print output from inside the SPCS container.

Important setup notes from live testing:

- Snowflake system compute pools such as `SYSTEM_COMPUTE_POOL_CPU` cannot run generic job services. The worker needs a generic SPCS compute pool with `USAGE` plus `CREATE SERVICE` privileges on the target schema.
- Flow runs that need to reach Prefect Cloud from SPCS require a Snowflake external access integration. Without it, the container starts but fails DNS/network access to the Cloud API/websocket endpoint.

## Contributor/compatibility notes

The original experimental SPCS worker was contributed by Oscar Björhn in #16393, with follow-up production-driven fixes in #18105, #18358, #18403, and #19446. Those PRs explicitly mention production usage, including 50-100 service jobs/day.

To avoid disrupting that usage, this branch keeps the worker in the experimental module and preserves the current infrastructure PID contract: the worker records the Snowflake service name. Cancellation derives the database and schema from the configured `compute_pool`, so it does not introduce a new persisted identifier format.

## Ready for review checklist

- [x] Keep the implementation under `prefect_snowflake.experimental.workers.spcs` and avoid adding a new stable public `SPCSWorker` export.
- [x] Remove unrelated files from the PR.
- [x] Verify the CLI can discover and start the experimental worker type.
- [x] Verify a real Prefect Cloud deployment can run end-to-end on SPCS.
- [x] Rebase on current `main` and re-run local validation.
- [x] Verify GitHub CI is green after rebase.

## Validation

- `uv run --project ./src/integrations/prefect-snowflake pytest src/integrations/prefect-snowflake/tests -q`
- `uv run --project ./src/integrations/prefect-snowflake pytest src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py`
- `uv run ruff check src/integrations/prefect-snowflake/prefect_snowflake/__init__.py src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py`
- `uv run ruff format --check src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py`
- `git diff --check`
- manual Snowflake SPCS smoke test
- CLI-created Prefect Cloud deployment run on SPCS, completed successfully
