### PR TITLE
fix(deployments): deep-copy storage in `afrom_storage` to avoid concurrent clobber

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -1228,13 +1228,15 @@ class RunnerDeployment(BaseModel):
 
         job_variables = job_variables or {}
 
-        # Operate on a copy so concurrent callers that share the same storage
-        # instance (e.g. a single flow reused across many concurrent
+        # Operate on a shallow copy so concurrent callers that share the same
+        # storage instance (e.g. a single flow reused across many concurrent
         # `to_deployment()` calls via `asyncio.gather`) don't clobber each
-        # other's destination via `set_base_path`. The original storage is
-        # still attached to the returned deployment so caller-facing identity
-        # and equality are preserved.
-        working_storage = copy.deepcopy(storage)
+        # other's destination via `set_base_path`. Shallow-copy keeps inner
+        # references (credentials, spies, pull-step metadata) aliased with
+        # the original -- we only need `_storage_base_path` to be per-call.
+        # The original storage is still attached to the returned deployment
+        # so caller-facing identity and equality are preserved.
+        working_storage = copy.copy(storage)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             working_storage.set_base_path(Path(tmpdir))
@@ -1377,12 +1379,12 @@ class RunnerDeployment(BaseModel):
 
         job_variables = job_variables or {}
 
-        # Operate on a copy so callers that share the same storage instance
-        # across threads don't clobber each other's destination via
+        # Operate on a shallow copy so callers that share the same storage
+        # instance across threads don't clobber each other's destination via
         # `set_base_path`. The original storage is still attached to the
         # returned deployment so caller-facing identity and equality are
         # preserved. See `afrom_storage` for the async-path rationale.
-        working_storage = copy.deepcopy(storage)
+        working_storage = copy.copy(storage)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             working_storage.set_base_path(Path(tmpdir))

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -31,6 +31,7 @@ Example:
 
 from __future__ import annotations
 
+import copy
 import importlib
 import os
 import sys
@@ -1227,14 +1228,22 @@ class RunnerDeployment(BaseModel):
 
         job_variables = job_variables or {}
 
+        # Operate on a copy so concurrent callers that share the same storage
+        # instance (e.g. a single flow reused across many concurrent
+        # `to_deployment()` calls via `asyncio.gather`) don't clobber each
+        # other's destination via `set_base_path`. The original storage is
+        # still attached to the returned deployment so caller-facing identity
+        # and equality are preserved.
+        working_storage = copy.deepcopy(storage)
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            storage.set_base_path(Path(tmpdir))
-            await storage.pull_code()
+            working_storage.set_base_path(Path(tmpdir))
+            await working_storage.pull_code()
 
             if ":" in entrypoint:
-                full_entrypoint = str(storage.destination / entrypoint)
+                full_entrypoint = str(working_storage.destination / entrypoint)
             else:
-                sys.path.insert(0, str(storage.destination))
+                sys.path.insert(0, str(working_storage.destination))
                 full_entrypoint = entrypoint
 
             try:
@@ -1243,7 +1252,7 @@ class RunnerDeployment(BaseModel):
                 )
             finally:
                 if ":" not in entrypoint:
-                    sys.path.remove(str(storage.destination))
+                    sys.path.remove(str(working_storage.destination))
 
         kwargs: dict[str, Any] = dict(
             name=name,
@@ -1275,7 +1284,7 @@ class RunnerDeployment(BaseModel):
             if ":" in entrypoint
             else EntrypointType.MODULE_PATH
         )
