### PR TITLE
Add isolated workspace resolver for flow run setup

### DIFF
--- a/src/prefect/deployments/steps/core.py
+++ b/src/prefect/deployments/steps/core.py
@@ -19,6 +19,7 @@ import subprocess
 import warnings
 from copy import deepcopy
 from importlib import import_module
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
@@ -44,6 +45,13 @@ class StepExecutionError(Exception):
     """
     Raised when a step fails to execute.
     """
+
+
+def _safe_current_working_directory() -> Path | None:
+    try:
+        return Path.cwd().resolve()
+    except OSError:
+        return None
 
 
 def _strip_version(requirement: str) -> str:
@@ -150,6 +158,7 @@ async def run_steps(
     deployment: Any | None = None,
     flow_run: Any | None = None,
     logger: Any | None = None,
+    step_completion_callback: Any | None = None,
 ) -> dict[str, Any]:
     upstream_outputs = deepcopy(upstream_outputs) if upstream_outputs else {}
     for step_index, step in enumerate(steps):
@@ -177,6 +186,11 @@ async def run_steps(
 
         try:
             # catch warnings to ensure deprecation warnings are printed
+            step_start_cwd = (
+                _safe_current_working_directory()
+                if step_completion_callback is not None
+                else None
+            )
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter(
                     "always",
@@ -200,6 +214,14 @@ async def run_steps(
                             # default to printing without styling
                             print_function(message)
                         printed_messages.append(message)
+
+            if step_completion_callback is not None:
+                step_completion_callback(
+                    step,
+                    step_output,
+                    step_start_cwd,
+                    _safe_current_working_directory(),
+                )
 
             if not isinstance(step_output, dict):
                 if PREFECT_DEBUG_MODE:

--- a/src/prefect/deployments/steps/core.py
+++ b/src/prefect/deployments/steps/core.py
@@ -17,6 +17,9 @@ import os
 import re
 import subprocess
 import warnings
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from copy import deepcopy
 from importlib import import_module
 from pathlib import Path
@@ -40,6 +43,15 @@ from prefect.utilities.templating import (
 
 RESERVED_KEYWORDS = {"id", "requires"}
 
+_StepCompletionObserver = Callable[
+    [dict[str, Any], Any, Path | None, Path | None],
+    None,
+]
+_STEP_COMPLETION_OBSERVER: ContextVar[_StepCompletionObserver | None] = ContextVar(
+    "step_completion_observer",
+    default=None,
+)
+
 
 class StepExecutionError(Exception):
     """
@@ -52,6 +64,15 @@ def _safe_current_working_directory() -> Path | None:
         return Path.cwd().resolve()
     except OSError:
         return None
+
+
+@contextmanager
+def _observe_step_completion(callback: _StepCompletionObserver) -> Iterator[None]:
+    token = _STEP_COMPLETION_OBSERVER.set(callback)
+    try:
+        yield
+    finally:
+        _STEP_COMPLETION_OBSERVER.reset(token)
 
 
 def _strip_version(requirement: str) -> str:
@@ -158,9 +179,9 @@ async def run_steps(
     deployment: Any | None = None,
     flow_run: Any | None = None,
     logger: Any | None = None,
-    step_completion_callback: Any | None = None,
 ) -> dict[str, Any]:
     upstream_outputs = deepcopy(upstream_outputs) if upstream_outputs else {}
+    step_completion_observer = _STEP_COMPLETION_OBSERVER.get()
     for step_index, step in enumerate(steps):
         if not step:
             continue
@@ -188,7 +209,7 @@ async def run_steps(
             # catch warnings to ensure deprecation warnings are printed
             step_start_cwd = (
                 _safe_current_working_directory()
-                if step_completion_callback is not None
+                if step_completion_observer is not None
                 else None
             )
             with warnings.catch_warnings(record=True) as w:
@@ -215,8 +236,8 @@ async def run_steps(
                             print_function(message)
                         printed_messages.append(message)
 
-            if step_completion_callback is not None:
-                step_completion_callback(
+            if step_completion_observer is not None:
+                step_completion_observer(
                     step,
                     step_output,
                     step_start_cwd,

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -14,7 +14,7 @@ import anyio
 from pydantic import BaseModel
 
 from prefect.client.orchestration import get_client
-from prefect.deployments.steps.core import run_steps
+from prefect.deployments.steps.core import _observe_step_completion, run_steps
 from prefect.filesystems import LocalFileSystem
 from prefect.logging.loggers import get_logger
 from prefect.utilities.filesystem import relative_path_to_current_platform
@@ -210,14 +210,14 @@ async def prepare_workspace(
             if step_end_cwd is not None and step_end_cwd != step_start_cwd:
                 working_directory = step_end_cwd
 
-        await run_steps(
-            deployment.pull_steps,
-            print_function=_stderr_print,
-            deployment=deployment,
-            flow_run=flow_run,
-            logger=LOGGER,
-            step_completion_callback=_track_step_workspace,
-        )
+        with _observe_step_completion(_track_step_workspace):
+            await run_steps(
+                deployment.pull_steps,
+                print_function=_stderr_print,
+                deployment=deployment,
+                flow_run=flow_run,
+                logger=LOGGER,
+            )
 
     project_root = _find_project_root(working_directory, resolved_workspace_root)
     return PreparedWorkspace(

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -123,6 +123,19 @@ def _capture_sys_path() -> list[str]:
     return [str(path_entry) for path_entry in sys.path]
 
 
+def _resolve_local_deployment_path(
+    path: str | None, workspace_root: Path, source_cwd: Path
+) -> str | None:
+    if path is None:
+        return None
+
+    path = path.replace("$STORAGE_BASE_PATH", str(workspace_root))
+    resolved_path = Path(path).expanduser()
+    if resolved_path.is_absolute():
+        return str(resolved_path.resolve())
+    return str((source_cwd / resolved_path).resolve())
+
+
 @contextlib.contextmanager
 def _redirect_stdout_to_stderr() -> Any:
     stdout = sys.stdout
@@ -147,6 +160,7 @@ async def _pull_storage_into_workspace(
     client: "PrefectClient",
     deployment: "DeploymentResponse",
     workspace_root: Path,
+    source_cwd: Path,
 ) -> None:
     if deployment.storage_document_id:
         storage_document = await client.read_block_document(
@@ -155,19 +169,21 @@ async def _pull_storage_into_workspace(
         from prefect.blocks.core import Block
 
         storage_block = Block._from_block_document(storage_document)
+        from_path = (
+            str(deployment.path).replace("$STORAGE_BASE_PATH", str(workspace_root))
+            if deployment.path
+            else None
+        )
     else:
-        basepath = deployment.path
-        if basepath:
-            basepath = str(basepath).replace("$STORAGE_BASE_PATH", str(workspace_root))
-        storage_block = LocalFileSystem(basepath=basepath)
+        from_path = _resolve_local_deployment_path(
+            deployment.path, workspace_root, source_cwd
+        )
+        storage_block = LocalFileSystem(basepath=from_path)
 
-    from_path = (
-        str(deployment.path).replace("$STORAGE_BASE_PATH", str(workspace_root))
-        if deployment.path
-        else None
-    )
     LOGGER.info("Downloading flow code from storage at %r", from_path)
-    await storage_block.get_directory(from_path=from_path, local_path=".")
+    await storage_block.get_directory(
+        from_path=from_path, local_path=str(workspace_root)
+    )
 
 
 async def prepare_workspace(
@@ -181,14 +197,20 @@ async def prepare_workspace(
             f"Deployment {deployment.id} does not have an entrypoint and can not be run."
         )
 
+    source_cwd = Path.cwd().resolve()
     resolved_workspace_root = Path(workspace_root).expanduser().resolve()
     resolved_workspace_root.mkdir(parents=True, exist_ok=True)
-    os.chdir(resolved_workspace_root)
-    working_directory = Path.cwd().resolve()
+    working_directory = resolved_workspace_root
 
     if not deployment.pull_steps:
-        await _pull_storage_into_workspace(client, deployment, resolved_workspace_root)
+        await _pull_storage_into_workspace(
+            client, deployment, resolved_workspace_root, source_cwd
+        )
+        os.chdir(resolved_workspace_root)
+        working_directory = Path.cwd().resolve()
     else:
+        os.chdir(resolved_workspace_root)
+        working_directory = Path.cwd().resolve()
         LOGGER.info("Running %s deployment pull step(s)", len(deployment.pull_steps))
 
         def _track_step_workspace(

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import argparse
+import builtins
+import contextlib
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+from uuid import UUID
+
+import anyio
+from pydantic import BaseModel
+
+from prefect.client.orchestration import get_client
+from prefect.deployments.steps.core import run_steps
+from prefect.filesystems import LocalFileSystem
+from prefect.logging.loggers import get_logger
+from prefect.utilities.filesystem import relative_path_to_current_platform
+from prefect.utilities.processutils import get_sys_executable
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import PrefectClient
+    from prefect.client.schemas.objects import FlowRun
+    from prefect.client.schemas.responses import DeploymentResponse
+
+LOGGER = get_logger("prefect.runner.workspace_resolver")
+
+
+class PreparedWorkspace(BaseModel):
+    workspace_root: Path
+    working_directory: Path
+    project_root: Path | None = None
+    runtime_entrypoint: str
+    environment: dict[str, str]
+    sys_path: list[str]
+
+
+class PreparedWorkspaceError(BaseModel):
+    error_type: str
+    error_message: str
+    cause_type: str | None = None
+    cause_message: str | None = None
+
+
+class PreparedWorkspaceResult(BaseModel):
+    status: Literal["success", "error"]
+    workspace: PreparedWorkspace | None = None
+    error: PreparedWorkspaceError | None = None
+
+
+def get_workspace_resolver_command(
+    flow_run_id: UUID | str, workspace_root: Path | str
+) -> list[str]:
+    return [
+        get_sys_executable(),
+        "-m",
+        "prefect.runner._workspace_resolver",
+        str(flow_run_id),
+        str(workspace_root),
+    ]
+
+
+def _stderr_print(*args: Any, **kwargs: Any) -> None:
+    kwargs.pop("style", None)
+    builtins.print(*args, file=sys.stderr, **kwargs)
+
+
+def _resolve_runtime_entrypoint(entrypoint: str) -> str:
+    if ":" not in entrypoint:
+        return entrypoint
+    return str(relative_path_to_current_platform(entrypoint))
+
+
+def _resolve_directory_output(
+    step_output: dict[str, Any], step_end_cwd: Path | None
+) -> Path | None:
+    directory = step_output.get("directory")
+    candidate = Path(directory).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve()
+    if step_end_cwd is None:
+        return None
+    return (step_end_cwd / candidate).resolve()
+
+
+def _find_nearest_pyproject_ancestor(start: Path, lower_bound: Path) -> Path | None:
+    current = start.resolve()
+    boundary = lower_bound.resolve()
+
+    while True:
+        if (current / "pyproject.toml").is_file():
+            return current
+        if current == boundary:
+            return None
+        current = current.parent
+
+
+def _find_project_root(working_directory: Path, workspace_root: Path) -> Path | None:
+    resolved_working_directory = working_directory.resolve()
+    resolved_workspace_root = workspace_root.resolve()
+
+    try:
+        resolved_working_directory.relative_to(resolved_workspace_root)
+    except ValueError:
+        return _find_nearest_pyproject_ancestor(
+            resolved_working_directory,
+            Path(resolved_working_directory.anchor),
+        )
+
+    return _find_nearest_pyproject_ancestor(
+        resolved_working_directory,
+        resolved_workspace_root,
+    )
+
+
+def _capture_environment() -> dict[str, str]:
+    return dict(os.environ)
+
+
+def _capture_sys_path() -> list[str]:
+    return [str(path_entry) for path_entry in sys.path]
+
+
+@contextlib.contextmanager
+def _redirect_stdout_to_stderr() -> Any:
+    stdout = sys.stdout
+    stderr = sys.stderr
+
+    stdout.flush()
+    stderr.flush()
+
+    saved_stdout_fd = os.dup(stdout.fileno())
+    try:
+        os.dup2(stderr.fileno(), stdout.fileno())
+        with contextlib.redirect_stdout(stderr):
+            yield
+            stderr.flush()
+    finally:
+        stdout.flush()
+        os.dup2(saved_stdout_fd, stdout.fileno())
+        os.close(saved_stdout_fd)
+
+
+async def _pull_storage_into_workspace(
+    client: "PrefectClient",
+    deployment: "DeploymentResponse",
+    workspace_root: Path,
+) -> None:
+    if deployment.storage_document_id:
+        storage_document = await client.read_block_document(
+            deployment.storage_document_id
+        )
+        from prefect.blocks.core import Block
+
+        storage_block = Block._from_block_document(storage_document)
+    else:
+        basepath = deployment.path
+        if basepath:
+            basepath = str(basepath).replace("$STORAGE_BASE_PATH", str(workspace_root))
+        storage_block = LocalFileSystem(basepath=basepath)
+
+    from_path = (
+        str(deployment.path).replace("$STORAGE_BASE_PATH", str(workspace_root))
+        if deployment.path
+        else None
+    )
+    LOGGER.info("Downloading flow code from storage at %r", from_path)
+    await storage_block.get_directory(from_path=from_path, local_path=".")
+
+
+async def prepare_workspace(
+    client: "PrefectClient",
+    flow_run: "FlowRun",
+    deployment: "DeploymentResponse",
+    workspace_root: Path | str,
+) -> PreparedWorkspace:
+    if deployment.entrypoint is None:
+        raise ValueError(
+            f"Deployment {deployment.id} does not have an entrypoint and can not be run."
+        )
+
+    resolved_workspace_root = Path(workspace_root).expanduser().resolve()
+    resolved_workspace_root.mkdir(parents=True, exist_ok=True)
+    os.chdir(resolved_workspace_root)
+    working_directory = Path.cwd().resolve()
+
+    if not deployment.pull_steps:
+        await _pull_storage_into_workspace(client, deployment, resolved_workspace_root)
+    else:
+        LOGGER.info("Running %s deployment pull step(s)", len(deployment.pull_steps))
+
+        def _track_step_workspace(
+            _step: dict[str, Any],
+            step_output: Any,
+            step_start_cwd: Path | None,
+            step_end_cwd: Path | None,
+        ) -> None:
+            nonlocal working_directory
+
+            if isinstance(step_output, dict) and "directory" in step_output:
+                resolved_directory = _resolve_directory_output(
+                    step_output, step_end_cwd
+                )
+                if resolved_directory is not None:
+                    working_directory = resolved_directory
+                return
+
+            if step_end_cwd is not None and step_end_cwd != step_start_cwd:
+                working_directory = step_end_cwd
+
+        await run_steps(
+            deployment.pull_steps,
+            print_function=_stderr_print,
+            deployment=deployment,
+            flow_run=flow_run,
+            logger=LOGGER,
+            step_completion_callback=_track_step_workspace,
+        )
+
+    project_root = _find_project_root(working_directory, resolved_workspace_root)
+    return PreparedWorkspace(
+        workspace_root=resolved_workspace_root,
+        working_directory=working_directory,
+        project_root=project_root,
+        runtime_entrypoint=_resolve_runtime_entrypoint(deployment.entrypoint),
+        environment=_capture_environment(),
+        sys_path=_capture_sys_path(),
+    )
+
+
+async def prepare_workspace_for_flow_run(
+    flow_run_id: UUID | str,
+    workspace_root: Path | str,
+) -> PreparedWorkspace:
+    async with get_client() as client:
+        flow_run = await client.read_flow_run(UUID(str(flow_run_id)))
+        if flow_run.deployment_id is None:
+            raise ValueError("Flow run does not have an associated deployment")
+
+        deployment = await client.read_deployment(flow_run.deployment_id)
+        return await prepare_workspace(client, flow_run, deployment, workspace_root)
+
+
+def _build_error(exc: BaseException) -> PreparedWorkspaceError:
+    cause = exc.__cause__
+    return PreparedWorkspaceError(
+        error_type=type(exc).__name__,
+        error_message=str(exc),
+        cause_type=type(cause).__name__ if cause else None,
+        cause_message=str(cause) if cause else None,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare a flow run workspace in an isolated subprocess."
+    )
+    parser.add_argument("flow_run_id", type=UUID)
+    parser.add_argument("workspace_root")
+    return parser.parse_args(argv)
+
+
+async def _main_async(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        with _redirect_stdout_to_stderr():
+            workspace = await prepare_workspace_for_flow_run(
+                args.flow_run_id, args.workspace_root
+            )
+    except Exception as exc:
+        traceback.print_exc(file=sys.stderr)
+        result = PreparedWorkspaceResult(status="error", error=_build_error(exc))
+        sys.stdout.write(result.model_dump_json())
+        sys.stdout.write("\n")
+        return 1
+
+    result = PreparedWorkspaceResult(status="success", workspace=workspace)
+    sys.stdout.write(result.model_dump_json())
+    sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return anyio.run(_main_async, argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from prefect.client.schemas.responses import DeploymentResponse
 
 LOGGER = get_logger("prefect.runner.workspace_resolver")
+STORAGE_BASE_PATH_PLACEHOLDER = "$STORAGE_BASE_PATH"
 
 
 class PreparedWorkspace(BaseModel):
@@ -123,17 +124,54 @@ def _capture_sys_path() -> list[str]:
     return [str(path_entry) for path_entry in sys.path]
 
 
+def _get_configured_storage_base_path() -> Path | None:
+    storage_base_path = os.environ.get("PREFECT__STORAGE_BASE_PATH")
+    if not storage_base_path:
+        return None
+    return Path(storage_base_path).expanduser().resolve()
+
+
+def _substitute_storage_base_path(path: str, storage_base_path: Path | None) -> str:
+    if storage_base_path is None:
+        return path
+    return path.replace(STORAGE_BASE_PATH_PLACEHOLDER, str(storage_base_path))
+
+
 def _resolve_local_deployment_path(
-    path: str | None, workspace_root: Path, source_cwd: Path
+    path: str | None, source_cwd: Path, storage_base_path: Path | None
 ) -> str | None:
     if path is None:
         return None
 
-    path = path.replace("$STORAGE_BASE_PATH", str(workspace_root))
+    path = _substitute_storage_base_path(path, storage_base_path)
     resolved_path = Path(path).expanduser()
     if resolved_path.is_absolute():
         return str(resolved_path.resolve())
     return str((source_cwd / resolved_path).resolve())
+
+
+def _workspace_destination_for_deployment_path(
+    path: str | None, workspace_root: Path, storage_base_path: Path | None
+) -> Path:
+    if (
+        path is None
+        or storage_base_path is None
+        or STORAGE_BASE_PATH_PLACEHOLDER not in path
+    ):
+        return workspace_root
+
+    source_path = Path(
+        path.replace(STORAGE_BASE_PATH_PLACEHOLDER, str(storage_base_path))
+    ).expanduser()
+    if not source_path.is_absolute():
+        return workspace_root
+
+    try:
+        relative_destination = source_path.resolve().relative_to(storage_base_path)
+    except ValueError:
+        return workspace_root
+
+    return (workspace_root / relative_destination).resolve()
 
 
 @contextlib.contextmanager
@@ -161,7 +199,12 @@ async def _pull_storage_into_workspace(
     deployment: "DeploymentResponse",
     workspace_root: Path,
     source_cwd: Path,
-) -> None:
+    storage_base_path: Path | None,
+) -> Path:
+    local_path = _workspace_destination_for_deployment_path(
+        deployment.path, workspace_root, storage_base_path
+    )
+
     if deployment.storage_document_id:
         storage_document = await client.read_block_document(
             deployment.storage_document_id
@@ -170,20 +213,19 @@ async def _pull_storage_into_workspace(
 
         storage_block = Block._from_block_document(storage_document)
         from_path = (
-            str(deployment.path).replace("$STORAGE_BASE_PATH", str(workspace_root))
+            _substitute_storage_base_path(str(deployment.path), storage_base_path)
             if deployment.path
             else None
         )
     else:
         from_path = _resolve_local_deployment_path(
-            deployment.path, workspace_root, source_cwd
+            deployment.path, source_cwd, storage_base_path
         )
         storage_block = LocalFileSystem(basepath=from_path)
 
     LOGGER.info("Downloading flow code from storage at %r", from_path)
-    await storage_block.get_directory(
-        from_path=from_path, local_path=str(workspace_root)
-    )
+    await storage_block.get_directory(from_path=from_path, local_path=str(local_path))
+    return local_path
 
 
 async def prepare_workspace(
@@ -198,15 +240,20 @@ async def prepare_workspace(
         )
 
     source_cwd = Path.cwd().resolve()
+    storage_base_path = _get_configured_storage_base_path()
     resolved_workspace_root = Path(workspace_root).expanduser().resolve()
     resolved_workspace_root.mkdir(parents=True, exist_ok=True)
     working_directory = resolved_workspace_root
 
     if not deployment.pull_steps:
-        await _pull_storage_into_workspace(
-            client, deployment, resolved_workspace_root, source_cwd
+        working_directory = await _pull_storage_into_workspace(
+            client,
+            deployment,
+            resolved_workspace_root,
+            source_cwd,
+            storage_base_path,
         )
-        os.chdir(resolved_workspace_root)
+        os.chdir(working_directory)
         working_directory = Path.cwd().resolve()
     else:
         os.chdir(resolved_workspace_root)

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -268,7 +268,7 @@ async def prepare_workspace(
         ) -> None:
             nonlocal working_directory
 
-            if isinstance(step_output, dict) and "directory" in step_output:
+            if isinstance(step_output, dict) and step_output.get("directory"):
                 resolved_directory = _resolve_directory_output(
                     step_output, step_end_cwd
                 )

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import shutil
 import subprocess
@@ -17,7 +18,11 @@ from prefect.blocks.core import Block
 from prefect.blocks.system import Secret
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.deployments.steps import run_step
-from prefect.deployments.steps.core import StepExecutionError, run_steps
+from prefect.deployments.steps.core import (
+    StepExecutionError,
+    _observe_step_completion,
+    run_steps,
+)
 from prefect.deployments.steps.pull import agit_clone, set_working_directory
 from prefect.deployments.steps.utility import run_shell_script
 from prefect.utilities.filesystem import tmpchdir
@@ -290,6 +295,12 @@ class TestRunStep:
 
 
 class TestRunSteps:
+    def test_run_steps_does_not_expose_step_observer_argument(self):
+        parameters = inspect.signature(run_steps).parameters
+
+        assert "step_completion_callback" not in parameters
+        assert "step_completion_observer" not in parameters
+
     @pytest.mark.usefixtures("clean_asserting_events_client")
     async def test_run_steps_emits_pull_step_events(
         self, monkeypatch: pytest.MonkeyPatch
@@ -826,7 +837,7 @@ class TestRunSteps:
             f"Expected no all-complete log, got: {mock_logger.info.call_args_list}"
         )
 
-    async def test_run_steps_does_not_probe_cwd_without_completion_callback(
+    async def test_run_steps_does_not_probe_cwd_without_step_observer(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ):
         recovery_directory = tmp_path / "recovered"
@@ -853,7 +864,7 @@ class TestRunSteps:
         monkeypatch.setattr(
             "prefect.deployments.steps.core._safe_current_working_directory",
             lambda: (_ for _ in ()).throw(
-                AssertionError("cwd should not be probed without a callback")
+                AssertionError("cwd should not be probed without a step observer")
             ),
         )
 
@@ -867,7 +878,7 @@ class TestRunSteps:
 
         assert output["directory"] == str(recovery_directory.resolve())
 
-    async def test_run_steps_callback_allows_deleted_cwd_after_successful_step(
+    async def test_step_observer_allows_deleted_cwd_after_successful_step(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ):
         recovery_directory = tmp_path / "recovered"
@@ -887,7 +898,7 @@ class TestRunSteps:
             }[fqn],
         )
 
-        with tmpchdir(doomed_directory):
+        with tmpchdir(doomed_directory), _observe_step_completion(callback):
             output = await run_steps(
                 [
                     {
@@ -897,7 +908,6 @@ class TestRunSteps:
                     }
                 ],
                 {},
-                step_completion_callback=callback,
             )
 
         assert output["directory"] == str(recovery_directory)

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -818,9 +818,98 @@ class TestRunSteps:
         with pytest.raises(StepExecutionError):
             await run_steps(steps, {}, logger=mock_logger)
 
-        info_calls = [str(c) for c in mock_logger.info.call_args_list]
-        assert not any(
-            "All deployment steps completed successfully" in c for c in info_calls
+        all_complete_logged = any(
+            "All deployment steps completed successfully" in str(c)
+            for c in mock_logger.info.call_args_list
+        )
+        assert not all_complete_logged, (
+            f"Expected no all-complete log, got: {mock_logger.info.call_args_list}"
+        )
+
+    async def test_run_steps_does_not_probe_cwd_without_completion_callback(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        recovery_directory = tmp_path / "recovered"
+        doomed_directory = tmp_path / "doomed"
+        doomed_directory.mkdir()
+
+        def remove_current_directory() -> dict[str, str]:
+            current_directory = Path.cwd()
+            shutil.rmtree(current_directory)
+            return {}
+
+        def set_working_directory(directory: str) -> dict[str, str]:
+            Path(directory).mkdir(parents=True, exist_ok=True)
+            os.chdir(directory)
+            return {"directory": str(Path(directory).resolve())}
+
+        monkeypatch.setattr(
+            "prefect.deployments.steps.core._get_function_for_step",
+            lambda fqn, requires=None: {
+                "tests.remove_current_directory": remove_current_directory,
+                "tests.set_working_directory": set_working_directory,
+            }[fqn],
+        )
+        monkeypatch.setattr(
+            "prefect.deployments.steps.core._safe_current_working_directory",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("cwd should not be probed without a callback")
+            ),
+        )
+
+        steps = [
+            {"tests.remove_current_directory": {}},
+            {"tests.set_working_directory": {"directory": str(recovery_directory)}},
+        ]
+
+        with tmpchdir(doomed_directory):
+            output = await run_steps(steps, {})
+
+        assert output["directory"] == str(recovery_directory.resolve())
+
+    async def test_run_steps_callback_allows_deleted_cwd_after_successful_step(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        recovery_directory = tmp_path / "recovered"
+        doomed_directory = tmp_path / "doomed"
+        doomed_directory.mkdir()
+        callback = MagicMock()
+
+        def remove_current_directory(return_directory: str) -> dict[str, str]:
+            current_directory = Path.cwd()
+            shutil.rmtree(current_directory)
+            return {"directory": return_directory}
+
+        monkeypatch.setattr(
+            "prefect.deployments.steps.core._get_function_for_step",
+            lambda fqn, requires=None: {
+                "tests.remove_current_directory": remove_current_directory,
+            }[fqn],
+        )
+
+        with tmpchdir(doomed_directory):
+            output = await run_steps(
+                [
+                    {
+                        "tests.remove_current_directory": {
+                            "return_directory": str(recovery_directory)
+                        }
+                    }
+                ],
+                {},
+                step_completion_callback=callback,
+            )
+
+        assert output["directory"] == str(recovery_directory)
+        callback.assert_called_once_with(
+            {
+                "tests.remove_current_directory": {
+                    "return_directory": str(recovery_directory)
+                }
+            },
+            {"directory": str(recovery_directory)},
+            doomed_directory.resolve(),
+            None,
         )
 
 

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -145,6 +145,55 @@ class TestWorkspaceResolverProcess:
             "from prefect import flow\n\n@flow\ndef hello():\n    return 'relative'\n"
         )
 
+    async def test_resolves_storage_base_path_into_matching_workspace_directory(
+        self,
+        prefect_client,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        storage_base = tmp_path / "runner-storage-base"
+        storage_destination = storage_base / "stored-project"
+        flow_file = storage_destination / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'stored'\n"
+        )
+        storage_destination.joinpath("pyproject.toml").write_text(
+            "[project]\nname = 'stored-project'\nversion = '0.1.0'\n"
+        )
+        monkeypatch.setenv("PREFECT__STORAGE_BASE_PATH", str(storage_base))
+
+        flow_id = await prefect_client.create_flow_from_name("stored-local-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="stored-local-storage-deployment",
+            entrypoint="flows/hello.py:hello",
+            path="$STORAGE_BASE_PATH/stored-project",
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        workspace_root = tmp_path / "stored-local-workspace"
+        unrelated_cwd = tmp_path / "unrelated-cwd"
+        unrelated_cwd.mkdir()
+        with tmpchdir(unrelated_cwd):
+            process = _run_workspace_resolver(flow_run.id, workspace_root)
+            assert Path.cwd() == unrelated_cwd.resolve()
+
+        result = _parse_result(process)
+        workspace_project = workspace_root / "stored-project"
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == workspace_project.resolve()
+        assert result.workspace.project_root == workspace_project.resolve()
+        assert (workspace_project / "flows" / "hello.py").read_text() == (
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'stored'\n"
+        )
+        assert not (workspace_root / "flows" / "hello.py").exists()
+
     async def test_resolves_git_clone_with_chained_working_directory_and_custom_step(
         self,
         prefect_client,

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -103,6 +103,48 @@ class TestWorkspaceResolverProcess:
         assert result.workspace.working_directory == local_project.resolve()
         assert result.workspace.project_root == local_project.resolve()
 
+    async def test_resolves_relative_local_storage_path_before_entering_workspace(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        local_project = tmp_path / "relative-source-project"
+        flow_file = local_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'relative'\n"
+        )
+        local_project.joinpath("pyproject.toml").write_text(
+            "[project]\nname = 'relative-source-project'\nversion = '0.1.0'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("relative-local-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="relative-local-storage-deployment",
+            entrypoint="flows/hello.py:hello",
+            path=".",
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        workspace_root = tmp_path / "relative-local-workspace"
+        with tmpchdir(local_project):
+            process = _run_workspace_resolver(flow_run.id, workspace_root)
+            assert Path.cwd() == local_project.resolve()
+
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == workspace_root.resolve()
+        assert result.workspace.project_root == workspace_root.resolve()
+        assert (workspace_root / "flows" / "hello.py").read_text() == (
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'relative'\n"
+        )
+
     async def test_resolves_git_clone_with_chained_working_directory_and_custom_step(
         self,
         prefect_client,

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -302,6 +302,35 @@ class TestWorkspaceResolverProcess:
         assert result.workspace is not None
         assert result.workspace.working_directory == (workspace_root / "src").resolve()
 
+    async def test_ignores_empty_directory_output_from_custom_step(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        flow_id = await prefect_client.create_flow_from_name("empty-directory-output")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="empty-directory-output-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.return_empty_directory": {},
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        workspace_root = tmp_path / "empty-directory-output-workspace"
+        process = _run_workspace_resolver(flow_run.id, workspace_root)
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == workspace_root.resolve()
+
     async def test_later_custom_chdir_overrides_stale_directory_output(
         self,
         prefect_client,

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from prefect.filesystems import LocalFileSystem
+from prefect.runner._workspace_resolver import (
+    PreparedWorkspaceResult,
+    _find_project_root,
+    get_workspace_resolver_command,
+)
+from prefect.runner.storage import BlockStorageAdapter, RemoteStorage
+from prefect.settings import get_current_settings
+from prefect.utilities.filesystem import tmpchdir
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CUSTOM_STEP_FQN = "tests.utilities.workspace_resolver_steps"
+
+
+def _run_workspace_resolver(
+    flow_run_id, workspace_root: Path
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        **get_current_settings().to_environment_variables(exclude_unset=True),
+    }
+    pythonpath = str(REPO_ROOT)
+    if env.get("PYTHONPATH"):
+        pythonpath = f"{pythonpath}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = pythonpath
+
+    return subprocess.run(
+        get_workspace_resolver_command(flow_run_id, workspace_root),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _parse_result(process: subprocess.CompletedProcess[str]) -> PreparedWorkspaceResult:
+    assert process.stdout, process.stderr
+    return PreparedWorkspaceResult.model_validate_json(process.stdout)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True)
+
+
+def _create_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init")
+    _git(path, "config", "user.email", "workspace-resolver@example.com")
+    _git(path, "config", "user.name", "Workspace Resolver")
+    _git(path, "add", ".")
+    _git(path, "commit", "-m", "initial")
+
+
+@pytest.mark.timeout(60)
+class TestWorkspaceResolverProcess:
+    async def test_resolves_absolute_set_working_directory_project_root(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        local_project = tmp_path / "local-project"
+        flow_file = local_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'local'\n"
+        )
+        local_project.joinpath("pyproject.toml").write_text(
+            "[project]\nname = 'local-project'\nversion = '0.1.0'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("local-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="local-storage-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": str(local_project)
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(flow_run.id, tmp_path / "local-workspace")
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == local_project.resolve()
+        assert result.workspace.project_root == local_project.resolve()
+
+    async def test_resolves_git_clone_with_chained_working_directory_and_custom_step(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        source_repo = tmp_path / "source-repo"
+        flow_file = source_repo / "service" / "src" / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'hi'\n"
+        )
+        (source_repo / "service" / "pyproject.toml").write_text(
+            "[project]\nname = 'workspace-resolver-test'\nversion = '0.1.0'\n"
+        )
+        _create_git_repo(source_repo)
+
+        flow_id = await prefect_client.create_flow_from_name("hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="git-clone-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.git_clone": {
+                        "id": "clone",
+                        "repository": source_repo.as_uri(),
+                        "clone_directory_name": "checkout",
+                    }
+                },
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": "{{ clone.directory }}/service"
+                    }
+                },
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": "src"
+                    }
+                },
+                {
+                    f"{CUSTOM_STEP_FQN}.write_marker": {
+                        "filename": "marker.txt",
+                    }
+                },
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        parent_cwd = tmp_path / "parent-cwd"
+        parent_cwd.mkdir()
+        workspace_root = tmp_path / "workspace"
+
+        with tmpchdir(parent_cwd):
+            process = _run_workspace_resolver(flow_run.id, workspace_root)
+            assert Path.cwd() == parent_cwd.resolve()
+
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.workspace_root == workspace_root.resolve()
+        assert (
+            result.workspace.working_directory
+            == (workspace_root / "checkout" / "service" / "src").resolve()
+        )
+        assert (
+            result.workspace.project_root
+            == (workspace_root / "checkout" / "service").resolve()
+        )
+        assert result.workspace.runtime_entrypoint == "flows/hello.py:hello"
+        marker = result.workspace.working_directory / "marker.txt"
+        assert marker.read_text() == str(result.workspace.working_directory)
+
+    async def test_tracks_relative_directory_output_from_custom_chdir_step(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        flow_id = await prefect_client.create_flow_from_name("custom-chdir")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="custom-chdir-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.make_directory_and_change_directory": {
+                        "directory": "src",
+                        "return_directory": ".",
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        workspace_root = tmp_path / "custom-chdir-workspace"
+        process = _run_workspace_resolver(flow_run.id, workspace_root)
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == (workspace_root / "src").resolve()
+
+    async def test_later_custom_chdir_overrides_stale_directory_output(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        flow_id = await prefect_client.create_flow_from_name("custom-chdir-stale")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="custom-chdir-stale-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.make_directory_and_change_directory": {
+                        "directory": "src",
+                        "return_directory": ".",
+                    }
+                },
+                {
+                    f"{CUSTOM_STEP_FQN}.make_directory_and_change_directory": {
+                        "directory": "../actual",
+                    }
+                },
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        workspace_root = tmp_path / "custom-stale-workspace"
+        process = _run_workspace_resolver(flow_run.id, workspace_root)
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert (
+            result.workspace.working_directory == (workspace_root / "actual").resolve()
+        )
+
+    async def test_captures_environment_and_sys_path_mutations(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        local_project = tmp_path / "process-state-project"
+        support_dir = local_project / "support"
+        flow_file = local_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        support_dir.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'state'\n"
+        )
+        local_project.joinpath("pyproject.toml").write_text(
+            "[project]\nname = 'process-state-project'\nversion = '0.1.0'\n"
+        )
+
+        env_var_name = "WORKSPACE_RESOLVER_TEST_ENV"
+        env_var_value = "configured"
+
+        flow_id = await prefect_client.create_flow_from_name("process-state-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="process-state-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": str(local_project)
+                    }
+                },
+                {
+                    f"{CUSTOM_STEP_FQN}.set_environment_variable": {
+                        "name": env_var_name,
+                        "value": env_var_value,
+                    }
+                },
+                {
+                    f"{CUSTOM_STEP_FQN}.prepend_to_sys_path": {
+                        "path": "support",
+                    }
+                },
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(
+            flow_run.id, tmp_path / "process-state-workspace"
+        )
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.environment[env_var_name] == env_var_value
+        assert result.workspace.sys_path[0] == str(support_dir.resolve())
+        assert os.environ.get(env_var_name) is None
+
+    async def test_uses_absolute_directory_output_when_step_removed_cwd(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        recovered_project = tmp_path / "recovered-project"
+        flow_file = recovered_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'recovered'\n"
+        )
+        recovered_project.joinpath("pyproject.toml").write_text(
+            "[project]\nname = 'recovered-project'\nversion = '0.1.0'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("removed-cwd-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="removed-cwd-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.remove_current_directory": {
+                        "return_directory": str(recovered_project)
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(
+            flow_run.id, tmp_path / "removed-cwd-workspace"
+        )
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == recovered_project.resolve()
+        assert result.workspace.project_root == recovered_project.resolve()
+
+    async def test_resolves_remote_storage_pull_without_changing_parent_cwd(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        remote_source = tmp_path / "remote-source"
+        flow_file = remote_source / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'remote'\n"
+        )
+        (remote_source / "pyproject.toml").write_text(
+            "[project]\nname = 'remote-source'\nversion = '0.1.0'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("remote-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="remote-storage-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.pull_from_remote_storage": {
+                        "url": remote_source.as_uri()
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        parent_cwd = tmp_path / "remote-parent-cwd"
+        parent_cwd.mkdir()
+        workspace_root = tmp_path / "remote-workspace"
+
+        with tmpchdir(parent_cwd):
+            process = _run_workspace_resolver(flow_run.id, workspace_root)
+            assert Path.cwd() == parent_cwd.resolve()
+
+        result = _parse_result(process)
+        expected_storage = RemoteStorage(url=remote_source.as_uri())
+        expected_storage.set_base_path(workspace_root.resolve())
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == expected_storage.destination
+        assert result.workspace.project_root is None
+
+    async def test_resolves_block_pull_step(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        block_source = tmp_path / "block-source"
+        flow_file = block_source / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'block'\n"
+        )
+        (block_source / "pyproject.toml").write_text(
+            "[project]\nname = 'block-source'\nversion = '0.1.0'\n"
+        )
+
+        block_name = f"workspace-resolver-{uuid4()}"
+        await LocalFileSystem(basepath=str(block_source)).save(
+            block_name,
+            overwrite=True,
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("block-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="block-storage-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.pull_with_block": {
+                        "block_document_name": block_name,
+                        "block_type_slug": LocalFileSystem.get_block_type_slug(),
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(flow_run.id, tmp_path / "block-workspace")
+        result = _parse_result(process)
+        expected_storage = BlockStorageAdapter(
+            LocalFileSystem.load(block_name, _sync=True)
+        )
+        expected_storage.set_base_path((tmp_path / "block-workspace").resolve())
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert result.workspace is not None
+        assert result.workspace.working_directory == expected_storage.destination
+        assert result.workspace.project_root == expected_storage.destination
+
+    async def test_returns_structured_failure_payload(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        flow_id = await prefect_client.create_flow_from_name("broken-flow")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="broken-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.raise_error": {
+                        "message": "resolver exploded",
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(flow_run.id, tmp_path / "broken-workspace")
+        result = _parse_result(process)
+
+        assert process.returncode == 1
+        assert result.status == "error"
+        assert result.error is not None
+        assert result.error.error_type == "StepExecutionError"
+        assert "Encountered error while running" in result.error.error_message
+        assert result.error.cause_type == "RuntimeError"
+        assert result.error.cause_message == "resolver exploded"
+        assert "resolver exploded" in process.stderr
+
+    async def test_keeps_stdout_reserved_for_json_payload(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        local_project = tmp_path / "noisy-project"
+        flow_file = local_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'noisy'\n"
+        )
+        local_project.joinpath("pyproject.toml").write_text(
+            "[project]\nname = 'noisy-project'\nversion = '0.1.0'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("noisy-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="noisy-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.emit_inherited_stdout": {
+                        "message": "resolver-step-noise",
+                    }
+                },
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": str(local_project)
+                    }
+                },
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(flow_run.id, tmp_path / "noisy-workspace")
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+        assert "resolver-step-noise" in process.stderr
+        assert "resolver-step-noise" not in process.stdout
+        assert result.workspace is not None
+        assert result.workspace.project_root == local_project.resolve()
+
+
+class TestProjectRootDetection:
+    def test_does_not_walk_above_workspace_root(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'outside-workspace'\nversion = '0.1.0'\n"
+        )
+
+        assert _find_project_root(workspace_root, workspace_root) is None
+
+    def test_returns_project_root_for_absolute_working_directory_outside_workspace_root(
+        self, tmp_path: Path
+    ) -> None:
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        outside_project = tmp_path / "outside"
+        nested_directory = outside_project / "src"
+        nested_directory.mkdir(parents=True)
+        (outside_project / "pyproject.toml").write_text(
+            "[project]\nname = 'outside'\nversion = '0.1.0'\n"
+        )
+
+        assert _find_project_root(nested_directory, workspace_root) == outside_project

--- a/tests/utilities/workspace_resolver_steps.py
+++ b/tests/utilities/workspace_resolver_steps.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_marker(filename: str) -> dict[str, str]:
+    marker = Path(filename)
+    marker.write_text(str(Path.cwd()))
+    return {"marker": str(marker.resolve())}
+
+
+def change_directory(directory: str) -> dict[str, str]:
+    os.chdir(directory)
+    return {}
+
+
+def make_directory_and_change_directory(
+    directory: str, return_directory: str | None = None
+) -> dict[str, str]:
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    os.chdir(directory)
+    if return_directory is None:
+        return {}
+    return {"directory": return_directory}
+
+
+def emit_inherited_stdout(message: str) -> dict[str, str]:
+    subprocess.run(
+        [sys.executable, "-c", f"print({message!r})"],
+        check=True,
+    )
+    return {}
+
+
+def set_environment_variable(name: str, value: str) -> dict[str, str]:
+    os.environ[name] = value
+    return {}
+
+
+def prepend_to_sys_path(path: str) -> dict[str, str]:
+    sys.path.insert(0, str(Path(path).resolve()))
+    return {}
+
+
+def remove_current_directory(return_directory: str | None = None) -> dict[str, str]:
+    current_directory = Path.cwd()
+
+    if return_directory is not None:
+        Path(return_directory).mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import shutil, sys; shutil.rmtree(sys.argv[1])",
+            str(current_directory),
+        ],
+        cwd=current_directory.parent,
+        check=True,
+    )
+
+    if return_directory is None:
+        return {}
+    return {"directory": return_directory}
+
+
+def raise_error(message: str) -> dict[str, str]:
+    raise RuntimeError(message)

--- a/tests/utilities/workspace_resolver_steps.py
+++ b/tests/utilities/workspace_resolver_steps.py
@@ -45,6 +45,10 @@ def prepend_to_sys_path(path: str) -> dict[str, str]:
     return {}
 
 
+def return_empty_directory() -> dict[str, str | None]:
+    return {"directory": None}
+
+
 def remove_current_directory(return_directory: str | None = None) -> dict[str, str]:
     current_directory = Path.cwd()
 


### PR DESCRIPTION
refs #19321

this PR adds an internal workspace resolver primitive for safely preparing deployment workspaces before later uv launcher integration.

<details>
<summary>Details</summary>

- introduces private `prefect.runner._workspace_resolver` subprocess entrypoint that prepares storage and pull-step workspaces and returns structured metadata as JSON
- preserves parent cwd by running resolution in a child process, keeping stdout reserved for JSON and redirecting pull-step output to stderr
- tracks pull-step cwd outputs, local path project roots, environment, and sys.path metadata for later executor wiring
- adds a narrow optional `run_steps` completion callback with best-effort cwd probing only when the callback is supplied
- covers local storage, git clone, remote and block storage, custom cwd behavior, noisy stdout, process state capture, structured failures, and deleted cwd recovery

### Reviewer example

For a deployment whose pull steps clone a repo and then enter a nested `src` directory:

```yaml
pull:
- prefect.deployments.steps.git_clone:
    id: clone
    repository: https://github.com/acme/data-jobs.git
    clone_directory_name: repo
- prefect.deployments.steps.set_working_directory:
    directory: "{{ clone.directory }}/service/src"

deployments:
- name: daily-report
  entrypoint: flows/report.py:daily_report
```

the resolver can be invoked before the eventual flow subprocess:

```bash
python -m prefect.runner._workspace_resolver "$FLOW_RUN_ID" "/tmp/prefect-workspaces/$FLOW_RUN_ID"
```

It prepares the pull-step workspace and returns metadata like:

```json
{
  "status": "success",
  "workspace": {
    "workspace_root": "/tmp/prefect-workspaces/abc",
    "working_directory": "/tmp/prefect-workspaces/abc/repo/service/src",
    "project_root": "/tmp/prefect-workspaces/abc/repo/service",
    "runtime_entrypoint": "flows/report.py:daily_report"
  }
}
```

A uv-aware executor can then run from `working_directory` while using `project_root` for project dependency resolution:

```bash
cd /tmp/prefect-workspaces/abc/repo/service/src

PREFECT__FLOW_RUN_ID="$FLOW_RUN_ID" \
PREFECT__FLOW_ENTRYPOINT="flows/report.py:daily_report" \
uv run --project /tmp/prefect-workspaces/abc/repo/service \
  python -m prefect.engine
```

</details>
