### PR TITLE
fix bundle execute path duplicate pending proposal

### DIFF
--- a/src/prefect/_experimental/bundles/execute.py
+++ b/src/prefect/_experimental/bundles/execute.py
@@ -39,6 +39,7 @@ async def execute_bundle(bundle: dict) -> None:
                 control_channel=ctx.control_channel,
             ),
             resolve_flow=resolve_flow,
+            propose_submitting=False,
         )
         await executor.submit()
 

--- a/tests/_experimental/bundles/test_execute.py
+++ b/tests/_experimental/bundles/test_execute.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from prefect import flow
+from prefect._experimental.bundles.execute import execute_bundle
+from prefect.client.orchestration import PrefectClient
+
+
+async def test_execute_bundle_creates_executor_with_propose_submitting_false(
+    prefect_client: PrefectClient,
+):
+    @flow
+    def test_flow() -> str:
+        return "ok"
+
+    flow_run = await prefect_client.create_flow_run(test_flow)
+    bundle: dict[str, Any] = {
+        "flow_run": flow_run.model_dump(mode="json"),
+    }
+
+    captured_kwargs: dict[str, Any] = {}
+    mock_submit = AsyncMock(return_value=None)
+
+    from prefect.runner._flow_run_executor import FlowRunExecutorContext
+
+    original_create_executor = FlowRunExecutorContext.create_executor
+
+    def capture_create_executor(
+        self_ctx: FlowRunExecutorContext, *args: Any, **kwargs: Any
+    ) -> Any:
+        captured_kwargs.update(kwargs)
+        result = original_create_executor(self_ctx, *args, **kwargs)
+        result.submit = mock_submit
+        return result
+
+    with patch.object(
+        FlowRunExecutorContext,
+        "create_executor",
+        side_effect=capture_create_executor,
+        autospec=True,
+    ):
+        await execute_bundle(bundle)
+
+    assert captured_kwargs.get("propose_submitting") is False


### PR DESCRIPTION
this PR makes the experimental bundle execution path opt out of the extra Submitting proposal, matching the fix in #21411.

### What changed
- pass `propose_submitting=False` when the bundle executor constructs `FlowRunExecutor`
- add a regression test that captures `FlowRunExecutorContext.create_executor(...)` and asserts the bundle path disables the extra proposal

### Root cause
The bundle executor was still using the default `propose_submitting=True`. Against Prefect Cloud, bundle-launched runs can already be at the pending submission boundary, so proposing another pending sub-state can be rejected as an illegal `PENDING -> PENDING` transition.

### User impact
Bundle execution should no longer abort with messages like `This run is in a PENDING state and cannot transition to a PENDING state.`