### PR TITLE
docs: fix broken internal links

### DIFF
--- a/docs/integrations/prefect-dbt/index.mdx
+++ b/docs/integrations/prefect-dbt/index.mdx
@@ -3,7 +3,7 @@ title: prefect-dbt
 keywords: ["dbt", "data build tool", "transformation", "analytics", "SQL"]
 ---
 
-With `prefect-dbt`, you can trigger and observe dbt Cloud jobs, execute dbt Core CLI commands, and incorporate other tools, such as [Snowflake](/integrations/prefect-snowflake/index), into your dbt runs.
+With `prefect-dbt`, you can trigger and observe dbt Cloud jobs, execute dbt Core CLI commands, and incorporate other tools, such as [Snowflake](/integrations/prefect-snowflake), into your dbt runs.
 Prefect provides a global view of the state of your workflows and allows you to take action based on state changes.
 
 Prefect integrations may provide pre-built [blocks](/v3/develop/blocks), [flows](/v3/develop/write-flows), or [tasks](/v3/develop/write-tasks) for interacting with external systems.

--- a/docs/v3/advanced/daemonize-processes.mdx
+++ b/docs/v3/advanced/daemonize-processes.mdx
@@ -68,7 +68,7 @@ to target the `prefect` application in the `bin` subdirectory of your virtual en
 
 Next, set up your environment so the Prefect client knows which server to connect to.
 
-If connecting to Prefect Cloud, follow [the instructions](v3/how-to-guides/cloud/connect-to-cloud)
+If connecting to Prefect Cloud, follow [the instructions](/v3/how-to-guides/cloud/connect-to-cloud)
 to obtain an API key, and then run the following:
 
 ```bash

--- a/docs/v3/advanced/worker-healthchecks.mdx
+++ b/docs/v3/advanced/worker-healthchecks.mdx
@@ -88,7 +88,7 @@ livenessProbe:
   failureThreshold: 3
 ```
 
-This is enabled by default when using [Prefect's Helm Chart](v3/advanced/server-helm).
+This is enabled by default when using [Prefect's Helm Chart](/v3/advanced/server-helm).
 
 ### Docker Compose with Health Checks
 
@@ -133,7 +133,7 @@ For more information see [Docker Compose's reference guide](https://docs.docker.
 - Check for network connectivity issues between worker and Prefect API
 - Review worker logs for authentication or authorization errors (API key issues)
 - Verify `PREFECT_API_URL` is correctly configured and accessible
-- Check for temporary API outages or [rate limiting](v3/concepts/rate-limits)
+- Check for temporary API outages or [rate limiting](/v3/concepts/rate-limits)
 
 ## Related Configuration
 


### PR DESCRIPTION
## Summary
- fix broken relative links in `docs/v3/advanced/daemonize-processes.mdx`
- fix broken relative links in `docs/v3/advanced/worker-healthchecks.mdx`
- point the `prefect-dbt` Snowflake link at the live integration page

## Why
These links currently resolve relative to the current page instead of the docs root, so they send readers to missing pages.
