### PR TITLE
fix: sort TRR bulk upsert batches by task_run.id to prevent deadlocks

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -195,9 +195,13 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
     unique_task_runs_by_id: dict[UUID, dict[str, Any]] = {}
     for tr in all_task_runs:
         unique_task_runs_by_id[tr["task_run"].id] = tr
-    unique_task_runs = list(unique_task_runs_by_id.values())
+    unique_task_runs = sorted(
+        unique_task_runs_by_id.values(), key=lambda tr: tr["task_run"].id
+    )
 
-    # Batch by keys to avoid column mismatches during bulk insert
+    # Batch by keys to avoid column mismatches during bulk insert.
+    # Each batch preserves the ID sort order established above for
+    # deterministic lock acquisition, preventing deadlocks under concurrency.
     batches_by_keys: dict[frozenset[str], list] = {}
     for tr in unique_task_runs:
         key_signature = frozenset(tr["task_run_dict"].keys())

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -3,10 +3,12 @@ from datetime import datetime, timedelta, timezone
 from itertools import permutations
 from pathlib import Path
 from typing import AsyncGenerator
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.dml import Insert
 
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.models.flow_runs import create_flow_run
@@ -1341,3 +1343,42 @@ async def test_bulk_insert_handles_shuffled_interleaved_events(
             StateType.RUNNING,
             StateType.COMPLETED,
         }
+
+
+async def test_bulk_upserts_are_sorted_by_task_run_id(
+    session: AsyncSession,
+    flow_run,
+):
+    """Bulk upsert VALUES are sorted by task_run.id so concurrent recorders
+    acquire row-level locks in the same order, preventing deadlocks."""
+    captured_id_orders: list[list[UUID]] = []
+    original_values = Insert.values
+
+    def spy_values(self, *args, **kwargs):
+        if args and isinstance(args[0], list) and args[0]:
+            if isinstance(args[0][0], dict) and "task_key" in args[0][0]:
+                captured_id_orders.append([row["id"] for row in args[0]])
+        return original_values(self, *args, **kwargs)
+
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+    flow_run_id = str(flow_run.id)
+    task_run_ids = [str(uuid4()) for _ in range(10)]
+
+    events = [
+        make_event_with_flow_run(
+            task_run_id=tid,
+            flow_run_id=flow_run_id,
+            task_key=f"task-{tid}",
+            dynamic_key=f"dyn-{tid}",
+            state_ts=base_time,
+            state_type=StateType.RUNNING,
+        )
+        for tid in task_run_ids
+    ]
+
+    with patch.object(Insert, "values", spy_values):
+        await task_run_recorder.record_bulk_task_run_events(events)
+
+    assert len(captured_id_orders) > 0
+    for ids in captured_id_orders:
+        assert ids == sorted(ids)


### PR DESCRIPTION
Sort unique task runs by ID before partitioning so that concurrent Task Run Recorder instances acquire row-level locks in the same deterministic order, eliminating deadlock risk when batches overlap.

closes #21716

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
