### PR TITLE
Fix task run recorder conflict handling

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -55,6 +55,20 @@ def _task_run_upsert_key(task_run: TaskRun) -> TaskRunUpsertKey:
     )
 
 
+def _task_run_conflict_keys(task_run: TaskRun) -> list[TaskRunUpsertKey]:
+    keys: list[TaskRunUpsertKey] = [("id", task_run.id)]
+    if task_run.flow_run_id is not None:
+        keys.append(
+            (
+                "natural-key",
+                task_run.flow_run_id,
+                task_run.task_key,
+                task_run.dynamic_key,
+            )
+        )
+    return keys
+
+
 @db_injector
 async def _insert_task_run_states(
     db: PrefectDBInterface, session: AsyncSession, task_runs: list[TaskRun]
@@ -183,16 +197,43 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
         for task_run, task_run_dict in [db_recordable_task_run_from_event(event)]
     ]
 
-    # Drop duplicate task runs, keep the one with the latest state_timestamp.
-    # For task runs linked to a flow run, the database identity is the natural key
-    # (flow_run_id, task_key, dynamic_key); task run events can arrive with
-    # different resource ids for the same natural key.
+    # Drop duplicate task run rows, keep the one with the latest state_timestamp.
+    # A single bulk flush can contain events that collide on either id or natural
+    # key, so coalesce connected conflicts before choosing the ON CONFLICT target.
     all_task_runs.sort(key=lambda tr: tr["task_run"].state.timestamp)
-    unique_task_runs_by_key: dict[TaskRunUpsertKey, dict[str, Any]] = {}
+    parent: dict[TaskRunUpsertKey, TaskRunUpsertKey] = {}
+
+    def find(key: TaskRunUpsertKey) -> TaskRunUpsertKey:
+        parent.setdefault(key, key)
+        if parent[key] != key:
+            parent[key] = find(parent[key])
+        return parent[key]
+
+    def union(left: TaskRunUpsertKey, right: TaskRunUpsertKey) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
     for tr in all_task_runs:
-        unique_task_runs_by_key[_task_run_upsert_key(tr["task_run"])] = tr
+        conflict_keys = _task_run_conflict_keys(tr["task_run"])
+        for conflict_key in conflict_keys[1:]:
+            union(conflict_keys[0], conflict_key)
+
+    unique_task_runs_by_group: dict[TaskRunUpsertKey, dict[str, Any]] = {}
+    upsert_key_aliases: dict[TaskRunUpsertKey, TaskRunUpsertKey] = {}
+    for tr in all_task_runs:
+        conflict_group = find(_task_run_conflict_keys(tr["task_run"])[0])
+        unique_task_runs_by_group[conflict_group] = tr
+
+    for tr in all_task_runs:
+        conflict_group = find(_task_run_conflict_keys(tr["task_run"])[0])
+        upsert_key_aliases[_task_run_upsert_key(tr["task_run"])] = (
+            _task_run_upsert_key(unique_task_runs_by_group[conflict_group]["task_run"])
+        )
+
     unique_task_runs = sorted(
-        unique_task_runs_by_key.values(),
+        unique_task_runs_by_group.values(),
         key=lambda tr: _task_run_upsert_key(tr["task_run"]),
     )
 
@@ -337,6 +378,9 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
                     canonical_task_run_ids[_task_run_upsert_key(tr["task_run"])] = tr[
                         "task_run"
                     ].id
+
+        for alias_key, canonical_key in upsert_key_aliases.items():
+            canonical_task_run_ids[alias_key] = canonical_task_run_ids[canonical_key]
 
         for tr in all_task_runs:
             task_run = tr["task_run"]

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -221,13 +221,17 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
             union(conflict_keys[0], conflict_key)
 
     unique_task_runs_by_group: dict[TaskRunUpsertKey, dict[str, Any]] = {}
+    conflict_keys_by_group: dict[TaskRunUpsertKey, set[TaskRunUpsertKey]] = {}
     upsert_key_aliases: dict[TaskRunUpsertKey, TaskRunUpsertKey] = {}
     for tr in all_task_runs:
