### PR TITLE
repro: cyclopts runner state leak across in-process invocations

### DIFF
--- a/tests/cli/deploy/test_cyclopts_runner_state_leak.py
+++ b/tests/cli/deploy/test_cyclopts_runner_state_leak.py
@@ -1,0 +1,84 @@
+"""Reproducer for a cyclopts runner state leak that makes a sequence of
+`CycloptsCliRunner.invoke(...)` calls behave differently from individual calls.
+
+Observed symptom
+----------------
+Three tests in `tests/cli/deploy/test_deploy_versioning.py` pass when run in
+isolation but fail when run as a group::
+
+    uv run pytest tests/cli/deploy/test_deploy_versioning.py
+    FAILED tests/cli/deploy/test_deploy_versioning.py::test_deploy_with_inferred_version
+    FAILED tests/cli/deploy/test_deploy_versioning.py::test_deploy_with_inferred_version_and_version_name
+    FAILED tests/cli/deploy/test_deploy_versioning.py::test_deploy_with_simple_type_and_no_version_uses_flow_version
+
+The captured stderr on the second-and-subsequent failures is::
+
+    ╭─ Error ─────────────────────────╮
+    │ Unknown option: "-n".           │
+    ╰─────────────────────────────────╯
+
+i.e. cyclopts no longer recognizes the `-n` alias on `deploy --name`. The
+alias is clearly registered -- it works on the first invocation of the
+process and in isolation.
+
+The minimal reproduction in this module strips everything back to:
+
+1. invoke `prefect deploy --help` once (which triggers cyclopts lazy-loading
+   of `prefect.cli.deploy.deploy_app`),
+2. invoke `prefect deploy ./x.py:f -n x -p p` -- which now fails parsing.
+
+Hypothesis
+----------
+`CommandSpec.resolve()` in cyclopts caches the imported App on first access
+and returns the cached instance thereafter. Something about the help-flag
+show-state mutation at the end of `resolve()`, or cyclopts' parameter
+parsing caching, is leaving the resolved deploy app in a state where later
+token parses no longer see the `-n` alias. Needs someone familiar with
+cyclopts internals to confirm.
+
+Both `CycloptsCliRunner.invoke` and `prefect.cli._app._app.meta` are
+plausible fix sites; this test is strictly a reproducer.
+
+Marked xfail so the rest of the suite is unaffected; remove the marker
+once the leak is fixed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prefect.testing.cli import CycloptsCliRunner
+
+
+@pytest.mark.xfail(
+    reason=(
+        "cyclopts runner state leak: second `deploy` invocation loses the "
+        "`-n` alias after a prior `deploy --help` call in the same process"
+    ),
+    strict=True,
+)
+def test_deploy_n_alias_survives_prior_invocation():
+    """First invocation: `deploy --help` (clean exit, triggers lazy load).
+    Second invocation: `deploy ... -n NAME ...` should still parse `-n`.
+
+    Currently fails: cyclopts reports `Unknown option: "-n".` on the second
+    call even though the first call left exit_code=0 and the alias is
+    defined exactly once in `src/prefect/cli/deploy/_commands.py`.
+    """
+    # Cleanly triggers lazy load of the deploy subcommand.
+    first = CycloptsCliRunner().invoke(["deploy", "--help"])
+    assert first.exit_code == 0
+
+    # Same process, second invocation. We don't care whether deploy
+    # *succeeds* here -- no workpool, no flow file -- we only care that
+    # cyclopts parses the flags. If this regresses into "Unknown option:
+    # -n", the leak is back.
+    second = CycloptsCliRunner().invoke(
+        ["deploy", "./does_not_matter.py:f", "-n", "my-name", "-p", "some-pool"]
+    )
+    stderr_text = second.stderr or ""
+    # The check we actually care about: the parser must have accepted the
+    # tokens, regardless of subsequent failures in the command body.
+    assert "Unknown option" not in stderr_text, (
+        f"cyclopts lost an alias across invocations; stderr: {stderr_text[:300]!r}"
+    )


### PR DESCRIPTION
## What this PR is

**Draft / reproducer only.** Lands a single `xfail(strict=True)` test that exercises a state leak in how `CycloptsCliRunner` / cyclopts handle repeated in-process invocations of the `deploy` subcommand. No fix yet — I wasn't able to isolate which layer needs the fix without help from someone with more cyclopts internals context.

## What's broken

Three tests in `tests/cli/deploy/test_deploy_versioning.py` pass in isolation but fail when run as a group:

```
FAILED tests/cli/deploy/test_deploy_versioning.py::test_deploy_with_inferred_version
FAILED tests/cli/deploy/test_deploy_versioning.py::test_deploy_with_inferred_version_and_version_name
FAILED tests/cli/deploy/test_deploy_versioning.py::test_deploy_with_simple_type_and_no_version_uses_flow_version
```

The captured stderr on the second-and-subsequent failures is:

```
╭─ Error ─────────────────────────╮
│ Unknown option: "-n".           │
╰─────────────────────────────────╯
```

i.e. cyclopts no longer recognizes the `-n` alias for `--name` on the `deploy` command. The alias works on the first invocation in the process and in isolation.

## Minimal repro (also in this PR)

```python
def test_deploy_n_alias_survives_prior_invocation():
    first = CycloptsCliRunner().invoke(["deploy", "--help"])
    assert first.exit_code == 0

    second = CycloptsCliRunner().invoke(
        ["deploy", "./does_not_matter.py:f", "-n", "my-name", "-p", "some-pool"]
    )
    assert "Unknown option" not in (second.stderr or "")
```

First invocation: clean exit, triggers cyclopts' lazy-load of `prefect.cli.deploy:deploy_app`.
Second invocation: fails at argument parsing. No fixtures, no mocks, no threads, no cwd changes. Just two back-to-back in-process invocations.

## What I investigated

- Not sys.modules or import caches — confirmed with a snapshot diff across calls.
- Not the `CycloptsCliRunner` stdin/stdout/stderr swap — that's fully restored in `finally`.
- Not `_normalize_top_level_flags` — `-n` only appears after the command name so it's passed through unchanged.
- `CommandSpec.resolve()` in cyclopts caches the imported `App` on first access. At the end of `resolve()` it mutates `self._resolved[flag].show = False` for help/version flags, but that's a one-time mutation and runs on the first call too. Not obviously the trigger.
- Couldn't reproduce the leak calling `invoke` twice in a plain Python script — only under pytest. So there's some interaction with pytest's test-boundary teardown that's relevant.

## What would unblock a fix

Someone who knows cyclopts' parameter parsing / token resolution cache can probably identify the mutated field in a couple of minutes. My guess is either:
1. Cyclopts is caching a resolved `Parameter` set per `App` and one of the mutations invalidates the alias map, or
2. The `CycloptsCliRunner` should be reinstantiating `_app` per invocation (it currently uses the module-level singleton).

Happy to drive whichever direction lands on.

## Test plan

- [x] New `xfail(strict=True)` test reproduces the leak (will XPASS and flag the PR that fixes it)
- [ ] Fix + remove `xfail` marker (follow-up)
- [ ] Verify `tests/cli/deploy/test_deploy_versioning.py` all 4 tests pass when run together

🤖 Generated with [Claude Code](https://claude.com/claude-code)
