### PR TITLE
Fix `PrefectConcurrentFuture` completion tracking when done callbacks raise

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -194,6 +194,44 @@ class PrefectConcurrentFuture(PrefectWrappedFuture[R, concurrent.futures.Future[
     when the task run is submitted to a ThreadPoolExecutor.
     """
 
+    def __init__(
+        self,
+        task_run_id: uuid.UUID,
+        wrapped_future: concurrent.futures.Future[R],
+    ):
+        super().__init__(task_run_id, wrapped_future)
+        self._prefect_done_callbacks: list[Callable[[PrefectFuture[R]], None]] = []
+        self._prefect_done_callbacks_lock = threading.Lock()
+        self._prefect_done_event = threading.Event()
+
+        # Register Prefect's internal completion notifier before any user callbacks
+        # so wait()/as_completed() do not depend on callback chain ordering.
+        self._wrapped_future.add_done_callback(self._notify_prefect_done_callbacks)
+
+    def _add_prefect_done_callback(
+        self, fn: Callable[[PrefectFuture[R]], None]
+    ) -> None:
+        with self._prefect_done_callbacks_lock:
+            if self._prefect_done_event.is_set():
+                call_immediately = True
+            else:
+                self._prefect_done_callbacks.append(fn)
+                call_immediately = False
+
+        if call_immediately:
+            fn(self)
+
+    def _notify_prefect_done_callbacks(
+        self, future: concurrent.futures.Future[R]
+    ) -> None:
+        with self._prefect_done_callbacks_lock:
+            self._prefect_done_event.set()
+            callbacks = self._prefect_done_callbacks[:]
+            self._prefect_done_callbacks.clear()
+
+        for callback in callbacks:
+            callback(self)
+
     def wait(self, timeout: float | None = None) -> None:
         try:
             result = self._wrapped_future.result(timeout=timeout)
@@ -538,6 +576,17 @@ class PrefectFutureList(list[PrefectFuture[R]], Iterator[PrefectFuture[R]]):
         return results
 
 
+def _register_prefect_done_callback(
+    future: PrefectFuture[R], callback: Callable[[PrefectFuture[R]], None]
+) -> None:
+    add_prefect_done_callback = getattr(future, "_add_prefect_done_callback", None)
+    if add_prefect_done_callback is not None:
+        add_prefect_done_callback(callback)
+        return
+
+    future.add_done_callback(callback)
+
+
 def as_completed(
     futures: list[PrefectFuture[R]], timeout: float | None = None
 ) -> Generator[PrefectFuture[R], None]:
@@ -560,7 +609,7 @@ def as_completed(
                     finished_event.set()
 
             for future in pending:
-                future.add_done_callback(add_to_done)
+                _register_prefect_done_callback(future, add_to_done)
 
             while pending:
                 finished_event.wait()
@@ -651,7 +700,7 @@ def wait(
 
             # Add callbacks to all pending futures
             for future in not_done:
-                future.add_done_callback(mark_done)
+                _register_prefect_done_callback(future, mark_done)
 
             # Wait for futures to complete within timeout
             while not_done:

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -162,6 +162,64 @@ class TestUtilityFunctions:
                     results.append(future.result())
             assert exc_info.value.args[0] == f"2 (of {len(timings)}) futures unfinished"
 
+    @pytest.mark.timeout(method="thread")
+    def test_wait_uses_private_completion_callback_for_prefect_concurrent_future(self):
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        callback_errors: list[BaseException] = []
+
+        def raising_callback(_future: PrefectFuture[Any]):
+            raise KeyboardInterrupt("boom")
+
+        future.add_done_callback(raising_callback)
+
+        def resolve_future():
+            try:
+                wrapped_future.set_result(Completed(data=42))
+            except BaseException as exc:
+                callback_errors.append(exc)
+
+        thread = threading.Thread(target=resolve_future)
+        thread.start()
+        done, not_done = wait([future], timeout=0.5)
+        thread.join()
+
+        assert done == {future}
+        assert not not_done
+        assert future.result() == 42
+        assert len(callback_errors) == 1
+        assert isinstance(callback_errors[0], KeyboardInterrupt)
+
+    @pytest.mark.timeout(method="thread")
+    def test_as_completed_uses_private_completion_callback_for_prefect_concurrent_future(
+        self,
+    ):
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        callback_errors: list[BaseException] = []
+
+        def raising_callback(_future: PrefectFuture[Any]):
+            raise KeyboardInterrupt("boom")
+
+        future.add_done_callback(raising_callback)
+
+        def resolve_future():
+            try:
+                wrapped_future.set_result(Completed(data=42))
+            except BaseException as exc:
+                callback_errors.append(exc)
+
+        thread = threading.Thread(target=resolve_future)
+        thread.start()
+        results = [
+            done_future.result() for done_future in as_completed([future], timeout=0.5)
+        ]
+        thread.join()
+
+        assert results == [42]
+        assert len(callback_errors) == 1
+        assert isinstance(callback_errors[0], KeyboardInterrupt)
+
     async def test_as_completed_yields_correct_order_dist(self, events_pipeline):
         @task
         async def my_task(seconds):


### PR DESCRIPTION
closes #21615

this PR decouples `PrefectConcurrentFuture` completion tracking from user callback execution order so Prefect's own `wait()` / `as_completed()` bookkeeping no longer depends on later done callbacks running.

<details>
<summary>Details</summary>

- registers a private completion notifier on the wrapped `concurrent.futures.Future` during `PrefectConcurrentFuture` initialization
- routes Prefect's internal completion registration through that private path when available, while leaving normal `add_done_callback` behavior unchanged
- adds regressions for the `BaseException` ordering case so `wait()` and `as_completed()` still complete even if a user callback raises `KeyboardInterrupt`

This is an alternative to swallowing `BaseException` in user callbacks. It fixes the reproduced hang in Prefect's internal completion tracking without changing stdlib callback semantics.
</details>