-        conflict_group = find(_task_run_conflict_keys(tr["task_run"])[0])
+        conflict_keys = _task_run_conflict_keys(tr["task_run"])
+        conflict_group = find(conflict_keys[0])
+        tr["conflict_group"] = conflict_group
         unique_task_runs_by_group[conflict_group] = tr
+        conflict_keys_by_group.setdefault(conflict_group, set()).update(conflict_keys)
 
     for tr in all_task_runs:
-        conflict_group = find(_task_run_conflict_keys(tr["task_run"])[0])
+        conflict_group = tr["conflict_group"]
         upsert_key_aliases[_task_run_upsert_key(tr["task_run"])] = _task_run_upsert_key(
             unique_task_runs_by_group[conflict_group]["task_run"]
         )
@@ -239,21 +243,19 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
 
     db = provide_database_interface()
 
-    task_run_ids = [tr["task_run"].id for tr in unique_task_runs]
-    natural_keys = [
-        (
-            task_run.flow_run_id,
-            task_run.task_key,
-            task_run.dynamic_key,
-        )
-        for tr in unique_task_runs
-        for task_run in [tr["task_run"]]
-        if task_run.flow_run_id is not None
-    ]
+    task_run_ids: list[UUID] = []
+    natural_keys: list[tuple[UUID, str, str]] = []
+    for conflict_keys in conflict_keys_by_group.values():
+        for conflict_key in conflict_keys:
+            if len(conflict_key) == 2:
+                task_run_ids.append(conflict_key[1])
+            else:
+                natural_keys.append((conflict_key[1], conflict_key[2], conflict_key[3]))
 
     async with db.session_context() as session:
         existing_task_run_ids: set[UUID] = set()
         existing_natural_keys: set[tuple[UUID, str, str]] = set()
+        existing_task_run_ids_by_key: dict[TaskRunUpsertKey, UUID] = {}
         if task_run_ids or natural_keys:
             conditions = []
             if task_run_ids:
@@ -276,8 +278,12 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
             )
             for task_run_id, flow_run_id, task_key, dynamic_key in result.all():
                 existing_task_run_ids.add(task_run_id)
+                existing_task_run_ids_by_key[("id", task_run_id)] = task_run_id
                 if flow_run_id is not None:
                     existing_natural_keys.add((flow_run_id, task_key, dynamic_key))
+                    existing_task_run_ids_by_key[
+                        ("natural-key", flow_run_id, task_key, dynamic_key)
+                    ] = task_run_id
 
         def conflict_target(tr: dict[str, Any]) -> str:
             task_run = tr["task_run"]
@@ -293,6 +299,14 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
                 return "natural-key"
             if task_run.id in existing_task_run_ids:
                 return "id"
+            for conflict_key in sorted(
+                conflict_keys_by_group[tr["conflict_group"]], key=str
+            ):
+                if conflict_key in existing_task_run_ids_by_key:
+                    canonical_task_run_id = existing_task_run_ids_by_key[conflict_key]
+                    task_run.id = canonical_task_run_id
+                    tr["task_run_dict"]["id"] = canonical_task_run_id
+                    return "id"
             if task_run.flow_run_id is not None:
                 return "natural-key"
             return "id"

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncGenerator, NoReturn, Optional
 from uuid import UUID
 
+import sqlalchemy as sa
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,6 +40,19 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 DEFAULT_PERSIST_MAX_RETRIES = 5
+
+TaskRunUpsertKey = tuple[str, UUID] | tuple[str, UUID, str, str]
+
+
+def _task_run_upsert_key(task_run: TaskRun) -> TaskRunUpsertKey:
+    if task_run.flow_run_id is None:
+        return ("id", task_run.id)
+    return (
+        "natural-key",
+        task_run.flow_run_id,
+        task_run.task_key,
+        task_run.dynamic_key,
+    )
 
 
 @db_injector
