### PR TITLE
surface git clone stderr when no hint pattern matches

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -482,6 +482,21 @@ class GitRepository:
                 else exc
             )
             safe_url = strip_auth_from_url(self._url)
+            sanitized_stderr = _sanitize_git_output(
+                _decode_stderr(exc),
+                extra_secrets=[parsed_url.password] if parsed_url.password else None,
+            )
+            # Surface the raw git error at DEBUG so users can opt in via log
+            # level when the hint patterns don't match. The exception chain is
+            # suppressed above when credentials are present, so DEBUG is the
+            # only way to see the actual git output in that case.
+            if sanitized_stderr:
+                self._logger.debug(
+                    "git clone failed (exit %d) for %r: %s",
+                    exc.returncode,
+                    safe_url,
+                    sanitized_stderr.strip(),
+                )
             error_message = (
                 f"Failed to clone repository {safe_url!r} with exit code"
                 f" {exc.returncode}."
@@ -489,6 +504,14 @@ class GitRepository:
             hint = _get_git_clone_error_hint(exc)
             if hint:
                 error_message += f" {hint}"
+            elif sanitized_stderr:
+                # No pattern matched -- surface the actual git error so the
+                # user doesn't have to enable DEBUG to know what went wrong.
+                snippet = sanitized_stderr.strip().splitlines()
+                # Keep the last few lines; git's final 'fatal:' line is usually
+                # the actionable one.
+                tail = " | ".join(snippet[-3:])
+                error_message += f" git stderr: {tail}"
             raise RuntimeError(error_message) from exc_chain
 
         if self._commit_sha:
@@ -962,15 +985,41 @@ _GIT_CLONE_ERROR_HINTS: list[tuple[str, str]] = [
 ]
 
 
+def _decode_stderr(exc: subprocess.CalledProcessError) -> str:
+    """Decode a CalledProcessError's stderr to text, tolerating bytes/None."""
+    if not exc.stderr:
+        return ""
+    if isinstance(exc.stderr, bytes):
+        return exc.stderr.decode("utf-8", errors="replace")
+    return str(exc.stderr)
+
+
+# Match inline basic-auth creds in URLs (e.g. https://user:token@host/...).
+# The replacement preserves the scheme and host so sanitized output is still
+# readable, but scrubs anything between `://` and the last `@` before the host.
+_URL_AUTH_PATTERN = re.compile(r"(?P<scheme>https?://)[^/\s@]+@", flags=re.IGNORECASE)
+
+
+def _sanitize_git_output(text: str, extra_secrets: Optional[list[str]] = None) -> str:
+    """Strip embedded credentials and caller-supplied secrets from git output.
+
+    Git writes the clone URL back to stderr in many failure modes (e.g. "fatal:
+    could not read Username for 'https://token@github.com'"), so we sanitize
+    before logging or surfacing in error messages. Returns `text` unchanged if
+    nothing needs scrubbing.
+    """
+    if not text:
+        return text
+    sanitized = _URL_AUTH_PATTERN.sub(r"\g<scheme>", text)
+    for secret in extra_secrets or ():
+        if secret:
+            sanitized = sanitized.replace(secret, "***")
+    return sanitized
+
+
 def _get_git_clone_error_hint(exc: subprocess.CalledProcessError) -> str | None:
     """Extract a resolution hint from a git clone CalledProcessError's stderr."""
-    stderr = ""
-    if exc.stderr:
-        stderr = (
-            exc.stderr.decode("utf-8", errors="replace")
-            if isinstance(exc.stderr, bytes)
-            else str(exc.stderr)
-        )
+    stderr = _decode_stderr(exc)
     for pattern, hint in _GIT_CLONE_ERROR_HINTS:
         if pattern.lower() in stderr.lower():
             return hint

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -22,6 +22,7 @@ from prefect.runner.storage import (
     RunnerStorage,
     _get_git_clone_error_hint,
     _get_remote_storage_error_hint,
+    _sanitize_git_output,
     create_storage_from_source,
 )
 from prefect.utilities.filesystem import tmpchdir
@@ -1337,6 +1338,104 @@ class TestGitCloneErrorHints:
         repo = GitRepository(url="https://github.com/org/repo.git")
         with pytest.raises(RuntimeError, match="credentials or access token"):
             await repo.pull_code()
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (
+                "fatal: could not read Username for 'https://github.com'",
+                "fatal: could not read Username for 'https://github.com'",
+            ),
+            (
+                "fatal: unable to access 'https://ghp_abc123@github.com/org/repo.git/'",
+                "fatal: unable to access 'https://github.com/org/repo.git/'",
+            ),
+            (
+                "error for https://user:secret@gitlab.com/path and https://tok@example.com/x",
+                "error for https://gitlab.com/path and https://example.com/x",
+            ),
+            ("", ""),
+            ("no urls here", "no urls here"),
+        ],
+    )
+    def test_sanitize_git_output_strips_url_auth(self, raw, expected):
+        assert _sanitize_git_output(raw) == expected
+
+    def test_sanitize_git_output_redacts_extra_secrets(self):
+        text = "remote: token=ghp_abc123 hit rate limit"
+        assert (
+            _sanitize_git_output(text, extra_secrets=["ghp_abc123"])
+            == "remote: token=*** hit rate limit"
+        )
+
+    async def test_clone_repo_surfaces_stderr_when_no_hint_matches(self, monkeypatch):
+        """When git's stderr doesn't match any known pattern, the raw (sanitized)
+        stderr should appear in the RuntimeError so users don't have to
+        monkey-patch Prefect to find out what actually went wrong.
+
+        Regression for private-repo clone failures in GCP Cloud Run Jobs where
+        users saw only `exit code 1.` with no further signal.
+        """
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+
+        stderr = (
+            b"remote: Counting objects: 100% (1/1), done.\n"
+            b"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly\n"
+            b"fatal: early EOF\n"
+        )
+
+        async def mock_run_process_transient(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, ["git", "clone"], stderr=stderr)
+
+        monkeypatch.setattr(
+            "prefect.runner.storage.run_process", mock_run_process_transient
+        )
+
+        repo = GitRepository(url="https://github.com/org/repo.git")
+        with pytest.raises(RuntimeError) as exc_info:
+            await repo.pull_code()
+
+        message = str(exc_info.value)
+        assert "exit code 1" in message
+        assert "git stderr:" in message
+        # The actionable final line should be visible to the user.
+        assert "early EOF" in message
+
+    async def test_clone_repo_logs_sanitized_stderr_at_debug(self, monkeypatch, caplog):
+        """Sanitized stderr should be emitted on the GitRepository debug logger
+        even when credentials are present (so the exception chain is suppressed)."""
+        import logging
+
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+
+        stderr = (
+            b"fatal: unable to access "
+            b"'https://ghp_SECRETTOKEN@github.com/org/repo.git/': HTTP/2 stream closed\n"
+        )
+
+        async def mock_run_process(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, ["git", "clone"], stderr=stderr)
+
+        monkeypatch.setattr("prefect.runner.storage.run_process", mock_run_process)
+
+        # Embed credentials directly in the URL so exc_chain is suppressed.
+        repo = GitRepository(url="https://ghp_SECRETTOKEN@github.com/org/repo.git")
+        with caplog.at_level(
+            logging.DEBUG, logger="prefect.runner.storage.git-repository.repo"
+        ):
+            with pytest.raises(RuntimeError):
+                await repo.pull_code()
+
+        debug_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+            and "git clone failed" in record.getMessage()
+        ]
+        assert debug_messages, "expected a DEBUG log with sanitized git stderr"
+        joined = "\n".join(debug_messages)
+        assert "ghp_SECRETTOKEN" not in joined, "token must be sanitized"
+        assert "github.com" in joined
 
 
 class TestRemoteStorageErrorHints:


