### PR TITLE
Add new `flow.visualize` output format for Mermaid

### DIFF
--- a/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
+++ b/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
@@ -1,15 +1,26 @@
 ---
 title: How to visualize workflow structure
 sidebarTitle: Visualize workflow structure
-keywords: ["visualize", "graph", "DAG", "workflow structure", "flow diagram"]
+keywords: ["visualize", "graph", "DAG", "workflow structure", "flow diagram", "mermaid"]
 ---
 
-You can visualize the structure of your flow using the `visualize()` method.
+You can visualize the structure of your flow using the `visualize()` method. Two output formats are supported via the `graph_output_format` parameter:
+
+- **`"graphviz"`** (default) — renders a PNG and opens it in a new window, or inline in Jupyter notebooks. Requires the Graphviz system package.
+- **`"mermaid"`** — prints a [Mermaid](https://mermaid.js.org/) `flowchart TD` diagram to stdout. No additional dependencies required.
+
+<Warning>
+**Calling `visualize()` will execute code outside of tasks**
+
+Code outside of tasks will run when calling `visualize()`. To avoid inadvertent execution, place code you don't want to run in tasks.
+</Warning>
+
+## Graphviz output
 
 <Note>
 **Install Graphviz**
 
-To use the `visualize()` method, you must have Graphviz installed. Please follow the [Graphviz installation instructions](https://graphviz.org/download/) for your platform.
+To use the default graphviz output, you must have Graphviz installed. Please follow the [Graphviz installation instructions](https://graphviz.org/download/) for your platform.
 </Note>
 
 ```python
@@ -38,17 +49,52 @@ if __name__ == "__main__":
 
 ![A simple flow visualized with the .visualize() method](/v3/img/orchestration/hello-flow-viz.png)
 
-<Warning>
-**Calling `visualize()` will execute code outside of tasks**
+## Mermaid output
 
-Code outside of tasks will run when calling `visualize()`. To avoid inadvertent execution, place code you don't want to run in tasks.
-</Warning>
+Pass `graph_output_format="mermaid"` to print a Mermaid diagram to stdout instead. This is useful when you want to embed the diagram in GitHub markdown, Notion, or any other tool that supports Mermaid.
 
+```python
+from prefect import flow, task
+
+@task(name="Print Hello")
+def print_hello(name):
+    msg = f"Hello {name}!"
+    print(msg)
+    return msg
+
+@task(name="Print Hello Again")
+def print_hello_again(name):
+    msg = f"Hello {name}!"
+    print(msg)
+    return msg
+
+@flow(name="Hello Flow")
+def hello_world(name="world"):
+    message = print_hello(name)
+    message2 = print_hello_again(message)
+
+if __name__ == "__main__":
+    hello_world.visualize(graph_output_format="mermaid")
+```
+
+This prints a diagram like:
+
+```
+flowchart TD
+    Print_Hello_0["Print Hello-0"]
+    Print_Hello_Again_0["Print Hello Again-0"]
+    Print_Hello_0 --> Print_Hello_Again_0
+```
+
+Paste the output into [mermaid.live](https://mermaid.live) or any Mermaid-compatible renderer to view the diagram.
+
+## Dynamic flows with mock return values
 
 For workflows with dynamic structure using loops and/or if/else statements, you can provide tasks with mock return values for use in the `visualize()` call to choose which code paths to visualize.
 
 ```python
 from prefect import flow, task
+
 @task(viz_return_value=[4])
 def get_list():
     return [1, 2, 3]

--- a/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
+++ b/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
@@ -4,15 +4,15 @@ sidebarTitle: Visualize workflow structure
 keywords: ["visualize", "graph", "DAG", "workflow structure", "flow diagram", "mermaid"]
 ---
 
-You can visualize the structure of your flow using the `visualize()` method. Two output formats are supported via the `graph_output_format` parameter:
+You can visualize the structure of your flow using two methods:
 
-- **`"graphviz"`** (default) — renders a PNG and opens it in a new window, or inline in Jupyter notebooks. Requires the Graphviz system package.
-- **`"mermaid"`** — prints a [Mermaid](https://mermaid.js.org/) `flowchart TD` diagram to stdout. No additional dependencies required.
+- **`flow.visualize()`** — renders a PNG via Graphviz and opens it in a new window, or inline in Jupyter notebooks. Requires the Graphviz system package.
+- **`flow.generate_mermaid_graph()`** — returns a [Mermaid](https://mermaid.js.org/) `flowchart TD` diagram as a string. No additional dependencies required.
 
 <Warning>
-**Calling `visualize()` will execute code outside of tasks**
+**These methods execute code outside of tasks**
 
-Code outside of tasks will run when calling `visualize()`. To avoid inadvertent execution, place code you don't want to run in tasks.
+Code outside of tasks will run when calling `visualize()` or `generate_mermaid_graph()`. To avoid inadvertent execution, place code you don't want to run in tasks.
 </Warning>
 
 ## Graphviz output
@@ -20,7 +20,7 @@ Code outside of tasks will run when calling `visualize()`. To avoid inadvertent 
 <Note>
 **Install Graphviz**
 
-To use the default graphviz output, you must have Graphviz installed. Please follow the [Graphviz installation instructions](https://graphviz.org/download/) for your platform.
+To use `visualize()`, you must have Graphviz installed. Please follow the [Graphviz installation instructions](https://graphviz.org/download/) for your platform.
 </Note>
 
 ```python
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 
 ## Mermaid output
 
-Pass `graph_output_format="mermaid"` to print a Mermaid diagram to stdout instead. This is useful when you want to embed the diagram in GitHub markdown, Notion, or any other tool that supports Mermaid.
+`generate_mermaid_graph()` returns a Mermaid diagram string. This is useful when you want to embed the diagram in GitHub markdown, Notion, or any other tool that supports Mermaid.
 
 ```python
 from prefect import flow, task
@@ -74,18 +74,15 @@ def hello_world(name="world"):
     message2 = print_hello_again(message)
 
 if __name__ == "__main__":
-    diagram = hello_world.visualize(graph_output_format="mermaid")
+    diagram = hello_world.generate_mermaid_graph()
     print(diagram)
 ```
 
-`visualize(graph_output_format="mermaid")` returns the diagram as a string, so you can print it, write it to a file, or embed it directly in other output:
+Because the diagram is returned as a string, you can also write it to a file or embed it in other output:
 
 {/* pmd-metadata: notest */}
 ```python
-diagram = hello_world.visualize(graph_output_format="mermaid")
-# print to terminal
-print(diagram)
-# or write to a file
+diagram = hello_world.generate_mermaid_graph()
 with open("flow.md", "w") as f:
     f.write(f"```mermaid\n{diagram}\n```")
 ```
@@ -103,7 +100,7 @@ Paste the output into [mermaid.live](https://mermaid.live) or any Mermaid-compat
 
 ## Dynamic flows with mock return values
 
-For workflows with dynamic structure using loops and/or if/else statements, you can provide tasks with mock return values for use in the `visualize()` call to choose which code paths to visualize.
+For workflows with dynamic structure using loops and/or if/else statements, you can provide tasks with mock return values to choose which code paths to visualize.
 
 ```python
 from prefect import flow, task

--- a/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
+++ b/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
@@ -80,6 +80,7 @@ if __name__ == "__main__":
 
 `visualize(graph_output_format="mermaid")` returns the diagram as a string, so you can print it, write it to a file, or embed it directly in other output:
 
+{/* pmd-metadata: notest */}
 ```python
 diagram = hello_world.visualize(graph_output_format="mermaid")
 # print to terminal

--- a/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
+++ b/docs/v3/how-to-guides/workflows/visualize-workflow-structure.mdx
@@ -74,10 +74,22 @@ def hello_world(name="world"):
     message2 = print_hello_again(message)
 
 if __name__ == "__main__":
-    hello_world.visualize(graph_output_format="mermaid")
+    diagram = hello_world.visualize(graph_output_format="mermaid")
+    print(diagram)
 ```
 
-This prints a diagram like:
+`visualize(graph_output_format="mermaid")` returns the diagram as a string, so you can print it, write it to a file, or embed it directly in other output:
+
+```python
+diagram = hello_world.visualize(graph_output_format="mermaid")
+# print to terminal
+print(diagram)
+# or write to a file
+with open("flow.md", "w") as f:
+    f.write(f"```mermaid\n{diagram}\n```")
+```
+
+The returned string looks like:
 
 ```
 flowchart TD

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1886,14 +1886,23 @@ class Flow(Generic[P, R]):
             return_type=return_type,
         )
 
-    async def avisualize(self, *args: "P.args", **kwargs: "P.kwargs") -> None:
+    async def avisualize(
+        self,
+        *args: "P.args",
+        graph_output_format: Literal["graphviz", "mermaid"] = "graphviz",
+        **kwargs: "P.kwargs",
+    ) -> None:
         """
-        Generates a graphviz object representing the current flow. In IPython notebooks,
-        it's rendered inline, otherwise in a new window as a PNG.
+        Generates a visualization representing the current flow. In IPython notebooks,
+        graphviz output is rendered inline, otherwise in a new window as a PNG.
+        Mermaid output is printed to stdout.
+
+        Args:
+            graph_output_format: Output format, either "graphviz" (default) or "mermaid".
 
         Raises:
-            - ImportError: If `graphviz` isn't installed.
-            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found.
+            - ImportError: If `graphviz` isn't installed (graphviz format only).
+            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found (graphviz format only).
             - FlowVisualizationError: If the flow can't be visualized for any other reason.
         """
         from prefect.utilities.visualization import (
@@ -1902,6 +1911,7 @@ class Flow(Generic[P, R]):
             GraphvizImportError,
             TaskVizTracker,
             VisualizationUnsupportedError,
+            build_mermaid_dependencies,
             build_task_dependencies,
             visualize_task_dependencies,
         )
@@ -1919,9 +1929,11 @@ class Flow(Generic[P, R]):
                 else:
                     self.fn(*args, **kwargs)
 
-                graph = build_task_dependencies(tracker)
-
-                visualize_task_dependencies(graph, self.name)
+                if graph_output_format == "mermaid":
+                    print(build_mermaid_dependencies(tracker))
+                else:
+                    graph = build_task_dependencies(tracker)
+                    visualize_task_dependencies(graph, self.name)
 
         except GraphvizImportError:
             raise
@@ -1945,14 +1957,23 @@ class Flow(Generic[P, R]):
             raise new_exception
 
     @async_dispatch(avisualize)
-    def visualize(self, *args: "P.args", **kwargs: "P.kwargs") -> None:
+    def visualize(
+        self,
+        *args: "P.args",
+        graph_output_format: Literal["graphviz", "mermaid"] = "graphviz",
+        **kwargs: "P.kwargs",
+    ) -> None:
         """
-        Generates a graphviz object representing the current flow. In IPython notebooks,
-        it's rendered inline, otherwise in a new window as a PNG.
+        Generates a visualization representing the current flow. In IPython notebooks,
+        graphviz output is rendered inline, otherwise in a new window as a PNG.
+        Mermaid output is printed to stdout.
+
+        Args:
+            graph_output_format: Output format, either "graphviz" (default) or "mermaid".
 
         Raises:
-            - ImportError: If `graphviz` isn't installed.
-            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found.
+            - ImportError: If `graphviz` isn't installed (graphviz format only).
+            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found (graphviz format only).
             - FlowVisualizationError: If the flow can't be visualized for any other reason.
         """
         from prefect.utilities.visualization import (
@@ -1961,6 +1982,7 @@ class Flow(Generic[P, R]):
             GraphvizImportError,
             TaskVizTracker,
             VisualizationUnsupportedError,
+            build_mermaid_dependencies,
             build_task_dependencies,
             visualize_task_dependencies,
         )
@@ -1979,9 +2001,11 @@ class Flow(Generic[P, R]):
                 else:
                     self.fn(*args, **kwargs)
 
-                graph = build_task_dependencies(tracker)
-
-                visualize_task_dependencies(graph, self.name)
+                if graph_output_format == "mermaid":
+                    print(build_mermaid_dependencies(tracker))
+                else:
+                    graph = build_task_dependencies(tracker)
+                    visualize_task_dependencies(graph, self.name)
 
         except GraphvizImportError:
             raise

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2063,7 +2063,6 @@ class Flow(Generic[P, R]):
             new_exception.__traceback__ = e.__traceback__
             raise new_exception
 
-    @async_dispatch(agenerate_mermaid_graph)
     def generate_mermaid_graph(
         self,
         *args: "P.args",

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1891,14 +1891,17 @@ class Flow(Generic[P, R]):
         *args: "P.args",
         graph_output_format: Literal["graphviz", "mermaid"] = "graphviz",
         **kwargs: "P.kwargs",
-    ) -> None:
+    ) -> Optional[str]:
         """
         Generates a visualization representing the current flow. In IPython notebooks,
         graphviz output is rendered inline, otherwise in a new window as a PNG.
-        Mermaid output is printed to stdout.
+        Mermaid output is returned as a string.
 
         Args:
             graph_output_format: Output format, either "graphviz" (default) or "mermaid".
+
+        Returns:
+            The Mermaid diagram string when `graph_output_format="mermaid"`, otherwise None.
 
         Raises:
             - ImportError: If `graphviz` isn't installed (graphviz format only).
@@ -1930,10 +1933,11 @@ class Flow(Generic[P, R]):
                     self.fn(*args, **kwargs)
 
                 if graph_output_format == "mermaid":
-                    print(build_mermaid_dependencies(tracker))
+                    return build_mermaid_dependencies(tracker)
                 else:
                     graph = build_task_dependencies(tracker)
                     visualize_task_dependencies(graph, self.name)
+                    return None
 
         except GraphvizImportError:
             raise
@@ -1962,14 +1966,17 @@ class Flow(Generic[P, R]):
         *args: "P.args",
         graph_output_format: Literal["graphviz", "mermaid"] = "graphviz",
         **kwargs: "P.kwargs",
-    ) -> None:
+    ) -> Optional[str]:
         """
         Generates a visualization representing the current flow. In IPython notebooks,
         graphviz output is rendered inline, otherwise in a new window as a PNG.
-        Mermaid output is printed to stdout.
+        Mermaid output is returned as a string.
 
         Args:
             graph_output_format: Output format, either "graphviz" (default) or "mermaid".
+
+        Returns:
+            The Mermaid diagram string when `graph_output_format="mermaid"`, otherwise None.
 
         Raises:
             - ImportError: If `graphviz` isn't installed (graphviz format only).
@@ -2002,10 +2009,11 @@ class Flow(Generic[P, R]):
                     self.fn(*args, **kwargs)
 
                 if graph_output_format == "mermaid":
-                    print(build_mermaid_dependencies(tracker))
+                    return build_mermaid_dependencies(tracker)
                 else:
                     graph = build_task_dependencies(tracker)
                     visualize_task_dependencies(graph, self.name)
+                    return None
 
         except GraphvizImportError:
             raise

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1889,23 +1889,15 @@ class Flow(Generic[P, R]):
     async def avisualize(
         self,
         *args: "P.args",
-        graph_output_format: Literal["graphviz", "mermaid"] = "graphviz",
         **kwargs: "P.kwargs",
-    ) -> Optional[str]:
+    ) -> None:
         """
         Generates a visualization representing the current flow. In IPython notebooks,
         graphviz output is rendered inline, otherwise in a new window as a PNG.
-        Mermaid output is returned as a string.
-
-        Args:
-            graph_output_format: Output format, either "graphviz" (default) or "mermaid".
-
-        Returns:
-            The Mermaid diagram string when `graph_output_format="mermaid"`, otherwise None.
 
         Raises:
-            - ImportError: If `graphviz` isn't installed (graphviz format only).
-            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found (graphviz format only).
+            - ImportError: If `graphviz` isn't installed.
+            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found.
             - FlowVisualizationError: If the flow can't be visualized for any other reason.
         """
         from prefect.utilities.visualization import (
@@ -1914,7 +1906,6 @@ class Flow(Generic[P, R]):
             GraphvizImportError,
             TaskVizTracker,
             VisualizationUnsupportedError,
-            build_mermaid_dependencies,
             build_task_dependencies,
             visualize_task_dependencies,
         )
@@ -1932,12 +1923,8 @@ class Flow(Generic[P, R]):
                 else:
                     self.fn(*args, **kwargs)
 
-                if graph_output_format == "mermaid":
-                    return build_mermaid_dependencies(tracker)
-                else:
-                    graph = build_task_dependencies(tracker)
-                    visualize_task_dependencies(graph, self.name)
-                    return None
+                graph = build_task_dependencies(tracker)
+                visualize_task_dependencies(graph, self.name)
 
         except GraphvizImportError:
             raise
@@ -1964,23 +1951,15 @@ class Flow(Generic[P, R]):
     def visualize(
         self,
         *args: "P.args",
-        graph_output_format: Literal["graphviz", "mermaid"] = "graphviz",
         **kwargs: "P.kwargs",
-    ) -> Optional[str]:
+    ) -> None:
         """
         Generates a visualization representing the current flow. In IPython notebooks,
         graphviz output is rendered inline, otherwise in a new window as a PNG.
-        Mermaid output is returned as a string.
-
-        Args:
-            graph_output_format: Output format, either "graphviz" (default) or "mermaid".
-
-        Returns:
-            The Mermaid diagram string when `graph_output_format="mermaid"`, otherwise None.
 
         Raises:
-            - ImportError: If `graphviz` isn't installed (graphviz format only).
-            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found (graphviz format only).
+            - ImportError: If `graphviz` isn't installed.
+            - GraphvizExecutableNotFoundError: If the `dot` executable isn't found.
             - FlowVisualizationError: If the flow can't be visualized for any other reason.
         """
         from prefect.utilities.visualization import (
@@ -1989,7 +1968,6 @@ class Flow(Generic[P, R]):
             GraphvizImportError,
             TaskVizTracker,
             VisualizationUnsupportedError,
-            build_mermaid_dependencies,
             build_task_dependencies,
             visualize_task_dependencies,
         )
@@ -2008,12 +1986,8 @@ class Flow(Generic[P, R]):
                 else:
                     self.fn(*args, **kwargs)
 
-                if graph_output_format == "mermaid":
-                    return build_mermaid_dependencies(tracker)
-                else:
-                    graph = build_task_dependencies(tracker)
-                    visualize_task_dependencies(graph, self.name)
-                    return None
+                graph = build_task_dependencies(tracker)
+                visualize_task_dependencies(graph, self.name)
 
         except GraphvizImportError:
             raise
@@ -2033,6 +2007,113 @@ class Flow(Generic[P, R]):
 
             new_exception = type(e)(str(e) + "\n" + msg)
             # Copy traceback information from the original exception
+            new_exception.__traceback__ = e.__traceback__
+            raise new_exception
+
+    async def agenerate_mermaid_graph(
+        self,
+        *args: "P.args",
+        **kwargs: "P.kwargs",
+    ) -> str:
+        """
+        Generates a Mermaid flowchart diagram representing the structure of the current
+        flow and returns it as a string.
+
+        Returns:
+            A Mermaid `flowchart TD` diagram string.
+
+        Raises:
+            - FlowVisualizationError: If the flow can't be visualized for any other reason.
+        """
+        from prefect.utilities.visualization import (
+            FlowVisualizationError,
+            TaskVizTracker,
+            VisualizationUnsupportedError,
+            build_mermaid_dependencies,
+        )
+
+        if not PREFECT_TESTING_UNIT_TEST_MODE:
+            warnings.warn(
+                "`flow.generate_mermaid_graph()` will execute code inside of your flow"
+                " that is not decorated with `@task` or `@flow`."
+            )
+
+        try:
+            with TaskVizTracker() as tracker:
+                if self.isasync:
+                    await self.fn(*args, **kwargs)  # type: ignore[reportGeneralTypeIssues]
+                else:
+                    self.fn(*args, **kwargs)
+
+                return build_mermaid_dependencies(tracker)
+
+        except VisualizationUnsupportedError:
+            raise
+        except FlowVisualizationError:
+            raise
+        except Exception as e:
+            msg = (
+                "It's possible you are trying to visualize a flow that contains "
+                "code that directly interacts with the result of a task"
+                " inside of the flow. \nTry passing a `viz_return_value` "
+                "to the task decorator, e.g. `@task(viz_return_value=[1, 2, 3]).`"
+            )
+
+            new_exception = type(e)(str(e) + "\n" + msg)
+            new_exception.__traceback__ = e.__traceback__
+            raise new_exception
+
+    @async_dispatch(agenerate_mermaid_graph)
+    def generate_mermaid_graph(
+        self,
+        *args: "P.args",
+        **kwargs: "P.kwargs",
+    ) -> str:
+        """
+        Generates a Mermaid flowchart diagram representing the structure of the current
+        flow and returns it as a string.
+
+        Returns:
+            A Mermaid `flowchart TD` diagram string.
+
+        Raises:
+            - FlowVisualizationError: If the flow can't be visualized for any other reason.
+        """
+        from prefect.utilities.visualization import (
+            FlowVisualizationError,
+            TaskVizTracker,
+            VisualizationUnsupportedError,
+            build_mermaid_dependencies,
+        )
+
+        if not PREFECT_TESTING_UNIT_TEST_MODE:
+            warnings.warn(
+                "`flow.generate_mermaid_graph()` will execute code inside of your flow"
+                " that is not decorated with `@task` or `@flow`."
+            )
+
+        try:
+            with TaskVizTracker() as tracker:
+                if self.isasync:
+                    run_coro_as_sync(self.fn(*args, **kwargs))
+                else:
+                    self.fn(*args, **kwargs)
+
+                return build_mermaid_dependencies(tracker)
+
+        except VisualizationUnsupportedError:
+            raise
+        except FlowVisualizationError:
+            raise
+        except Exception as e:
+            msg = (
+                "It's possible you are trying to visualize a flow that contains "
+                "code that directly interacts with the result of a task"
+                " inside of the flow. \nTry passing a `viz_return_value` "
+                "to the task decorator, e.g. `@task(viz_return_value=[1, 2, 3]).`"
+            )
+
+            new_exception = type(e)(str(e) + "\n" + msg)
             new_exception.__traceback__ = e.__traceback__
             raise new_exception
 

--- a/src/prefect/utilities/visualization.py
+++ b/src/prefect/utilities/visualization.py
@@ -149,6 +149,24 @@ class TaskVizTracker:
         self.object_id_to_task[id(viz_return_value)] = viz_task
 
 
+def build_mermaid_dependencies(task_run_tracker: TaskVizTracker) -> str:
+    """
+    Constructs a Mermaid flowchart string representing the dependencies between
+    tasks in the given TaskVizTracker.
+    """
+    lines = ["flowchart TD"]
+    node_ids: dict[str, str] = {}
+    for task in task_run_tracker.tasks:
+        # Mermaid node IDs must be alphanumeric + underscore only
+        node_id = task.name.replace("-", "_")
+        node_ids[task.name] = node_id
+        lines.append(f'    {node_id}["{task.name}"]')
+    for task in task_run_tracker.tasks:
+        for upstream in task.upstream_tasks:
+            lines.append(f"    {node_ids[upstream.name]} --> {node_ids[task.name]}")
+    return "\n".join(lines)
+
+
 def build_task_dependencies(task_run_tracker: TaskVizTracker) -> graphviz.Digraph:
     """
     Constructs a Graphviz directed graph object that represents the dependencies

--- a/src/prefect/utilities/visualization.py
+++ b/src/prefect/utilities/visualization.py
@@ -158,7 +158,7 @@ def build_mermaid_dependencies(task_run_tracker: TaskVizTracker) -> str:
     node_ids: dict[str, str] = {}
     for task in task_run_tracker.tasks:
         # Mermaid node IDs must be alphanumeric + underscore only
-        node_id = task.name.replace("-", "_")
+        node_id = task.name.replace("-", "_").replace(" ", "_")
         node_ids[task.name] = node_id
         lines.append(f'    {node_id}["{task.name}"]')
     for task in task_run_tracker.tasks:

--- a/tests/utilities/test_visualization.py
+++ b/tests/utilities/test_visualization.py
@@ -427,6 +427,47 @@ class TestBuildMermaidDependencies:
                 assert " " not in node_id
 
 
+class TestVisualizeMermaidReturn:
+    def test_mermaid_returns_string(self, monkeypatch):
+        @flow
+        def my_flow():
+            sync_task_a()
+
+        result = my_flow.visualize(graph_output_format="mermaid")
+        assert isinstance(result, str)
+        assert result.startswith("flowchart TD")
+
+    def test_mermaid_does_not_print(self, monkeypatch, capsys):
+        @flow
+        def my_flow():
+            sync_task_a()
+
+        my_flow.visualize(graph_output_format="mermaid")
+        assert capsys.readouterr().out == ""
+
+    def test_graphviz_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            "prefect.utilities.visualization.visualize_task_dependencies",
+            MagicMock(return_value=None),
+        )
+
+        @flow
+        def my_flow():
+            sync_task_a()
+
+        result = my_flow.visualize(graph_output_format="graphviz")
+        assert result is None
+
+    async def test_mermaid_returns_string_async(self, monkeypatch):
+        @flow
+        async def my_async_flow():
+            sync_task_a()
+
+        result = await my_async_flow.visualize(graph_output_format="mermaid")
+        assert isinstance(result, str)
+        assert result.startswith("flowchart TD")
+
+
 class TestAsyncDispatch:
     """Tests for async_dispatch behavior of Flow.visualize."""
 

--- a/tests/utilities/test_visualization.py
+++ b/tests/utilities/test_visualization.py
@@ -456,12 +456,12 @@ class TestGenerateMermaidGraph:
         assert "sync_task_b_0" in result
         assert "sync_task_a_0 --> sync_task_b_0" in result
 
-    async def test_returns_string_async_flow(self):
+    def test_returns_string_async_flow(self):
         @flow
         async def my_async_flow():
             sync_task_a()
 
-        result = await my_async_flow.generate_mermaid_graph()
+        result = my_async_flow.generate_mermaid_graph()
         assert isinstance(result, str)
         assert result.startswith("flowchart TD")
 

--- a/tests/utilities/test_visualization.py
+++ b/tests/utilities/test_visualization.py
@@ -427,43 +427,41 @@ class TestBuildMermaidDependencies:
                 assert " " not in node_id
 
 
-class TestVisualizeMermaidReturn:
-    def test_mermaid_returns_string(self, monkeypatch):
+class TestGenerateMermaidGraph:
+    def test_returns_string(self):
         @flow
         def my_flow():
             sync_task_a()
 
-        result = my_flow.visualize(graph_output_format="mermaid")
+        result = my_flow.generate_mermaid_graph()
         assert isinstance(result, str)
         assert result.startswith("flowchart TD")
 
-    def test_mermaid_does_not_print(self, monkeypatch, capsys):
+    def test_does_not_print(self, capsys):
         @flow
         def my_flow():
             sync_task_a()
 
-        my_flow.visualize(graph_output_format="mermaid")
+        my_flow.generate_mermaid_graph()
         assert capsys.readouterr().out == ""
 
-    def test_graphviz_returns_none(self, monkeypatch):
-        monkeypatch.setattr(
-            "prefect.utilities.visualization.visualize_task_dependencies",
-            MagicMock(return_value=None),
-        )
-
+    def test_contains_task_nodes(self):
         @flow
         def my_flow():
-            sync_task_a()
+            a = sync_task_a()
+            sync_task_b(a)
 
-        result = my_flow.visualize(graph_output_format="graphviz")
-        assert result is None
+        result = my_flow.generate_mermaid_graph()
+        assert "sync_task_a_0" in result
+        assert "sync_task_b_0" in result
+        assert "sync_task_a_0 --> sync_task_b_0" in result
 
-    async def test_mermaid_returns_string_async(self, monkeypatch):
+    async def test_returns_string_async_flow(self):
         @flow
         async def my_async_flow():
             sync_task_a()
 
-        result = await my_async_flow.visualize(graph_output_format="mermaid")
+        result = await my_async_flow.generate_mermaid_graph()
         assert isinstance(result, str)
         assert result.startswith("flowchart TD")
 

--- a/tests/utilities/test_visualization.py
+++ b/tests/utilities/test_visualization.py
@@ -8,6 +8,7 @@ from prefect.utilities.visualization import (
     VisualizationUnsupportedError,
     VizTask,
     _track_viz_task,
+    build_mermaid_dependencies,
     get_task_viz_tracker,
 )
 
@@ -350,6 +351,80 @@ class TestFlowVisualise:
         assert actual_nodes == expected_nodes, (
             f"Expected nodes {expected_nodes} but found {actual_nodes}"
         )
+
+
+class TestBuildMermaidDependencies:
+    def _make_tracker(
+        self, task_names: list[str], edges: list[tuple[int, int]] | None = None
+    ) -> TaskVizTracker:
+        tracker = TaskVizTracker()
+        tasks: list[VizTask] = []
+        for name in task_names:
+            viz_task = VizTask(name)
+            tracker.add_task(viz_task)
+            tasks.append(tracker.tasks[-1])
+        if edges:
+            for src_idx, dst_idx in edges:
+                tasks[dst_idx].upstream_tasks.append(tasks[src_idx])
+        return tracker
+
+    def test_starts_with_flowchart_td(self):
+        tracker = self._make_tracker(["my_task"])
+        result = build_mermaid_dependencies(tracker)
+        assert result.startswith("flowchart TD\n")
+
+    def test_simple_node_no_spaces(self):
+        tracker = self._make_tracker(["my_task"])
+        result = build_mermaid_dependencies(tracker)
+        lines = result.splitlines()
+        assert '    my_task_0["my_task-0"]' in lines
+
+    def test_node_id_strips_spaces(self):
+        """Node IDs with spaces are invalid Mermaid syntax."""
+        tracker = self._make_tracker(["Data Ingestion Flow"])
+        result = build_mermaid_dependencies(tracker)
+        lines = result.splitlines()
+        # node ID must have no spaces; label preserves original name
+        assert '    Data_Ingestion_Flow_0["Data Ingestion Flow-0"]' in lines
+        for line in lines[1:]:
+            node_id = line.strip().split("[")[0].split("-->")[0].strip()
+            assert " " not in node_id, f"Space found in node ID: {line!r}"
+
+    def test_node_id_strips_hyphens(self):
+        tracker = self._make_tracker(["my-task"])
+        result = build_mermaid_dependencies(tracker)
+        lines = result.splitlines()
+        assert '    my_task_0["my-task-0"]' in lines
+
+    def test_edge_syntax(self):
+        tracker = self._make_tracker(["task_a", "task_b"], edges=[(0, 1)])
+        result = build_mermaid_dependencies(tracker)
+        assert "    task_a_0 --> task_b_0" in result
+
+    def test_edge_with_spaces_in_names(self):
+        tracker = self._make_tracker(
+            ["Data Ingestion Flow", "Visitor Analytics Flow"],
+            edges=[(0, 1)],
+        )
+        result = build_mermaid_dependencies(tracker)
+        assert "    Data_Ingestion_Flow_0 --> Visitor_Analytics_Flow_0" in result
+
+    def test_no_isolated_nodes_produce_valid_output(self):
+        tracker = self._make_tracker(
+            [
+                "Data Ingestion Flow",
+                "Visitor Analytics Flow",
+                "Financial Analytics Flow",
+            ],
+            edges=[(0, 1), (0, 2), (1, 2)],
+        )
+        result = build_mermaid_dependencies(tracker)
+        lines = result.splitlines()
+        # All node-declaration lines must have IDs without spaces
+        for line in lines[1:]:
+            if "-->" not in line:
+                node_id = line.strip().split("[")[0]
+                assert " " not in node_id
 
 
 class TestAsyncDispatch:


### PR DESCRIPTION
 This PR adds a new flow.generate_mermaid_graph() method that returns a Mermaid flowchart      
  diagram of the flow's task dependency structure.                                              
                                                                                                
  `flow.generate_mermaid_graph()` returns a flowchart TD Mermaid string, which you can paste into 
  any Mermaid renderer (GitHub markdown, mermaid.live, Notion, etc.), including deployment descriptions            
  descriptions in the UI:

<img width="1798" height="1039" alt="image" src="https://github.com/user-attachments/assets/2c8f2ca6-75ab-4ec8-bf0f-84891dbf141d" />


Usage:
```py
@flow
def my_flow():                                                                              
      a = task_a()
      task_b(a)

# default graphviz
my_flow.visualize()
                                                                                                
# mermaid output 
my_flow.generate_mermaid_graph()
```                  

Note that this requires _no additional dependencies_ (unlike graphviz)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
