### PR TITLE
docs: fix GitLab token scopes for stored flow code

### DIFF
--- a/docs/v3/how-to-guides/deployments/store-flow-code.mdx
+++ b/docs/v3/how-to-guides/deployments/store-flow-code.mdx
@@ -395,7 +395,7 @@ If using the Python `deploy` method with a private repository that references a 
 
     For accessing a private repository, we recommend using HTTPS with [Project Access Tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 
-    [Create a token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with the **read_repository** scope.
+[Create a token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with the **read_repository** and **api** scopes.
 
     If using a `Secret` block, you can create it through code or the UI ahead of time and reference it at deployment creation as shown above. 
 


### PR DESCRIPTION
Closes #16645

  ## What changed

  I updated the GitLab section in the "How to retrieve code from storage" docs.

  It previously said that a GitLab access token only needed the `read_repository` scope. Based on the issue report, that
  is incomplete for this use case. The docs now say the token should include both `read_repository` and `api`.

  ## Why

  Without the `api` scope, the documented setup can fail for users trying to retrieve code from a private GitLab
  repository. This change makes the instructions match the permissions that are actually needed.

  ## Testing

  Docs-only change, so no tests were run.