### PR TITLE
Route flow-run execute through workspace resolver

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import tempfile
 import threading
 import webbrowser
+from pathlib import Path
 from types import FrameType
 from typing import TYPE_CHECKING, Annotated, Any, Optional
 from uuid import UUID
@@ -36,10 +38,9 @@ from prefect.client.schemas.objects import StateType
 from prefect.client.schemas.responses import SetStateStatus
 from prefect.client.schemas.sorting import FlowRunSort, LogSort
 from prefect.exceptions import Abort, ObjectNotFound
-from prefect.flows import load_flow_from_flow_run
 from prefect.logging import get_logger
 from prefect.runner._flow_run_executor import FlowRunExecutorContext
-from prefect.runner._starter_engine import EngineCommandStarter
+from prefect.runner._workspace_starter import WorkspaceResolvingEngineCommandStarter
 from prefect.states import AwaitingRetry, State, exception_to_crashed_state
 from prefect.types._datetime import human_friendly_diff
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
@@ -707,10 +708,15 @@ async def execute(
         if reschedule_mode:
             signal.signal(signal.SIGTERM, _handle_reschedule_sigterm)
 
-        executor = ctx.create_executor(
-            flow_run,
-            EngineCommandStarter(control_channel=ctx.control_channel),
-            resolve_flow=lambda fr: load_flow_from_flow_run(flow_run=fr),
-            propose_submitting=False,
-        )
-        await executor.submit()
+        with tempfile.TemporaryDirectory(prefix="prefect-flow-run-") as workspace_root:
+            starter = WorkspaceResolvingEngineCommandStarter(
+                workspace_root=Path(workspace_root),
+                control_channel=ctx.control_channel,
+            )
+            executor = ctx.create_executor(
+                flow_run,
+                starter,
+                resolve_flow=starter.resolve_flow,
+                propose_submitting=False,
+            )
+            await executor.submit()

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -675,40 +675,40 @@ async def execute(
     if id is None:
         exit_with_error("Could not determine the ID of the flow run to execute.")
 
-    async with FlowRunExecutorContext() as ctx:
-        flow_run = await ctx.client.read_flow_run(id)
+    with tempfile.TemporaryDirectory(prefix="prefect-flow-run-") as workspace_root:
+        async with FlowRunExecutorContext() as ctx:
+            flow_run = await ctx.client.read_flow_run(id)
 
-        on_sigterm = os.environ.get(
-            "PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR", ""
-        ).lower()
-        reschedule_mode = (
-            threading.current_thread() is threading.main_thread()
-            and on_sigterm == "reschedule"
-        )
+            on_sigterm = os.environ.get(
+                "PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR", ""
+            ).lower()
+            reschedule_mode = (
+                threading.current_thread() is threading.main_thread()
+                and on_sigterm == "reschedule"
+            )
 
-        def _handle_reschedule_sigterm(_signal: int, _frame: FrameType | None):
-            """Reschedule the flow run and kill the child process (if running)."""
-            logger.info("SIGTERM received, initiating graceful shutdown...")
-            with get_client(sync_client=True) as sync_client:
-                try:
-                    propose_state_sync(sync_client, AwaitingRetry(), flow_run_id=id)
-                except Abort:
-                    pass
-                except Exception:
-                    logger.exception("Failed to reschedule flow run")
+            def _handle_reschedule_sigterm(_signal: int, _frame: FrameType | None):
+                """Reschedule the flow run and kill the child process (if running)."""
+                logger.info("SIGTERM received, initiating graceful shutdown...")
+                with get_client(sync_client=True) as sync_client:
+                    try:
+                        propose_state_sync(sync_client, AwaitingRetry(), flow_run_id=id)
+                    except Abort:
+                        pass
+                    except Exception:
+                        logger.exception("Failed to reschedule flow run")
 
-            handle = ctx.process_manager.get(id)
-            if handle and handle.pid:
-                try:
-                    os.kill(handle.pid, signal.SIGTERM)
-                except ProcessLookupError:
-                    pass
-            exit_with_success("Flow run successfully rescheduled.")
+                handle = ctx.process_manager.get(id)
+                if handle and handle.pid:
+                    try:
+                        os.kill(handle.pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                exit_with_success("Flow run successfully rescheduled.")
 
-        if reschedule_mode:
-            signal.signal(signal.SIGTERM, _handle_reschedule_sigterm)
+            if reschedule_mode:
+                signal.signal(signal.SIGTERM, _handle_reschedule_sigterm)
 
-        with tempfile.TemporaryDirectory(prefix="prefect-flow-run-") as workspace_root:
             starter = WorkspaceResolvingEngineCommandStarter(
                 workspace_root=Path(workspace_root),
                 control_channel=ctx.control_channel,

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -12,6 +12,7 @@ import anyio
 import anyio.abc
 
 from prefect.exceptions import MissingFlowError
+from prefect.flows import load_flow_from_entrypoint, load_function_and_convert_to_flow
 from prefect.runner._process_manager import ProcessHandle
 from prefect.runner._starter_engine import EngineCommandStarter
 from prefect.runner._workspace_resolver import (
@@ -151,11 +152,6 @@ def _prepared_workspace_context(workspace: PreparedWorkspace) -> Iterator[None]:
 async def load_flow_from_prepared_workspace(
     workspace: PreparedWorkspace,
 ) -> "Flow[Any, Any]":
-    from prefect.flows import (
-        load_flow_from_entrypoint,
-        load_function_and_convert_to_flow,
-    )
-
     entrypoint = _absolute_file_entrypoint(workspace)
     with _prepared_workspace_context(workspace):
         try:

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator
+from uuid import UUID
+
+import anyio
+import anyio.abc
+
+from prefect.exceptions import MissingFlowError
+from prefect.runner._process_manager import ProcessHandle
+from prefect.runner._starter_engine import EngineCommandStarter
+from prefect.runner._workspace_resolver import (
+    PreparedWorkspace,
+    PreparedWorkspaceResult,
+    get_workspace_resolver_command,
+)
+from prefect.settings import get_current_settings
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.processutils import sanitize_subprocess_env
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.objects import FlowRun
+    from prefect.flows import Flow
+    from prefect.runner._control_channel import ControlChannel
+
+
+def _decode_process_output(output: bytes | str | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode(errors="replace")
+    return output
+
+
+def _format_workspace_error(result: PreparedWorkspaceResult) -> str:
+    if result.error is None:
+        return "Workspace resolver failed without a structured error payload."
+
+    message = f"{result.error.error_type}: {result.error.error_message}"
+    if result.error.cause_type:
+        message += f" (caused by {result.error.cause_type}"
+        if result.error.cause_message:
+            message += f": {result.error.cause_message}"
+        message += ")"
+    return message
+
+
+async def resolve_workspace_in_subprocess(
+    flow_run_id: UUID | str, workspace_root: Path
+) -> PreparedWorkspace:
+    environment = {
+        **os.environ,
+        **get_current_settings().to_environment_variables(exclude_unset=True),
+    }
+    process = await anyio.run_process(
+        get_workspace_resolver_command(flow_run_id, workspace_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=sanitize_subprocess_env(environment),
+        check=False,
+    )
+
+    stderr = _decode_process_output(process.stderr)
+    if stderr:
+        sys.stderr.write(stderr)
+        sys.stderr.flush()
+
+    stdout = _decode_process_output(process.stdout)
+    try:
+        result = PreparedWorkspaceResult.model_validate_json(stdout)
+    except ValueError as exc:
+        raise RuntimeError(
+            "Workspace resolver did not return a valid JSON payload."
+        ) from exc
+
+    if process.returncode != 0 or result.status == "error":
+        raise RuntimeError(_format_workspace_error(result))
+
+    if result.workspace is None:
+        raise RuntimeError("Workspace resolver returned success without a workspace.")
+
+    return result.workspace
+
+
+def _workspace_sys_path(workspace: PreparedWorkspace) -> list[str]:
+    entries: list[str] = []
+    for entry in [str(workspace.working_directory), *workspace.sys_path]:
+        if not entry:
+            resolved_entry = str(workspace.working_directory)
+        else:
+            path = Path(entry).expanduser()
+            if path.is_absolute():
+                resolved_entry = str(path)
+            else:
+                resolved_entry = str((workspace.working_directory / path).resolve())
+
+        if resolved_entry not in entries:
+            entries.append(resolved_entry)
+    return entries
+
+
+def workspace_environment(workspace: PreparedWorkspace) -> dict[str, str]:
+    environment = dict(workspace.environment)
+    pythonpath_entries = _workspace_sys_path(workspace)
+    existing_pythonpath = environment.get("PYTHONPATH")
+    if existing_pythonpath:
+        for entry in existing_pythonpath.split(os.pathsep):
+            if entry and entry not in pythonpath_entries:
+                pythonpath_entries.append(entry)
+
+    environment["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    return environment
+
+
+def _absolute_file_entrypoint(workspace: PreparedWorkspace) -> str:
+    entrypoint = workspace.runtime_entrypoint
+    if ":" not in entrypoint:
+        return entrypoint
+
+    path, object_name = entrypoint.rsplit(":", 1)
+    entrypoint_path = Path(path).expanduser()
+    if not entrypoint_path.is_absolute():
+        entrypoint_path = workspace.working_directory / entrypoint_path
+    return f"{entrypoint_path.resolve()}:{object_name}"
+
+
+@contextmanager
+def _prepared_workspace_context(workspace: PreparedWorkspace) -> Iterator[None]:
+    original_environment = dict(os.environ)
+    original_sys_path = list(sys.path)
+
+    try:
+        os.environ.clear()
+        os.environ.update(workspace_environment(workspace))
+        sys.path[:] = _workspace_sys_path(workspace)
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original_environment)
+        sys.path[:] = original_sys_path
+
+
+async def load_flow_from_prepared_workspace(
+    workspace: PreparedWorkspace,
+) -> "Flow[Any, Any]":
+    from prefect.flows import (
+        load_flow_from_entrypoint,
+        load_function_and_convert_to_flow,
+    )
+
+    entrypoint = _absolute_file_entrypoint(workspace)
+    with _prepared_workspace_context(workspace):
+        try:
+            return await run_sync_in_worker_thread(
+                load_flow_from_entrypoint,
+                entrypoint,
+                use_placeholder_flow=False,
+            )
+        except MissingFlowError:
+            return await run_sync_in_worker_thread(
+                load_function_and_convert_to_flow,
+                entrypoint,
+            )
+
+
+class WorkspaceResolvingEngineCommandStarter:
+    def __init__(
+        self,
+        *,
+        workspace_root: Path,
+        command: str | None = None,
+        stream_output: bool = True,
+        heartbeat_seconds: int | None = None,
+        control_channel: ControlChannel | None = None,
+    ) -> None:
+        self._workspace_root = workspace_root
+        self._command = command
+        self._stream_output = stream_output
+        self._heartbeat_seconds = heartbeat_seconds
+        self._control_channel = control_channel
+        self._workspace: PreparedWorkspace | None = None
+
+    @property
+    def workspace(self) -> PreparedWorkspace | None:
+        return self._workspace
+
+    async def _resolve_workspace(self, flow_run_id: UUID | str) -> PreparedWorkspace:
+        if self._workspace is None:
+            self._workspace = await resolve_workspace_in_subprocess(
+                flow_run_id, self._workspace_root
+            )
+        return self._workspace
+
+    async def start(
+        self,
+        flow_run: FlowRun,
+        task_status: anyio.abc.TaskStatus[ProcessHandle] = anyio.TASK_STATUS_IGNORED,
+    ) -> None:
+        workspace = await self._resolve_workspace(flow_run.id)
+        starter = EngineCommandStarter(
+            command=self._command,
+            cwd=workspace.working_directory,
+            env=workspace_environment(workspace),
+            entrypoint=workspace.runtime_entrypoint,
+            stream_output=self._stream_output,
+            heartbeat_seconds=self._heartbeat_seconds,
+            control_channel=self._control_channel,
+        )
+        await starter.start(flow_run, task_status=task_status)
+
+    async def resolve_flow(self, flow_run: FlowRun) -> "Flow[Any, Any]":
+        workspace = await self._resolve_workspace(flow_run.id)
+        return await load_flow_from_prepared_workspace(workspace)

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -123,6 +123,9 @@ def _absolute_file_entrypoint(workspace: PreparedWorkspace) -> str:
         return entrypoint
 
     path, object_name = entrypoint.rsplit(":", 1)
+    if not path.endswith(".py"):
+        return entrypoint
+
     entrypoint_path = Path(path).expanduser()
     if not entrypoint_path.is_absolute():
         entrypoint_path = workspace.working_directory / entrypoint_path

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -20,6 +20,7 @@ from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import LogCreate
 from prefect.client.schemas.objects import FlowRun
 from prefect.deployments.runner import RunnerDeployment
+from prefect.runner._workspace_starter import WorkspaceResolvingEngineCommandStarter
 from prefect.settings import PREFECT_UI_URL, temporary_settings
 from prefect.settings.context import get_current_settings
 from prefect.states import (
@@ -1714,10 +1715,6 @@ class TestFlowRunExecute:
             from prefect.cli.flow_run import execute
 
             await execute(id=flow_run.id)
-
-        from prefect.runner._workspace_starter import (
-            WorkspaceResolvingEngineCommandStarter,
-        )
 
         assert isinstance(
             captured_starter["starter"], WorkspaceResolvingEngineCommandStarter

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 from time import sleep
 from typing import Any, Awaitable, Callable
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import anyio
@@ -15,11 +15,12 @@ import pytest
 
 import prefect.exceptions
 from prefect import __development_base_path__, flow
-from prefect.cli.flow_run import LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS
+from prefect.cli.flow_run import LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS, execute
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import LogCreate
 from prefect.client.schemas.objects import FlowRun
 from prefect.deployments.runner import RunnerDeployment
+from prefect.runner._flow_run_executor import FlowRunExecutorContext
 from prefect.runner._workspace_starter import WorkspaceResolvingEngineCommandStarter
 from prefect.settings import PREFECT_UI_URL, temporary_settings
 from prefect.settings.context import get_current_settings
@@ -1682,8 +1683,6 @@ class TestFlowRunExecute:
     ):
         """prefect flow-run execute must construct the executor with
         propose_submitting=False so that the Submitting state is never proposed."""
-        from unittest.mock import AsyncMock, patch
-
         deployment_id = await (await hello_flow.to_deployment(__file__)).apply()
         flow_run = await prefect_client.create_flow_run_from_deployment(
             deployment_id=deployment_id
@@ -1702,8 +1701,6 @@ class TestFlowRunExecute:
             result.submit = mock_submit
             return result
 
-        from prefect.runner._flow_run_executor import FlowRunExecutorContext
-
         original_create_executor = FlowRunExecutorContext.create_executor
 
         with patch.object(
@@ -1712,8 +1709,6 @@ class TestFlowRunExecute:
             side_effect=capture_create_executor,
             autospec=True,
         ):
-            from prefect.cli.flow_run import execute
-
             await execute(id=flow_run.id)
 
         assert isinstance(
@@ -1724,6 +1719,51 @@ class TestFlowRunExecute:
             == captured_starter["starter"].resolve_flow
         )
         assert captured_kwargs.get("propose_submitting") is False
+
+    async def test_execute_keeps_workspace_alive_until_executor_context_exits(
+        self,
+        prefect_client: PrefectClient,
+    ):
+        deployment_id = await (await hello_flow.to_deployment(__file__)).apply()
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        captured_starter: dict[str, WorkspaceResolvingEngineCommandStarter] = {}
+        workspace_exists_during_context_exit: list[bool] = []
+        workspace_path: list[Path] = []
+        mock_submit = AsyncMock(return_value=None)
+
+        original_create_executor = FlowRunExecutorContext.create_executor
+        original_aexit = FlowRunExecutorContext.__aexit__
+
+        def capture_create_executor(self_ctx, *args, **kwargs):
+            starter = args[1]
+            captured_starter["starter"] = starter
+            workspace_path.append(starter._workspace_root)
+            result = original_create_executor(self_ctx, *args, **kwargs)
+            result.submit = mock_submit
+            return result
+
+        async def capture_aexit(self_ctx, *exc_info):
+            workspace = captured_starter["starter"]._workspace_root
+            workspace_exists_during_context_exit.append(workspace.exists())
+            return await original_aexit(self_ctx, *exc_info)
+
+        with (
+            patch.object(
+                FlowRunExecutorContext,
+                "create_executor",
+                side_effect=capture_create_executor,
+                autospec=True,
+            ),
+            patch.object(FlowRunExecutorContext, "__aexit__", capture_aexit),
+        ):
+            await execute(id=flow_run.id)
+
+        assert workspace_exists_during_context_exit == [True]
+        assert workspace_path
+        assert not workspace_path[0].exists()
 
 
 class TestSignalHandling:
@@ -1797,8 +1837,6 @@ class TestSignalHandling:
     ):
         """The SIGTERM reschedule handler is installed before submit() runs,
         so it is active even if submit exits early (e.g. rejected by server)."""
-        from unittest.mock import AsyncMock, patch
-
         monkeypatch.setenv("PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR", "reschedule")
 
         deployment_id = await (await hello_flow.to_deployment(__file__)).apply()
@@ -1824,8 +1862,6 @@ class TestSignalHandling:
                 mock_submit,
             ),
         ):
-            from prefect.cli.flow_run import execute
-
             await execute(id=flow_run.id)
 
             # The handler is installed before submit() so it covers the

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -4,6 +4,7 @@ import json
 import os
 import signal
 import subprocess
+from pathlib import Path
 from time import sleep
 from typing import Any, Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock
@@ -1637,6 +1638,42 @@ class TestFlowRunExecute:
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state.is_completed()
 
+    async def test_execute_flow_run_uses_resolved_pull_step_workspace(
+        self, prefect_client: PrefectClient, tmp_path: Path
+    ):
+        local_project = tmp_path / "local-project"
+        flow_file = local_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'hello'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("pull-step-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="pull-step-workspace",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": str(local_project)
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=["flow-run", "execute", str(flow_run.id)],
+            expected_code=0,
+        )
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_completed()
+
     async def test_execute_creates_executor_with_propose_submitting_false(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1652,11 +1689,13 @@ class TestFlowRunExecute:
         )
 
         captured_kwargs: dict[str, Any] = {}
+        captured_starter: dict[str, Any] = {}
         mock_submit = AsyncMock(return_value=None)
 
         original_create_executor = None
 
         def capture_create_executor(self_ctx, *args, **kwargs):
+            captured_starter["starter"] = args[1]
             captured_kwargs.update(kwargs)
             result = original_create_executor(self_ctx, *args, **kwargs)
             result.submit = mock_submit
@@ -1676,6 +1715,17 @@ class TestFlowRunExecute:
 
             await execute(id=flow_run.id)
 
+        from prefect.runner._workspace_starter import (
+            WorkspaceResolvingEngineCommandStarter,
+        )
+
+        assert isinstance(
+            captured_starter["starter"], WorkspaceResolvingEngineCommandStarter
+        )
+        assert (
+            captured_kwargs.get("resolve_flow")
+            == captured_starter["starter"].resolve_flow
+        )
         assert captured_kwargs.get("propose_submitting") is False
 
 

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -173,3 +173,26 @@ async def test_load_flow_from_prepared_workspace_does_not_change_parent_cwd(
 
     assert flow.name == "hello"
     assert sys.path == original_sys_path
+
+
+async def test_load_flow_from_prepared_workspace_preserves_module_entrypoint(
+    tmp_path: Path,
+):
+    workspace = _prepared_workspace(tmp_path)
+    package = workspace.working_directory / "package"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "module.py").write_text(
+        "from prefect import flow\n\n@flow\ndef hello():\n    return 'hello'\n"
+    )
+    workspace.runtime_entrypoint = "package.module:hello"
+    parent_cwd = tmp_path / "parent-cwd"
+    parent_cwd.mkdir()
+    original_sys_path = list(sys.path)
+
+    with tmpchdir(parent_cwd):
+        flow = await load_flow_from_prepared_workspace(workspace)
+        assert Path.cwd() == parent_cwd.resolve()
+
+    assert flow.name == "hello"
+    assert sys.path == original_sys_path

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from prefect.runner._workspace_resolver import (
+    PreparedWorkspace,
+    PreparedWorkspaceError,
+    PreparedWorkspaceResult,
+)
+from prefect.runner._workspace_starter import (
+    WorkspaceResolvingEngineCommandStarter,
+    load_flow_from_prepared_workspace,
+    resolve_workspace_in_subprocess,
+    workspace_environment,
+)
+from prefect.utilities.filesystem import tmpchdir
+
+
+def _prepared_workspace(tmp_path: Path) -> PreparedWorkspace:
+    workspace_root = tmp_path / "workspace"
+    working_directory = workspace_root / "project"
+    working_directory.mkdir(parents=True)
+    return PreparedWorkspace(
+        workspace_root=workspace_root,
+        working_directory=working_directory,
+        project_root=working_directory,
+        runtime_entrypoint="flows.py:hello",
+        environment={**os.environ, "WORKSPACE_TEST_ENV": "1"},
+        sys_path=[str(tmp_path / "support")],
+    )
+
+
+def test_workspace_environment_prepends_workspace_paths(tmp_path: Path):
+    workspace = _prepared_workspace(tmp_path)
+    workspace.environment["PYTHONPATH"] = str(tmp_path / "existing")
+
+    environment = workspace_environment(workspace)
+    pythonpath = environment["PYTHONPATH"].split(os.pathsep)
+
+    assert environment["WORKSPACE_TEST_ENV"] == "1"
+    assert pythonpath[:3] == [
+        str(workspace.working_directory),
+        str(tmp_path / "support"),
+        str(tmp_path / "existing"),
+    ]
+
+
+async def test_resolve_workspace_in_subprocess_returns_success_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    captured: dict[str, object] = {}
+
+    async def fake_run_process(command: list[str], **kwargs: object):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=PreparedWorkspaceResult(status="success", workspace=workspace)
+            .model_dump_json()
+            .encode(),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.anyio.run_process", fake_run_process
+    )
+
+    result = await resolve_workspace_in_subprocess(uuid4(), tmp_path / "workspace")
+
+    assert result == workspace
+    assert "prefect.runner._workspace_resolver" in captured["command"]
+    assert captured["kwargs"]["stdout"] == subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == subprocess.PIPE
+    assert "env" in captured["kwargs"]
+    assert captured["kwargs"]["check"] is False
+
+
+async def test_resolve_workspace_in_subprocess_raises_structured_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    command = ["python", "-m", "prefect.runner._workspace_resolver"]
+    result = PreparedWorkspaceResult(
+        status="error",
+        error=PreparedWorkspaceError(
+            error_type="StepExecutionError",
+            error_message="pull failed",
+            cause_type="RuntimeError",
+            cause_message="boom",
+        ),
+    )
+
+    async def fake_run_process(*args: object, **kwargs: object):
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout=result.model_dump_json().encode(),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.anyio.run_process", fake_run_process
+    )
+
+    with pytest.raises(RuntimeError, match="StepExecutionError: pull failed"):
+        await resolve_workspace_in_subprocess(uuid4(), tmp_path / "workspace")
+
+
+async def test_workspace_resolving_starter_delegates_to_engine_starter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    resolver = AsyncMock(return_value=workspace)
+    flow_run = MagicMock()
+    flow_run.id = uuid4()
+    instances: list[object] = []
+
+    class FakeEngineCommandStarter:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            instances.append(self)
+
+        async def start(self, flow_run_arg: object, task_status: object) -> None:
+            self.flow_run = flow_run_arg
+            self.task_status = task_status
+
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.resolve_workspace_in_subprocess", resolver
+    )
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.EngineCommandStarter",
+        FakeEngineCommandStarter,
+    )
+
+    starter = WorkspaceResolvingEngineCommandStarter(
+        workspace_root=tmp_path / "workspace-root"
+    )
+    await starter.start(flow_run)
+
+    assert starter.workspace == workspace
+    resolver.assert_awaited_once_with(flow_run.id, tmp_path / "workspace-root")
+    assert len(instances) == 1
+    engine_starter = instances[0]
+    assert engine_starter.kwargs["cwd"] == workspace.working_directory
+    assert engine_starter.kwargs["entrypoint"] == workspace.runtime_entrypoint
+    assert engine_starter.kwargs["env"]["WORKSPACE_TEST_ENV"] == "1"
+    assert engine_starter.flow_run is flow_run
+
+
+async def test_load_flow_from_prepared_workspace_does_not_change_parent_cwd(
+    tmp_path: Path,
+):
+    workspace = _prepared_workspace(tmp_path)
+    flow_file = workspace.working_directory / "flows.py"
+    flow_file.write_text(
+        "from prefect import flow\n\n@flow\ndef hello():\n    return 'hello'\n"
+    )
+    parent_cwd = tmp_path / "parent-cwd"
+    parent_cwd.mkdir()
+    original_sys_path = list(sys.path)
+
+    with tmpchdir(parent_cwd):
+        flow = await load_flow_from_prepared_workspace(workspace)
+        assert Path.cwd() == parent_cwd.resolve()
+
+    assert flow.name == "hello"
+    assert sys.path == original_sys_path


### PR DESCRIPTION
refs #19321

this PR routes the standalone `prefect flow-run execute` path through the isolated workspace resolver added in PR #21699, while keeping the existing `python -m prefect.engine` launcher.

<details>
<summary>Details</summary>

- adds a private `WorkspaceResolvingEngineCommandStarter` that prepares the workspace inside the `ProcessStarter` contract before delegating to `EngineCommandStarter`
- launches the engine subprocess from the resolved working directory with the resolver's environment, sys.path-derived `PYTHONPATH`, and runtime entrypoint
- wires crash/cancellation hook flow loading to the prepared workspace without changing the parent process cwd
- keeps `prefect flow-run execute` using `propose_submitting=False` and the existing legacy engine command
- adds regression coverage for resolver subprocess errors, environment/sys.path propagation, cwd-safe hook imports, CLI wiring, and a pull-step-backed `flow-run execute` run

</details>