### PR TITLE
fix: encode non-ASCII filenames in Content-Disposition header for logs download

### DIFF
--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -1,3 +1,4 @@
+from urllib.parse import quote
 """
 Routes for interacting with flow run objects.
 """
@@ -1044,7 +1045,7 @@ async def download_logs(
             generate(),
             media_type="text/csv",
             headers={
-                "Content-Disposition": f"attachment; filename={flow_run.name}-logs.csv"
+                "Content-Disposition": f"attachment; filename*=UTF-8''{quote(f'{flow_run.name}-logs.csv')}"
             },
         )
 


### PR DESCRIPTION
## Summary

Fixes #21719

When flow run names contain non-ASCII characters (emoji, CJK, Cyrillic), the `/logs/download` endpoint fails because browsers reject non-ASCII values in HTTP headers.

## Root Cause

```python
f"attachment; filename={flow_run.name}-logs.csv"
```

Browsers enforce ASCII-only HTTP headers and will drop this response.

## Fix

Use RFC 5987 encoding:

```python
from urllib.parse import quote
f"attachment; filename*=UTF-8''{quote(f'{flow_run.name}-logs.csv')}"
```

Closes #21719
