### PR TITLE
fix(futures): catch exceptions in PrefectWrappedFuture done callbacks to prevent silent hangs

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -181,7 +181,13 @@ class PrefectWrappedFuture(PrefectTaskRunFuture[R], abc.ABC, Generic[R, F]):
 
             def call_with_self(future: F):
                 """Call the callback with self as the argument, this is necessary to ensure we remove the future from the pending set"""
-                fn(self)
+                try:
+                    fn(self)
+                except BaseException:
+                    logger.exception(
+                        "Exception in done callback for task run %s",
+                        self.task_run_id,
+                    )
 
             self._wrapped_future.add_done_callback(call_with_self)
             return

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -866,3 +866,125 @@ class TestFlowReturningMappedFutures:
         result = my_flow()
         assert isinstance(result, list)
         assert not isinstance(result, PrefectFutureList)
+
+
+class TestPrefectWrappedFutureCallbackExceptions:
+    """Regression tests for https://github.com/PrefectHQ/prefect/issues/21674
+
+    Verifies that exceptions raised inside done callbacks are logged rather than
+    silently swallowed, and that normal callback execution still works correctly.
+    """
+
+    def test_callback_exception_is_logged(self, caplog):
+        """Exceptions in callbacks should be logged via logger.exception."""
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+
+        def failing_callback(fut):
+            raise RuntimeError("callback blew up")
+
+        with caplog.at_level("ERROR", logger="prefect.futures"):
+            future.add_done_callback(failing_callback)
+            wrapped_future.set_result(Completed(data=42))
+
+        assert any(
+            "Exception in done callback" in record.message
+            for record in caplog.records
+        )
+        assert any(
+            record.levelname == "ERROR" for record in caplog.records
+        )
+
+    def test_callback_exception_includes_task_run_id(self, caplog):
+        """The log message should include the task run ID for debugging."""
+        task_run_id = uuid.uuid4()
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(task_run_id, wrapped_future)
+
+        def failing_callback(fut):
+            raise ValueError("bad callback")
+
+        with caplog.at_level("ERROR", logger="prefect.futures"):
+            future.add_done_callback(failing_callback)
+            wrapped_future.set_result(Completed(data=1))
+
+        error_records = [
+            r for r in caplog.records if "Exception in done callback" in r.message
+        ]
+        assert len(error_records) == 1
+        assert str(task_run_id) in error_records[0].message
+
+    def test_normal_callback_executes_successfully(self):
+        """Callbacks that don't raise should execute normally."""
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        results = []
+
+        def normal_callback(fut):
+            results.append("called")
+
+        future.add_done_callback(normal_callback)
+        wrapped_future.set_result(Completed(data=99))
+
+        assert results == ["called"]
+
+    def test_multiple_callbacks_mixed_exceptions(self, caplog):
+        """When some callbacks fail and others succeed, all should run and failures should be logged."""
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        results = []
+
+        def good_callback(fut):
+            results.append("good")
+
+        def bad_callback(fut):
+            results.append("bad")
+            raise RuntimeError("oops")
+
+        def another_good_callback(fut):
+            results.append("another_good")
+
+        with caplog.at_level("ERROR", logger="prefect.futures"):
+            future.add_done_callback(good_callback)
+            future.add_done_callback(bad_callback)
+            future.add_done_callback(another_good_callback)
+            wrapped_future.set_result(Completed(data=0))
+
+        # All three callbacks should have executed
+        assert results == ["good", "bad", "another_good"]
+        # The exception should have been logged
+        assert any(
+            "Exception in done callback" in record.message
+            for record in caplog.records
+        )
+
+    def test_callback_on_already_completed_future(self):
+        """Callbacks added after the future is complete should be called immediately."""
+        wrapped_future = Future()
+        wrapped_future.set_result(Completed(data=7))
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        results = []
+
+        def late_callback(fut):
+            results.append("late")
+
+        future.add_done_callback(late_callback)
+
+        assert results == ["late"]
+
+    def test_baseexception_is_also_logged(self, caplog):
+        """BaseException subclasses (e.g., KeyboardInterrupt) should also be caught and logged."""
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+
+        def raising_base_exception(fut):
+            raise KeyboardInterrupt("simulated")
+
+        with caplog.at_level("ERROR", logger="prefect.futures"):
+            future.add_done_callback(raising_base_exception)
+            wrapped_future.set_result(Completed(data=0))
+
+        assert any(
+            "Exception in done callback" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary

When a callback passed to `PrefectWrappedFuture.add_done_callback()` raises an exception, `concurrent.futures.Future._invoke_callbacks` catches and silently swallows it. This means `_final_state` is never set, causing the flow run to hang indefinitely as a zombie pod in Kubernetes environments.

This wraps the callback invocation in a `try/except BaseException` block so that unexpected exceptions are logged via `logger.exception()` instead of being silently dropped. The broader callback chain can continue resolving, preventing zombie flow runs.

Fixes #21615

## Details

The issue describes a specific case where cloudpickle deserialization fails in `_UnpicklingFuture`, but the same pattern applies to any exception in any done callback registered on a wrapped future. This is a defense-in-depth fix that protects against all such cases, not just the deserialization scenario already fixed in #21612.