### PR TITLE
Add UI v2 default result storage controls

### DIFF
--- a/ui-v2/src/api/admin/admin.test.ts
+++ b/ui-v2/src/api/admin/admin.test.ts
@@ -1,11 +1,17 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { buildApiUrl, createWrapper, server } from "@tests/utils";
 import { HttpResponse, http } from "msw";
 import { expect, test } from "vitest";
 import { createFakeServerSettings, createFakeVersion } from "@/mocks";
 
-import { buildGetSettingsQuery, buildGetVersionQuery } from "./admin";
+import {
+	buildGetDefaultResultStorageQuery,
+	buildGetSettingsQuery,
+	buildGetVersionQuery,
+	useClearDefaultResultStorage,
+	useUpdateDefaultResultStorage,
+} from "./admin";
 
 test("buildGetVersionQuery -- fetches version query from API", async () => {
 	const MOCK_VERSION = createFakeVersion();
@@ -45,4 +51,65 @@ test("buildSettingsQuery -- fetches version query from API", async () => {
 
 	await waitFor(() => expect(result.current.isSuccess).toBe(true));
 	expect(result.current.data).toEqual(MOCK_SETTINGS_RESPONSE);
+});
+
+test("buildGetDefaultResultStorageQuery -- fetches default result storage from API", async () => {
+	const MOCK_STORAGE_RESPONSE = {
+		default_result_storage_block_id: "e8607583-f98e-48c5-bb49-6f031d7bff12",
+	};
+
+	server.use(
+		http.get(buildApiUrl("/admin/storage"), () => {
+			return HttpResponse.json(MOCK_STORAGE_RESPONSE);
+		}),
+	);
+
+	const { result } = renderHook(
+		() => useSuspenseQuery(buildGetDefaultResultStorageQuery()),
+		{ wrapper: createWrapper() },
+	);
+
+	await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	expect(result.current.data).toEqual(MOCK_STORAGE_RESPONSE);
+});
+
+test("useUpdateDefaultResultStorage -- updates default result storage through API", async () => {
+	const MOCK_STORAGE_RESPONSE = {
+		default_result_storage_block_id: "e8607583-f98e-48c5-bb49-6f031d7bff12",
+	};
+
+	server.use(
+		http.put(buildApiUrl("/admin/storage"), async ({ request }) => {
+			expect(await request.json()).toEqual(MOCK_STORAGE_RESPONSE);
+			return HttpResponse.json(MOCK_STORAGE_RESPONSE);
+		}),
+	);
+
+	const { result } = renderHook(useUpdateDefaultResultStorage, {
+		wrapper: createWrapper(),
+	});
+
+	act(() => {
+		result.current.updateDefaultResultStorage(MOCK_STORAGE_RESPONSE);
+	});
+
+	await waitFor(() => expect(result.current.isSuccess).toBe(true));
+});
+
+test("useClearDefaultResultStorage -- clears default result storage through API", async () => {
+	server.use(
+		http.delete(buildApiUrl("/admin/storage"), () => {
+			return new HttpResponse(null, { status: 204 });
+		}),
+	);
+
+	const { result } = renderHook(useClearDefaultResultStorage, {
+		wrapper: createWrapper(),
+	});
+
+	act(() => {
+		result.current.clearDefaultResultStorage();
+	});
+
+	await waitFor(() => expect(result.current.isSuccess).toBe(true));
 });

--- a/ui-v2/src/api/admin/admin.test.ts
+++ b/ui-v2/src/api/admin/admin.test.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { QueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { buildApiUrl, createWrapper, server } from "@tests/utils";
 import { HttpResponse, http } from "msw";
@@ -9,6 +9,7 @@ import {
 	buildGetDefaultResultStorageQuery,
 	buildGetSettingsQuery,
 	buildGetVersionQuery,
+	queryKeyFactory,
 	useClearDefaultResultStorage,
 	useUpdateDefaultResultStorage,
 } from "./admin";
@@ -84,9 +85,15 @@ test("useUpdateDefaultResultStorage -- updates default result storage through AP
 			return HttpResponse.json(MOCK_STORAGE_RESPONSE);
 		}),
 	);
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
 
 	const { result } = renderHook(useUpdateDefaultResultStorage, {
-		wrapper: createWrapper(),
+		wrapper: createWrapper({ queryClient }),
 	});
 
 	act(() => {
@@ -94,6 +101,9 @@ test("useUpdateDefaultResultStorage -- updates default result storage through AP
 	});
 
 	await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	expect(
+		queryClient.getQueryData(queryKeyFactory.defaultResultStorage()),
+	).toEqual(MOCK_STORAGE_RESPONSE);
 });
 
 test("useClearDefaultResultStorage -- clears default result storage through API", async () => {
@@ -102,9 +112,15 @@ test("useClearDefaultResultStorage -- clears default result storage through API"
 			return new HttpResponse(null, { status: 204 });
 		}),
 	);
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
 
 	const { result } = renderHook(useClearDefaultResultStorage, {
-		wrapper: createWrapper(),
+		wrapper: createWrapper({ queryClient }),
 	});
 
 	act(() => {
@@ -112,4 +128,7 @@ test("useClearDefaultResultStorage -- clears default result storage through API"
 	});
 
 	await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	expect(
+		queryClient.getQueryData(queryKeyFactory.defaultResultStorage()),
+	).toEqual({ default_result_storage_block_id: null });
 });

--- a/ui-v2/src/api/admin/admin.ts
+++ b/ui-v2/src/api/admin/admin.ts
@@ -1,17 +1,29 @@
-import { queryOptions } from "@tanstack/react-query";
+import {
+	queryOptions,
+	useMutation,
+	useQueryClient,
+} from "@tanstack/react-query";
+import type { components } from "@/api/prefect";
 import { getQueryService } from "@/api/service";
 
 /**
  * ```
  *  🏗️ Admin queries construction 👷
- *  settings   =>   ['settings'] // key to match ['settings']
- *  version   =>   ['version'] // key to match ['version']
+ *  settings              =>   ['settings'] // key to match ['settings']
+ *  version               =>   ['version'] // key to match ['version']
+ *  defaultResultStorage  =>   ['default-result-storage'] // key to match ['default-result-storage']
  * ```
  * */
 export const queryKeyFactory = {
 	settings: () => ["settings"] as const,
 	version: () => ["version"] as const,
+	defaultResultStorage: () => ["default-result-storage"] as const,
 };
+
+export type ServerDefaultResultStorage =
+	components["schemas"]["ServerDefaultResultStorage"];
+export type ServerDefaultResultStorageUpdate =
+	components["schemas"]["ServerDefaultResultStorageUpdate"];
 
 // ----- 🔑 Queries 🗄️
 // ----------------------------
@@ -47,3 +59,48 @@ export const buildGetSettingsQuery = () =>
 			return res.data;
 		},
 	});
