### PR TITLE
fix(server): prevent deadlock in mark_deployments_ready / mark_deployments_not_ready

### DIFF
--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -1297,28 +1297,39 @@ async def mark_deployments_ready(
     async with db.session_context(
         begin_transaction=True,
     ) as session:
-        result = await session.execute(
-            select(db.Deployment.id).where(
+        # ORDER BY id locks rows in deterministic order so concurrent
+        # calls cannot deadlock. SKIP LOCKED is intentionally avoided —
+        # a fresh poll must wait for a concurrent stale transition,
+        # not no-op and let the stale transition overwrite it.
+        locked = (
+            select(db.Deployment.id, db.Deployment.status)
+            .where(
                 sa.or_(
                     db.Deployment.id.in_(deployment_ids),
                     db.Deployment.work_queue_id.in_(work_queue_ids),
                 ),
-                db.Deployment.status == DeploymentStatus.NOT_READY,
             )
+            .order_by(db.Deployment.id)
+            .with_for_update()
+            .cte("locked")
         )
-        unready_deployments = list(result.scalars().unique().all())
+
+        result = await session.execute(select(locked.c.id, locked.c.status))
+        rows = result.all()
+
+        if not rows:
+            return
+
+        unready_deployments = [
+            row.id for row in rows if row.status == DeploymentStatus.NOT_READY
+        ]
 
         last_polled = now("UTC")
 
         # keeps `updated` untouched to not trigger recent schedules calculation
         await session.execute(
             sa.update(db.Deployment)
-            .where(
-                sa.or_(
-                    db.Deployment.id.in_(deployment_ids),
-                    db.Deployment.work_queue_id.in_(work_queue_ids),
-                )
-            )
+            .where(db.Deployment.id.in_(select(locked.c.id)))
             .values(
                 status=DeploymentStatus.READY,
                 last_polled=last_polled,
@@ -1357,26 +1368,34 @@ async def mark_deployments_not_ready(
         async with db.session_context(
             begin_transaction=True,
         ) as session:
-            result = await session.execute(
-                select(db.Deployment.id).where(
-                    sa.or_(
-                        db.Deployment.id.in_(deployment_ids),
-                        db.Deployment.work_queue_id.in_(work_queue_ids),
-                    ),
-                    db.Deployment.status == DeploymentStatus.READY,
-                )
-            )
-            ready_deployments = list(result.scalars().unique().all())
-
-            # keeps `updated` untouched to not trigger recent schedules calculation
-            await session.execute(
-                sa.update(db.Deployment)
+            # See comment in mark_deployments_ready.
+            locked = (
+                select(db.Deployment.id, db.Deployment.status)
                 .where(
                     sa.or_(
                         db.Deployment.id.in_(deployment_ids),
                         db.Deployment.work_queue_id.in_(work_queue_ids),
-                    )
+                    ),
                 )
+                .order_by(db.Deployment.id)
+                .with_for_update()
+                .cte("locked")
+            )
+
+            result = await session.execute(select(locked.c.id, locked.c.status))
+            rows = result.all()
+
+            if not rows:
+                return
+
+            ready_deployments = [
+                row.id for row in rows if row.status == DeploymentStatus.READY
+            ]
+
+            # keeps `updated` untouched to not trigger recent schedules calculation
+            await session.execute(
+                sa.update(db.Deployment)
+                .where(db.Deployment.id.in_(select(locked.c.id)))
                 .values(
                     status=DeploymentStatus.NOT_READY, updated=db.Deployment.updated
                 )

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 from typing import List
 from uuid import uuid4
@@ -9,8 +10,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models, schemas
 from prefect.server.database import orm_models
+from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.schemas import filters, states
 from prefect.server.schemas.states import StateType
+from prefect.server.schemas.statuses import DeploymentStatus
 from prefect.settings import PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS
 from prefect.types._datetime import now, start_of_day
 
@@ -2015,3 +2018,90 @@ class TestDeploymentLabels:
         )
 
         assert merged_labels == expected
+
+
+class TestMarkDeploymentsReady:
+    async def test_marks_not_ready_deployments_as_ready(
+        self,
+        session: AsyncSession,
+        deployment: orm_models.Deployment,
+    ):
+        assert deployment.status == DeploymentStatus.NOT_READY
+
+        await models.deployments.mark_deployments_ready(
+            db=provide_database_interface(),
+            deployment_ids=[deployment.id],
+        )
+
+        await session.refresh(deployment)
+        assert deployment.status == DeploymentStatus.READY
+        assert deployment.last_polled is not None
+
+    async def test_marks_ready_by_work_queue_id(
+        self,
+        session: AsyncSession,
+        deployment: orm_models.Deployment,
+    ):
+        await models.deployments.mark_deployments_ready(
+            db=provide_database_interface(),
+            work_queue_ids=[deployment.work_queue_id],
+        )
+
+        await session.refresh(deployment)
+        assert deployment.status == DeploymentStatus.READY
+
+    async def test_already_ready_is_idempotent(
+        self,
+        session: AsyncSession,
+        deployment: orm_models.Deployment,
+    ):
+        for _ in range(2):
+            await models.deployments.mark_deployments_ready(
+                db=provide_database_interface(),
+                deployment_ids=[deployment.id],
+            )
+        await session.refresh(deployment)
+        assert deployment.status == DeploymentStatus.READY
+
+    async def test_blocks_when_row_is_locked_by_concurrent_transition(
+        self,
+        deployment: orm_models.Deployment,
+    ):
+        # A concurrent transition holding the row must make us wait, not
+        # silently no-op (as SKIP LOCKED would) — otherwise the other
+        # transition commits and overwrites this fresh poll's state.
+        db = provide_database_interface()
+        if db.dialect.name != "postgresql":
+            pytest.skip("Row-level locking is PostgreSQL-only")
+
+        async with db.session_context(begin_transaction=True) as locker:
+            await locker.execute(
+                sa.select(db.Deployment.id)
+                .where(db.Deployment.id == deployment.id)
+                .with_for_update()
+            )
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    models.deployments.mark_deployments_ready(
+                        db=db, deployment_ids=[deployment.id]
+                    ),
+                    timeout=0.5,
+                )
+
+
+class TestMarkDeploymentsNotReady:
+    async def test_marks_ready_deployments_as_not_ready(
+        self,
+        session: AsyncSession,
+        deployment: orm_models.Deployment,
+    ):
+        await models.deployments.mark_deployments_ready(
+            db=provide_database_interface(),
+            deployment_ids=[deployment.id],
+        )
+
+        await models.deployments.mark_deployments_not_ready(
+            deployment_ids=[deployment.id],
+        )
+        await session.refresh(deployment)
+        assert deployment.status == DeploymentStatus.NOT_READY


### PR DESCRIPTION
Both functions did a SELECT then a broad UPDATE targeting the same rows without acquiring row-level locks. Under concurrent execution on PostgreSQL — which happens by design, since the function is enqueued from three docket call sites with different keys (work pool, work queue, deployment IDs) — two transactions could acquire exclusive locks on overlapping rows in conflicting order, deadlocking. At production scale (10 server replicas, 42k+ deployments per work queue), the deadlock was 100% reproducible.

Acquire row locks up front with `SELECT ... ORDER BY id FOR UPDATE` in a CTE, then UPDATE only the locked rows by id:

- ORDER BY id makes lock acquisition deterministic — concurrent transactions wait on each other instead of deadlocking.
- SKIP LOCKED is deliberately avoided so a fresh READY transition waits behind a stale NOT_READY transition instead of silently no-oping.
- Driving the UPDATE from the locked CTE avoids materializing all matching deployment ids as query parameters.

SQLAlchemy strips FOR UPDATE on SQLite, so no dialect gating is needed — and SQLite uses database-level locking that cannot deadlock at the row level.

Closes https://github.com/PrefectHQ/prefect/issues/21791

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.