### PR TITLE
[codex] Avoid retaining Prefect tasks in Dask scheduler

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/client.py
+++ b/src/integrations/prefect-dask/prefect_dask/client.py
@@ -1,5 +1,4 @@
 import asyncio
-from functools import wraps
 from uuid import uuid4
 
 from distributed import Client, Future
@@ -11,7 +10,28 @@ from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.engine import collect_task_run_inputs_sync
 
 
+def _run_prefect_task(*args, **kwargs):
+    task = kwargs["task"]
+    if task.isasync:
+        return asyncio.run(run_task_async(*args, **kwargs))
+    else:
+        return run_task_sync(*args, **kwargs)
+
+
 class PrefectDaskClient(Client):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._prefect_task_futures: dict[int, Future] = {}
+
+    def _get_prefect_task_future(self, task: Task) -> Future:
+        task_id = id(task)
+        if task_id not in self._prefect_task_futures:
+            self._prefect_task_futures[task_id] = self.scatter(
+                task, broadcast=True, hash=False
+            )
+
+        return self._prefect_task_futures[task_id]
+
     def submit(
         self,
         func,
@@ -30,7 +50,7 @@ class PrefectDaskClient(Client):
     ):
         if isinstance(func, Task):
             run_task_kwargs = {}
-            run_task_kwargs["task"] = func
+            run_task_kwargs["task"] = self._get_prefect_task_future(func)
             task_run_id = uuid4()
             run_task_kwargs["task_run_id"] = task_run_id
 
@@ -62,17 +82,14 @@ class PrefectDaskClient(Client):
                     "copy_to_child_ctx": True,
                 }
             )
-            run_task_kwargs["context"] = context
+            context_future = self.scatter(context, broadcast=False, hash=False)
+            run_task_kwargs["context"] = context_future
 
-            @wraps(func)
-            def wrapper_func(*args, **kwargs):
-                if func.isasync:
-                    return asyncio.run(run_task_async(*args, **kwargs))
-                else:
-                    return run_task_sync(*args, **kwargs)
+            if key is None:
+                key = f"{func.name}-{uuid4().hex}"
 
             future = super().submit(
-                wrapper_func,
+                _run_prefect_task,
                 key=key,
                 workers=workers,
                 resources=resources,
@@ -87,6 +104,7 @@ class PrefectDaskClient(Client):
             )
 
             future.task_run_id = run_task_kwargs["task_run_id"]
+            future.add_done_callback(lambda _: context_future.release())
             return future
         else:
             return super().submit(

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -62,6 +62,45 @@ def default_dask_task_runner():  # noqa
     )
 
 
+def _count_retained_prefect_tasks_in_dask_specs(dask_scheduler) -> int:
+    import gc
+
+    def is_prefect_task(obj) -> bool:
+        obj_type = type(obj)
+        return obj_type.__module__ == "prefect.tasks" and obj_type.__name__ == "Task"
+
+    def contains_prefect_task(obj) -> bool:
+        seen: set[int] = set()
+        stack = [obj]
+
+        while stack:
+            current = stack.pop()
+            current_id = id(current)
+            if current_id in seen:
+                continue
+            seen.add(current_id)
+
+            if is_prefect_task(current):
+                return True
+            elif isinstance(current, dict):
+                stack.extend(current.keys())
+                stack.extend(current.values())
+            elif isinstance(current, (list, tuple, set, frozenset)):
+                stack.extend(current)
+
+        return False
+
+    return sum(
+        1
+        for obj in gc.get_objects()
+        if type(obj).__module__ == "dask._task_spec"
+        and type(obj).__name__ == "Task"
+        and contains_prefect_task(
+            (getattr(obj, "args", ()), getattr(obj, "kwargs", {}))
+        )
+    )
+
+
 class TestDaskTaskRunner:
     @pytest.fixture(
         params=[
@@ -323,6 +362,32 @@ class TestDaskTaskRunner:
         assert all(
             future.wrapped_future.key.startswith("my_task-") for future in futures
         )
+
+    def test_scheduler_does_not_retain_prefect_tasks(self, cluster):
+        task_runner = DaskTaskRunner(address=cluster.scheduler_address)
+
+        @task
+        def make_range(n: int) -> list[int]:
+            return list(range(n))
+
+        @task
+        def identity(x: int) -> int:
+            return x
+
+        @flow(task_runner=task_runner)
+        def test_flow(n: int):
+            values = make_range.submit(n)
+            futures = identity.map(values)
+            return [future.result() for future in futures]
+
+        assert test_flow(10) == list(range(10))
+
+        with distributed.Client(cluster) as client:
+            retained_prefect_tasks = client.run_on_scheduler(
+                _count_retained_prefect_tasks_in_dask_specs
+            )
+
+        assert retained_prefect_tasks == 0
 
     async def test_dask_cluster_adapt_is_properly_called(self):
         # mock of cluster instances with synchronous adapt method like


### PR DESCRIPTION
closes #21697

this PR avoids retaining heavyweight Prefect task objects in Dask scheduler task specs when `prefect-dask` submits Prefect tasks to an existing Dask scheduler.

<details>
<summary>Details</summary>

The repro showed Dask scheduler RSS growing roughly linearly across repeated flow runs. Scheduler introspection showed no active Dask tasks or task groups after completion, but historical Dask task specs/messages still referenced Prefect `Task` objects through the submitted task payloads.

This changes Prefect Dask submission so that:

- Prefect tasks execute through a module-level `_run_prefect_task` function instead of a per-submit wrapper closure.
- Prefect `Task` objects are scattered once per client and passed to Dask tasks by future instead of embedded directly in each task spec.
- Serialized per-run context is scattered and released when the submitted task future completes.
- Generated Dask keys still preserve the Prefect task name prefix.

In the issue repro, the patched wheel changed scheduler RSS from repeatedly growing by about 80MiB per run to mostly flattening after the first run. Scheduler introspection after the patched runs still showed retained lightweight Dask task specs, but no retained Prefect `Task` objects reachable from those specs.

Added a regression test that runs a mapped Prefect task on an existing Dask cluster, then inspects retained `dask._task_spec.Task` objects on the scheduler to assert they do not reference Prefect `Task` objects.

Validation:

```bash
uv run --project ./src/integrations/prefect-dask pytest src/integrations/prefect-dask/tests/test_client.py src/integrations/prefect-dask/tests/test_task_runners.py::TestDaskTaskRunner::test_dask_task_key_has_prefect_task_name src/integrations/prefect-dask/tests/test_task_runners.py::TestDaskTaskRunner::test_scheduler_does_not_retain_prefect_tasks
uv run --project ./src/integrations/prefect-dask ruff check src/integrations/prefect-dask/prefect_dask/client.py src/integrations/prefect-dask/tests/test_task_runners.py
```

</details>