### PR TITLE
fix(cli): infer logs page size from API response

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -48,7 +48,7 @@ from prefect.utilities.urls import url_for
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
-    from prefect.client.schemas.objects import FlowRun
+    from prefect.client.schemas.objects import FlowRun, Log
 
 flow_run_app: cyclopts.App = cyclopts.App(
     name="flow-run",
@@ -58,7 +58,6 @@ flow_run_app: cyclopts.App = cyclopts.App(
     help_flags=["--help"],
 )
 
-LOGS_DEFAULT_PAGE_SIZE = 200
 LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS = 20
 
 logger: logging.Logger = get_logger(__name__)
@@ -540,14 +539,11 @@ async def logs(
     if output and output.lower() != "json":
         exit_with_error("Only 'json' output format is supported.")
 
-    output_json = bool(output and output.lower() == "json")
-    offset = 0
-    more_logs = True
-    num_logs_returned = 0
-    collected_logs: list[dict[str, Any]] = []
-
     if head and tail:
         exit_with_error("Please provide either a `head` or `tail` option but not both.")
+
+    output_json = bool(output and output.lower() == "json")
+    collected_logs: list[dict[str, Any]] = []
 
     user_specified_num_logs = (
         num_logs or LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS
@@ -555,10 +551,21 @@ async def logs(
         else None
     )
 
-    if tail:
-        offset = max(0, user_specified_num_logs - LOGS_DEFAULT_PAGE_SIZE)
-
     log_filter = LogFilter(flow_run_id={"any_": [id]})
+    sort = LogSort.TIMESTAMP_DESC if reverse or tail else LogSort.TIMESTAMP_ASC
+
+    def render(logs_to_render: "list[Log]") -> None:
+        if output_json:
+            collected_logs.extend(log.model_dump(mode="json") for log in logs_to_render)
+            return
+        for log in logs_to_render:
+            timestamp = f"{log.timestamp:%Y-%m-%d %H:%M:%S.%f}"[:-3]
+            log_level = f"{logging.getLevelName(log.level):7s}"
+            flow_run_info = f"Flow run {flow_run.name!r} - {escape(log.message)}"
+            _cli.console.print(
+                f"{timestamp} | {log_level} | {flow_run_info}",
+                soft_wrap=True,
+            )
 
     async with get_client() as client:
         try:
@@ -566,62 +573,64 @@ async def logs(
         except ObjectNotFound:
             exit_with_error(f"Flow run '{id!s}' not found!")
 
-        while more_logs:
-            num_logs_to_return_from_page = (
-                LOGS_DEFAULT_PAGE_SIZE
-                if user_specified_num_logs is None
-                else min(
-                    LOGS_DEFAULT_PAGE_SIZE, user_specified_num_logs - num_logs_returned
-                )
-            )
+        # Page size is discovered from the first response; the API returns up to
+        # PREFECT_API_DEFAULT_LIMIT logs when no limit is given, so we let the
+        # first request observe whatever the server is configured for.
+        page_size: Optional[int] = None
+        offset = 0
+        num_logs_collected = 0
+        tail_buffer: list[Log] = []
+
+        while True:
+            if page_size is None:
+                limit = None
+            elif user_specified_num_logs is not None:
+                remaining = user_specified_num_logs - num_logs_collected
+                if remaining <= 0:
+                    break
+                limit = min(page_size, remaining)
+            else:
+                limit = page_size
 
             page_logs = await client.read_logs(
                 log_filter=log_filter,
-                limit=num_logs_to_return_from_page,
+                limit=limit,
                 offset=offset,
-                sort=(
-                    LogSort.TIMESTAMP_DESC if reverse or tail else LogSort.TIMESTAMP_ASC
-                ),
+                sort=sort,
             )
 
-            logs_to_render = (
-                list(reversed(page_logs)) if tail and not reverse else page_logs
-            )
+            if page_size is None:
+                page_size = len(page_logs)
+                if page_size == 0:
+                    break
 
-            if output_json:
-                collected_logs.extend(
-                    log.model_dump(mode="json") for log in logs_to_render
-                )
-            else:
-                for log in logs_to_render:
-                    timestamp = f"{log.timestamp:%Y-%m-%d %H:%M:%S.%f}"[:-3]
-                    log_level = f"{logging.getLevelName(log.level):7s}"
-                    flow_run_info = (
-                        f"Flow run {flow_run.name!r} - {escape(log.message)}"
-                    )
-
-                    log_message = f"{timestamp} | {log_level} | {flow_run_info}"
-                    _cli.console.print(
-                        log_message,
-                        soft_wrap=True,
-                    )
-
-            num_logs_returned += num_logs_to_return_from_page
+            if (
+                user_specified_num_logs is not None
+                and len(page_logs) > user_specified_num_logs - num_logs_collected
+            ):
+                page_logs = page_logs[: user_specified_num_logs - num_logs_collected]
 
             if tail:
-                if offset != 0:
-                    offset = (
-                        0
-                        if offset < LOGS_DEFAULT_PAGE_SIZE
-                        else offset - LOGS_DEFAULT_PAGE_SIZE
-                    )
-                else:
-                    more_logs = False
+                tail_buffer.extend(page_logs)
             else:
-                if len(page_logs) == LOGS_DEFAULT_PAGE_SIZE:
-                    offset += LOGS_DEFAULT_PAGE_SIZE
-                else:
-                    more_logs = False
+                render(page_logs)
+
+            num_logs_collected += len(page_logs)
+            offset += len(page_logs)
+
+            if (
+                user_specified_num_logs is not None
+                and num_logs_collected >= user_specified_num_logs
+            ):
+                break
+            if len(page_logs) < page_size:
+                break
+
+        if tail:
+            # tail_buffer is in DESC order across pages; reverse to ASC unless --reverse
+            if not reverse:
+                tail_buffer = list(reversed(tail_buffer))
+            render(tail_buffer)
 
     if output_json:
         json_output = orjson.dumps(collected_logs, option=orjson.OPT_INDENT_2).decode()

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -603,7 +603,8 @@ async def logs(
                 if (
                     page_size is None
                     and limit is not None
-                    and exc.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+                    and exc.response.status_code
+                    == status.HTTP_422_UNPROCESSABLE_CONTENT
                     and "Invalid limit" in exc.response.text
                 ):
                     limit = None

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -573,9 +573,9 @@ async def logs(
         except ObjectNotFound:
             exit_with_error(f"Flow run '{id!s}' not found!")
 
-        # Page size is discovered from the first response; the API returns up to
-        # PREFECT_API_DEFAULT_LIMIT logs when no limit is given, so we let the
-        # first request observe whatever the server is configured for.
+        # Bounded requests start with the requested count to avoid overfetching.
+        # If that exceeds the server maximum, retry without a limit to discover
+        # the server page size from the first response.
         page_size: Optional[int] = None
         offset = 0
         num_logs_collected = 0
@@ -583,7 +583,7 @@ async def logs(
 
         while True:
             if page_size is None:
-                limit = None
+                limit = user_specified_num_logs
             elif user_specified_num_logs is not None:
                 remaining = user_specified_num_logs - num_logs_collected
                 if remaining <= 0:
@@ -592,15 +592,32 @@ async def logs(
             else:
                 limit = page_size
 
-            page_logs = await client.read_logs(
-                log_filter=log_filter,
-                limit=limit,
-                offset=offset,
-                sort=sort,
-            )
+            try:
+                page_logs = await client.read_logs(
+                    log_filter=log_filter,
+                    limit=limit,
+                    offset=offset,
+                    sort=sort,
+                )
+            except httpx.HTTPStatusError as exc:
+                if (
+                    page_size is None
+                    and limit is not None
+                    and exc.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+                    and "Invalid limit" in exc.response.text
+                ):
+                    limit = None
+                    page_logs = await client.read_logs(
+                        log_filter=log_filter,
+                        limit=limit,
+                        offset=offset,
+                        sort=sort,
+                    )
+                else:
+                    raise
 
             if page_size is None:
-                page_size = len(page_logs)
+                page_size = limit if limit is not None else len(page_logs)
                 if page_size == 0:
                     break
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1459,6 +1459,28 @@ class TestFlowRunLogs:
             expected_line_count=251,
         )
 
+    async def test_pagination_infers_page_size_from_server(self, flow_run_factory):
+        """When the server is configured with a non-default API limit, the CLI
+        should still paginate correctly by inferring the page size from the
+        first response rather than relying on a hard-coded value."""
+        from prefect.settings import PREFECT_SERVER_API_DEFAULT_LIMIT
+
+        configured_limit = 50
+        total_logs = 120
+        flow_run = await flow_run_factory(num_logs=total_logs)
+
+        with temporary_settings({PREFECT_SERVER_API_DEFAULT_LIMIT: configured_limit}):
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=["flow-run", "logs", str(flow_run.id)],
+                expected_code=0,
+                expected_output_contains=[
+                    f"Flow run '{flow_run.name}' - Log {i} from flow_run {flow_run.id}."
+                    for i in range(total_logs)
+                ],
+                expected_line_count=total_logs,
+            )
+
 
 class TestFlowRunWatch:
     def test_watch_completed_flow_run(self, flow_run: FlowRun, monkeypatch):

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1481,6 +1481,44 @@ class TestFlowRunLogs:
                 expected_line_count=total_logs,
             )
 
+    async def test_bounded_tail_avoids_default_page_overfetch(
+        self, flow_run_factory, monkeypatch
+    ):
+        from prefect.settings import PREFECT_SERVER_API_DEFAULT_LIMIT
+
+        configured_limit = 100
+        requested_logs = 10
+        flow_run = await flow_run_factory(num_logs=configured_limit)
+        read_log_limits: list[int | None] = []
+        original_read_logs = PrefectClient.read_logs
+
+        async def read_logs_spy(self, *args: Any, **kwargs: Any):
+            read_log_limits.append(kwargs.get("limit"))
+            return await original_read_logs(self, *args, **kwargs)
+
+        monkeypatch.setattr(PrefectClient, "read_logs", read_logs_spy)
+
+        with temporary_settings({PREFECT_SERVER_API_DEFAULT_LIMIT: configured_limit}):
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "flow-run",
+                    "logs",
+                    str(flow_run.id),
+                    "--tail",
+                    "--num-logs",
+                    str(requested_logs),
+                ],
+                expected_code=0,
+                expected_output_contains=[
+                    f"Flow run '{flow_run.name}' - Log {i} from flow_run {flow_run.id}."
+                    for i in range(configured_limit - requested_logs, configured_limit)
+                ],
+                expected_line_count=requested_logs,
+            )
+
+        assert read_log_limits == [requested_logs]
+
 
 class TestFlowRunWatch:
     def test_watch_completed_flow_run(self, flow_run: FlowRun, monkeypatch):

--- a/tests/cli/test_task_run.py
+++ b/tests/cli/test_task_run.py
@@ -9,8 +9,10 @@ import pytest
 from click.testing import Result
 
 from prefect import flow, task
-from prefect.cli.flow_run import LOGS_DEFAULT_PAGE_SIZE
-from prefect.cli.task_run import LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS
+from prefect.cli.task_run import (
+    LOGS_DEFAULT_PAGE_SIZE,
+    LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS,
+)
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import LogCreate
 from prefect.client.schemas.objects import TaskRun


### PR DESCRIPTION
This PR implements the dynamic logs pagination logic requested in #8002

- Removes hard-coded `LOGS_DEFAULT_PAGE_SIZE = 200` in flow-run logs CLI
- Dynamically discovers page size by passing `limit=None` on the first request
- Refactors `--tail` logic to buffer pages in `TIMESTAMP_DESC` order to avoid offset math errors
- Adds test to verify pagination respects custom `PREFECT_SERVER_API_DEFAULT_LIMIT`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request closes #8002
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