-        deployment._path = str(storage.destination).replace(
+        deployment._path = str(working_storage.destination).replace(
             tmpdir, "$STORAGE_BASE_PATH"
         )
 
@@ -1368,21 +1377,28 @@ class RunnerDeployment(BaseModel):
 
         job_variables = job_variables or {}
 
+        # Operate on a copy so callers that share the same storage instance
+        # across threads don't clobber each other's destination via
+        # `set_base_path`. The original storage is still attached to the
+        # returned deployment so caller-facing identity and equality are
+        # preserved. See `afrom_storage` for the async-path rationale.
+        working_storage = copy.deepcopy(storage)
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            storage.set_base_path(Path(tmpdir))
-            run_coro_as_sync(storage.pull_code())
+            working_storage.set_base_path(Path(tmpdir))
+            run_coro_as_sync(working_storage.pull_code())
 
             if ":" in entrypoint:
-                full_entrypoint = str(storage.destination / entrypoint)
+                full_entrypoint = str(working_storage.destination / entrypoint)
             else:
-                sys.path.insert(0, str(storage.destination))
+                sys.path.insert(0, str(working_storage.destination))
                 full_entrypoint = entrypoint
 
             try:
                 flow = load_flow_from_entrypoint(full_entrypoint)
             finally:
                 if ":" not in entrypoint:
-                    sys.path.remove(str(storage.destination))
+                    sys.path.remove(str(working_storage.destination))
 
         kwargs: dict[str, Any] = dict(
             name=name,
@@ -1414,7 +1430,7 @@ class RunnerDeployment(BaseModel):
             if ":" in entrypoint
             else EntrypointType.MODULE_PATH
         )
-        deployment._path = str(storage.destination).replace(
+        deployment._path = str(working_storage.destination).replace(
             tmpdir, "$STORAGE_BASE_PATH"
         )
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -3632,6 +3632,89 @@ class TestRunnerDeployment:
         )
         assert deployment.name == "pricing-subflow-v2.0.1"
 
+    async def test_afrom_storage_concurrent_calls_do_not_clobber_shared_storage(
+        self,
+    ):
+        """
+        Regression test: concurrent `afrom_storage` calls that share the same
+        storage instance must not mutate one another's destination.
+
+        Previously, `afrom_storage` called `storage.set_base_path(tmpdir)` which
+        mutates shared state on the storage object. When multiple tasks ran
+        concurrently via `asyncio.gather`, whichever task called
+        `set_base_path` last would win, and every other task would observe the
+        winner's destination -- either reading files from the wrong tmpdir
+        (FileNotFoundError once a sibling task's TemporaryDirectory was cleaned
+        up) or producing deployments whose `_path` did not contain
+        `$STORAGE_BASE_PATH` because the substitution target (`tmpdir`) did not
+        match the clobbered `storage.destination`.
+        """
+
+        n = 5
+        # Shared barrier state lives in a closure, not on the storage
+        # instance, so the implementation is free to deep-copy the storage
+        # (as the fix does) without fragmenting the barrier.
+        arrived = 0
+        go = asyncio.Event()
+
+        class _BarrierMockStorage:
+            """MockStorage variant that forces all concurrent tasks to reach
+            `pull_code` before any of them returns, guaranteeing the race."""
+
+            code = MockStorage.code
+            pull_interval = 60
+
+            def __init__(self) -> None:
+                self._base_path: Path | None = None
+
+            def set_base_path(self, path: Path) -> None:
+                self._base_path = path
+
+            @property
+            def destination(self) -> Path | None:
+                return self._base_path
+
+            async def pull_code(self) -> None:
+                # Hold every concurrent caller here until all have called
+                # set_base_path. If state leaks across tasks, each task's
+                # local `self._base_path` will reflect the wrong tmpdir once
+                # the barrier releases.
+                nonlocal arrived
+                arrived += 1
+                if arrived >= n:
+                    go.set()
+                await go.wait()
+                assert self._base_path is not None
+                (self._base_path / "flows.py").write_text(self.code)
+
+            def to_pull_step(self) -> dict[str, Any]:
+                return {"prefect.fake.module": {}}
+
+        storage = _BarrierMockStorage()
+
+        deployments = await asyncio.gather(
+            *(
+                RunnerDeployment.afrom_storage(
+                    storage=storage,
+                    entrypoint="flows.py:test_flow",
+                    name=f"test-deployment-{i}",
+                )
+                for i in range(n)
+            )
+        )
+
+        assert len(deployments) == n
+        for i, deployment in enumerate(deployments):
+            assert deployment.name == f"test-deployment-{i}"
+            assert deployment._path is not None
+            # Every deployment's path must have been substituted against its
+            # own tmpdir. If storage state leaked across tasks, N-1 of these
+            # will still contain a literal `/tmp/...` path.
+            assert "$STORAGE_BASE_PATH" in deployment._path, (
+                f"deployment {i} _path={deployment._path!r} was not substituted "
+                "-- storage state leaked across concurrent afrom_storage calls"
+            )
+
     def test_from_storage_with_module_path_entrypoint(
         self, temp_module_storage: MockModuleStorage
     ):


### PR DESCRIPTION
## Context

While investigating a Slack report about `prefect deploy` failing in GCP Cloud Run Jobs (only N/M deployments succeeding, rest failing with `RuntimeError: Failed to clone repository ...`), I found a real concurrency bug in `afrom_storage` — but I want to be upfront: subsequent discussion with the reporter suggests their specific failure also reproduces **sequentially** in GCP, so **this PR is not a claimed fix for that exact symptom**. It fixes a distinct and verifiable concurrency bug that was surfaced in the same area.

## The bug this PR fixes

`RunnerDeployment.afrom_storage` mutates the caller's storage object:

```python
with tempfile.TemporaryDirectory() as tmpdir:
    storage.set_base_path(Path(tmpdir))   # mutates shared state
    await storage.pull_code()
    ...
```

When many `await flow_obj.to_deployment(...)` calls run concurrently via `asyncio.gather` and share a single `Flow._storage` instance, every task's `set_base_path` clobbers the others. Whichever task sets it last wins; the other tasks observe that tmpdir as `storage.destination` and either:

- raise `FileNotFoundError` once a sibling's `TemporaryDirectory` context exits and cleans up the path they were still reading from, or
- produce deployments whose `_path` still contains a raw `/tmp/...` string because the `str(storage.destination).replace(tmpdir, \"\$STORAGE_BASE_PATH\")` substitution no longer matches.

A concurrent `git clone` can also fail with exit code 1 when two invocations race on the same destination directory.

<details>
<summary>Local reproduction</summary>

```python
import asyncio
from prefect.flows import Flow

NUM_FLOWS = 20
REPO = \"https://github.com/PrefectHQ/examples.git\"
ENTRYPOINT = \"flows/hello_world.py:hello\"

async def deploy(i, f):
    try:
        await f.to_deployment(name=f\"repro-{i}\")
        return True
    except Exception:
        return False

async def main():
    f = await Flow.afrom_source(source=REPO, entrypoint=ENTRYPOINT)
    results = await asyncio.gather(*(deploy(i, f) for i in range(NUM_FLOWS)))
    print(f\"successes: {sum(results)} / {NUM_FLOWS}\")

asyncio.run(main())
```

Before the fix: ~4/20 succeed, and every failure's `FileNotFoundError` points at the same tmpdir. With a separate `Flow` per task (so each has its own `_storage`): 20/20. After the fix: 20/20 with shared storage.

</details>

## The fix

Operate on a `copy.copy(storage)` (shallow) for the mutation / `pull_code` / flow-load block. Shallow-copy keeps inner references (credentials, loggers, pull-step metadata, test spies) aliased with the original — we only need `_storage_base_path` to be per-call. The original storage is still passed to the deployment constructor so `deployment.storage` identity and equality with the caller's reference are preserved. Sync `from_storage` gets the same treatment.

I originally used `copy.deepcopy`, but that broke `test_runner_caches_adhoc_pulls` — it also copied the `MagicMock` spy, so the deployment-creation pull stopped showing up on the original's spy. Shallow copy is the right level of isolation here.

## Regression test

`test_afrom_storage_concurrent_calls_do_not_clobber_shared_storage` forces N concurrent `afrom_storage` calls to meet at a barrier inside `pull_code` (guaranteeing the race window) and asserts every resulting deployment has its own `\$STORAGE_BASE_PATH`-substituted `_path`. Barrier state lives in a closure, not on the storage instance, so it works whether or not the implementation copies storage. Fails cleanly on `main`, passes with the fix.

## Test plan

- [x] new regression test passes
- [x] `tests/runner/test_runner.py::TestRunnerDeployment` (78 tests) passes
- [x] `tests/runner/` full suite (593 tests, 5 skipped) passes
- [x] `test_runner_caches_adhoc_pulls` still passes after switching from deepcopy to shallow copy
- [x] `tests/test_flows.py -k \"from_source or afrom_source\"` (9 tests) passes
- [x] `tests/runner/test_storage.py` (126 tests) passes

## Scope caveat

The original Slack reporter observes failures deploying N flows in GCP Cloud Run Jobs, including **sequentially**, and cannot reproduce locally. That behavior points at something environmental (resource limits, network egress, /tmp size, or auth state in the container) and is not what this PR addresses. This PR fixes a concurrency-safety bug in the same code path that we were able to reproduce deterministically; it is worth landing on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)