### PR TITLE
feat: inline-block-placeholder-substitution

### DIFF
--- a/src/prefect/utilities/templating/__init__.py
+++ b/src/prefect/utilities/templating/__init__.py
@@ -314,6 +314,17 @@ async def resolve_block_document_references(
     -------------------------------------
     For system blocks, which only contain a `value` attribute, this attribute is resolved by default.
 
+    Inline Substitution:
+    -------------------
+    Block placeholders can be used either as an entire string value (e.g.,
+    `"{{ prefect.blocks.secret.my-token }}"`) or embedded within other text
+    (e.g., `"{{ prefect.blocks.secret.my-registry }}/my-image"`).
+
+    When embedded in other text, the resolved block value is coerced to a string and
+    substituted in place. If a placeholder resolves to a non-scalar value (e.g., a
+    `dict` or `list`), a `ValueError` is raised because there is no unambiguous
+    inline string representation.
+
     Args:
         template: The template to resolve block documents in
         value_transformer: A function that takes the block placeholder and the block value and returns replacement text for the template
@@ -325,6 +336,43 @@ async def resolve_block_document_references(
         # The @inject_client decorator takes care of providing the client, but
         # the function signature must mark it as optional to callers.
         assert client is not None
+
+    async def _resolve_single_placeholder(placeholder: Placeholder) -> Any:
+        parts = placeholder.name.replace(BLOCK_DOCUMENT_PLACEHOLDER_PREFIX, "").split(
+            ".", 2
+        )
+        if len(parts) < 2:
+            raise ValueError(
+                f"Invalid block placeholder format: '{placeholder.name}'. "
+                "Expected format: prefect.blocks.<block-type-slug>.<block-document-name>"
+            )
+        block_type_slug, block_document_name, *value_keypath = parts
+
+        block_document = await client.read_block_document_by_name(
+            name=block_document_name, block_type_slug=block_type_slug
+        )
+
+        data = block_document.data
+        value: Any = data
+
+        if len(data) == 1 and "value" in data:
+            # only resolve the value if the keypath is not already pointing to "value"
+            if not (value_keypath and value_keypath[0].startswith("value")):
+                data = value = value["value"]
+
+        if value_keypath:
+            from_dict: Any = get_from_dict(data, value_keypath[0], default=NotSet)
+            if from_dict is NotSet:
+                raise ValueError(
+                    f"Invalid template: {template!r}. Could not resolve the"
+                    " keypath in the block document data."
+                )
+            value = from_dict
+
+        if value_transformer:
+            value = value_transformer(placeholder.full_match, value)
+
+        return value
 
     if isinstance(template, dict):
         block_document_id = template.get("$ref", {}).get("block_document_id")
@@ -358,49 +406,26 @@ async def resolve_block_document_references(
             and list(placeholders)[0].full_match == template
             and list(placeholders)[0].type is PlaceholderType.BLOCK_DOCUMENT
         ):
-            # value_keypath will be a list containing a dot path if additional
-            # attributes are accessed and an empty list otherwise.
             [placeholder] = placeholders
-            parts = placeholder.name.replace(
-                BLOCK_DOCUMENT_PLACEHOLDER_PREFIX, ""
-            ).split(".", 2)
-            if len(parts) < 2:
-                raise ValueError(
-                    f"Invalid block placeholder format: '{placeholder.name}'. "
-                    "Expected format: prefect.blocks.<block-type-slug>.<block-document-name>"
-                )
-            block_type_slug, block_document_name, *value_keypath = parts
-            block_document = await client.read_block_document_by_name(
-                name=block_document_name, block_type_slug=block_type_slug
-            )
-            data = block_document.data
-            value: Union[T, dict[str, Any]] = data
-
-            # resolving system blocks to their data for backwards compatibility
-            if len(data) == 1 and "value" in data:
-                # only resolve the value if the keypath is not already pointing to "value"
-                if not (value_keypath and value_keypath[0].startswith("value")):
-                    data = value = value["value"]
-
-            # resolving keypath/block attributes
-            if value_keypath:
-                from_dict: Any = get_from_dict(data, value_keypath[0], default=NotSet)
-                if from_dict is NotSet:
-                    raise ValueError(
-                        f"Invalid template: {template!r}. Could not resolve the"
-                        " keypath in the block document data."
-                    )
-                value = from_dict
-
-            if value_transformer:
-                value = value_transformer(placeholder.full_match, value)
-
-            return value
+            return await _resolve_single_placeholder(placeholder)
         else:
-            raise ValueError(
-                f"Invalid template: {template!r}. Only a single block placeholder is"
-                " allowed in a string and no surrounding text is allowed."
-            )
+            # Inline substitution: replace each block placeholder with its resolved value.
+            # Any non-block placeholders are left intact for later resolution.
+            result = template
+            for placeholder in placeholders:
+                if placeholder.type is not PlaceholderType.BLOCK_DOCUMENT:
+                    continue
+                value = await _resolve_single_placeholder(placeholder)
+                if isinstance(value, (dict, list)):
+                    raise ValueError(
+                        f"Invalid template: {template!r}. Block placeholder"
+                        f" {placeholder.full_match!r} resolved to a {type(value).__name__},"
+                        " which cannot be used for inline string substitution."
+                        " Resolve a scalar attribute instead (e.g., '.value' or '.url')."
+                    )
+                result = result.replace(placeholder.full_match, str(value))
+
+            return cast(T, result)
 
     return template
 

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import pytest
 
 from prefect.blocks.core import Block
+from prefect.blocks.system import Secret
 from prefect.blocks.webhook import Webhook
 from prefect.client.orchestration import PrefectClient
 from prefect.utilities.annotations import NotSet
@@ -448,38 +449,64 @@ class TestResolveBlockDocumentReferences:
 
         assert result == {"key": block_document.data}
 
-    async def test_resolve_block_document_references_raises_on_multiple_placeholders(
+    async def test_resolve_block_document_references_allows_inline_substitution(
+        self, prefect_client, block_document_id
+    ):
+        slug = block_document_id["slug"]
+        doc_name = block_document_id["name"]
+        template = {
+            "key": f"prefix-{{{{ prefect.blocks.{slug}.{doc_name}.b }}}}-suffix"
+        }
+
+        result = await resolve_block_document_references(
+            template, client=prefect_client
+        )
+
+        assert result == {"key": "prefix-hello-suffix"}
+
+    async def test_resolve_block_document_references_allows_inline_substitution_for_system_blocks(
         self, prefect_client
     ):
+        secret_name = f"secret-block-{uuid.uuid4().hex[:8]}"
+        await Secret(value="my-private-repo.com").save(name=secret_name, overwrite=True)
+
+        template = {
+            "key": f"{{{{ prefect.blocks.secret.{secret_name}.value }}}}/my-image-name"
+        }
+        result = await resolve_block_document_references(
+            template, client=prefect_client
+        )
+
+        assert result == {"key": "my-private-repo.com/my-image-name"}
+
+    async def test_resolve_block_document_references_allows_mixed_placeholders_in_string(
+        self, prefect_client, block_document_id
+    ):
+        slug = block_document_id["slug"]
+        doc_name = block_document_id["name"]
         template = {
             "key": (
-                "{{ prefect.blocks.arbitraryblock.arbitrary-block }} {{"
-                " another_placeholder }}"
+                f"{{{{ standard_placeholder }}}}/{{{{ prefect.blocks.{slug}.{doc_name}.b }}}}"
             )
         }
 
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Only a single block placeholder is allowed in a string and no"
-                " surrounding text is allowed."
-            ),
-        ):
-            await resolve_block_document_references(template, client=prefect_client)
+        result = await resolve_block_document_references(
+            template, client=prefect_client
+        )
 
-    async def test_resolve_block_document_references_raises_on_extra_text(
-        self, prefect_client
+        # Standard placeholders should be left intact for later resolution.
+        assert result == {"key": "{{ standard_placeholder }}/hello"}
+
+    async def test_resolve_block_document_references_raises_on_inline_non_scalar_value(
+        self, prefect_client, block_document_id
     ):
-        template = {
-            "key": "{{ prefect.blocks.arbitraryblock.arbitrary-block }} extra text"
-        }
+        slug = block_document_id["slug"]
+        doc_name = block_document_id["name"]
+        template = {"key": f"{{{{ prefect.blocks.{slug}.{doc_name} }}}} extra text"}
 
         with pytest.raises(
             ValueError,
-            match=(
-                "Only a single block placeholder is allowed in a string and no"
-                " surrounding text is allowed."
-            ),
+            match="cannot be used for inline string substitution",
         ):
             await resolve_block_document_references(template, client=prefect_client)
 


### PR DESCRIPTION
closes: #17916

- This change adds support for inline substitution of block document placeholders within strings in Prefect templating.
- Previously, block placeholders were required to occupy the entire string value.

**Example:**

- Before:
      **yaml**
`image_name: "{{ prefect.blocks.secret.my-repo.value }}"`

- After:
`image_name: "{{ prefect.blocks.secret.my-repo.value }}/my-image"`

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
