### PR TITLE
Fix task run recorder natural key upserts

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncGenerator, NoReturn, Optional
 from uuid import UUID
 
+import sqlalchemy as sa
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,6 +40,19 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 DEFAULT_PERSIST_MAX_RETRIES = 5
+
+TaskRunUpsertKey = tuple[str, UUID] | tuple[str, UUID, str, str]
+
+
+def _task_run_upsert_key(task_run: TaskRun) -> TaskRunUpsertKey:
+    if task_run.flow_run_id is None:
+        return ("id", task_run.id)
+    return (
+        "natural-key",
+        task_run.flow_run_id,
+        task_run.task_key,
+        task_run.dynamic_key,
+    )
 
 
 @db_injector
@@ -134,32 +148,11 @@ def db_recordable_task_run_from_event(
 
 async def record_task_run_event(event: ReceivedEvent, depth: int = 0) -> None:
     """Record a single task run event in the database"""
-    db = provide_database_interface()
-
     max_attempts = 2
     for attempt in range(1, max_attempts + 1):
         try:
-            async with db.session_context() as session:
-                task_run, task_run_dict = db_recordable_task_run_from_event(event)
-
-                assert task_run.state is not None
-
-                now = prefect.types._datetime.now("UTC")
-
-                await session.execute(
-                    db.queries.insert(db.TaskRun)
-                    .values(**task_run_dict | {"created": now})
-                    .on_conflict_do_update(
-                        index_elements=["id"],
-                        set_={**task_run_dict | {"updated": now}},
-                        where=db.TaskRun.state_timestamp < task_run.state.timestamp,
-                    )
-                )
-
-                await _insert_task_run_states(session, [task_run])
-
-                await session.commit()
-                return
+            await record_bulk_task_run_events([event])
+            return
         except IntegrityError:
             if attempt < max_attempts:
                 logger.info(
@@ -190,21 +183,29 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
         for task_run, task_run_dict in [db_recordable_task_run_from_event(event)]
     ]
 
-    # Drop duplicate tasks, keep the one with the latest state_timestamp
+    # Drop duplicate task runs, keep the one with the latest state_timestamp.
+    # For task runs linked to a flow run, the database identity is the natural key
+    # (flow_run_id, task_key, dynamic_key); task run events can arrive with
+    # different resource ids for the same natural key.
     all_task_runs.sort(key=lambda tr: tr["task_run"].state.timestamp)
-    unique_task_runs_by_id: dict[UUID, dict[str, Any]] = {}
+    unique_task_runs_by_key: dict[TaskRunUpsertKey, dict[str, Any]] = {}
     for tr in all_task_runs:
-        unique_task_runs_by_id[tr["task_run"].id] = tr
+        unique_task_runs_by_key[_task_run_upsert_key(tr["task_run"])] = tr
     unique_task_runs = sorted(
-        unique_task_runs_by_id.values(), key=lambda tr: tr["task_run"].id
+        unique_task_runs_by_key.values(),
+        key=lambda tr: _task_run_upsert_key(tr["task_run"]),
     )
 
     # Batch by keys to avoid column mismatches during bulk insert.
-    # Each batch preserves the ID sort order established above for
+    # Each batch preserves the conflict-key sort order established above for
     # deterministic lock acquisition, preventing deadlocks under concurrency.
-    batches_by_keys: dict[frozenset[str], list] = {}
+    batches_by_keys: dict[tuple[frozenset[str], bool], list] = {}
     for tr in unique_task_runs:
-        key_signature = frozenset(tr["task_run_dict"].keys())
+        task_run = tr["task_run"]
+        key_signature = (
+            frozenset(tr["task_run_dict"].keys()),
+            task_run.flow_run_id is not None,
+        )
         batches_by_keys.setdefault(key_signature, []).append(tr)
 
     logger.debug(
@@ -214,8 +215,10 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
     db = provide_database_interface()
 
     async with db.session_context() as session:
-        for key_signature, batch in batches_by_keys.items():
-            update_cols = set(key_signature) - {"id", "created"}
+        canonical_task_run_ids: dict[TaskRunUpsertKey, UUID] = {}
+
+        for (column_keys, has_natural_key), batch in batches_by_keys.items():
+            update_cols = set(column_keys) - {"id", "created"}
 
             logger.debug(f"Preparing to bulk insert {len(batch)} task runs")
             to_insert = [
@@ -223,15 +226,18 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
             ]
 
             insert_statement = db.queries.insert(db.TaskRun).values(to_insert)
+            index_elements = (
+                db.orm.task_run_unique_upsert_columns if has_natural_key else ["id"]
+            )
             upsert_statement = insert_statement.on_conflict_do_update(
-                index_elements=["id"],
+                index_elements=index_elements,
                 set_={
                     # See https://www.postgresql.org/docs/current/sql-insert.html for details on excluded.
                     # Idea is excluded.x references the proposed insertion value for column x.
                     **{
                         col.name: getattr(insert_statement.excluded, col.name)
                         for col in insert_statement.excluded
-                        if col.name in update_cols | {"updated"}
+                        if col.name in (update_cols | {"updated"}) - {"id"}
                     },
                 },
                 where=db.TaskRun.state_timestamp
@@ -240,6 +246,48 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
             await session.execute(upsert_statement)
 
             logger.debug(f"Finished bulk inserting {len(batch)} task runs")
+
+            if has_natural_key:
+                natural_keys = [
+                    (
+                        tr["task_run"].flow_run_id,
+                        tr["task_run"].task_key,
+                        tr["task_run"].dynamic_key,
+                    )
+                    for tr in batch
+                ]
+                result = await session.execute(
+                    sa.select(
+                        db.TaskRun.flow_run_id,
+                        db.TaskRun.task_key,
+                        db.TaskRun.dynamic_key,
+                        db.TaskRun.id,
+                    ).where(
+                        sa.tuple_(
+                            db.TaskRun.flow_run_id,
+                            db.TaskRun.task_key,
+                            db.TaskRun.dynamic_key,
+                        ).in_(natural_keys)
+                    )
+                )
+                for flow_run_id, task_key, dynamic_key, task_run_id in result.all():
+                    canonical_task_run_ids[
+                        ("natural-key", flow_run_id, task_key, dynamic_key)
+                    ] = task_run_id
+            else:
+                for tr in batch:
+                    canonical_task_run_ids[_task_run_upsert_key(tr["task_run"])] = tr[
+                        "task_run"
+                    ].id
+
+        for tr in all_task_runs:
+            task_run = tr["task_run"]
+            canonical_task_run_id = canonical_task_run_ids[
+                _task_run_upsert_key(task_run)
+            ]
+            task_run.id = canonical_task_run_id
+            if task_run.state is not None:
+                task_run.state.state_details.task_run_id = canonical_task_run_id
 
         # Insert all task run states - we only coalesce task run updates, not states
         await _insert_task_run_states(session, [tr["task_run"] for tr in all_task_runs])

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1196,15 +1196,13 @@ def make_event_with_flow_run(
     )
 
 
-async def test_bulk_upsert_natural_key_conflict_raises_for_consumer_retry(
+async def test_bulk_upsert_natural_key_conflict_updates_existing_task_run(
     session: AsyncSession,
     flow_run,
 ):
     """When two sequential bulk upserts have different task_run_ids but the
     same (flow_run_id, task_key, dynamic_key), record_bulk_task_run_events
-    raises IntegrityError so the consumer's flush() retry mechanism can
-    handle it."""
-    from sqlalchemy.exc import IntegrityError
+    updates the existing task run and attaches the state to its canonical id."""
 
     flow_run_id = str(flow_run.id)
     task_key = "my_task-abcdefg"
@@ -1239,8 +1237,22 @@ async def test_bulk_upsert_natural_key_conflict_raises_for_consumer_retry(
         state_type=StateType.RUNNING,
     )
 
-    with pytest.raises(IntegrityError):
-        await task_run_recorder.record_bulk_task_run_events([second_event])
+    await task_run_recorder.record_bulk_task_run_events([second_event])
+
+    session.expire_all()
+    task_run = await read_task_run(session=session, task_run_id=first_task_run_id)
+    assert task_run is not None
+    assert task_run.state_type == StateType.RUNNING
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=second_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
 async def test_single_upsert_with_natural_key_conflict_does_not_raise(
@@ -1287,7 +1299,63 @@ async def test_single_upsert_with_natural_key_conflict_does_not_raise(
     session.expire_all()
     task_run = await read_task_run(session=session, task_run_id=first_task_run_id)
     assert task_run is not None
-    assert task_run.state_type == StateType.PENDING
+    assert task_run.state_type == StateType.RUNNING
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=second_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
+
+
+async def test_bulk_upsert_coalesces_natural_key_conflicts_in_same_batch(
+    session: AsyncSession,
+    flow_run,
+):
+    flow_run_id = str(flow_run.id)
+    task_key = "my_task-abcdefg"
+    dynamic_key = "3"
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+    first_task_run_id = str(uuid4())
+    second_task_run_id = str(uuid4())
+
+    first_event = make_event_with_flow_run(
+        task_run_id=first_task_run_id,
+        flow_run_id=flow_run_id,
+        task_key=task_key,
+        dynamic_key=dynamic_key,
+        state_ts=base_time,
+        state_type=StateType.PENDING,
+    )
+    second_event = make_event_with_flow_run(
+        task_run_id=second_task_run_id,
+        flow_run_id=flow_run_id,
+        task_key=task_key,
+        dynamic_key=dynamic_key,
+        state_ts=base_time + timedelta(minutes=1),
+        state_type=StateType.RUNNING,
+    )
+
+    await task_run_recorder.record_bulk_task_run_events([first_event, second_event])
+
+    task_run = await read_task_run(session=session, task_run_id=second_task_run_id)
+    assert task_run is not None
+    assert task_run.state_type == StateType.RUNNING
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=first_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
 async def test_bulk_insert_handles_shuffled_interleaved_events(
@@ -1345,19 +1413,24 @@ async def test_bulk_insert_handles_shuffled_interleaved_events(
         }
 
 
-async def test_bulk_upserts_are_sorted_by_task_run_id(
+async def test_bulk_upserts_are_sorted_by_conflict_key(
     session: AsyncSession,
     flow_run,
 ):
-    """Bulk upsert VALUES are sorted by task_run.id so concurrent recorders
+    """Bulk upsert VALUES are sorted by conflict key so concurrent recorders
     acquire row-level locks in the same order, preventing deadlocks."""
-    captured_id_orders: list[list[UUID]] = []
+    captured_key_orders: list[list[tuple[UUID, str, str]]] = []
     original_values = Insert.values
 
     def spy_values(self, *args, **kwargs):
         if args and isinstance(args[0], list) and args[0]:
             if isinstance(args[0][0], dict) and "task_key" in args[0][0]:
-                captured_id_orders.append([row["id"] for row in args[0]])
+                captured_key_orders.append(
+                    [
+                        (row["flow_run_id"], row["task_key"], row["dynamic_key"])
+                        for row in args[0]
+                    ]
+                )
         return original_values(self, *args, **kwargs)
 
     base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
@@ -1379,6 +1452,6 @@ async def test_bulk_upserts_are_sorted_by_task_run_id(
     with patch.object(Insert, "values", spy_values):
         await task_run_recorder.record_bulk_task_run_events(events)
 
-    assert len(captured_id_orders) > 0
-    for ids in captured_id_orders:
-        assert ids == sorted(ids)
+    assert len(captured_key_orders) > 0
+    for keys in captured_key_orders:
+        assert keys == sorted(keys)


### PR DESCRIPTION
closes #20144

this PR updates task run event recording to upsert flow-run task runs by their database natural key and attach state history to the canonical task run id.

<details>
<summary>Details</summary>

- uses `(flow_run_id, task_key, dynamic_key)` as the conflict target for task runs linked to flow runs
- preserves the existing task run primary key on natural-key conflict instead of updating `id`
- resolves the canonical task run id before inserting task run states, so state rows remain attached to the persisted task run
- keeps id-based upserts for task run events without a flow run id
- covers sequential and same-batch natural-key conflicts for both bulk and single-event recorder paths

</details>

Tests:
- `/tmp/prefect-uv/bin/uv run ruff check src/prefect/server/services/task_run_recorder.py tests/server/services/test_task_run_recorder.py`
- `/tmp/prefect-uv/bin/uv run pytest tests/server/services/test_task_run_recorder.py --tb=short`
- `PREFECT_SERVER_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost:55432/prefect /tmp/prefect-uv/bin/uv run pytest tests/server/services/test_task_run_recorder.py --tb=short`
