### PR TITLE
Document uv run --project for local integrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,11 @@ uv sync                                # Install all dev dependencies
 just install                           # Same as above, plus perf group
 
 # Running code
-uv run -s my_script.py                 # Run a script with an editable prefect install
-uv run --extra aws repros/1234.py      # Run repro needing an integration extra
-uv run --project ./src/integrations/prefect-redis <cmd>  # Run against a local integration from repo root
-prefect server start                   # Start local server
-prefect config view                    # Inspect current configuration
+uv run -s my_script.py                             # Run a script with an editable prefect install
+uv run --extra aws repros/1234.py                  # Run repro needing an integration extra
+uv run --project ./src/integrations/<name> <cmd>   # Run against a local integration from repo root
+prefect server start                               # Start local server
+prefect config view                                # Inspect current configuration
 
 # Testing (see tests/AGENTS.md for full details)
 uv run pytest tests/path.py -k name    # Run specific test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ just install                           # Same as above, plus perf group
 # Running code
 uv run -s my_script.py                 # Run a script with an editable prefect install
 uv run --extra aws repros/1234.py      # Run repro needing an integration extra
+uv run --project ./src/integrations/prefect-redis <cmd>  # Run against a local integration from repo root
 prefect server start                   # Start local server
 prefect config view                    # Inspect current configuration
 


### PR DESCRIPTION
this PR documents the `uv run --project ./src/integrations/<name> ...` pattern in the root `AGENTS.md`.

<details>
<summary>why</summary>

When working from the repo root, `uv run --project ./src/integrations/<name>` is the clean way to target a local integration source tree without relying on `PYTHONPATH`.

</details>

Validation:
- not run; docs-only change
