### PR TITLE
docs: tighten client/server versioning policy and release kickoff

### DIFF
--- a/.github/workflows/kickoff-release.yaml
+++ b/.github/workflows/kickoff-release.yaml
@@ -1,10 +1,12 @@
 # Kickoff Release Workflow
 #
-# This workflow automates weekly patch releases by triggering a Devin.ai playbook that:
-#   1. Gets the latest release version and increments the patch number
-#   2. Generates release notes using `just prepare-release`
-#   3. Cleans up formatting and creates a PR for review
-#   4. After PR merge, creates a GitHub release for the new version
+# This workflow automates weekly releases by triggering a Devin.ai playbook that:
+#   1. Gets the latest release version
+#   2. Inspects commits since the last tag and classifies the bump level
+#      (major / minor / patch) per docs/contribute/styles-practices.mdx
+#   3. Generates release notes using `just prepare-release`
+#   4. Cleans up formatting and creates a PR for review
+#   5. After PR merge, creates a GitHub release for the new version
 #
 # Schedule: Every Thursday at 1PM CST (7PM UTC)
 # Manual trigger: Available via workflow_dispatch
@@ -30,16 +32,31 @@ jobs:
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         run: |
-          prompt="Run the Prefect Patch Release Notes playbook to create release notes for the next patch release. Get the latest release version, increment the patch number, generate release notes using just prepare-release, clean up the formatting, and create a PR for review. Once the PR is merged, create a GitHub release for the new version."
+          prompt=$(cat <<'PROMPT'
+          Run the Prefect Release Notes playbook to create release notes for the next release.
+
+          1. Get the latest release tag.
+          2. Inspect every commit between that tag and HEAD on main. Classify the release as major, minor, or patch per the policy in docs/contribute/styles-practices.mdx (section "Prefect's versioning scheme"):
+             - major: backwards-incompatible changes to public Python APIs, CLI, REST API, or client↔server wire schema; dropping a Python/database/runtime version
+             - minor: backwards-compatible additions or observable behavior changes; new features, CLI commands, REST endpoints, or public Python APIs; additive schema changes; removing a deprecated feature; dependency range changes
+             - patch: bug fixes and internal changes with no observable impact on users
+          3. If ANY commit touches src/prefect/client/schemas/**, the client-exported Python surface, or changes client-server compatibility, the release is at minimum a minor bump.
+          4. Compute the next version from the classified bump level. If there is any doubt between two levels, pick the higher one and note it in the PR description for human review.
+          5. Generate release notes with 'just prepare-release <VERSION>', clean up the formatting, and open a PR for review. In the PR description, include the chosen bump level and the commits that drove the classification.
+          6. Once the PR is merged, create a GitHub release for the new version.
+          PROMPT
+          )
+
+          payload=$(jq -n \
+            --arg prompt "$prompt" \
+            --arg snapshot "$DEVIN_SNAPSHOT_ID" \
+            --arg playbook "$DEVIN_PLAYBOOK_ID" \
+            '{prompt: $prompt, snapshot_id: $snapshot, playbook_id: $playbook}')
 
           response=$(curl -s -w "\n%{http_code}" -X POST "$DEVIN_API_URL" \
             -H "Authorization: Bearer $DEVIN_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"prompt\": \"$prompt\",
-              \"snapshot_id\": \"$DEVIN_SNAPSHOT_ID\",
-              \"playbook_id\": \"$DEVIN_PLAYBOOK_ID\"
-            }")
+            -d "$payload")
 
           http_code=$(echo "$response" | tail -n1)
           body=$(echo "$response" | sed '$d')

--- a/docs/contribute/styles-practices.mdx
+++ b/docs/contribute/styles-practices.mdx
@@ -295,20 +295,32 @@ right of it reset to zero.
 
 ## Prefect's versioning scheme
 
-Prefect increases the major version when significant and widespread changes are made to the core product.
+Prefect and `prefect-client` follow [semantic versioning](https://semver.org/). Both packages ship from the same git tag and always have the same version.
 
-Prefect increases the minor version when:
+Prefect increases the **major** version for backwards-incompatible changes. Examples:
 
-*   Introducing a new concept that changes how to use Prefect
-*   Changing an existing concept in a way that fundamentally alters its usage
-*   Removing a deprecated feature
+*   Removing or renaming public Python APIs
+*   Removing or renaming CLI commands or flags
+*   Changing the REST API or client↔server wire schema in a backwards-incompatible way
+*   Dropping support for a Python version, database, or other runtime dependency
 
-Prefect increases the patch version when:
+Prefect increases the **minor** version for backwards-compatible additions or behavior changes. Examples:
 
-*   Making enhancements to existing features
-*   Fixing behavior in existing features
-*   Adding new capabilities to existing concepts
-*   Updating dependencies
+*   New features, CLI commands, REST endpoints, or public Python APIs
+*   Additive changes to client schemas (new optional fields, new variants)
+*   Changes to import-time or default runtime behavior that a caller could observe (for example, eagerly rebuilding Pydantic models that were previously deferred)
+*   Removing a deprecated feature after its deprecation window
+*   Dependency version bumps that widen or narrow supported ranges
+
+Prefect increases the **patch** version only for bug fixes and internal changes with no observable impact on users. Examples:
+
+*   Fixing a regression or bug in an existing feature
+*   Performance or reliability improvements that do not change behavior
+*   Internal refactors, test changes, and documentation
+
+<Warning>
+Any change touching `src/prefect/client/schemas/**`, the client-exported Python surface, or client↔server compatibility is **at minimum a minor bump**. Pin client versions accordingly when running against a fixed server version. See [client compatibility with Prefect](#client-compatibility-with-prefect) below.
+</Warning>
 
 ## Deprecation
 
@@ -326,6 +338,10 @@ sometimes you cannot use new clients with an old server. The new client may expe
 it does not yet include. For this reason, we recommend that all clients are the same version as the server or older.
 
 For example, you can use a client on 2.1.0 with a server on 2.5.0. You cannot use a client on 2.5.0 with a server on 2.1.0.
+
+We recommend pinning the client to a tested **minor** version when running against a fixed server version. Patch releases
+target bug fixes and do not intentionally change client behavior, but compatibility within a minor series is the stable
+guarantee. Upgrade patches through your normal change-management process rather than assuming drop-in compatibility.
 
 ## Client compatibility with Cloud
 


### PR DESCRIPTION
## Summary

- Rewrite `docs/contribute/styles-practices.mdx` "Prefect's versioning scheme" to follow standard semver. The prior text treated enhancements, new capabilities, and dependency updates as patch-worthy, which in practice allowed client behavior changes (e.g. eager `model_rebuild` in 3.6.27) to ship as patches.
- Add an explicit rule that changes to `src/prefect/client/schemas/**` or the client-exported surface are at minimum a minor bump, and recommend that users pin clients to a tested minor when running against a fixed server version.
- Update `.github/workflows/kickoff-release.yaml` so the weekly Devin playbook classifies the bump level from commits since the last tag instead of hardcoding a patch bump. Switch to `jq --arg` for payload construction so multi-line prompts can embed quotes safely.

Paired with prefecthq/customer-managed PR that rewords the matching "any patch version is compatible" note in the release docs.

Related to [OSS-7859](https://linear.app/prefect/issue/OSS-7859/revisit-prefect-client-versioning-strategy-for-impact-on-downstream).

## Test plan

- [x] Docs preview renders the updated "Prefect's versioning scheme" section with the `<Warning>` block.
- [ ] Manually dispatch the updated `Kickoff Release` workflow and confirm the Devin session prompt contains the classification steps (not the prior "increment the patch number" wording).
- [ ] Dry-run the classification prompt against the last 3 months of commits; `38cb60b5fb` (eager `model_rebuild`) should classify as at least minor.