### PR DESCRIPTION
## Motivation

A user on Slack reported `prefect deploy` failing in GCP Cloud Run Jobs with:

> `RuntimeError: Failed to clone repository 'https://github.com/.../armor1-apps.git' with exit code 1.`

…and nothing else. No hint, no stderr, no `__cause__` chain (we suppress it when credentials are in the URL, to prevent token leak). That leaves the user with nothing actionable — they don't know if it's auth, network, rate-limiting, or something weirder.

`_clone_repo` discards `git`'s stderr entirely unless it matches one of seven hardcoded substrings in `_GIT_CLONE_ERROR_HINTS` ("Authentication failed", "repository not found", "Could not resolve host", "Connection refused", "Permission denied", "destination path", "not found"). Anything else — transient network failures (`error: RPC failed`, `fatal: early EOF`, HTTP 429 from GitHub secondary rate limits), private-repo-specific errors, or unusual infrastructure-layer problems — gets a bare exit-code message and the evidence is thrown away.

## Changes

Two changes, both in `GitRepository._clone_repo`:

1. **Emit the sanitized git stderr at DEBUG** on the `prefect.runner.storage.git-repository.<name>` logger. Works even when credentials are in the URL, where the exception chain is suppressed — DEBUG is the only channel that reaches the user in that case.
2. **When no hint pattern matches, append a tail of the sanitized stderr to the `RuntimeError` message.** The actionable last line (usually `fatal: ...`) is visible without enabling DEBUG.

### Sanitization

`_sanitize_git_output` scrubs:

- Inline basic-auth credentials in URL-like substrings (git commonly echoes the clone URL back in its stderr — e.g. `fatal: unable to access 'https://ghp_XXX@github.com/...'` becomes `https://github.com/...`)
- Caller-supplied secret strings (passed as `extra_secrets=[...]` when we know the token value at call time)

### Before / after

Before:
```
RuntimeError: Failed to clone repository 'https://github.com/org/repo.git' with exit code 1.
```

After (same failure, no config change):
```
RuntimeError: Failed to clone repository 'https://github.com/org/repo.git' with exit code 1. git stderr: remote: Counting objects: 100% (1/1), done. | error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly | fatal: early EOF
```

And at DEBUG, even when credentials are in the URL (token is scrubbed):
```
DEBUG | prefect.runner.storage.git-repository.repo - git clone failed (exit 1) for 'https://github.com/org/repo.git': fatal: unable to access 'https://github.com/org/repo.git/': HTTP/2 stream closed
```

## Test plan

- [x] 7 new tests covering `_sanitize_git_output`, the DEBUG log path with credentials, and the error-message tail
- [x] All 134 tests in `tests/runner/test_storage.py` pass
- [x] Existing `test_clone_repo_includes_hint_in_error` still passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
