### PR TITLE
Hydrate schedule.parameters in deployment schedules API to fix dehydrated wrappers leaking into flow runs

### DIFF
--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -1270,6 +1270,26 @@ async def create_deployment_schedules(
                 status.HTTP_404_NOT_FOUND, detail="Deployment not found."
             )
 
+        # Hydrate any dehydrated `__prefect_kind` values in the schedules'
+        # parameter overrides so the persisted form is the runtime form.
+        # Without this, the dehydrated wrappers leak into auto-scheduled
+        # flow runs and cause SignatureMismatchError at run time (#18701).
+        ctx = await HydrationContext.build(
+            session=session,
+            raise_on_error=True,
+            render_jinja=True,
+            render_workspace_variables=True,
+        )
+        for schedule in schedules:
+            if schedule.parameters:
+                try:
+                    schedule.parameters = hydrate(schedule.parameters, ctx)
+                except HydrationError as exc:
+                    raise HTTPException(
+                        status.HTTP_400_BAD_REQUEST,
+                        detail=f"Error hydrating schedule parameters: {exc}",
+                    )
+
         try:
             created = await models.deployments.create_deployment_schedules(
                 session=session,
@@ -1306,6 +1326,24 @@ async def update_deployment_schedule(
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND, detail="Deployment not found."
             )
+
+        # Hydrate any dehydrated `__prefect_kind` values before persisting,
+        # otherwise the dehydrated wrappers leak into auto-scheduled flow
+        # runs and cause SignatureMismatchError at run time (#18701).
+        if schedule.parameters:
+            try:
+                ctx = await HydrationContext.build(
+                    session=session,
+                    raise_on_error=True,
+                    render_jinja=True,
+                    render_workspace_variables=True,
+                )
+                schedule.parameters = hydrate(schedule.parameters, ctx)
+            except HydrationError as exc:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    detail=f"Error hydrating schedule parameters: {exc}",
+                )
 
         updated = await models.deployments.update_deployment_schedule(
             session=session,

--- a/tests/server/orchestration/api/test_deployment_schedules.py
+++ b/tests/server/orchestration/api/test_deployment_schedules.py
@@ -198,6 +198,65 @@ class TestCreateDeploymentSchedules:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert b"Deployment" in response.content
 
+    async def test_dehydrated_parameters_are_hydrated_on_create(
+        self,
+        get_server_session: AsyncSessionGetter,
+        client: AsyncClient,
+        schedules_url: Callable[..., str],
+        deployment,
+    ):
+        """Regression test for #18701.
+
+        When a schedule is created via the UI with parameter overrides, the
+        UI sends parameters in their dehydrated `__prefect_kind` form
+        (`{"value": "<json string>", "__prefect_kind": "json"}`).  These
+        must be hydrated before being persisted, otherwise the dehydrated
+        wrapper objects leak into auto-scheduled flow runs and cause
+        `SignatureMismatchError` at runtime.
+        """
+        async with get_server_session() as session:
+            await models.deployments.delete_schedules_for_deployment(
+                session=session, deployment_id=deployment.id
+            )
+            await session.commit()
+
+        url = schedules_url(deployment.id)
+
+        dehydrated_payload = {
+            "tables_to_fetch": {
+                "value": '[{"prop": "value", "some_arr": []}]',
+                "__prefect_kind": "json",
+            }
+        }
+        expected_hydrated = {
+            "tables_to_fetch": [{"prop": "value", "some_arr": []}],
+        }
+
+        response = await client.post(
+            url,
+            json=[
+                {
+                    **schemas.actions.DeploymentScheduleCreate(
+                        schedule=schemas.schedules.IntervalSchedule(
+                            interval=timedelta(days=1)
+                        ),
+                        slug="dehydrated-schedule",
+                    ).model_dump(mode="json"),
+                    "parameters": dehydrated_payload,
+                }
+            ],
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.text
+
+        async with get_server_session() as session:
+            schedules = await models.deployments.read_deployment_schedules(
+                session=session, deployment_id=deployment.id
+            )
+
+        assert len(schedules) == 1
+        assert schedules[0].parameters == expected_hydrated
+
 
 class TestReadDeploymentSchedules:
     async def test_can_read_schedules_for_deployment(
@@ -316,6 +375,47 @@ class TestUpdateDeploymentSchedule:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert b"Schedule" in response.content
+
+    async def test_dehydrated_parameters_are_hydrated_on_update(
+        self,
+        get_server_session: AsyncSessionGetter,
+        client: AsyncClient,
+        deployment_with_schedules,
+        schedules_url: Callable[..., str],
+        schedule_to_update: schemas.core.DeploymentSchedule,
+    ):
+        """Regression test for #18701 — PATCH path of the same bug."""
+        url = schedules_url(
+            deployment_with_schedules.id, schedule_id=schedule_to_update.id
+        )
+
+        dehydrated_payload = {
+            "tables_to_fetch": {
+                "value": '[{"prop": "value", "some_arr": []}]',
+                "__prefect_kind": "json",
+            }
+        }
+        expected_hydrated = {
+            "tables_to_fetch": [{"prop": "value", "some_arr": []}],
+        }
+
+        response = await client.patch(
+            url,
+            json={"parameters": dehydrated_payload},
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
+
+        async with get_server_session() as session:
+            schedules = await models.deployments.read_deployment_schedules(
+                session=session,
+                deployment_id=deployment_with_schedules.id,
+            )
+
+        the_schedule = next(
+            schedule for schedule in schedules if schedule.id == schedule_to_update.id
+        )
+        assert the_schedule.parameters == expected_hydrated
 
     async def test_updating_schedule_removes_scheduled_runs(
         self,


### PR DESCRIPTION
## Summary

Fixes #18701. The POST and PATCH `/deployments/{id}/schedules` API handlers persist `schedule.parameters` verbatim. When the UI sends overrides in dehydrated `__prefect_kind` form (e.g. `{"value": "<json>", "__prefect_kind": "json"}`), the auto-scheduler in `models/deployments.py:940` merges those wrappers straight into `flow_run.parameters`. At runtime `parameters_to_args_kwargs` then sees `value` / `__prefect_kind` keys instead of the real argument and raises `SignatureMismatchError`.

The same code already hydrates parameters in the deployment-update and quick-run paths — only the schedules endpoints were missed.

## Fix

`src/prefect/server/api/deployments.py` (create + patch handlers): call `hydrate(schedule.parameters, ctx)` with a `HydrationContext` that renders Jinja and workspace variables, raising HTTP 400 on `HydrationError`.

Production change ~38 LOC.

## Test

`tests/server/orchestration/api/test_deployment_schedules.py`:
- `TestCreateDeploymentSchedules::test_dehydrated_parameters_are_hydrated_on_create`
- `TestUpdateDeploymentSchedule::test_dehydrated_parameters_are_hydrated_on_update`

Both RED before patch, GREEN after. `pytest tests/server/orchestration/api/test_deployment_schedules.py tests/utilities/schema_tools/test_hydration.py` → 78 passed; schedule-tagged subset of `test_deployments.py` → 39 passed. `ruff` clean.

## Risk notes
- Additive: parameters not in dehydrated form pass through `hydrate()` unchanged.
- Already-poisoned schedule rows in user databases need a manual re-save — out of scope for this fix.

Refs #18701