### PR TITLE
fix: apprise-logger-level-normalization

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -60,7 +60,10 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         apprise_logger = logging.getLogger("apprise")
         root_logger = logging.getLogger()
 
-        if apprise_logger.level == logging.NOTSET or apprise_logger.level < root_logger.level:
+        if (
+            apprise_logger.level == logging.NOTSET
+            or apprise_logger.level < root_logger.level
+        ):
             apprise_logger.setLevel(root_logger.level)
 
         with LogEavesdropper("apprise", level=apprise_logger.level) as eavesdropper:
@@ -81,7 +84,10 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         apprise_logger = logging.getLogger("apprise")
         root_logger = logging.getLogger()
 
-        if apprise_logger.level == logging.NOTSET or apprise_logger.level < root_logger.level:
+        if (
+            apprise_logger.level == logging.NOTSET
+            or apprise_logger.level < root_logger.level
+        ):
             apprise_logger.setLevel(root_logger.level)
 
         with LogEavesdropper("apprise", level=apprise_logger.level) as eavesdropper:

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -60,13 +60,12 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         apprise_logger = logging.getLogger("apprise")
         root_logger = logging.getLogger()
 
-        if (
-            apprise_logger.level == logging.NOTSET
-            or apprise_logger.level < root_logger.level
-        ):
-            apprise_logger.setLevel(root_logger.level)
+        if apprise_logger.level == logging.NOTSET:
+            log_level = root_logger.getEffectiveLevel()
+        else:
+            log_level = max(apprise_logger.level, root_logger.getEffectiveLevel())
 
-        with LogEavesdropper("apprise", level=apprise_logger.level) as eavesdropper:
+        with LogEavesdropper("apprise", level=log_level) as eavesdropper:
             result = await self._apprise_client.async_notify(  # pyright: ignore[reportUnknownMemberType] incomplete type hints in apprise
                 body=body,
                 title=subject or "",
@@ -84,13 +83,12 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         apprise_logger = logging.getLogger("apprise")
         root_logger = logging.getLogger()
 
-        if (
-            apprise_logger.level == logging.NOTSET
-            or apprise_logger.level < root_logger.level
-        ):
-            apprise_logger.setLevel(root_logger.level)
+        if apprise_logger.level == logging.NOTSET:
+            log_level = root_logger.getEffectiveLevel()
+        else:
+            log_level = max(apprise_logger.level, root_logger.getEffectiveLevel())
 
-        with LogEavesdropper("apprise", level=apprise_logger.level) as eavesdropper:
+        with LogEavesdropper("apprise", level=log_level) as eavesdropper:
             result = self._apprise_client.notify(  # pyright: ignore[reportUnknownMemberType] incomplete type hints in apprise
                 body=body,
                 title=subject or "",

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -57,7 +57,13 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         body: str,
         subject: str | None = None,
     ) -> None:
-        with LogEavesdropper("apprise", level=logging.DEBUG) as eavesdropper:
+        apprise_logger = logging.getLogger("apprise")
+        root_logger = logging.getLogger()
+
+        if apprise_logger.level == logging.NOTSET or apprise_logger.level < root_logger.level:
+            apprise_logger.setLevel(root_logger.level)
+
+        with LogEavesdropper("apprise", level=apprise_logger.level) as eavesdropper:
             result = await self._apprise_client.async_notify(  # pyright: ignore[reportUnknownMemberType] incomplete type hints in apprise
                 body=body,
                 title=subject or "",
@@ -72,7 +78,13 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         body: str,
         subject: str | None = None,
     ) -> None:
-        with LogEavesdropper("apprise", level=logging.DEBUG) as eavesdropper:
+        apprise_logger = logging.getLogger("apprise")
+        root_logger = logging.getLogger()
+
+        if apprise_logger.level == logging.NOTSET or apprise_logger.level < root_logger.level:
+            apprise_logger.setLevel(root_logger.level)
+
+        with LogEavesdropper("apprise", level=apprise_logger.level) as eavesdropper:
             result = self._apprise_client.notify(  # pyright: ignore[reportUnknownMemberType] incomplete type hints in apprise
                 body=body,
                 title=subject or "",

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -372,7 +372,9 @@ class TestAppriseLoggingLevels:
                     assert logging.getLogger("apprise").level == logging.WARNING
                     return True
 
-                apprise_instance_mock.async_notify = AsyncMock(side_effect=_assert_level)
+                apprise_instance_mock.async_notify = AsyncMock(
+                    side_effect=_assert_level
+                )
 
                 block = CustomWebhookNotificationBlock(
                     url="https://example.com/notification"

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -378,7 +378,7 @@ class TestAppriseLoggingLevels:
 
                 block = SlackWebhook(
                     url="https://hooks.slack.com/services/T1234/B5678/abcdefghijk"
-                    )
+                )
                 await block.notify("test")
         finally:
             apprise_logger.setLevel(original_apprise_level)

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -376,7 +376,9 @@ class TestAppriseLoggingLevels:
                     side_effect=_assert_level
                 )
 
-                block = SlackWebhook(url="https://hooks.slack.com/services/T1234/B5678/abcdefghijk")
+                block = SlackWebhook(
+                    url="https://hooks.slack.com/services/T1234/B5678/abcdefghijk"
+                    )
                 await block.notify("test")
         finally:
             apprise_logger.setLevel(original_apprise_level)

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -377,6 +377,7 @@ class TestAppriseLoggingLevels:
                 )
 
                 block = CustomWebhookNotificationBlock(
+                    name="test-block",
                     url="https://example.com/notification"
                 )
                 await block.notify("test")

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -376,10 +376,7 @@ class TestAppriseLoggingLevels:
                     side_effect=_assert_level
                 )
 
-                block = CustomWebhookNotificationBlock(
-                    name="test-block",
-                    url="https://example.com/notification"
-                )
+                block = SlackWebhook(url="https://hooks.slack.com/services/T1234/B5678/abcdefghijk")
                 await block.notify("test")
         finally:
             apprise_logger.setLevel(original_apprise_level)

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -1,3 +1,4 @@
+import logging
 import urllib
 from typing import Type
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -350,6 +351,36 @@ class TestSlackWebhook:
         assert posted_url == (
             "https://hooks.slack.com/services/TABC123/BDEF456/secrettoken"
         )
+
+
+class TestAppriseLoggingLevels:
+    async def test_notify_does_not_force_apprise_to_debug(self):
+        apprise_logger = logging.getLogger("apprise")
+        root_logger = logging.getLogger()
+
+        original_apprise_level = apprise_logger.level
+        original_root_level = root_logger.level
+
+        try:
+            root_logger.setLevel(logging.WARNING)
+            apprise_logger.setLevel(logging.NOTSET)
+
+            with patch("apprise.Apprise", autospec=True) as AppriseMock:
+                apprise_instance_mock = AppriseMock.return_value
+
+                async def _assert_level(*args, **kwargs):
+                    assert logging.getLogger("apprise").level == logging.WARNING
+                    return True
+
+                apprise_instance_mock.async_notify = AsyncMock(side_effect=_assert_level)
+
+                block = CustomWebhookNotificationBlock(
+                    url="https://example.com/notification"
+                )
+                await block.notify("test")
+        finally:
+            apprise_logger.setLevel(original_apprise_level)
+            root_logger.setLevel(original_root_level)
 
 
 class TestMattermostWebhook:


### PR DESCRIPTION
closes: #19390

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

Explicitly set the apprise logger level to match the root logger when unset or lower than desired.
