### PR TITLE
stop leaking `sys.modules` entries in `load_script_as_module`

### DIFF
--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -1,4 +1,5 @@
 import ast
+import hashlib
 import importlib
 import importlib.util
 import os
@@ -95,7 +96,16 @@ def load_script_as_module(path: str) -> ModuleType:
 
     # fall back in case of filenames with the same names as modules
     if module_name in sys.modules:
-        module_name = f"__prefect_loader_{id(path)}__"
+        # Key on the resolved absolute path (via a short stable hash) so that
+        # repeated loads of the same file reuse the same `sys.modules` slot
+        # rather than leaking a fresh entry every call. Previously this used
+        # `id(path)`, which is the identity of the Python string argument --
+        # fresh on every call site -- so callers that loaded the same file in
+        # a loop grew `sys.modules` unboundedly.
+        path_digest = hashlib.sha1(
+            str(Path(path).resolve()).encode("utf-8")
+        ).hexdigest()[:16]
+        module_name = f"__prefect_loader_{path_digest}__"
 
     spec = importlib.util.spec_from_file_location(
         module_name,

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -401,6 +401,48 @@ def test_safe_load_namespace_implicit_relative_imports():
     assert "get_bar" in namespace
 
 
+def test_load_script_as_module_does_not_leak_sys_modules_on_repeated_loads(
+    tmp_path: Path,
+):
+    """Regression: `load_script_as_module` fell back to `__prefect_loader_{id(path)}__`
+    when the simple filename-derived module name was already claimed. `id(path)` is
+    the id of the *Python string object* passed in -- fresh on every call -- so
+    repeated loads of the same file (e.g. `Flow.afrom_source` in a loop against a
+    fresh tmpdir) added a new `sys.modules` entry every iteration, never popping
+    prior ones. Unbounded growth in long-running deploy scripts.
+    """
+    # First, make the simple name collide so the fallback path is exercised.
+    # The fixture gives us a fresh tmpdir; put two separate directories inside
+    # so both have a my_flow.py with different content.
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_a / "my_flow.py").write_text("x = 1\n")
+    (dir_b / "my_flow.py").write_text("x = 2\n")
+
+    before = set(sys.modules)
+    try:
+        # Claims sys.modules["my_flow"].
+        load_script_as_module(str(dir_a / "my_flow.py"))
+        # Each of these hits the fallback because "my_flow" is already taken.
+        # With the bug, every call allocates a new __prefect_loader_{id}__ key
+        # because `id(str(dir_b / "my_flow.py"))` is fresh each call.
+        for _ in range(5):
+            load_script_as_module(str(dir_b / "my_flow.py"))
+        added = set(sys.modules) - before
+    finally:
+        for k in set(sys.modules) - before:
+            sys.modules.pop(k, None)
+
+    # Expected: one "my_flow" slot (from dir_a) + one stable fallback slot (dir_b).
+    # With the bug: 1 + 5 = 6 slots.
+    assert len(added) <= 2, (
+        f"load_script_as_module leaked {len(added)} sys.modules entries for "
+        f"repeated loads of the same file: {sorted(added)}"
+    )
+
+
 def test_concurrent_script_loading(tmpdir: Path):
     """Test that loading multiple scripts concurrently is thread-safe.
 


### PR DESCRIPTION
## History of this code path

This file has a layered history that's worth walking before explaining the fix, because each prior change was correct in isolation and the leak only emerges from their combination.

**Before December 2024** — `module_name` was the literal string `"__prefect_loader__"`. Not thread-safe: concurrent `load_script_as_module` calls clobbered each other's `sys.modules["__prefect_loader__"]` entry mid-flight. After loading, the entry was popped in a `finally` block along with `sys.path` entries.

**[#16458](https://github.com/PrefectHQ/prefect/pull/16458) (Dec 2024)** — "make `from_source` safe to use concurrently." Switched to `f"__prefect_loader_{id(path)}__"` so each concurrent call got a distinct key. Still popped after load. Addressed the race condition.

**[#17524](https://github.com/PrefectHQ/prefect/pull/17524) (Mar 2025)** — "Don't pop the loader module." Closed six multiprocessing/pickle issues (#9329, #5984, #17150, #9542, #6762, #17449), all variants of `Pool` workers failing to unpickle objects whose `__module__` pointed at a name that was no longer in `sys.modules`. Two changes:

- **Primary path**: use the filename (`my_flow`) as the module name, so pickle-via-qualname resolves correctly.
- **Fallback**: keep `f"__prefect_loader_{id(path)}__"` for when the filename collides.
- **Removed** the `sys.modules.pop(...)` and `sys.path.remove(...)` in the `finally`.

The six closed issues remain fixed — they depend on the *primary* path, and the module staying resident in `sys.modules` under its filename-based name. This PR does not touch the primary path.

## The leak this PR fixes

With #17524's no-pop behavior in place, the `id(path)` fallback from #16458 becomes a leak source. `id(path)` is the identity of the **Python string object** passed in by the caller — fresh on every call site. So any code path that enters the fallback branch more than once (e.g. `Flow.afrom_source` in a loop, each iteration with a new tmpdir and the same basename) allocates a brand-new `__prefect_loader_<some-id>__` key in `sys.modules` every time, and nothing ever pops.

I measured on a sequential loop of 10 `Flow.afrom_source` calls against a trivial public repo: `sys.modules` grew by +1 every iteration. For flow modules that top-level import heavy packages (pandas, sqlalchemy, internal packages), each leaked module's `__globals__` pins the whole transitive import graph, preventing GC. In constrained containers the accumulated RSS can push `posix_spawn` of subsequent `git clone` calls into exit-1 territory — which is the shape of the user-reported failure that kicked off this thread.

This PR is not a claimed cause of that specific user's GCP failure — [#21689](https://github.com/PrefectHQ/prefect/pull/21689) addresses their visibility problem independently — but the leak is real and worth fixing on its own.

## Fix

Key the fallback on a short stable hash of the **resolved absolute path** instead of `id(path)`:

```python
# before (since #16458, kept as fallback in #17524)
if module_name in sys.modules:
    module_name = f"__prefect_loader_{id(path)}__"  # fresh every call

# after
if module_name in sys.modules:
    path_digest = hashlib.sha1(
        str(Path(path).resolve()).encode("utf-8")
    ).hexdigest()[:16]
    module_name = f"__prefect_loader_{path_digest}__"
```

Repeated loads of the same file now reuse the same `sys.modules` slot instead of allocating a new one each call.

## Why this doesn't regress #17524

#17524's six closed issues all involve workers failing to unpickle objects because the loader module isn't in `sys.modules`. Those failures depend on the primary path, where `module_name = "my_flow"` is used. This PR does not touch the primary path.

The fallback branch is only taken when a *second* file with the same basename as an already-loaded module is loaded (e.g. two different `my_flow.py` files in different tmpdirs). That's the edge case that's been leaking since #17524.

## Trade-off to flag explicitly

With this change, loading the *same path* through the fallback branch twice in one process will **overwrite** the previous `sys.modules` entry instead of allocating a fresh one. Concretely: if iter-2 captured a Flow into a variable and iter-3 loads the same file again, iter-3 replaces `sys.modules[key]` and iter-2's module object may be GC'd once no other references remain. In a multiprocessing scenario where iter-2's Flow was passed to a pool worker, a `spawn`-mode worker that unpickles *after* iter-3 has run in the parent might see iter-3's module under the same key, with different class identity.

I believe this is acceptable because:
1. Deploy-time loops (the motivating use case) finish all their loads before any multiprocessing starts.
2. The fallback branch is already an edge case — two distinct files with the same basename, in the same process.
3. The existing behavior on this edge case is unbounded memory growth, which is its own failure mode.

Happy to swap to an explicit cleanup / context-manager style (return `(module, cleanup_fn)` so callers opt into popping) if the overwrite semantics are a blocker. That's a bigger diff touching `import_object` and call sites, which is why I'd prefer to ship the narrower fix first.

## Test plan

- [x] New regression test (TDD-style — fails on `main` with 6 leaked entries, passes with the fix)
- [x] `tests/utilities/test_importtools.py` — 41 tests pass, including `test_concurrent_script_loading` (from #16458, exercises thread-safety) and the other tests updated in #17524
- [x] `tests/test_flows.py -k "load_flow or from_source"` — 29 tests pass
- [ ] (reviewer) manual sanity on `integration-tests/test_multiprocessing_flow.py` (regression test for #9329 added in #17524) — only loads one flow, so the fallback branch isn't exercised, but worth confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)
