### PR TITLE
fix(prefect-gcp): detect CONTAINER_MISSING using current Cloud Run V2 enums

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/models/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/models/cloud_run_v2.py
@@ -258,13 +258,10 @@ class JobV2(BaseModel):
         Returns:
             Whether the job is missing a container.
         """
-        if (
-            ready_condition.get("state") == "CONTAINER_FAILED"
-            and ready_condition.get("reason") == "ContainerMissing"
-        ):
-            return True
-
-        return False
+        return (
+            ready_condition.get("state") == "CONDITION_FAILED"
+            and ready_condition.get("reason") == "CONTAINER_MISSING"
+        )
 
 
 class ExecutionV2(BaseModel):

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_v2.py
@@ -64,8 +64,8 @@ class TestJobV2:
             launchStage="BETA",
             terminalCondition={
                 "type": "Ready",
-                "state": "CONTAINER_FAILED",
-                "reason": "ContainerMissing",
+                "state": "CONDITION_FAILED",
+                "reason": "CONTAINER_MISSING",
             },
             executionCount=1,
             reconciling=False,
@@ -120,8 +120,8 @@ class TestJobV2:
         [
             (
                 {
-                    "state": "CONTAINER_FAILED",
-                    "reason": "ContainerMissing",
+                    "state": "CONDITION_FAILED",
+                    "reason": "CONTAINER_MISSING",
                 },
                 True,
             ),


### PR DESCRIPTION
## Summary

`JobV2._is_missing_container` was comparing the Cloud Run V2 `Condition`'s `state` / `reason` against `"CONTAINER_FAILED"` and `"ContainerMissing"`, which are not valid enum values in the [Cloud Run V2 `Condition` spec](https://docs.cloud.google.com/run/docs/reference/rest/v2/Condition).

Image-pull failures actually surface as `state="CONDITION_FAILED"` / `reason="CONTAINER_MISSING"`, so the existing check always returned `False`, `JobV2.is_ready()` never raised, and `CloudRunWorkerV2._wait_for_job_creation` polled forever on a permanently-failed job — child flow runs stayed stuck in `Submitting` until the parent flow timed out.

This PR aligns the comparison with the official Cloud Run V2 enums (`CONDITION_FAILED` / `CONTAINER_MISSING`) so `is_ready()` raises and the worker fails fast.

## Observed logs

Logs from `_wait_for_job_creation` repeating every few seconds for hours on a job that had already permanently failed:

```
Current Job Condition: {'type': 'Ready', 'state': 'CONDITION_RECONCILING', 'lastTransitionTime': '2026-04-24T20:24:56.496826Z'}
Current Job Condition: {'type': 'Ready', 'state': 'CONDITION_FAILED', 'message': "Image '<REGION>-docker.pkg.dev/<PROJECT>/<REPO>/<IMAGE>:<TAG>' not found.", 'lastTransitionTime': '2026-04-24T20:24:56.570894Z', 'reason': 'CONTAINER_MISSING'}
Current Job Condition: {'type': 'Ready', 'state': 'CONDITION_FAILED', 'message': "Image '<REGION>-docker.pkg.dev/<PROJECT>/<REPO>/<IMAGE>:<TAG>' not found.", 'lastTransitionTime': '2026-04-24T20:24:56.570894Z', 'reason': 'CONTAINER_MISSING'}
```

The `state` / `reason` values are exactly the spec-compliant enum identifiers, but the prior check looked for `state="CONTAINER_FAILED"` / `reason="ContainerMissing"` which never appear in current Cloud Run V2 responses.

## Reference

- [Cloud Run V2 `Condition` spec — `State` / `CommonReason` enums](https://docs.cloud.google.com/run/docs/reference/rest/v2/Condition)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.