### PR TITLE
Handle exceptions in wrapped future callbacks

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -183,7 +183,7 @@ class PrefectWrappedFuture(PrefectTaskRunFuture[R], abc.ABC, Generic[R, F]):
                 """Call the callback with self as the argument, this is necessary to ensure we remove the future from the pending set"""
                 try:
                     fn(self)
-                except BaseException:
+                except Exception:
                     logger.exception(
                         "Exception in done callback for task run %s",
                         self.task_run_id,

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -181,7 +181,13 @@ class PrefectWrappedFuture(PrefectTaskRunFuture[R], abc.ABC, Generic[R, F]):
 
             def call_with_self(future: F):
                 """Call the callback with self as the argument, this is necessary to ensure we remove the future from the pending set"""
-                fn(self)
+                try:
+                    fn(self)
+                except BaseException:
+                    logger.exception(
+                        "Exception in done callback for task run %s",
+                        self.task_run_id,
+                    )
 
             self._wrapped_future.add_done_callback(call_with_self)
             return

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -199,8 +199,10 @@ class TestUtilityFunctions:
 
 
 class TestPrefectConcurrentFuture:
-    def test_add_done_callback_swallows_baseexception(self, caplog: pytest.LogCaptureFixture):
-        class CallbackBaseException(BaseException):
+    def test_add_done_callback_swallows_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        class CallbackError(Exception):
             pass
 
         wrapped_future = Future()
@@ -209,7 +211,7 @@ class TestPrefectConcurrentFuture:
 
         def on_done(_future: PrefectFuture[Any]) -> None:
             callback_called.set()
-            raise CallbackBaseException("boom")
+            raise CallbackError("boom")
 
         future.add_done_callback(on_done)
 
@@ -219,6 +221,21 @@ class TestPrefectConcurrentFuture:
         assert callback_called.is_set()
         assert future.result() == 42
         assert "Exception in done callback for task run" in caplog.text
+
+    def test_add_done_callback_propagates_baseexception(self):
+        class CallbackBaseException(BaseException):
+            pass
+
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+
+        def on_done(_future: PrefectFuture[Any]) -> None:
+            raise CallbackBaseException("boom")
+
+        future.add_done_callback(on_done)
+
+        with pytest.raises(CallbackBaseException, match="boom"):
+            wrapped_future.set_result(Completed(data=42))
 
     def test_wait_with_timeout(self):
         wrapped_future = Future()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -199,6 +199,27 @@ class TestUtilityFunctions:
 
 
 class TestPrefectConcurrentFuture:
+    def test_add_done_callback_swallows_baseexception(self, caplog: pytest.LogCaptureFixture):
+        class CallbackBaseException(BaseException):
+            pass
+
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        callback_called = threading.Event()
+
+        def on_done(_future: PrefectFuture[Any]) -> None:
+            callback_called.set()
+            raise CallbackBaseException("boom")
+
+        future.add_done_callback(on_done)
+
+        with caplog.at_level("ERROR", logger="prefect.futures"):
+            wrapped_future.set_result(Completed(data=42))
+
+        assert callback_called.is_set()
+        assert future.result() == 42
+        assert "Exception in done callback for task run" in caplog.text
+
     def test_wait_with_timeout(self):
         wrapped_future = Future()
         future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)


### PR DESCRIPTION
Closes #21615

Wrap the callback invocation in `PrefectWrappedFuture.add_done_callback` so callback `Exception` instances are logged instead of leaking out of the wrapped future implementation. `BaseException` still propagates, matching the stdlib `concurrent.futures.Future` behavior.

### Testing
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python -m pytest tests/test_futures.py -x --tb=short
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python -m pytest tests/test_task_runners.py -k add_done_callback -x --tb=short
- mkdir -p /tmp/fake-nvm && touch /tmp/fake-nvm/nvm.sh && PATH="$PWD/.venv/bin:$PATH" NVM_DIR=/tmp/fake-nvm ./.venv/bin/python -m pre_commit run --show-diff-on-failure --color=always --all-files
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/prefect version
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/prefect server start --host 127.0.0.1 --port 4301
- curl -fsS http://127.0.0.1:4301/api/health

### Checklist
- [x] This pull request references any related issue by including "closes <link to issue>"
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.