### PR TITLE
Document default result storage

### DIFF
--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -319,6 +319,11 @@ configuration is used by infrastructure-bound flows submitted to that work pool.
 Azure Blob Storage configure commands, Prefect stores bundle upload and execution steps on the work pool
 and sets a work-pool-scoped default result storage block.
 
+This means infrastructure-bound flows submitted to that work pool can persist and retrieve return values
+from the work pool's remote storage without each flow specifying `result_storage`. It does not change
+ordinary local flow runs; local flow runs only use an API-level default if you configure one with
+`prefect result-storage set`.
+
 `prefect result-storage ...` configures the API-level default result storage. Use it when you want a
 general default across flows that do not have a more specific flow, task, profile, or work-pool default.
 </Tip>

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -228,10 +228,24 @@ if your team wants all persisted results to go to an S3 bucket by default:
 
 1. Install the storage integration anywhere that creates the block and anywhere that will run flows.
 
+<Tabs>
+<Tab title="uv">
+
+{/* pmd-metadata: notest */}
+```bash
+uv add "prefect[aws]"
+```
+
+</Tab>
+<Tab title="pip">
+
 {/* pmd-metadata: notest */}
 ```bash
 pip install "prefect[aws]"
 ```
+
+</Tab>
+</Tabs>
 
 2. Create and save a filesystem block for the bucket.
 
@@ -301,8 +315,9 @@ default is used for those flow runs.
 **How this relates to work pool storage**
 
 `prefect work-pool storage configure ...` configures storage for a specific work pool. That storage