+
+/**
+ *
+ * @returns react query options object for getting the server default result storage block
+ */
+export const buildGetDefaultResultStorageQuery = () =>
+	queryOptions({
+		queryKey: queryKeyFactory.defaultResultStorage(),
+		queryFn: async () => {
+			const res = await (await getQueryService()).GET("/admin/storage");
+			if (!res.data) {
+				throw new Error("'data' expected");
+			}
+			return res.data;
+		},
+	});
+
+export const useUpdateDefaultResultStorage = () => {
+	const queryClient = useQueryClient();
+
+	const { mutate: updateDefaultResultStorage, ...rest } = useMutation({
+		mutationFn: async (body: ServerDefaultResultStorageUpdate) =>
+			(await getQueryService()).PUT("/admin/storage", { body }),
+		onSettled: () =>
+			queryClient.invalidateQueries({
+				queryKey: queryKeyFactory.defaultResultStorage(),
+			}),
+	});
+
+	return { updateDefaultResultStorage, ...rest };
+};
+
+export const useClearDefaultResultStorage = () => {
+	const queryClient = useQueryClient();
+
+	const { mutate: clearDefaultResultStorage, ...rest } = useMutation({
+		mutationFn: async () => (await getQueryService()).DELETE("/admin/storage"),
+		onSettled: () =>
+			queryClient.invalidateQueries({
+				queryKey: queryKeyFactory.defaultResultStorage(),
+			}),
+	});
+
+	return { clearDefaultResultStorage, ...rest };
+};