@@ -134,32 +148,11 @@ def db_recordable_task_run_from_event(
 
 async def record_task_run_event(event: ReceivedEvent, depth: int = 0) -> None:
     """Record a single task run event in the database"""
-    db = provide_database_interface()
-
     max_attempts = 2
     for attempt in range(1, max_attempts + 1):
         try:
-            async with db.session_context() as session:
-                task_run, task_run_dict = db_recordable_task_run_from_event(event)
-
-                assert task_run.state is not None
-
-                now = prefect.types._datetime.now("UTC")
-
-                await session.execute(
-                    db.queries.insert(db.TaskRun)
-                    .values(**task_run_dict | {"created": now})
-                    .on_conflict_do_update(
-                        index_elements=["id"],
-                        set_={**task_run_dict | {"updated": now}},
-                        where=db.TaskRun.state_timestamp < task_run.state.timestamp,
-                    )
-                )
-
-                await _insert_task_run_states(session, [task_run])
-
-                await session.commit()
-                return
+            await record_bulk_task_run_events([event])
+            return
         except IntegrityError:
             if attempt < max_attempts:
                 logger.info(
@@ -190,21 +183,29 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
         for task_run, task_run_dict in [db_recordable_task_run_from_event(event)]
     ]
 
-    # Drop duplicate tasks, keep the one with the latest state_timestamp
+    # Drop duplicate task runs, keep the one with the latest state_timestamp.
+    # For task runs linked to a flow run, the database identity is the natural key
+    # (flow_run_id, task_key, dynamic_key); task run events can arrive with
+    # different resource ids for the same natural key.
     all_task_runs.sort(key=lambda tr: tr["task_run"].state.timestamp)
-    unique_task_runs_by_id: dict[UUID, dict[str, Any]] = {}
+    unique_task_runs_by_key: dict[TaskRunUpsertKey, dict[str, Any]] = {}
     for tr in all_task_runs:
-        unique_task_runs_by_id[tr["task_run"].id] = tr
+        unique_task_runs_by_key[_task_run_upsert_key(tr["task_run"])] = tr
     unique_task_runs = sorted(
-        unique_task_runs_by_id.values(), key=lambda tr: tr["task_run"].id
+        unique_task_runs_by_key.values(),
+        key=lambda tr: _task_run_upsert_key(tr["task_run"]),
     )
 
     # Batch by keys to avoid column mismatches during bulk insert.
-    # Each batch preserves the ID sort order established above for
+    # Each batch preserves the conflict-key sort order established above for
     # deterministic lock acquisition, preventing deadlocks under concurrency.
-    batches_by_keys: dict[frozenset[str], list] = {}
+    batches_by_keys: dict[tuple[frozenset[str], bool], list] = {}
     for tr in unique_task_runs:
-        key_signature = frozenset(tr["task_run_dict"].keys())
+        task_run = tr["task_run"]
+        key_signature = (
+            frozenset(tr["task_run_dict"].keys()),
+            task_run.flow_run_id is not None,
+        )
         batches_by_keys.setdefault(key_signature, []).append(tr)
 
     logger.debug(
@@ -214,8 +215,10 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
     db = provide_database_interface()
 
     async with db.session_context() as session:
-        for key_signature, batch in batches_by_keys.items():
-            update_cols = set(key_signature) - {"id", "created"}
+        canonical_task_run_ids: dict[TaskRunUpsertKey, UUID] = {}
+
+        for (column_keys, has_natural_key), batch in batches_by_keys.items():
+            update_cols = set(column_keys) - {"id", "created"}
 
             logger.debug(f"Preparing to bulk insert {len(batch)} task runs")
             to_insert = [
@@ -223,15 +226,18 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
             ]
 
             insert_statement = db.queries.insert(db.TaskRun).values(to_insert)
+            index_elements = (
+                db.orm.task_run_unique_upsert_columns if has_natural_key else ["id"]
+            )
             upsert_statement = insert_statement.on_conflict_do_update(
-                index_elements=["id"],
+                index_elements=index_elements,
                 set_={
                     # See https://www.postgresql.org/docs/current/sql-insert.html for details on excluded.
                     # Idea is excluded.x references the proposed insertion value for column x.
                     **{
                         col.name: getattr(insert_statement.excluded, col.name)
                         for col in insert_statement.excluded
-                        if col.name in update_cols | {"updated"}
+                        if col.name in (update_cols | {"updated"}) - {"id"}
                     },
                 },
                 where=db.TaskRun.state_timestamp
@@ -240,6 +246,48 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
             await session.execute(upsert_statement)
 
             logger.debug(f"Finished bulk inserting {len(batch)} task runs")
+
+            if has_natural_key:
+                natural_keys = [
+                    (
+                        tr["task_run"].flow_run_id,
+                        tr["task_run"].task_key,
+                        tr["task_run"].dynamic_key,
+                    )
+                    for tr in batch
+                ]
+                result = await session.execute(
+                    sa.select(
+                        db.TaskRun.flow_run_id,
+                        db.TaskRun.task_key,
+                        db.TaskRun.dynamic_key,
+                        db.TaskRun.id,
+                    ).where(
+                        sa.tuple_(
+                            db.TaskRun.flow_run_id,
+                            db.TaskRun.task_key,
+                            db.TaskRun.dynamic_key,
+                        ).in_(natural_keys)
+                    )
+                )
+                for flow_run_id, task_key, dynamic_key, task_run_id in result.all():
+                    canonical_task_run_ids[
+                        ("natural-key", flow_run_id, task_key, dynamic_key)
+                    ] = task_run_id
+            else:
+                for tr in batch:
+                    canonical_task_run_ids[_task_run_upsert_key(tr["task_run"])] = tr[
+                        "task_run"
+                    ].id
+
+        for tr in all_task_runs:
+            task_run = tr["task_run"]
+            canonical_task_run_id = canonical_task_run_ids[
+                _task_run_upsert_key(task_run)
+            ]
+            task_run.id = canonical_task_run_id
+            if task_run.state is not None:
+                task_run.state.state_details.task_run_id = canonical_task_run_id
 
         # Insert all task run states - we only coalesce task run updates, not states
         await _insert_task_run_states(session, [tr["task_run"] for tr in all_task_runs])

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -196,28 +196,84 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
         key=lambda tr: _task_run_upsert_key(tr["task_run"]),
     )
 
-    # Batch by keys to avoid column mismatches during bulk insert.
-    # Each batch preserves the conflict-key sort order established above for
-    # deterministic lock acquisition, preventing deadlocks under concurrency.
-    batches_by_keys: dict[tuple[frozenset[str], bool], list] = {}
-    for tr in unique_task_runs:
-        task_run = tr["task_run"]
-        key_signature = (
-            frozenset(tr["task_run_dict"].keys()),
-            task_run.flow_run_id is not None,
-        )
-        batches_by_keys.setdefault(key_signature, []).append(tr)
-
-    logger.debug(
-        f"Partitioned task runs into {len(batches_by_keys)} groups by update columns"
-    )
-
     db = provide_database_interface()
 
+    task_run_ids = [tr["task_run"].id for tr in unique_task_runs]
+    natural_keys = [
+        (
+            task_run.flow_run_id,
+            task_run.task_key,
+            task_run.dynamic_key,
+        )
+        for tr in unique_task_runs
+        for task_run in [tr["task_run"]]
+        if task_run.flow_run_id is not None
+    ]
+
     async with db.session_context() as session:
+        existing_task_run_ids: set[UUID] = set()
+        existing_natural_keys: set[tuple[UUID, str, str]] = set()
+        if task_run_ids or natural_keys:
+            conditions = []
+            if task_run_ids:
+                conditions.append(db.TaskRun.id.in_(task_run_ids))
+            if natural_keys:
+                conditions.append(
+                    sa.tuple_(
+                        db.TaskRun.flow_run_id,
+                        db.TaskRun.task_key,
+                        db.TaskRun.dynamic_key,
+                    ).in_(natural_keys)
+                )
+            result = await session.execute(
+                sa.select(
+                    db.TaskRun.id,
+                    db.TaskRun.flow_run_id,
+                    db.TaskRun.task_key,
+                    db.TaskRun.dynamic_key,
+                ).where(sa.or_(*conditions))
+            )
+            for task_run_id, flow_run_id, task_key, dynamic_key in result.all():
+                existing_task_run_ids.add(task_run_id)
+                if flow_run_id is not None:
+                    existing_natural_keys.add((flow_run_id, task_key, dynamic_key))
+
+        def conflict_target(tr: dict[str, Any]) -> str:
+            task_run = tr["task_run"]
+            natural_key = (
+                task_run.flow_run_id,
+                task_run.task_key,
+                task_run.dynamic_key,
+            )
+            if (
+                task_run.flow_run_id is not None
+                and natural_key in existing_natural_keys
+            ):
+                return "natural-key"
+            if task_run.id in existing_task_run_ids:
+                return "id"
+            if task_run.flow_run_id is not None:
+                return "natural-key"
+            return "id"
+
+        # Batch by keys to avoid column mismatches during bulk insert.
+        # Each batch preserves the conflict-key sort order established above for
+        # deterministic lock acquisition, preventing deadlocks under concurrency.
+        batches_by_keys: dict[tuple[frozenset[str], str], list] = {}
+        for tr in unique_task_runs:
+            key_signature = (
+                frozenset(tr["task_run_dict"].keys()),
+                conflict_target(tr),
+            )
+            batches_by_keys.setdefault(key_signature, []).append(tr)
+
+        logger.debug(
+            f"Partitioned task runs into {len(batches_by_keys)} groups by update columns"
+        )
+
         canonical_task_run_ids: dict[TaskRunUpsertKey, UUID] = {}
 
-        for (column_keys, has_natural_key), batch in batches_by_keys.items():
+        for (column_keys, conflict_target_name), batch in batches_by_keys.items():
             update_cols = set(column_keys) - {"id", "created"}
 
             logger.debug(f"Preparing to bulk insert {len(batch)} task runs")
@@ -227,7 +283,9 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
 
             insert_statement = db.queries.insert(db.TaskRun).values(to_insert)
             index_elements = (
-                db.orm.task_run_unique_upsert_columns if has_natural_key else ["id"]
+                db.orm.task_run_unique_upsert_columns
+                if conflict_target_name == "natural-key"
+                else ["id"]
             )
             upsert_statement = insert_statement.on_conflict_do_update(
                 index_elements=index_elements,
@@ -247,7 +305,7 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
 
             logger.debug(f"Finished bulk inserting {len(batch)} task runs")
 
-            if has_natural_key:
+            if conflict_target_name == "natural-key":
                 natural_keys = [
                     (
                         tr["task_run"].flow_run_id,

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -228,8 +228,8 @@ async def record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
 
     for tr in all_task_runs:
         conflict_group = find(_task_run_conflict_keys(tr["task_run"])[0])
-        upsert_key_aliases[_task_run_upsert_key(tr["task_run"])] = (
-            _task_run_upsert_key(unique_task_runs_by_group[conflict_group]["task_run"])
+        upsert_key_aliases[_task_run_upsert_key(tr["task_run"])] = _task_run_upsert_key(
+            unique_task_runs_by_group[conflict_group]["task_run"]
         )
 
     unique_task_runs = sorted(

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1312,6 +1312,52 @@ async def test_single_upsert_with_natural_key_conflict_does_not_raise(
     assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
+async def test_bulk_upsert_id_conflict_updates_existing_task_run(
+    session: AsyncSession,
+    flow_run,
+):
+    """Task run recorder events can arrive after the task run row already exists."""
+
+    flow_run_id = str(flow_run.id)
+    task_run_id = str(uuid4())
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+    first_event = make_event_with_flow_run(
+        task_run_id=task_run_id,
+        flow_run_id=flow_run_id,
+        task_key="old-task-key",
+        dynamic_key="old-dynamic-key",
+        state_ts=base_time,
+        state_type=StateType.PENDING,
+    )
+
+    await task_run_recorder.record_bulk_task_run_events([first_event])
+
+    later_time = base_time + timedelta(minutes=1)
+    second_event = make_event_with_flow_run(
+        task_run_id=task_run_id,
+        flow_run_id=flow_run_id,
+        task_key="say_hello-8dfe6dff",
+        dynamic_key="02130dc3-eae9-4d10-94b7-78e81c9e6724",
+        state_ts=later_time,
+        state_type=StateType.RUNNING,
+    )
+
+    await task_run_recorder.record_bulk_task_run_events([second_event])
+
+    session.expire_all()
+    task_run = await read_task_run(session=session, task_run_id=task_run_id)
+    assert task_run is not None
+    assert task_run.task_key == "say_hello-8dfe6dff"
+    assert task_run.dynamic_key == "02130dc3-eae9-4d10-94b7-78e81c9e6724"
+    assert task_run.state_type == StateType.RUNNING
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
+
+
 async def test_bulk_upsert_coalesces_natural_key_conflicts_in_same_batch(
     session: AsyncSession,
     flow_run,

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1410,6 +1410,69 @@ async def test_bulk_upsert_coalesces_id_conflicts_in_same_batch(
     assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
+async def test_bulk_upsert_keeps_existing_id_hidden_by_same_batch_conflict(
+    session: AsyncSession,
+    flow_run,
+):
+    flow_run_id = str(flow_run.id)
+    task_run_id = str(uuid4())
+    duplicate_task_run_id = str(uuid4())
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+    first_event = make_event_with_flow_run(
+        task_run_id=task_run_id,
+        flow_run_id=flow_run_id,
+        task_key="old-task-key",
+        dynamic_key="old-dynamic-key",
+        state_ts=base_time,
+        state_type=StateType.PENDING,
+    )
+
+    await task_run_recorder.record_bulk_task_run_events([first_event])
+
+    await task_run_recorder.record_bulk_task_run_events(
+        [
+            make_event_with_flow_run(
+                task_run_id=task_run_id,
+                flow_run_id=flow_run_id,
+                task_key="new-task-key",
+                dynamic_key="new-dynamic-key",
+                state_ts=base_time + timedelta(minutes=1),
+                state_type=StateType.RUNNING,
+            ),
+            make_event_with_flow_run(
+                task_run_id=duplicate_task_run_id,
+                flow_run_id=flow_run_id,
+                task_key="new-task-key",
+                dynamic_key="new-dynamic-key",
+                state_ts=base_time + timedelta(minutes=2),
+                state_type=StateType.COMPLETED,
+            ),
+        ]
+    )
+
+    session.expire_all()
+    task_run = await read_task_run(session=session, task_run_id=task_run_id)
+    assert task_run is not None
+    assert task_run.task_key == "new-task-key"
+    assert task_run.dynamic_key == "new-dynamic-key"
+    assert task_run.state_type == StateType.COMPLETED
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=duplicate_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [
+        StateType.PENDING,
+        StateType.RUNNING,
+        StateType.COMPLETED,
+    ]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
+
+
 async def test_bulk_upsert_coalesces_natural_key_conflicts_in_same_batch(
     session: AsyncSession,
     flow_run,

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1358,6 +1358,58 @@ async def test_bulk_upsert_id_conflict_updates_existing_task_run(
     assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
+async def test_bulk_upsert_coalesces_id_conflicts_in_same_batch(
+    session: AsyncSession,
+    flow_run,
+):
+    flow_run_id = str(flow_run.id)
+    task_run_id = str(uuid4())
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+    first_event = make_event_with_flow_run(
+        task_run_id=task_run_id,
+        flow_run_id=flow_run_id,
+        task_key="old-task-key",
+        dynamic_key="old-dynamic-key",
+        state_ts=base_time,
+        state_type=StateType.PENDING,
+    )
+    second_event = make_event_with_flow_run(
+        task_run_id=task_run_id,
+        flow_run_id=flow_run_id,
+        task_key="say_hello-8dfe6dff",
+        dynamic_key="02130dc3-eae9-4d10-94b7-78e81c9e6724",
+        state_ts=base_time + timedelta(minutes=1),
+        state_type=StateType.RUNNING,
+    )
+    extra_events = [
+        make_event_with_flow_run(
+            task_run_id=str(uuid4()),
+            flow_run_id=flow_run_id,
+            task_key=f"other-task-{i}",
+            dynamic_key=f"other-dynamic-key-{i}",
+            state_ts=base_time + timedelta(seconds=i),
+            state_type=StateType.PENDING,
+        )
+        for i in range(25)
+    ]
+
+    await task_run_recorder.record_bulk_task_run_events(
+        [first_event, *extra_events, second_event]
+    )
+
+    task_run = await read_task_run(session=session, task_run_id=task_run_id)
+    assert task_run is not None
+    assert task_run.task_key == "say_hello-8dfe6dff"
+    assert task_run.dynamic_key == "02130dc3-eae9-4d10-94b7-78e81c9e6724"
+    assert task_run.state_type == StateType.RUNNING
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
+
+
 async def test_bulk_upsert_coalesces_natural_key_conflicts_in_same_batch(
     session: AsyncSession,
     flow_run,

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1196,15 +1196,13 @@ def make_event_with_flow_run(
     )
 
 
-async def test_bulk_upsert_natural_key_conflict_raises_for_consumer_retry(
+async def test_bulk_upsert_natural_key_conflict_updates_existing_task_run(
     session: AsyncSession,
     flow_run,
 ):
     """When two sequential bulk upserts have different task_run_ids but the
     same (flow_run_id, task_key, dynamic_key), record_bulk_task_run_events
-    raises IntegrityError so the consumer's flush() retry mechanism can
-    handle it."""
-    from sqlalchemy.exc import IntegrityError
+    updates the existing task run and attaches the state to its canonical id."""
 
     flow_run_id = str(flow_run.id)
     task_key = "my_task-abcdefg"
@@ -1239,8 +1237,22 @@ async def test_bulk_upsert_natural_key_conflict_raises_for_consumer_retry(
         state_type=StateType.RUNNING,
     )
 
-    with pytest.raises(IntegrityError):
-        await task_run_recorder.record_bulk_task_run_events([second_event])
+    await task_run_recorder.record_bulk_task_run_events([second_event])
+
+    session.expire_all()
+    task_run = await read_task_run(session=session, task_run_id=first_task_run_id)
+    assert task_run is not None
+    assert task_run.state_type == StateType.RUNNING
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=second_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
 async def test_single_upsert_with_natural_key_conflict_does_not_raise(
@@ -1287,7 +1299,63 @@ async def test_single_upsert_with_natural_key_conflict_does_not_raise(
     session.expire_all()
     task_run = await read_task_run(session=session, task_run_id=first_task_run_id)
     assert task_run is not None
-    assert task_run.state_type == StateType.PENDING
+    assert task_run.state_type == StateType.RUNNING
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=second_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
+
+
+async def test_bulk_upsert_coalesces_natural_key_conflicts_in_same_batch(
+    session: AsyncSession,
+    flow_run,
+):
+    flow_run_id = str(flow_run.id)
+    task_key = "my_task-abcdefg"
+    dynamic_key = "3"
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+    first_task_run_id = str(uuid4())
+    second_task_run_id = str(uuid4())
+
+    first_event = make_event_with_flow_run(
+        task_run_id=first_task_run_id,
+        flow_run_id=flow_run_id,
+        task_key=task_key,
+        dynamic_key=dynamic_key,
+        state_ts=base_time,
+        state_type=StateType.PENDING,
+    )
+    second_event = make_event_with_flow_run(
+        task_run_id=second_task_run_id,
+        flow_run_id=flow_run_id,
+        task_key=task_key,
+        dynamic_key=dynamic_key,
+        state_ts=base_time + timedelta(minutes=1),
+        state_type=StateType.RUNNING,
+    )
+
+    await task_run_recorder.record_bulk_task_run_events([first_event, second_event])
+
+    task_run = await read_task_run(session=session, task_run_id=second_task_run_id)
+    assert task_run is not None
+    assert task_run.state_type == StateType.RUNNING
+
+    duplicate_task_run = await read_task_run(
+        session=session, task_run_id=first_task_run_id
+    )
+    assert duplicate_task_run is None
+
+    states = await read_task_run_states(session, task_run.id)
+    assert [state.type for state in states] == [StateType.PENDING, StateType.RUNNING]
+    assert {state.task_run_id for state in states} == {task_run.id}
+    assert {state.state_details.task_run_id for state in states} == {task_run.id}
 
 
 async def test_bulk_insert_handles_shuffled_interleaved_events(
@@ -1345,19 +1413,24 @@ async def test_bulk_insert_handles_shuffled_interleaved_events(
         }
 
 
-async def test_bulk_upserts_are_sorted_by_task_run_id(
+async def test_bulk_upserts_are_sorted_by_conflict_key(
     session: AsyncSession,
     flow_run,
 ):
-    """Bulk upsert VALUES are sorted by task_run.id so concurrent recorders
+    """Bulk upsert VALUES are sorted by conflict key so concurrent recorders
     acquire row-level locks in the same order, preventing deadlocks."""
-    captured_id_orders: list[list[UUID]] = []
+    captured_key_orders: list[list[tuple[UUID, str, str]]] = []
     original_values = Insert.values
 
     def spy_values(self, *args, **kwargs):
         if args and isinstance(args[0], list) and args[0]:
             if isinstance(args[0][0], dict) and "task_key" in args[0][0]:
-                captured_id_orders.append([row["id"] for row in args[0]])
+                captured_key_orders.append(
+                    [
+                        (row["flow_run_id"], row["task_key"], row["dynamic_key"])
+                        for row in args[0]
+                    ]
+                )
         return original_values(self, *args, **kwargs)
 
     base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
@@ -1379,6 +1452,6 @@ async def test_bulk_upserts_are_sorted_by_task_run_id(
     with patch.object(Insert, "values", spy_values):
         await task_run_recorder.record_bulk_task_run_events(events)
 
-    assert len(captured_id_orders) > 0
-    for ids in captured_id_orders:
-        assert ids == sorted(ids)
+    assert len(captured_key_orders) > 0
+    for keys in captured_key_orders:
+        assert keys == sorted(keys)


### PR DESCRIPTION
closes #20144

this PR updates task run event recording to handle both task run uniqueness constraints when client-orchestrated task events are persisted by the task run recorder.

<details>
<summary>Details</summary>

- coalesces task run events by the persisted task run identity, using `(flow_run_id, task_key, dynamic_key)` when a flow run id is present
- chooses the upsert conflict target from existing database rows so the recorder handles both natural-key conflicts and primary-key `id` conflicts
- preserves the canonical persisted task run id before inserting task run state rows
- keeps id-based behavior for task runs without a flow run id
- covers sequential natural-key conflicts, same-batch natural-key conflicts, single-event recorder conflicts, and existing-id conflicts

</details>

Additional repro/stress script used for manual validation: https://gist.github.com/johangithub/c8c26bde1c16b82a19557de8f82b3fff

Commands run:

```bash
uv run ruff check src/prefect/server/services/task_run_recorder.py tests/server/services/test_task_run_recorder.py
uv run pytest tests/server/services/test_task_run_recorder.py --tb=short
PREFECT_SERVER_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost:55432/prefect uv run pytest tests/server/services/test_task_run_recorder.py --tb=short
PREFECT_API_URL=http://127.0.0.1:4200/api uv run pytest integration-tests/test_hello_tasks.py integration-tests/test_multiprocessing_flow.py --tb=short
PREFECT_API_URL=http://127.0.0.1:4200/api uv run -s repros/20144.py --runner process --runs 10 --tasks 25 --workers 4 --count-timeout 60
```

Selected stress result:

```text
10/10: flow_run=407cf593-dbf3-4fe2-b32c-2d3fd1e21cfa task_runs=50 elapsed=2.29s
```