-configuration can include bundle upload and execution steps for infrastructure-bound flows, and it can
-also set that work pool's default result storage.
+configuration is used by infrastructure-bound flows submitted to that work pool. For the S3, GCS, and
+Azure Blob Storage configure commands, Prefect stores bundle upload and execution steps on the work pool
+and sets a work-pool-scoped default result storage block.
 
 `prefect result-storage ...` configures the API-level default result storage. Use it when you want a
 general default across flows that do not have a more specific flow, task, profile, or work-pool default.

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -30,7 +30,7 @@ There are four categories of configuration for result persistence:
 - [whether to persist results at all](#enabling-result-persistence): this is configured through
 various keyword arguments, the `PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting, and the `PREFECT_TASKS_DEFAULT_PERSIST_RESULT` setting for tasks specifically.
 - [what filesystem to persist results to](#result-storage): this is configured through the `result_storage`
-keyword and the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting.
+keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a server default result storage block.
 - [how to serialize and deserialize results](#result-serialization): this is configured through
 the `result_serializer` keyword and the `PREFECT_RESULTS_DEFAULT_SERIALIZER` setting.
 - [what filename to use](#result-filenames): this is configured through one of
@@ -163,7 +163,7 @@ def my_flow():
 #### Specifying a default filesystem
 
 Alternatively, you can specify a different filesystem through the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting.
-Specifying a block document slug here will enable result persistence using that filesystem as the default.
+Specifying a block document slug here configures the filesystem Prefect uses when result persistence is enabled.
 
 For example:
 
@@ -174,6 +174,84 @@ prefect config set PREFECT_DEFAULT_RESULT_STORAGE_BLOCK='s3-bucket/my-prod-block
 <Info>
 Note that any explicit configuration of `result_storage` on either a flow or task will override this default.
 </Info>
+
+#### Specifying a server default filesystem
+
+If many flow runs should use the same result storage, you can set a default on your Prefect server.
+This is useful when you want every client, worker, and deployment connected to the same server to write
+persisted results to a shared location without setting `result_storage` in each flow or on every machine.
+
+Make sure your CLI profile is connected to your Prefect server before setting the default.
+If you are running Prefect locally, start the server first:
+
+{/* pmd-metadata: notest */}
+```bash
+prefect server start
+```
+
+For example, if your team wants all persisted results to go to an S3 bucket by default:
+
+1. Install the storage integration anywhere that creates the block and anywhere that will run flows.
+
+{/* pmd-metadata: notest */}
+```bash
+pip install "prefect[aws]"
+```
+
+2. Create and save a filesystem block for the bucket.
+
+{/* pmd-metadata: notest */}
+```python
+from prefect_aws.s3 import S3Bucket
+
+S3Bucket(
+    bucket_name="my-prefect-results",
+    bucket_folder="results",
+).save("default-results", overwrite=True)
+```
+
+This example relies on AWS credentials available through the normal Boto3 credential chain. If you need
+to store explicit credentials in Prefect, create an `AwsCredentials` block and pass it to `S3Bucket`.
+
+3. Set the saved block as the server default result storage.
+
+{/* pmd-metadata: notest */}
+```bash
+prefect server storage set s3-bucket/default-results
+```
+
+4. Turn on result persistence by default if you want tasks and flows to persist results without adding
+`persist_result=True` to each decorator.
+
+```bash
+prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
+```
+
+You can inspect or clear the configured server default from the CLI:
+
+{/* pmd-metadata: notest */}
+```bash
+prefect server storage inspect
+prefect server storage clear
+```
+
+<Note>
+The server default result storage applies to Prefect server. It is not used when your profile is connected
+to Prefect Cloud.
+</Note>
+
+<Info>
+More specific configuration still wins. Explicit `result_storage` on a flow or task overrides the server
+default. A local `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting also overrides the server default for that
+profile. For deployments submitted through a work pool with its own default result storage, the work pool
+default is used for those flow runs.
+</Info>
+
+<Warning>
+The default storage block only controls where persisted results are written. It does not make every result
+persist automatically by itself. Use `PREFECT_RESULTS_PERSIST_BY_DEFAULT=true`, `persist_result=True`, or
+another persistence-enabling option when you want Prefect to write results by default.
+</Warning>
 
 #### Result filenames
 

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -12,10 +12,19 @@ By default these results are not persisted and no reference to them is maintaine
 
 Enabling result persistence allows you to fully benefit from Prefect's orchestration features.
 
+<Note>
+Result storage is where Prefect writes serialized flow and task return values so they can be reused
+by Prefect features such as retries, caching, and reading a run's return value later. It does not
+change where your flow code writes files, uploads datasets, or stores artifacts that your code creates
+directly. For example, if your flow calls an S3 client to upload a CSV, that upload still uses the
+location specified in your flow code.
+</Note>
+
 <Tip>
 **Turn on persistence globally by default**
 
-The simplest way to turn on result persistence globally is through the `PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting:
+The simplest way to turn on result persistence globally for your current environment is through the
+`PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting:
 
 ```bash
 prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
@@ -97,8 +106,6 @@ This keyword accepts an instantiated [filesystem block](/v3/develop/blocks/), or
 Note that if you want your tasks to share a common cache, your result storage should be accessible by
 the infrastructure in which those tasks run. [Integrations](/integrations/integrations) have cloud-specific storage blocks.
 For example, a common distributed filesystem for result storage is AWS S3.
-
-Additionally, you can control the default persistence behavior for task results using the `default_persist_result` setting. This setting allows you to specify whether results should be persisted by default for all tasks. You can set this to `True` to enable persistence by default, or `False` to disable it. This setting can be overridden at the individual task or flow level.
 
 ```python
 from prefect import flow, task
@@ -182,6 +189,10 @@ This is useful when you want every client, worker, and deployment connected to t
 workspace or self-hosted Prefect server to write persisted results to a shared location without setting
 `result_storage` in each flow or on every machine.
 
+A configured API-level default result storage block also enables result persistence by default for
+flows and tasks that do not explicitly opt out. You do not need to set `PREFECT_RESULTS_PERSIST_BY_DEFAULT`
+in every worker environment when this default is configured.
+
 The `prefect result-storage` commands use your active CLI profile. Make sure the profile is connected
 to the API where you want to set the default. If you are running Prefect locally, start the server first:
 
@@ -235,7 +246,25 @@ S3Bucket(
 ```
 
 This example relies on AWS credentials available through the normal Boto3 credential chain. If you need
-to store explicit credentials in Prefect, create an `AwsCredentials` block and pass it to `S3Bucket`.
+to store explicit credentials in Prefect, create an `AwsCredentials` block and pass it to `S3Bucket`:
+
+{/* pmd-metadata: notest */}
+```python
+from prefect_aws import AwsCredentials
+from prefect_aws.s3 import S3Bucket
+
+credentials = AwsCredentials(
+    aws_access_key_id="...",
+    aws_secret_access_key="...",
+)
+credentials.save("my-aws-credentials", overwrite=True)
+
+S3Bucket(
+    bucket_name="my-prefect-results",
+    bucket_folder="results",
+    credentials=credentials,
+).save("default-results", overwrite=True)
+```
 
 3. Set the saved block as the default result storage.
 
@@ -257,6 +286,9 @@ The saved block and its dependencies must be available wherever results are writ
 if the default is an `S3Bucket`, install `prefect-aws` in the environment that creates the block and in
 worker environments that run flows using the block.
 </Note>
+
+After this is configured, a deployment that uses the same Prefect API and does not specify its own
+`result_storage` will use the S3 bucket for persisted flow and task return values.
 
 <Info>
 More specific configuration still wins. Explicit `result_storage` on a flow or task overrides the API

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -30,7 +30,7 @@ There are four categories of configuration for result persistence:
 - [whether to persist results at all](#enabling-result-persistence): this is configured through
 various keyword arguments, the `PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting, and the `PREFECT_TASKS_DEFAULT_PERSIST_RESULT` setting for tasks specifically.
 - [what filesystem to persist results to](#result-storage): this is configured through the `result_storage`
-keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a default result storage block on the API.
+keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a default result storage block on the API. A configured default result storage block also enables result persistence by default.
 - [how to serialize and deserialize results](#result-serialization): this is configured through
 the `result_serializer` keyword and the `PREFECT_RESULTS_DEFAULT_SERIALIZER` setting.
 - [what filename to use](#result-filenames): this is configured through one of
@@ -195,7 +195,6 @@ At minimum, you need:
 - a running Prefect API, either Prefect Cloud or a self-hosted Prefect server
 - a saved filesystem block, such as `S3Bucket`, `GcsBucket`, `AzureBlobStorageContainer`, or `LocalFileSystem`
 - `prefect result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` to set that block as the default
-- result persistence enabled for the flow or task, unless you only want this default to apply when persistence is enabled explicitly
 
 For local testing, you can use the built-in `LocalFileSystem` block:
 
@@ -211,7 +210,6 @@ LocalFileSystem(basepath="/tmp/prefect-results").save(
 {/* pmd-metadata: notest */}
 ```bash
 prefect result-storage set local-file-system/default-results
-prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
 ```
 
 For shared infrastructure, use a storage block that every runtime environment can access. For example,
@@ -246,13 +244,6 @@ to store explicit credentials in Prefect, create an `AwsCredentials` block and p
 prefect result-storage set s3-bucket/default-results
 ```
 
-4. Turn on result persistence by default if you want tasks and flows to persist results without adding
-`persist_result=True` to each decorator.
-
-```bash
-prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
-```
-
 You can inspect or clear the configured default from the CLI:
 
 {/* pmd-metadata: notest */}
@@ -284,12 +275,6 @@ also set that work pool's default result storage.
 `prefect result-storage ...` configures the API-level default result storage. Use it when you want a
 general default across flows that do not have a more specific flow, task, profile, or work-pool default.
 </Tip>
-
-<Warning>
-The default storage block only controls where persisted results are written. It does not make every result
-persist automatically by itself. Use `PREFECT_RESULTS_PERSIST_BY_DEFAULT=true`, `persist_result=True`, or
-another persistence-enabling option when you want Prefect to write results by default.
-</Warning>
 
 #### Result filenames
 

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -30,7 +30,7 @@ There are four categories of configuration for result persistence:
 - [whether to persist results at all](#enabling-result-persistence): this is configured through
 various keyword arguments, the `PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting, and the `PREFECT_TASKS_DEFAULT_PERSIST_RESULT` setting for tasks specifically.
 - [what filesystem to persist results to](#result-storage): this is configured through the `result_storage`
-keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a server default result storage block.
+keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a default result storage block on the API.
 - [how to serialize and deserialize results](#result-serialization): this is configured through
 the `result_serializer` keyword and the `PREFECT_RESULTS_DEFAULT_SERIALIZER` setting.
 - [what filename to use](#result-filenames): this is configured through one of
@@ -175,21 +175,47 @@ prefect config set PREFECT_DEFAULT_RESULT_STORAGE_BLOCK='s3-bucket/my-prod-block
 Note that any explicit configuration of `result_storage` on either a flow or task will override this default.
 </Info>
 
-#### Specifying a server default filesystem
+#### Specifying a default filesystem on the API
 
-If many flow runs should use the same result storage, you can set a default on your Prefect server.
-This is useful when you want every client, worker, and deployment connected to the same server to write
-persisted results to a shared location without setting `result_storage` in each flow or on every machine.
+If many flow runs should use the same result storage, you can set a default on the API.
+This is useful when you want every client, worker, and deployment connected to the same Prefect Cloud
+workspace or self-hosted Prefect server to write persisted results to a shared location without setting
+`result_storage` in each flow or on every machine.
 
-Make sure your CLI profile is connected to your Prefect server before setting the default.
-If you are running Prefect locally, start the server first:
+The `prefect result-storage` commands use your active CLI profile. Make sure the profile is connected
+to the API where you want to set the default. If you are running Prefect locally, start the server first:
 
 {/* pmd-metadata: notest */}
 ```bash
 prefect server start
 ```
 
-For example, if your team wants all persisted results to go to an S3 bucket by default:
+At minimum, you need:
+
+- a running Prefect API, either Prefect Cloud or a self-hosted Prefect server
+- a saved filesystem block, such as `S3Bucket`, `GcsBucket`, `AzureBlobStorageContainer`, or `LocalFileSystem`
+- `prefect result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` to set that block as the default
+- result persistence enabled for the flow or task, unless you only want this default to apply when persistence is enabled explicitly
+
+For local testing, you can use the built-in `LocalFileSystem` block:
+
+{/* pmd-metadata: notest */}
+```python
+from prefect.filesystems import LocalFileSystem
+
+LocalFileSystem(basepath="/tmp/prefect-results").save(
+    "default-results", overwrite=True
+)
+```
+
+{/* pmd-metadata: notest */}
+```bash
+prefect result-storage set local-file-system/default-results
+prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
+```
+
+For shared infrastructure, use a storage block that every runtime environment can access. For example,
+if your team wants all persisted results to go to an S3 bucket by default:
 
 1. Install the storage integration anywhere that creates the block and anywhere that will run flows.
 
@@ -213,11 +239,11 @@ S3Bucket(
 This example relies on AWS credentials available through the normal Boto3 credential chain. If you need
 to store explicit credentials in Prefect, create an `AwsCredentials` block and pass it to `S3Bucket`.
 
-3. Set the saved block as the server default result storage.
+3. Set the saved block as the default result storage.
 
 {/* pmd-metadata: notest */}
 ```bash
-prefect server storage set s3-bucket/default-results
+prefect result-storage set s3-bucket/default-results
 ```
 
 4. Turn on result persistence by default if you want tasks and flows to persist results without adding
@@ -227,25 +253,37 @@ prefect server storage set s3-bucket/default-results
 prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
 ```
 
-You can inspect or clear the configured server default from the CLI:
+You can inspect or clear the configured default from the CLI:
 
 {/* pmd-metadata: notest */}
 ```bash
-prefect server storage inspect
-prefect server storage clear
+prefect result-storage inspect
+prefect result-storage clear
 ```
 
 <Note>
-The server default result storage applies to Prefect server. It is not used when your profile is connected
-to Prefect Cloud.
+The saved block and its dependencies must be available wherever results are written and read. For example,
+if the default is an `S3Bucket`, install `prefect-aws` in the environment that creates the block and in
+worker environments that run flows using the block.
 </Note>
 
 <Info>
-More specific configuration still wins. Explicit `result_storage` on a flow or task overrides the server
-default. A local `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting also overrides the server default for that
+More specific configuration still wins. Explicit `result_storage` on a flow or task overrides the API
+default. A local `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting also overrides the API default for that
 profile. For deployments submitted through a work pool with its own default result storage, the work pool
 default is used for those flow runs.
 </Info>
+
+<Tip>
+**How this relates to work pool storage**
+
+`prefect work-pool storage configure ...` configures storage for a specific work pool. That storage
+configuration can include bundle upload and execution steps for infrastructure-bound flows, and it can
+also set that work pool's default result storage.
+
+`prefect result-storage ...` configures the API-level default result storage. Use it when you want a
+general default across flows that do not have a more specific flow, task, profile, or work-pool default.
+</Tip>
 
 <Warning>
 The default storage block only controls where persisted results are written. It does not make every result

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -193,8 +193,9 @@ A configured API-level default result storage block also enables result persiste
 flows and tasks that do not explicitly opt out. You do not need to set `PREFECT_RESULTS_PERSIST_BY_DEFAULT`
 in every worker environment when this default is configured.
 
-The `prefect result-storage` commands use your active CLI profile. Make sure the profile is connected
-to the API where you want to set the default. If you are running Prefect locally, start the server first:
+The experimental `prefect result-storage` commands use your active CLI profile and are subject to
+change while Prefect expands default storage configuration. Make sure the profile is connected to the
+API where you want to set the default. If you are running Prefect locally, start the server first:
 
 {/* pmd-metadata: notest */}
 ```bash
@@ -205,7 +206,8 @@ At minimum, you need:
 
 - a running Prefect API, either Prefect Cloud or a self-hosted Prefect server
 - a saved filesystem block, such as `S3Bucket`, `GcsBucket`, `AzureBlobStorageContainer`, or `LocalFileSystem`
-- `prefect result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` to set that block as the default
+- the experimental `prefect result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` command to set that block
+  as the default
 
 For local testing, you can use the built-in `LocalFileSystem` block:
 

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -193,7 +193,7 @@ A configured API-level default result storage block also enables result persiste
 flows and tasks that do not explicitly opt out. You do not need to set `PREFECT_RESULTS_PERSIST_BY_DEFAULT`
 in every worker environment when this default is configured.
 
-The experimental `prefect result-storage` commands use your active CLI profile and are subject to
+The `prefect experimental result-storage` commands use your active CLI profile and are subject to
 change while Prefect expands default storage configuration. Make sure the profile is connected to the
 API where you want to set the default. If you are running Prefect locally, start the server first:
 
@@ -206,8 +206,8 @@ At minimum, you need:
 
 - a running Prefect API, either Prefect Cloud or a self-hosted Prefect server
 - a saved filesystem block, such as `S3Bucket`, `GcsBucket`, `AzureBlobStorageContainer`, or `LocalFileSystem`
-- the experimental `prefect result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` command to set that block
-  as the default
+- `prefect experimental result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` to set that block as the
+  default
 
 For local testing, you can use the built-in `LocalFileSystem` block:
 
@@ -222,7 +222,7 @@ LocalFileSystem(basepath="/tmp/prefect-results").save(
 
 {/* pmd-metadata: notest */}
 ```bash
-prefect result-storage set local-file-system/default-results
+prefect experimental result-storage set local-file-system/default-results
 ```
 
 For shared infrastructure, use a storage block that every runtime environment can access. For example,
@@ -286,15 +286,15 @@ S3Bucket(
 
 {/* pmd-metadata: notest */}
 ```bash
-prefect result-storage set s3-bucket/default-results
+prefect experimental result-storage set s3-bucket/default-results
 ```
 
 You can inspect or clear the configured default from the CLI:
 
 {/* pmd-metadata: notest */}
 ```bash
-prefect result-storage inspect
-prefect result-storage clear
+prefect experimental result-storage inspect
+prefect experimental result-storage clear
 ```
 
 <Note>
@@ -324,10 +324,11 @@ and sets a work-pool-scoped default result storage block.
 This means infrastructure-bound flows submitted to that work pool can persist and retrieve return values
 from the work pool's remote storage without each flow specifying `result_storage`. It does not change
 ordinary local flow runs; local flow runs only use an API-level default if you configure one with
-`prefect result-storage set`.
+`prefect experimental result-storage set`.
 
-`prefect result-storage ...` configures the API-level default result storage. Use it when you want a
-general default across flows that do not have a more specific flow, task, profile, or work-pool default.
+`prefect experimental result-storage ...` configures the API-level default result storage. Use it when
+you want a general default across flows that do not have a more specific flow, task, profile, or
+work-pool default.
 </Tip>
 
 #### Result filenames

--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -39,7 +39,7 @@ There are four categories of configuration for result persistence:
 - [whether to persist results at all](#enabling-result-persistence): this is configured through
 various keyword arguments, the `PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting, and the `PREFECT_TASKS_DEFAULT_PERSIST_RESULT` setting for tasks specifically.
 - [what filesystem to persist results to](#result-storage): this is configured through the `result_storage`
-keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a default result storage block on the API. A configured default result storage block also enables result persistence by default.
+keyword, the `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting, or a server-side default result storage block. A configured default result storage block also enables result persistence by default.
 - [how to serialize and deserialize results](#result-serialization): this is configured through
 the `result_serializer` keyword and the `PREFECT_RESULTS_DEFAULT_SERIALIZER` setting.
 - [what filename to use](#result-filenames): this is configured through one of
@@ -182,14 +182,14 @@ prefect config set PREFECT_DEFAULT_RESULT_STORAGE_BLOCK='s3-bucket/my-prod-block
 Note that any explicit configuration of `result_storage` on either a flow or task will override this default.
 </Info>
 
-#### Specifying a default filesystem on the API
+#### Specifying a default filesystem server-side
 
-If many flow runs should use the same result storage, you can set a default on the API.
+If many flow runs should use the same result storage, you can set a server-side default.
 This is useful when you want every client, worker, and deployment connected to the same Prefect Cloud
 workspace or self-hosted Prefect server to write persisted results to a shared location without setting
 `result_storage` in each flow or on every machine.
 
-A configured API-level default result storage block also enables result persistence by default for
+A configured server-side default result storage block also enables result persistence by default for
 flows and tasks that do not explicitly opt out. You do not need to set `PREFECT_RESULTS_PERSIST_BY_DEFAULT`
 in every worker environment when this default is configured.
 
@@ -206,8 +206,6 @@ At minimum, you need:
 
 - a running Prefect API, either Prefect Cloud or a self-hosted Prefect server
 - a saved filesystem block, such as `S3Bucket`, `GcsBucket`, `AzureBlobStorageContainer`, or `LocalFileSystem`
-- `prefect experimental result-storage set <BLOCK_TYPE_SLUG>/<BLOCK_NAME>` to set that block as the
-  default
 
 For local testing, you can use the built-in `LocalFileSystem` block:
 
@@ -307,10 +305,9 @@ After this is configured, a deployment that uses the same Prefect API and does n
 `result_storage` will use the S3 bucket for persisted flow and task return values.
 
 <Info>
-More specific configuration still wins. Explicit `result_storage` on a flow or task overrides the API
-default. A local `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting also overrides the API default for that
-profile. For deployments submitted through a work pool with its own default result storage, the work pool
-default is used for those flow runs.
+More specific configuration still wins. Explicit `result_storage` on a flow or task overrides the
+server-side default. A local `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting also overrides the
+server-side default for that profile.
 </Info>
 
 <Tip>
@@ -319,16 +316,13 @@ default is used for those flow runs.
 `prefect work-pool storage configure ...` configures storage for a specific work pool. That storage
 configuration is used by infrastructure-bound flows submitted to that work pool. For the S3, GCS, and
 Azure Blob Storage configure commands, Prefect stores bundle upload and execution steps on the work pool
-and sets a work-pool-scoped default result storage block.
+and can set a work-pool-scoped default result storage block for those infrastructure-bound submissions.
 
-This means infrastructure-bound flows submitted to that work pool can persist and retrieve return values
-from the work pool's remote storage without each flow specifying `result_storage`. It does not change
-ordinary local flow runs; local flow runs only use an API-level default if you configure one with
-`prefect experimental result-storage set`.
+It does not change ordinary local flow runs; local flow runs only use a server-side default if you
+configure one with `prefect experimental result-storage set`.
 
-`prefect experimental result-storage ...` configures the API-level default result storage. Use it when
-you want a general default across flows that do not have a more specific flow, task, profile, or
-work-pool default.
+`prefect experimental result-storage ...` configures the server-side default result storage. Use it when
+you want a general default across flows that do not have a more specific flow, task, or profile default.
 </Tip>
 
 #### Result filenames


### PR DESCRIPTION
this PR documents server-side default result storage in the existing advanced results page.

<details>
<summary>Details</summary>

- keeps default result storage guidance with the existing result persistence and result storage docs instead of adding a separate advanced page
- defines Prefect results as serialized flow and task return values used for caching, retries, and readback, not arbitrary files or artifacts written by user code
- documents the minimal setup: connected API profile, saved filesystem block, and `prefect experimental result-storage set`
- explains that configuring a server-side default result storage block also enables result persistence by default unless a flow or task explicitly opts out
- includes local `LocalFileSystem` setup for quick testing and S3 setup for the bucket-by-default happy path
- clarifies precedence between explicit `result_storage`, explicit persistence settings, local `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK`, and the server-side default
- explains how this differs from `prefect work-pool storage configure`, which is work-pool-scoped and handles bundle upload/execution storage for infrastructure-bound flows

</details>

<details>
<summary>Validation</summary>

- `git diff --check origin/main...HEAD`
- `uv run pre-commit run codespell --files docs/v3/advanced/results.mdx`
- previous local docs walkthrough: followed the documented local `LocalFileSystem` path against a fresh Prefect server with an isolated SQLite database; `prefect experimental result-storage inspect` showed unset, `set local-file-system/default-results` configured the block, `inspect --output json` returned the block slug, a flow with no explicit `persist_result` or `result_storage` persisted and hydrated through the configured block with `PREFECT_RESULTS_PERSIST_BY_DEFAULT=false`, and `clear` returned the API to unset
- previous local deployment walkthrough: with that same configured default, created a `process` work pool, deployed a flow with no explicit `result_storage`, scheduled a deployment run, ran `prefect worker start --pool docs-smoke-pool --run-once`, confirmed the run completed, confirmed `state.result()` hydrated from the API, and confirmed the API state's `storage_block_id` matched the configured default block
- previous OSS Postgres deployment smoke: fresh server, S3-compatible bucket, saved `S3Bucket` block, `prefect experimental result-storage set s3-bucket/default-results`, process work pool deployment with no explicit `result_storage`, worker run with `PREFECT_RESULTS_PERSIST_BY_DEFAULT=false`; run completed, `state.result()` returned `test!`, and the result object was written under the configured bucket folder

</details>