--- a/ui-v2/src/api/admin/admin.ts
+++ b/ui-v2/src/api/admin/admin.ts
@@ -80,12 +80,21 @@ export const useUpdateDefaultResultStorage = () => {
 	const queryClient = useQueryClient();
 
 	const { mutate: updateDefaultResultStorage, ...rest } = useMutation({
-		mutationFn: async (body: ServerDefaultResultStorageUpdate) =>
-			(await getQueryService()).PUT("/admin/storage", { body }),
-		onSettled: () =>
-			queryClient.invalidateQueries({
+		mutationFn: async (body: ServerDefaultResultStorageUpdate) => {
+			const res = await (await getQueryService()).PUT("/admin/storage", {
+				body,
+			});
+			if (!res.data) {
+				throw new Error("'data' expected");
+			}
+			return res.data;
+		},
+		onSuccess: (data) => {
+			queryClient.setQueryData(queryKeyFactory.defaultResultStorage(), data);
+			void queryClient.invalidateQueries({
 				queryKey: queryKeyFactory.defaultResultStorage(),
-			}),
+			});
+		},
 	});
 
 	return { updateDefaultResultStorage, ...rest };
@@ -96,10 +105,14 @@ export const useClearDefaultResultStorage = () => {
 
 	const { mutate: clearDefaultResultStorage, ...rest } = useMutation({
 		mutationFn: async () => (await getQueryService()).DELETE("/admin/storage"),
-		onSettled: () =>
-			queryClient.invalidateQueries({
+		onSuccess: () => {
+			queryClient.setQueryData(queryKeyFactory.defaultResultStorage(), {
+				default_result_storage_block_id: null,
+			} satisfies ServerDefaultResultStorage);
+			void queryClient.invalidateQueries({
 				queryKey: queryKeyFactory.defaultResultStorage(),
-			}),
+			});
+		},
 	});
 
 	return { clearDefaultResultStorage, ...rest };

--- a/ui-v2/src/api/admin/index.ts
+++ b/ui-v2/src/api/admin/index.ts
@@ -1,11 +1,11 @@
+export type {
+	ServerDefaultResultStorage,
+	ServerDefaultResultStorageUpdate,
+} from "./admin";
 export {
 	buildGetDefaultResultStorageQuery,
 	buildGetSettingsQuery,
 	buildGetVersionQuery,
 	useClearDefaultResultStorage,
 	useUpdateDefaultResultStorage,
-} from "./admin";
-export type {
-	ServerDefaultResultStorage,
-	ServerDefaultResultStorageUpdate,
 } from "./admin";

--- a/ui-v2/src/api/admin/index.ts
+++ b/ui-v2/src/api/admin/index.ts
@@ -1,1 +1,11 @@
-export { buildGetSettingsQuery, buildGetVersionQuery } from "./admin";
+export {
+	buildGetDefaultResultStorageQuery,
+	buildGetSettingsQuery,
+	buildGetVersionQuery,
+	useClearDefaultResultStorage,
+	useUpdateDefaultResultStorage,
+} from "./admin";
+export type {
+	ServerDefaultResultStorage,
+	ServerDefaultResultStorageUpdate,
+} from "./admin";

--- a/ui-v2/src/api/admin/index.ts
+++ b/ui-v2/src/api/admin/index.ts
@@ -6,6 +6,7 @@ export {
 	buildGetDefaultResultStorageQuery,
 	buildGetSettingsQuery,
 	buildGetVersionQuery,
+	queryKeyFactory,
 	useClearDefaultResultStorage,
 	useUpdateDefaultResultStorage,
 } from "./admin";

--- a/ui-v2/src/api/block-documents/block-documents.test.ts
+++ b/ui-v2/src/api/block-documents/block-documents.test.ts
@@ -3,9 +3,11 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { buildApiUrl, createWrapper, server } from "@tests/utils";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
-
+import {
+	queryKeyFactory as adminQueryKeyFactory,
+	buildGetDefaultResultStorageQuery,
+} from "@/api/admin";
 import { createFakeBlockDocument } from "@/mocks";
-
 import {
 	type BlockDocument,
 	buildCheckBlockDocumentNameQuery,
@@ -193,6 +195,13 @@ describe("block documents queries", () => {
 		it("invalidates cache and fetches updated value", async () => {
 			const mockBlockDocument = createFakeBlockDocument();
 			mockFilterListBlocksAPI([]);
+			server.use(
+				http.get(buildApiUrl("/admin/storage"), () => {
+					return HttpResponse.json({
+						default_result_storage_block_id: null,
+					});
+				}),
+			);
 			const queryClient = new QueryClient();
 			const FILTER = {
 				offset: 0,
@@ -202,9 +211,16 @@ describe("block documents queries", () => {
 			queryClient.setQueryData(queryKeyFactory.listFilter(FILTER), [
 				mockBlockDocument,
 			]);
+			queryClient.setQueryData(adminQueryKeyFactory.defaultResultStorage(), {
+				default_result_storage_block_id: mockBlockDocument.id,
+			});
 
 			const { result: useListBlockDocumentsResult } = renderHook(
 				() => useSuspenseQuery(buildListFilterBlockDocumentsQuery(FILTER)),
+				{ wrapper: createWrapper({ queryClient }) },
+			);
+			const { result: useDefaultResultStorageResult } = renderHook(
+				() => useSuspenseQuery(buildGetDefaultResultStorageQuery()),
 				{ wrapper: createWrapper({ queryClient }) },
 			);
 
@@ -223,6 +239,9 @@ describe("block documents queries", () => {
 				expect(useDeleteBlockDocumentResult.current.isSuccess).toBe(true),
 			);
 			expect(useListBlockDocumentsResult.current.data).toHaveLength(0);
+			expect(useDefaultResultStorageResult.current.data).toEqual({
+				default_result_storage_block_id: null,
+			});
 		});
 	});
 

--- a/ui-v2/src/api/block-documents/block-documents.ts
+++ b/ui-v2/src/api/block-documents/block-documents.ts
@@ -8,6 +8,7 @@ import {
 import type { components } from "@/api/prefect";
 import { getQueryService } from "@/api/service";
 import useDebounce from "@/hooks/use-debounce";
+import { queryKeyFactory as adminQueryKeyFactory } from "../admin";
 
 export type BlockDocument = components["schemas"]["BlockDocument"];
 export type BlockDocumentsFilter =
@@ -215,6 +216,9 @@ export const useDeleteBlockDocument = () => {
 				}),
 				queryClient.invalidateQueries({
 					queryKey: queryKeyFactory.counts(),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: adminQueryKeyFactory.defaultResultStorage(),
 				}),
 			]);
 		},

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -8470,7 +8470,7 @@ export interface components {
          */
         IntervalSchedule: {
             /** Interval */
-            interval: number | string;
+            interval: number;
             /**
              * Anchor Date
              * Format: date-time

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -8470,7 +8470,7 @@ export interface components {
          */
         IntervalSchedule: {
             /** Interval */
-            interval: number;
+            interval: number | string;
             /**
              * Anchor Date
              * Format: date-time

--- a/ui-v2/src/components/blocks/blocks-page.tsx
+++ b/ui-v2/src/components/blocks/blocks-page.tsx
@@ -16,6 +16,7 @@ import { SearchInput } from "@/components/ui/input";
 import { BlockDocumentsDataTable } from "./block-document-data-table";
 import { BlockTypesMultiSelect } from "./block-types-multi-select";
 import { BlocksRowCount } from "./blocks-row-count";
+import { DefaultResultStorageCard } from "./default-result-storage-card";
 import { BlocksEmptyState } from "./empty-state";
 
 type BlocksPageProps = {
@@ -30,6 +31,14 @@ type BlocksPageProps = {
 	pagination: PaginationState;
 	onPaginationChange: (paginationState: PaginationState) => void;
 	onClearFilters: () => void;
+	defaultResultStorageBlockId: string | undefined;
+	defaultResultStorageBlock: BlockDocument | undefined;
+	storageBlockDocuments: Array<BlockDocument> | undefined;
+	onUpdateDefaultResultStorage: (blockDocumentId: string) => void;
+	onClearDefaultResultStorage: () => void;
+	isUpdatingDefaultResultStorage: boolean;
+	isClearingDefaultResultStorage: boolean;
+	isLoadingDefaultResultStorageBlock: boolean;
 };
 
 const BlocksFilteredEmptyState = ({
@@ -63,6 +72,14 @@ export const BlocksPage = ({
 	pagination,
 	onPaginationChange,
 	onClearFilters,
+	defaultResultStorageBlockId,
+	defaultResultStorageBlock,
+	storageBlockDocuments,
+	onUpdateDefaultResultStorage,
+	onClearDefaultResultStorage,
+	isUpdatingDefaultResultStorage,
+	isClearingDefaultResultStorage,
+	isLoadingDefaultResultStorageBlock,
 }: BlocksPageProps) => {
 	const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -80,6 +97,16 @@ export const BlocksPage = ({
 					</Link>
 				</Button>
 			</div>
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId={defaultResultStorageBlockId}
+				defaultResultStorageBlock={defaultResultStorageBlock}
+				storageBlockDocuments={storageBlockDocuments}
+				onUpdateDefaultResultStorage={onUpdateDefaultResultStorage}
+				onClearDefaultResultStorage={onClearDefaultResultStorage}
+				isUpdatingDefaultResultStorage={isUpdatingDefaultResultStorage}
+				isClearingDefaultResultStorage={isClearingDefaultResultStorage}
+				isLoadingDefaultResultStorageBlock={isLoadingDefaultResultStorageBlock}
+			/>
 			{allCount === 0 ? (
 				<BlocksEmptyState />
 			) : (

--- a/ui-v2/src/components/blocks/default-result-storage-card.stories.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+import { createFakeBlockDocument } from "@/mocks";
+import { routerDecorator, toastDecorator } from "@/storybook/utils";
+import { DefaultResultStorageCard } from "./default-result-storage-card";
+
+const storageBlockDocument = createFakeBlockDocument({
+	id: "fbb69463-262e-494a-8fff-362482ab3efd",
+	name: "s3-results",
+	block_type_name: "S3 Bucket",
+	block_type: {
+		id: "93e948b4-9a7e-4194-936c-3dd4fe2009ee",
+		created: "2026-05-03T00:00:00Z",
+		updated: "2026-05-03T00:00:00Z",
+		name: "S3 Bucket",
+		slug: "s3-bucket",
+		logo_url: null,
+		documentation_url: null,
+		description: null,
+		code_example: null,
+		is_protected: false,
+	},
+});
+
+const meta = {
+	title: "Components/Blocks/DefaultResultStorageCard",
+	component: DefaultResultStorageCard,
+	decorators: [toastDecorator, routerDecorator],
+	args: {
+		defaultResultStorageBlockId: storageBlockDocument.id,
+		defaultResultStorageBlock: storageBlockDocument,
+		storageBlockDocuments: [storageBlockDocument],
+		onUpdateDefaultResultStorage: fn(),
+		onClearDefaultResultStorage: fn(),
+		isUpdatingDefaultResultStorage: false,
+		isClearingDefaultResultStorage: false,
+		isLoadingDefaultResultStorageBlock: false,
+	},
+} satisfies Meta<typeof DefaultResultStorageCard>;
+
+export default meta;
+
+export const story: StoryObj = { name: "DefaultResultStorageCard" };
+
+export const NotConfigured: StoryObj<typeof DefaultResultStorageCard> = {
+	args: {
+		defaultResultStorageBlockId: undefined,
+		defaultResultStorageBlock: undefined,
+	},
+};

--- a/ui-v2/src/components/blocks/default-result-storage-card.stories.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.stories.tsx
@@ -58,13 +58,3 @@ export const LoadingConfiguredBlock: StoryObj<typeof DefaultResultStorageCard> =
 			isLoadingDefaultResultStorageBlock: true,
 		},
 	};
-
-export const ConfiguredBlockMissing: StoryObj<typeof DefaultResultStorageCard> =
-	{
-		args: {
-			defaultResultStorageBlockId: storageBlockDocument.id,
-			defaultResultStorageBlock: undefined,
-			storageBlockDocuments: [],
-			isLoadingDefaultResultStorageBlock: false,
-		},
-	};

--- a/ui-v2/src/components/blocks/default-result-storage-card.stories.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.stories.tsx
@@ -48,3 +48,23 @@ export const NotConfigured: StoryObj<typeof DefaultResultStorageCard> = {
 		defaultResultStorageBlock: undefined,
 	},
 };
+
+export const LoadingConfiguredBlock: StoryObj<typeof DefaultResultStorageCard> =
+	{
+		args: {
+			defaultResultStorageBlockId: storageBlockDocument.id,
+			defaultResultStorageBlock: undefined,
+			storageBlockDocuments: [],
+			isLoadingDefaultResultStorageBlock: true,
+		},
+	};
+
+export const ConfiguredBlockMissing: StoryObj<typeof DefaultResultStorageCard> =
+	{
+		args: {
+			defaultResultStorageBlockId: storageBlockDocument.id,
+			defaultResultStorageBlock: undefined,
+			storageBlockDocuments: [],
+			isLoadingDefaultResultStorageBlock: false,
+		},
+	};

--- a/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
@@ -1,0 +1,198 @@
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRouter,
+	Outlet,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockPointerEvents } from "@tests/utils/browser";
+import { createContext, type ReactNode, useContext } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BlockDocument } from "@/api/block-documents";
+import { createFakeBlockDocument } from "@/mocks";
+import { DefaultResultStorageCard } from "./default-result-storage-card";
+
+const TestChildrenContext = createContext<ReactNode>(null);
+
+function RenderTestChildren() {
+	const children = useContext(TestChildrenContext);
+	return (
+		<>
+			{children}
+			<Outlet />
+		</>
+	);
+}
+
+const renderWithRouter = async (ui: ReactNode) => {
+	const rootRoute = createRootRoute({
+		component: RenderTestChildren,
+		notFoundComponent: () => null,
+	});
+
+	const router = createRouter({
+		routeTree: rootRoute,
+		history: createMemoryHistory({ initialEntries: ["/"] }),
+	});
+
+	const result = render(
+		<TestChildrenContext.Provider value={ui}>
+			<RouterProvider router={router} />
+		</TestChildrenContext.Provider>,
+	);
+
+	await waitFor(() => {
+		expect(router.state.status).toBe("idle");
+	});
+
+	return result;
+};
+
+const createStorageBlockDocument = (
+	overrides?: Partial<BlockDocument>,
+): BlockDocument =>
+	createFakeBlockDocument({
+		id: "block-1",
+		name: "s3-results",
+		block_type_name: "S3 Bucket",
+		block_type: {
+			id: "block-type-1",
+			created: "2026-05-03T00:00:00Z",
+			updated: "2026-05-03T00:00:00Z",
+			name: "S3 Bucket",
+			slug: "s3-bucket",
+			logo_url: null,
+			documentation_url: null,
+			description: null,
+			code_example: null,
+			is_protected: false,
+		},
+		...overrides,
+	});
+
+describe("DefaultResultStorageCard", () => {
+	beforeEach(() => {
+		mockPointerEvents();
+	});
+
+	it("renders the configured default result storage block", async () => {
+		const blockDocument = createStorageBlockDocument();
+
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId={blockDocument.id}
+				defaultResultStorageBlock={blockDocument}
+				storageBlockDocuments={[blockDocument]}
+				onUpdateDefaultResultStorage={vi.fn()}
+				onClearDefaultResultStorage={vi.fn()}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={false}
+			/>,
+		);
+
+		expect(screen.getByText("Default result storage")).toBeVisible();
+		expect(screen.getByText("Configured")).toBeVisible();
+		expect(screen.getAllByText("s3-results")[0]).toBeVisible();
+		expect(screen.getByText("S3 Bucket")).toBeVisible();
+	});
+
+	it("renders the unconfigured state", async () => {
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId={undefined}
+				defaultResultStorageBlock={undefined}
+				storageBlockDocuments={[]}
+				onUpdateDefaultResultStorage={vi.fn()}
+				onClearDefaultResultStorage={vi.fn()}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={false}
+			/>,
+		);
+
+		expect(screen.getByText("Not configured")).toBeVisible();
+		expect(
+			screen.getByText("No default storage block is configured."),
+		).toBeVisible();
+		expect(
+			screen.getByRole("link", { name: /new storage block/i }),
+		).toBeVisible();
+	});
+
+	it("renders a loading state while the configured block is being resolved", async () => {
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId="block-1"
+				defaultResultStorageBlock={undefined}
+				storageBlockDocuments={[]}
+				onUpdateDefaultResultStorage={vi.fn()}
+				onClearDefaultResultStorage={vi.fn()}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={true}
+			/>,
+		);
+
+		expect(screen.getByText("Configured")).toBeVisible();
+		expect(
+			screen.getByText("Loading configured storage block..."),
+		).toBeVisible();
+		expect(
+			screen.queryByText(
+				"The configured default storage block could not be found.",
+			),
+		).not.toBeInTheDocument();
+	});
+
+	it("calls update when a storage block is selected", async () => {
+		const user = userEvent.setup();
+		const onUpdateDefaultResultStorage = vi.fn();
+		const blockDocument = createStorageBlockDocument();
+
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId={undefined}
+				defaultResultStorageBlock={undefined}
+				storageBlockDocuments={[blockDocument]}
+				onUpdateDefaultResultStorage={onUpdateDefaultResultStorage}
+				onClearDefaultResultStorage={vi.fn()}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={false}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("combobox", { name: /default result storage block/i }),
+		);
+		await user.click(screen.getByRole("option", { name: "s3-results" }));
+
+		expect(onUpdateDefaultResultStorage).toHaveBeenCalledWith(blockDocument.id);
+	});
+
+	it("calls clear when the clear button is clicked", async () => {
+		const user = userEvent.setup();
+		const onClearDefaultResultStorage = vi.fn();
+		const blockDocument = createStorageBlockDocument();
+
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId={blockDocument.id}
+				defaultResultStorageBlock={blockDocument}
+				storageBlockDocuments={[blockDocument]}
+				onUpdateDefaultResultStorage={vi.fn()}
+				onClearDefaultResultStorage={onClearDefaultResultStorage}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={false}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /clear/i }));
+
+		expect(onClearDefaultResultStorage).toHaveBeenCalledOnce();
+	});
+});

--- a/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
@@ -153,7 +153,7 @@ describe("DefaultResultStorageCard", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders a missing state when the configured block cannot be resolved", async () => {
+	it("does not surface stale configured-block recovery UI", async () => {
 		await renderWithRouter(
 			<DefaultResultStorageCard
 				defaultResultStorageBlockId="block-1"
@@ -167,9 +167,13 @@ describe("DefaultResultStorageCard", () => {
 			/>,
 		);
 
-		expect(screen.getByText("Configured")).toBeVisible();
-		expect(screen.getByText("Default storage block not found")).toBeVisible();
-		expect(screen.getByText(/could not be loaded/)).toBeVisible();
+		expect(screen.getByText("Not configured")).toBeVisible();
+		expect(
+			screen.getByText("No default storage block is configured."),
+		).toBeVisible();
+		expect(
+			screen.queryByText("Default storage block not found"),
+		).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: /remove stale default/i }),
 		).not.toBeInTheDocument();

--- a/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
@@ -123,6 +123,9 @@ describe("DefaultResultStorageCard", () => {
 		expect(
 			screen.getByRole("link", { name: /new storage block/i }),
 		).toBeVisible();
+		expect(
+			screen.queryByRole("button", { name: /clear/i }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders a loading state while the configured block is being resolved", async () => {
@@ -166,14 +169,13 @@ describe("DefaultResultStorageCard", () => {
 
 		expect(screen.getByText("Configured")).toBeVisible();
 		expect(screen.getByText("Default storage block not found")).toBeVisible();
+		expect(screen.getByText(/could not be loaded/)).toBeVisible();
 		expect(
-			screen.getByText(
-				/The server still points to a block that no longer exists/,
-			),
-		).toBeVisible();
+			screen.queryByRole("button", { name: /remove stale default/i }),
+		).not.toBeInTheDocument();
 		expect(
-			screen.getByRole("button", { name: /remove stale default/i }),
-		).toBeVisible();
+			screen.queryByRole("button", { name: /clear/i }),
+		).not.toBeInTheDocument();
 		expect(screen.getByText("Select storage block")).toBeVisible();
 	});
 

--- a/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
@@ -165,10 +165,14 @@ describe("DefaultResultStorageCard", () => {
 		);
 
 		expect(screen.getByText("Configured")).toBeVisible();
+		expect(screen.getByText("Default storage block not found")).toBeVisible();
 		expect(
 			screen.getByText(
-				"The configured default storage block could not be found.",
+				/The server still points to a block that no longer exists/,
 			),
+		).toBeVisible();
+		expect(
+			screen.getByRole("button", { name: /remove stale default/i }),
 		).toBeVisible();
 		expect(screen.getByText("Select storage block")).toBeVisible();
 	});

--- a/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
@@ -97,6 +97,9 @@ describe("DefaultResultStorageCard", () => {
 		expect(screen.getByText("Configured")).toBeVisible();
 		expect(screen.getAllByText("s3-results")[0]).toBeVisible();
 		expect(screen.getByText("S3 Bucket")).toBeVisible();
+		expect(
+			screen.queryByRole("img", { name: "S3 Bucket logo" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders the unconfigured state", async () => {
@@ -145,6 +148,29 @@ describe("DefaultResultStorageCard", () => {
 				"The configured default storage block could not be found.",
 			),
 		).not.toBeInTheDocument();
+	});
+
+	it("renders a missing state when the configured block cannot be resolved", async () => {
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId="block-1"
+				defaultResultStorageBlock={undefined}
+				storageBlockDocuments={[]}
+				onUpdateDefaultResultStorage={vi.fn()}
+				onClearDefaultResultStorage={vi.fn()}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={false}
+			/>,
+		);
+
+		expect(screen.getByText("Configured")).toBeVisible();
+		expect(
+			screen.getByText(
+				"The configured default storage block could not be found.",
+			),
+		).toBeVisible();
+		expect(screen.getByText("Select storage block")).toBeVisible();
 	});
 
 	it("calls update when a storage block is selected", async () => {

--- a/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.test.tsx
@@ -102,6 +102,29 @@ describe("DefaultResultStorageCard", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("keeps the configured block selected when it is outside the selectable block list", async () => {
+		const blockDocument = createStorageBlockDocument();
+
+		await renderWithRouter(
+			<DefaultResultStorageCard
+				defaultResultStorageBlockId={blockDocument.id}
+				defaultResultStorageBlock={blockDocument}
+				storageBlockDocuments={[]}
+				onUpdateDefaultResultStorage={vi.fn()}
+				onClearDefaultResultStorage={vi.fn()}
+				isUpdatingDefaultResultStorage={false}
+				isClearingDefaultResultStorage={false}
+				isLoadingDefaultResultStorageBlock={false}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("combobox", {
+				name: /default result storage block/i,
+			}),
+		).toHaveTextContent("s3-results");
+	});
+
 	it("renders the unconfigured state", async () => {
 		await renderWithRouter(
 			<DefaultResultStorageCard

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -1,0 +1,150 @@
+import { Link } from "@tanstack/react-router";
+import type { BlockDocument } from "@/api/block-documents";
+import { BlockTypeLogo } from "@/components/block-type-logo/block-type-logo";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Icon } from "@/components/ui/icons";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+type DefaultResultStorageCardProps = {
+	defaultResultStorageBlockId: string | undefined;
+	defaultResultStorageBlock: BlockDocument | undefined;
+	storageBlockDocuments: Array<BlockDocument> | undefined;
+	onUpdateDefaultResultStorage: (blockDocumentId: string) => void;
+	onClearDefaultResultStorage: () => void;
+	isUpdatingDefaultResultStorage: boolean;
+	isClearingDefaultResultStorage: boolean;
+	isLoadingDefaultResultStorageBlock: boolean;
+};
+
+export const DefaultResultStorageCard = ({
+	defaultResultStorageBlockId,
+	defaultResultStorageBlock,
+	storageBlockDocuments = [],
+	onUpdateDefaultResultStorage,
+	onClearDefaultResultStorage,
+	isUpdatingDefaultResultStorage,
+	isClearingDefaultResultStorage,
+	isLoadingDefaultResultStorageBlock,
+}: DefaultResultStorageCardProps) => {
+	const isMutating =
+		isUpdatingDefaultResultStorage || isClearingDefaultResultStorage;
+	const hasConfiguredMissingBlock =
+		Boolean(defaultResultStorageBlockId) &&
+		!defaultResultStorageBlock &&
+		!isLoadingDefaultResultStorageBlock;
+
+	return (
+		<Card className="gap-4 p-4">
+			<div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+				<div className="flex min-w-0 flex-1 flex-col gap-3">
+					<div className="flex flex-wrap items-center gap-2">
+						<h2 className="text-base font-semibold">Default result storage</h2>
+						{defaultResultStorageBlockId ? (
+							<Badge variant="secondary">Configured</Badge>
+						) : (
+							<Badge variant="outline">Not configured</Badge>
+						)}
+					</div>
+					<p className="max-w-3xl text-sm text-muted-foreground">
+						Persisted flow and task return values use this storage block when
+						runs do not set result storage explicitly.
+					</p>
+					{defaultResultStorageBlock ? (
+						<DefaultResultStorageBlock
+							blockDocument={defaultResultStorageBlock}
+						/>
+					) : (
+						<div className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
+							{isLoadingDefaultResultStorageBlock &&
+								"Loading configured storage block..."}
+							{hasConfiguredMissingBlock &&
+								"The configured default storage block could not be found."}
+							{!defaultResultStorageBlockId &&
+								"No default storage block is configured."}
+						</div>
+					)}
+				</div>
+				<div className="flex w-full flex-col gap-2 lg:w-80">
+					<Select
+						value={defaultResultStorageBlockId}
+						onValueChange={onUpdateDefaultResultStorage}
+						disabled={isMutating || storageBlockDocuments.length === 0}
+					>
+						<SelectTrigger aria-label="Default result storage block">
+							<SelectValue placeholder="Select storage block" />
+						</SelectTrigger>
+						<SelectContent>
+							{storageBlockDocuments.map((blockDocument) => (
+								<SelectItem key={blockDocument.id} value={blockDocument.id}>
+									{blockDocument.name ?? "Untitled block"}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<div className="flex flex-wrap gap-2">
+						<Button variant="outline" size="sm" asChild>
+							<Link to="/blocks/catalog">
+								<Icon id="Plus" className="size-4" />
+								New storage block
+							</Link>
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onClearDefaultResultStorage}
+							disabled={!defaultResultStorageBlockId || isMutating}
+						>
+							<Icon id="X" className="size-4" />
+							Clear
+						</Button>
+					</div>
+				</div>
+			</div>
+		</Card>
+	);
+};
+
+const DefaultResultStorageBlock = ({
+	blockDocument,
+}: {
+	blockDocument: BlockDocument;
+}) => {
+	const blockTypeName =
+		blockDocument.block_type_name ?? blockDocument.block_type?.name;
+
+	return (
+		<Link to="/blocks/block/$id" params={{ id: blockDocument.id }}>
+			<div className="flex items-center gap-3 rounded-lg border bg-muted/40 p-3 transition-colors hover:bg-muted">
+				{blockDocument.block_type && blockTypeName ? (
+					<BlockTypeLogo
+						size="sm"
+						logoUrl={blockDocument.block_type.logo_url}
+						alt={`${blockTypeName} logo`}
+					/>
+				) : (
+					<div className="flex size-8 items-center justify-center rounded border bg-muted">
+						<Icon id="Box" className="size-4 text-muted-foreground" />
+					</div>
+				)}
+				<div className="min-w-0">
+					<div className="truncate text-sm font-medium">
+						{blockDocument.name ?? "Untitled block"}
+					</div>
+					{blockTypeName && (
+						<div className="truncate text-sm text-muted-foreground">
+							{blockTypeName}
+						</div>
+					)}
+				</div>
+			</div>
+		</Link>
+	);
+};

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -53,9 +53,7 @@ export const DefaultResultStorageCard = ({
 			: !defaultResultStorageBlockId
 				? "empty"
 				: undefined;
-	const clearButtonLabel = hasConfiguredMissingBlock
-		? "Remove stale default"
-		: "Clear";
+	const canClearDefaultResultStorage = Boolean(defaultResultStorageBlock);
 
 	return (
 		<Card className="p-4">
@@ -108,15 +106,17 @@ export const DefaultResultStorageCard = ({
 								New storage block
 							</Link>
 						</Button>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={onClearDefaultResultStorage}
-							disabled={!defaultResultStorageBlockId || isMutating}
-						>
-							<Icon id="X" className="size-4" />
-							{clearButtonLabel}
-						</Button>
+						{canClearDefaultResultStorage && (
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={onClearDefaultResultStorage}
+								disabled={isMutating}
+							>
+								<Icon id="X" className="size-4" />
+								Clear
+							</Button>
+						)}
 					</div>
 				</div>
 			</div>
@@ -189,8 +189,8 @@ const DefaultResultStorageStatus = ({
 						Default storage block not found
 					</div>
 					<div>
-						The server still points to a block that no longer exists. Select a
-						new block or remove the stale default.
+						The configured default storage block could not be loaded. Select a
+						storage block to update the default.
 					</div>
 				</div>
 			</div>

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -56,8 +56,8 @@ export const DefaultResultStorageCard = ({
 
 	return (
 		<Card className="p-4">
-			<div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-				<div className="flex min-w-0 flex-1 flex-col gap-3 xl:max-w-4xl">
+			<div className="flex max-w-3xl flex-col gap-3">
+				<div className="flex min-w-0 flex-col gap-3">
 					<div className="flex flex-wrap items-center gap-2">
 						<h2 className="text-base font-semibold">Default result storage</h2>
 						{defaultResultStorageBlockId ? (
@@ -70,23 +70,24 @@ export const DefaultResultStorageCard = ({
 						Persisted flow and task return values use this storage block when
 						runs do not set result storage explicitly.
 					</p>
-					<div className="max-w-2xl">
-						{defaultResultStorageBlock ? (
-							<DefaultResultStorageBlock
-								blockDocument={defaultResultStorageBlock}
-							/>
-						) : (
-							<DefaultResultStorageStatus state={statusState} />
-						)}
-					</div>
+					{defaultResultStorageBlock ? (
+						<DefaultResultStorageBlock
+							blockDocument={defaultResultStorageBlock}
+						/>
+					) : (
+						<DefaultResultStorageStatus state={statusState} />
+					)}
 				</div>
-				<div className="flex w-full flex-col gap-2 xl:w-80 xl:pt-4">
+				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
 					<Select
 						value={selectValue}
 						onValueChange={onUpdateDefaultResultStorage}
 						disabled={isMutating || storageBlockDocuments.length === 0}
 					>
-						<SelectTrigger aria-label="Default result storage block">
+						<SelectTrigger
+							className="w-full sm:w-64"
+							aria-label="Default result storage block"
+						>
 							<SelectValue placeholder="Select storage block" />
 						</SelectTrigger>
 						<SelectContent>

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -46,11 +46,18 @@ export const DefaultResultStorageCard = ({
 		Boolean(defaultResultStorageBlockId) &&
 		!defaultResultStorageBlock &&
 		!isLoadingDefaultResultStorageBlock;
+	const statusState = isLoadingDefaultResultStorageBlock
+		? "loading"
+		: hasConfiguredMissingBlock
+			? "missing"
+			: !defaultResultStorageBlockId
+				? "empty"
+				: undefined;
 
 	return (
-		<Card className="gap-4 p-4">
-			<div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-				<div className="flex min-w-0 flex-1 flex-col gap-3">
+		<Card className="p-4">
+			<div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+				<div className="flex min-w-0 flex-1 flex-col gap-3 xl:max-w-4xl">
 					<div className="flex flex-wrap items-center gap-2">
 						<h2 className="text-base font-semibold">Default result storage</h2>
 						{defaultResultStorageBlockId ? (
@@ -63,22 +70,17 @@ export const DefaultResultStorageCard = ({
 						Persisted flow and task return values use this storage block when
 						runs do not set result storage explicitly.
 					</p>
-					{defaultResultStorageBlock ? (
-						<DefaultResultStorageBlock
-							blockDocument={defaultResultStorageBlock}
-						/>
-					) : (
-						<div className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
-							{isLoadingDefaultResultStorageBlock &&
-								"Loading configured storage block..."}
-							{hasConfiguredMissingBlock &&
-								"The configured default storage block could not be found."}
-							{!defaultResultStorageBlockId &&
-								"No default storage block is configured."}
-						</div>
-					)}
+					<div className="max-w-2xl">
+						{defaultResultStorageBlock ? (
+							<DefaultResultStorageBlock
+								blockDocument={defaultResultStorageBlock}
+							/>
+						) : (
+							<DefaultResultStorageStatus state={statusState} />
+						)}
+					</div>
 				</div>
-				<div className="flex w-full flex-col gap-2 lg:w-80">
+				<div className="flex w-full flex-col gap-2 xl:w-80 xl:pt-4">
 					<Select
 						value={selectValue}
 						onValueChange={onUpdateDefaultResultStorage}
@@ -153,5 +155,47 @@ const DefaultResultStorageBlock = ({
 				</div>
 			</div>
 		</Link>
+	);
+};
+
+const DefaultResultStorageStatus = ({
+	state,
+}: {
+	state: "empty" | "loading" | "missing" | undefined;
+}) => {
+	if (state === "loading") {
+		return (
+			<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+				<div className="flex size-8 items-center justify-center rounded border bg-background">
+					<Icon id="Loader2" className="size-4 animate-spin" />
+				</div>
+				Loading configured storage block...
+			</div>
+		);
+	}
+
+	if (state === "missing") {
+		return (
+			<div className="flex items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-muted-foreground">
+				<div className="flex size-8 items-center justify-center rounded border border-destructive/30 bg-background">
+					<Icon id="CircleAlert" className="size-4 text-destructive" />
+				</div>
+				<div>
+					<div className="font-medium text-foreground">
+						Configured block not found
+					</div>
+					<div>The configured default storage block could not be found.</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex items-center gap-3 rounded-lg border border-dashed bg-muted/20 p-3 text-sm text-muted-foreground">
+			<div className="flex size-8 items-center justify-center rounded border bg-background">
+				<Icon id="Box" className="size-4" />
+			</div>
+			No default storage block is configured.
+		</div>
 	);
 };

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -42,17 +42,13 @@ export const DefaultResultStorageCard = ({
 	const selectValue = selectedBlockDocumentExists
 		? defaultResultStorageBlockId
 		: undefined;
-	const hasConfiguredMissingBlock =
-		Boolean(defaultResultStorageBlockId) &&
-		!defaultResultStorageBlock &&
-		!isLoadingDefaultResultStorageBlock;
 	const statusState = isLoadingDefaultResultStorageBlock
 		? "loading"
-		: hasConfiguredMissingBlock
-			? "missing"
-			: !defaultResultStorageBlockId
-				? "empty"
-				: undefined;
+		: defaultResultStorageBlock
+			? undefined
+			: "empty";
+	const hasVisibleDefaultResultStorage =
+		Boolean(defaultResultStorageBlock) || isLoadingDefaultResultStorageBlock;
 	const canClearDefaultResultStorage = Boolean(defaultResultStorageBlock);
 
 	return (
@@ -61,7 +57,7 @@ export const DefaultResultStorageCard = ({
 				<div className="flex min-w-0 flex-col gap-3">
 					<div className="flex flex-wrap items-center gap-2">
 						<h2 className="text-base font-semibold">Default result storage</h2>
-						{defaultResultStorageBlockId ? (
+						{hasVisibleDefaultResultStorage ? (
 							<Badge variant="secondary">Configured</Badge>
 						) : (
 							<Badge variant="outline">Not configured</Badge>
@@ -165,7 +161,7 @@ const DefaultResultStorageBlock = ({
 const DefaultResultStorageStatus = ({
 	state,
 }: {
-	state: "empty" | "loading" | "missing" | undefined;
+	state: "empty" | "loading" | undefined;
 }) => {
 	if (state === "loading") {
 		return (
@@ -174,25 +170,6 @@ const DefaultResultStorageStatus = ({
 					<Icon id="Loader2" className="size-4 animate-spin" />
 				</div>
 				Loading configured storage block...
-			</div>
-		);
-	}
-
-	if (state === "missing") {
-		return (
-			<div className="flex items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-muted-foreground">
-				<div className="flex size-8 items-center justify-center rounded border border-destructive/30 bg-background">
-					<Icon id="CircleAlert" className="size-4 text-destructive" />
-				</div>
-				<div>
-					<div className="font-medium text-foreground">
-						Default storage block not found
-					</div>
-					<div>
-						The configured default storage block could not be loaded. Select a
-						storage block to update the default.
-					</div>
-				</div>
 			</div>
 		);
 	}

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -53,6 +53,9 @@ export const DefaultResultStorageCard = ({
 			: !defaultResultStorageBlockId
 				? "empty"
 				: undefined;
+	const clearButtonLabel = hasConfiguredMissingBlock
+		? "Remove stale default"
+		: "Clear";
 
 	return (
 		<Card className="p-4">
@@ -112,7 +115,7 @@ export const DefaultResultStorageCard = ({
 							disabled={!defaultResultStorageBlockId || isMutating}
 						>
 							<Icon id="X" className="size-4" />
-							Clear
+							{clearButtonLabel}
 						</Button>
 					</div>
 				</div>
@@ -183,9 +186,12 @@ const DefaultResultStorageStatus = ({
 				</div>
 				<div>
 					<div className="font-medium text-foreground">
-						Configured block not found
+						Default storage block not found
 					</div>
-					<div>The configured default storage block could not be found.</div>
+					<div>
+						The server still points to a block that no longer exists. Select a
+						new block or remove the stale default.
+					</div>
 				</div>
 			</div>
 		);

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -41,7 +41,7 @@ export const DefaultResultStorageCard = ({
 	);
 	const selectValue = selectedBlockDocumentExists
 		? defaultResultStorageBlockId
-		: undefined;
+		: "";
 	const statusState = isLoadingDefaultResultStorageBlock
 		? "loading"
 		: defaultResultStorageBlock

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -36,7 +36,14 @@ export const DefaultResultStorageCard = ({
 }: DefaultResultStorageCardProps) => {
 	const isMutating =
 		isUpdatingDefaultResultStorage || isClearingDefaultResultStorage;
-	const selectedBlockDocumentExists = storageBlockDocuments.some(
+	const selectableStorageBlockDocuments =
+		defaultResultStorageBlock &&
+		!storageBlockDocuments.some(
+			(blockDocument) => blockDocument.id === defaultResultStorageBlock.id,
+		)
+			? [defaultResultStorageBlock, ...storageBlockDocuments]
+			: storageBlockDocuments;
+	const selectedBlockDocumentExists = selectableStorageBlockDocuments.some(
 		(blockDocument) => blockDocument.id === defaultResultStorageBlockId,
 	);
 	const selectValue = selectedBlockDocumentExists
@@ -79,7 +86,9 @@ export const DefaultResultStorageCard = ({
 					<Select
 						value={selectValue}
 						onValueChange={onUpdateDefaultResultStorage}
-						disabled={isMutating || storageBlockDocuments.length === 0}
+						disabled={
+							isMutating || selectableStorageBlockDocuments.length === 0
+						}
 					>
 						<SelectTrigger
 							className="w-full sm:w-64"
@@ -88,7 +97,7 @@ export const DefaultResultStorageCard = ({
 							<SelectValue placeholder="Select storage block" />
 						</SelectTrigger>
 						<SelectContent>
-							{storageBlockDocuments.map((blockDocument) => (
+							{selectableStorageBlockDocuments.map((blockDocument) => (
 								<SelectItem key={blockDocument.id} value={blockDocument.id}>
 									{blockDocument.name ?? "Untitled block"}
 								</SelectItem>

--- a/ui-v2/src/components/blocks/default-result-storage-card.tsx
+++ b/ui-v2/src/components/blocks/default-result-storage-card.tsx
@@ -36,6 +36,12 @@ export const DefaultResultStorageCard = ({
 }: DefaultResultStorageCardProps) => {
 	const isMutating =
 		isUpdatingDefaultResultStorage || isClearingDefaultResultStorage;
+	const selectedBlockDocumentExists = storageBlockDocuments.some(
+		(blockDocument) => blockDocument.id === defaultResultStorageBlockId,
+	);
+	const selectValue = selectedBlockDocumentExists
+		? defaultResultStorageBlockId
+		: undefined;
 	const hasConfiguredMissingBlock =
 		Boolean(defaultResultStorageBlockId) &&
 		!defaultResultStorageBlock &&
@@ -74,7 +80,7 @@ export const DefaultResultStorageCard = ({
 				</div>
 				<div className="flex w-full flex-col gap-2 lg:w-80">
 					<Select
-						value={defaultResultStorageBlockId}
+						value={selectValue}
 						onValueChange={onUpdateDefaultResultStorage}
 						disabled={isMutating || storageBlockDocuments.length === 0}
 					>
@@ -119,14 +125,15 @@ const DefaultResultStorageBlock = ({
 }) => {
 	const blockTypeName =
 		blockDocument.block_type_name ?? blockDocument.block_type?.name;
+	const logoUrl = blockDocument.block_type?.logo_url;
 
 	return (
 		<Link to="/blocks/block/$id" params={{ id: blockDocument.id }}>
 			<div className="flex items-center gap-3 rounded-lg border bg-muted/40 p-3 transition-colors hover:bg-muted">
-				{blockDocument.block_type && blockTypeName ? (
+				{logoUrl && blockTypeName ? (
 					<BlockTypeLogo
 						size="sm"
-						logoUrl={blockDocument.block_type.logo_url}
+						logoUrl={logoUrl}
 						alt={`${blockTypeName} logo`}
 					/>
 				) : (

--- a/ui-v2/src/routes/blocks/index.tsx
+++ b/ui-v2/src/routes/blocks/index.tsx
@@ -4,11 +4,18 @@ import { createFileRoute } from "@tanstack/react-router";
 import type { PaginationState } from "@tanstack/react-table";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { useCallback, useMemo } from "react";
+import { toast } from "sonner";
 import { z } from "zod";
+import {
+	buildGetDefaultResultStorageQuery,
+	useClearDefaultResultStorage,
+	useUpdateDefaultResultStorage,
+} from "@/api/admin";
 import {
 	type BlockDocumentsFilter,
 	buildCountAllBlockDocumentsQuery,
 	buildCountFilterBlockDocumentsQuery,
+	buildGetBlockDocumentQuery,
 	buildListFilterBlockDocumentsQuery,
 } from "@/api/block-documents";
 import { buildListFilterBlockTypesQuery } from "@/api/block-types";
@@ -25,6 +32,21 @@ const searchParams = z.object({
 	limit: z.number().int().positive().optional().default(10).catch(10),
 });
 
+const storageBlockDocumentsFilter = {
+	sort: "BLOCK_TYPE_AND_NAME_ASC",
+	include_secrets: false,
+	offset: 0,
+	limit: 200,
+	block_documents: {
+		operator: "and_",
+		is_anonymous: { eq_: false },
+	},
+	block_schemas: {
+		operator: "and_",
+		block_capabilities: { all_: ["write-path"] },
+	},
+} satisfies BlockDocumentsFilter;
+
 export const Route = createFileRoute("/blocks/")({
 	validateSearch: zodValidator(searchParams),
 	component: function RouteComponent() {
@@ -37,6 +59,11 @@ export const Route = createFileRoute("/blocks/")({
 		const { data: allBlockDocumentsCount } = useSuspenseQuery(
 			buildCountAllBlockDocumentsQuery(),
 		);
+		const { data: defaultResultStorage } = useSuspenseQuery(
+			buildGetDefaultResultStorageQuery(),
+		);
+		const defaultResultStorageBlockId =
+			defaultResultStorage.default_result_storage_block_id ?? undefined;
 
 		const blockDocumentsFilter = useMemo(
 			() => ({
@@ -56,7 +83,6 @@ export const Route = createFileRoute("/blocks/")({
 			}),
 			[search, blockTypeSlugs],
 		);
-
 		const { data: blockDocuments } = useQuery(
 			buildListFilterBlockDocumentsQuery({
 				...blockDocumentsFilter,
@@ -68,6 +94,37 @@ export const Route = createFileRoute("/blocks/")({
 		const { data: filteredBlockDocumentsCount } = useQuery(
 			buildCountFilterBlockDocumentsQuery(blockDocumentsFilter),
 		);
+		const {
+			data: storageBlockDocuments,
+			isLoading: isLoadingStorageBlockDocuments,
+		} = useQuery(
+			buildListFilterBlockDocumentsQuery(storageBlockDocumentsFilter),
+		);
+		const {
+			data: defaultResultStorageBlock,
+			isLoading: isLoadingDefaultResultStorageBlockDetail,
+		} = useQuery({
+			...buildGetBlockDocumentQuery(defaultResultStorageBlockId ?? ""),
+			enabled: Boolean(defaultResultStorageBlockId),
+		});
+		const resolvedDefaultResultStorageBlock =
+			defaultResultStorageBlock ??
+			storageBlockDocuments?.find(
+				(blockDocument) => blockDocument.id === defaultResultStorageBlockId,
+			);
+		const isLoadingDefaultResultStorageBlock =
+			Boolean(defaultResultStorageBlockId) &&
+			!resolvedDefaultResultStorageBlock &&
+			(isLoadingDefaultResultStorageBlockDetail ||
+				isLoadingStorageBlockDocuments);
+		const {
+			updateDefaultResultStorage,
+			isPending: isUpdatingDefaultResultStorage,
+		} = useUpdateDefaultResultStorage();
+		const {
+			clearDefaultResultStorage,
+			isPending: isClearingDefaultResultStorage,
+		} = useClearDefaultResultStorage();
 
 		const handleRemoveBlockType = (id: string) => {
 			const newValue = blockTypeSlugs.filter((blockId) => blockId !== id);
@@ -95,6 +152,27 @@ export const Route = createFileRoute("/blocks/")({
 				replace: true,
 			});
 		}, [navigate]);
+		const handleUpdateDefaultResultStorage = useCallback(
+			(blockDocumentId: string) => {
+				if (blockDocumentId === defaultResultStorageBlockId) {
+					return;
+				}
+				updateDefaultResultStorage(
+					{ default_result_storage_block_id: blockDocumentId },
+					{
+						onSuccess: () => toast.success("Default result storage updated"),
+						onError: (error) => toast.error(error.message),
+					},
+				);
+			},
+			[defaultResultStorageBlockId, updateDefaultResultStorage],
+		);
+		const handleClearDefaultResultStorage = useCallback(() => {
+			clearDefaultResultStorage(undefined, {
+				onSuccess: () => toast.success("Default result storage cleared"),
+				onError: (error) => toast.error(error.message),
+			});
+		}, [clearDefaultResultStorage]);
 
 		return (
 			<BlocksPage
@@ -109,6 +187,14 @@ export const Route = createFileRoute("/blocks/")({
 				pagination={pagination}
 				onPaginationChange={onPaginationChange}
 				onClearFilters={onClearFilters}
+				defaultResultStorageBlockId={defaultResultStorageBlockId}
+				defaultResultStorageBlock={resolvedDefaultResultStorageBlock}
+				storageBlockDocuments={storageBlockDocuments}
+				onUpdateDefaultResultStorage={handleUpdateDefaultResultStorage}
+				onClearDefaultResultStorage={handleClearDefaultResultStorage}
+				isUpdatingDefaultResultStorage={isUpdatingDefaultResultStorage}
+				isClearingDefaultResultStorage={isClearingDefaultResultStorage}
+				isLoadingDefaultResultStorageBlock={isLoadingDefaultResultStorageBlock}
 			/>
 		);
 	},
@@ -138,6 +224,10 @@ export const Route = createFileRoute("/blocks/")({
 		// Prefetch all queries without awaiting to avoid blocking render
 		void queryClient.prefetchQuery(buildListFilterBlockTypesQuery());
 		void queryClient.prefetchQuery(buildCountAllBlockDocumentsQuery());
+		void queryClient.prefetchQuery(buildGetDefaultResultStorageQuery());
+		void queryClient.prefetchQuery(
+			buildListFilterBlockDocumentsQuery(storageBlockDocumentsFilter),
+		);
 		void queryClient.prefetchQuery(
 			buildListFilterBlockDocumentsQuery(paginatedFilter),
 		);


### PR DESCRIPTION
this PR adds the `ui-v2` blocks-page controls for OSS server-side default result storage.

<details>
<summary>Details</summary>

- Adds admin API query/mutation helpers for `/admin/storage`.
- Adds a compact `DefaultResultStorageCard` above the blocks table.
- Shows the configured default storage block name/type, links to the block, and supports selecting or clearing a resolved server default.
- Filters selectable blocks to block schemas accepted by the backend for result storage (`write-path`).
- Keeps the resolved configured block selected even when it is fetched separately from the selectable block list.
- Updates the default-storage query cache on successful set/clear mutations so the UI reflects changes immediately.
- Invalidates the default-storage query after block deletion so the UI observes the backend cleanup from #21862 instead of holding a stale default id.
- Removes the user-facing stale/missing configured-block recovery state; #21862 clears defaults when referenced block documents, schemas, or types are deleted.
- Adds Storybook coverage for configured, not-configured, and loading states.
- Keeps OSS scoped to server-level defaults only; no Cloud account/workspace inheritance concepts are introduced.
- Includes the generated `ui-v2/src/api/prefect.ts` OpenAPI sync required by the current backend schema.

</details>

Validation:

- `npm test -- default-result-storage-card block-documents.test.ts admin.test.ts`
- `npm run check -- src/components/blocks/default-result-storage-card.tsx src/components/blocks/default-result-storage-card.test.tsx src/components/blocks/default-result-storage-card.stories.tsx src/api/admin/admin.ts src/api/admin/admin.test.ts src/api/admin/index.ts src/api/block-documents/block-documents.ts src/api/block-documents/block-documents.test.ts src/routes/blocks/index.tsx src/components/blocks/blocks-page.tsx`
- `npm run lint -- src/components/blocks/default-result-storage-card.tsx src/components/blocks/default-result-storage-card.test.tsx src/components/blocks/default-result-storage-card.stories.tsx src/api/admin/admin.ts src/api/admin/admin.test.ts src/api/admin/index.ts src/api/block-documents/block-documents.ts src/api/block-documents/block-documents.test.ts src/routes/blocks/index.tsx src/components/blocks/blocks-page.tsx` (passes with unrelated existing warnings)
- `npm run build`
- Full local UI pass against a real Prefect server at `127.0.0.1:4200`, with UI v2 served at `127.0.0.1:5174/blocks`.
- pre-push hooks passed, including `Check UI v2`.
