### PR TITLE
Run prepared pyproject workspaces with uv

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -8,6 +8,7 @@ import multiprocessing
 import multiprocessing.context
 import os
 import signal
+import sys
 import threading
 import time
 from contextlib import (
@@ -66,7 +67,7 @@ from prefect.context import (
     hydrated_context,
     serialize_context,
 )
-from prefect.engine import handle_engine_signals
+from prefect.engine import _drive_run_flow_result, handle_engine_signals
 from prefect.events.related import RelatedResource, tags_as_related_resources
 from prefect.events.utilities import emit_event
 from prefect.exceptions import (
@@ -109,6 +110,7 @@ from prefect.states import (
     exception_to_failed_state,
     return_value_to_state,
 )
+from prefect.telemetry._metrics import RunMetrics
 from prefect.telemetry.run_telemetry import (
     LABELS_TRACEPARENT_KEY,
     TRACEPARENT_KEY,
@@ -142,6 +144,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 MINIMUM_HEARTBEAT_INTERVAL = 30
+_engine_logger = get_logger("engine")
 _CONTROL_CHANNEL_ENV_KEYS = frozenset(
     {"PREFECT__CONTROL_PORT", "PREFECT__CONTROL_TOKEN"}
 )
@@ -220,15 +223,18 @@ def load_flow_run(flow_run_id: UUID) -> FlowRun:
     return flow_run
 
 
+def _load_flow_from_runtime_entrypoint(entrypoint: str) -> Flow[..., Any]:
+    try:
+        return load_flow_from_entrypoint(entrypoint, use_placeholder_flow=False)
+    except MissingFlowError:
+        return load_function_and_convert_to_flow(entrypoint)
+
+
 def load_flow(flow_run: FlowRun) -> Flow[..., Any]:
     entrypoint = os.environ.get("PREFECT__FLOW_ENTRYPOINT")
 
     if entrypoint:
-        # we should not accept a placeholder flow at runtime
-        try:
-            flow = load_flow_from_entrypoint(entrypoint, use_placeholder_flow=False)
-        except MissingFlowError:
-            flow = load_function_and_convert_to_flow(entrypoint)
+        flow = _load_flow_from_runtime_entrypoint(entrypoint)
     else:
         flow = run_coro_as_sync(
             load_flow_from_flow_run(flow_run, use_placeholder_flow=False)
@@ -240,6 +246,51 @@ def load_flow_and_flow_run(flow_run_id: UUID) -> tuple[FlowRun, Flow[..., Any]]:
     flow_run = load_flow_run(flow_run_id)
     flow = load_flow(flow_run)
     return flow_run, flow
+
+
+def _run_flow_from_runtime_entrypoint(flow_run_id: UUID, entrypoint: str) -> None:
+    configure_from_env()
+
+    with handle_engine_signals(flow_run_id):
+        flow_run = load_flow_run(flow_run_id=flow_run_id)
+        run_logger = flow_run_logger(flow_run=flow_run)
+
+        try:
+            flow = _load_flow_from_runtime_entrypoint(entrypoint)
+        except Exception:
+            run_logger.error(
+                "Unexpected exception encountered when trying to load flow",
+                exc_info=True,
+            )
+            raise
+
+        with RunMetrics(flow_run, flow):
+            run_result = run_flow(flow, flow_run=flow_run, error_logger=run_logger)
+            _drive_run_flow_result(flow, run_result)
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        _engine_logger.error(
+            "Invalid flow entrypoint. Expected one argument; received: %s", args
+        )
+        return 1
+
+    flow_run_id_value = os.environ.get("PREFECT__FLOW_RUN_ID")
+    try:
+        flow_run_id = UUID(flow_run_id_value) if flow_run_id_value else None
+    except ValueError:
+        flow_run_id = None
+
+    if flow_run_id is None:
+        _engine_logger.error(
+            "Invalid flow run id. Expected PREFECT__FLOW_RUN_ID to contain a UUID."
+        )
+        return 1
+
+    _run_flow_from_runtime_entrypoint(flow_run_id, args[0])
+    return 0
 
 
 @contextmanager
@@ -2119,3 +2170,7 @@ def run_flow_in_subprocess(
     process.start()
 
     return process
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -22,7 +23,7 @@ from prefect.runner._workspace_resolver import (
 )
 from prefect.settings import get_current_settings
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
-from prefect.utilities.processutils import sanitize_subprocess_env
+from prefect.utilities.processutils import command_to_string, sanitize_subprocess_env
 
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
@@ -133,6 +134,41 @@ def _absolute_file_entrypoint(workspace: PreparedWorkspace) -> str:
     return f"{entrypoint_path.resolve()}:{object_name}"
 
 
+def _uv_run_command(workspace: PreparedWorkspace) -> str | None:
+    project_root = workspace.project_root
+    if project_root is None or not (project_root / "pyproject.toml").is_file():
+        return None
+
+    workspace_path = workspace.environment.get("PATH")
+    uv_executable = (
+        shutil.which("uv", path=workspace_path)
+        if workspace_path is not None
+        else shutil.which("uv")
+    )
+    if uv_executable is None:
+        return None
+
+    return command_to_string(
+        [
+            uv_executable,
+            "run",
+            "--project",
+            str(project_root),
+            "-m",
+            "prefect.flow_engine",
+            workspace.runtime_entrypoint,
+        ]
+    )
+
+
+def _workspace_command(
+    workspace: PreparedWorkspace, explicit_command: str | None
+) -> str | None:
+    if explicit_command is not None:
+        return explicit_command
+    return _uv_run_command(workspace)
+
+
 @contextmanager
 def _prepared_workspace_context(workspace: PreparedWorkspace) -> Iterator[None]:
     original_environment = dict(os.environ)
@@ -202,7 +238,7 @@ class WorkspaceResolvingEngineCommandStarter:
     ) -> None:
         workspace = await self._resolve_workspace(flow_run.id)
         starter = EngineCommandStarter(
-            command=self._command,
+            command=_workspace_command(workspace, self._command),
             cwd=workspace.working_directory,
             env=workspace_environment(workspace),
             entrypoint=workspace.runtime_entrypoint,

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -6,12 +6,15 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterable, Iterator
 from uuid import UUID
 
 import anyio
 import anyio.abc
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 
+from prefect._internal.compatibility.backports import tomllib
 from prefect.exceptions import MissingFlowError
 from prefect.flows import load_flow_from_entrypoint, load_function_and_convert_to_flow
 from prefect.runner._process_manager import ProcessHandle
@@ -134,9 +137,42 @@ def _absolute_file_entrypoint(workspace: PreparedWorkspace) -> str:
     return f"{entrypoint_path.resolve()}:{object_name}"
 
 
+def _dependencies_include_prefect(dependencies: object) -> bool:
+    if not isinstance(dependencies, Iterable) or isinstance(dependencies, (str, bytes)):
+        return False
+
+    for dependency in dependencies:
+        if not isinstance(dependency, str):
+            continue
+        try:
+            name = Requirement(dependency).name
+        except InvalidRequirement:
+            continue
+        if canonicalize_name(name) == "prefect":
+            return True
+    return False
+
+
+def _pyproject_declares_prefect_dependency(pyproject: Path) -> bool:
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return False
+
+    return _dependencies_include_prefect(project.get("dependencies"))
+
+
 def _uv_run_command(workspace: PreparedWorkspace) -> str | None:
     project_root = workspace.project_root
-    if project_root is None or not (project_root / "pyproject.toml").is_file():
+    if project_root is None:
+        return None
+
+    pyproject = project_root / "pyproject.toml"
+    if not pyproject.is_file() or not _pyproject_declares_prefect_dependency(pyproject):
         return None
 
     workspace_path = workspace.environment.get("PATH")

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -61,7 +61,10 @@ def test_workspace_command_uses_uv_for_pyproject_workspace(
     assert workspace.project_root is not None
     workspace.environment["PATH"] = "/workspace/bin"
     (workspace.project_root / "pyproject.toml").write_text(
-        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+        "[project]\n"
+        "name = 'test-project'\n"
+        "version = '0.1.0'\n"
+        "dependencies = ['prefect']\n"
     )
     captured_paths: list[str | None] = []
 
@@ -101,13 +104,32 @@ def test_workspace_command_falls_back_without_pyproject(
     assert _workspace_command(workspace, explicit_command=None) is None
 
 
+def test_workspace_command_falls_back_without_prefect_dependency(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    assert workspace.project_root is not None
+    (workspace.project_root / "pyproject.toml").write_text(
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\ndependencies = []\n"
+    )
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.shutil.which",
+        lambda executable, path=None: "/opt/bin/uv" if executable == "uv" else None,
+    )
+
+    assert _workspace_command(workspace, explicit_command=None) is None
+
+
 def test_workspace_command_falls_back_without_uv(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     workspace = _prepared_workspace(tmp_path)
     assert workspace.project_root is not None
     (workspace.project_root / "pyproject.toml").write_text(
-        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+        "[project]\n"
+        "name = 'test-project'\n"
+        "version = '0.1.0'\n"
+        "dependencies = ['prefect']\n"
     )
     monkeypatch.setattr(
         "prefect.runner._workspace_starter.shutil.which",
@@ -121,7 +143,7 @@ def test_workspace_command_preserves_explicit_command(tmp_path: Path):
     workspace = _prepared_workspace(tmp_path)
     assert workspace.project_root is not None
     (workspace.project_root / "pyproject.toml").write_text(
-        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\ndependencies = []\n"
     )
 
     assert (
@@ -240,7 +262,10 @@ async def test_workspace_resolving_starter_uses_uv_for_pyproject_workspace(
     workspace = _prepared_workspace(tmp_path)
     assert workspace.project_root is not None
     (workspace.project_root / "pyproject.toml").write_text(
-        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+        "[project]\n"
+        "name = 'test-project'\n"
+        "version = '0.1.0'\n"
+        "dependencies = ['prefect']\n"
     )
     resolver = AsyncMock(return_value=workspace)
     flow_run = MagicMock()

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -16,11 +16,13 @@ from prefect.runner._workspace_resolver import (
 )
 from prefect.runner._workspace_starter import (
     WorkspaceResolvingEngineCommandStarter,
+    _workspace_command,
     load_flow_from_prepared_workspace,
     resolve_workspace_in_subprocess,
     workspace_environment,
 )
 from prefect.utilities.filesystem import tmpchdir
+from prefect.utilities.processutils import command_from_string
 
 
 def _prepared_workspace(tmp_path: Path) -> PreparedWorkspace:
@@ -50,6 +52,82 @@ def test_workspace_environment_prepends_workspace_paths(tmp_path: Path):
         str(tmp_path / "support"),
         str(tmp_path / "existing"),
     ]
+
+
+def test_workspace_command_uses_uv_for_pyproject_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    assert workspace.project_root is not None
+    workspace.environment["PATH"] = "/workspace/bin"
+    (workspace.project_root / "pyproject.toml").write_text(
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+    )
+    captured_paths: list[str | None] = []
+
+    def fake_which(executable: str, path: str | None = None) -> str | None:
+        captured_paths.append(path)
+        return "/opt/bin/uv" if executable == "uv" else None
+
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.shutil.which",
+        fake_which,
+    )
+
+    command = _workspace_command(workspace, explicit_command=None)
+
+    assert captured_paths == [workspace.environment["PATH"]]
+    assert command is not None
+    assert command_from_string(command) == [
+        "/opt/bin/uv",
+        "run",
+        "--project",
+        str(workspace.project_root),
+        "-m",
+        "prefect.flow_engine",
+        workspace.runtime_entrypoint,
+    ]
+
+
+def test_workspace_command_falls_back_without_pyproject(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.shutil.which",
+        lambda executable, path=None: "/opt/bin/uv" if executable == "uv" else None,
+    )
+
+    assert _workspace_command(workspace, explicit_command=None) is None
+
+
+def test_workspace_command_falls_back_without_uv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    assert workspace.project_root is not None
+    (workspace.project_root / "pyproject.toml").write_text(
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+    )
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.shutil.which",
+        lambda executable, path=None: None,
+    )
+
+    assert _workspace_command(workspace, explicit_command=None) is None
+
+
+def test_workspace_command_preserves_explicit_command(tmp_path: Path):
+    workspace = _prepared_workspace(tmp_path)
+    assert workspace.project_root is not None
+    (workspace.project_root / "pyproject.toml").write_text(
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+    )
+
+    assert (
+        _workspace_command(workspace, explicit_command="python custom.py")
+        == "python custom.py"
+    )
 
 
 async def test_resolve_workspace_in_subprocess_returns_success_payload(
@@ -149,10 +227,65 @@ async def test_workspace_resolving_starter_delegates_to_engine_starter(
     resolver.assert_awaited_once_with(flow_run.id, tmp_path / "workspace-root")
     assert len(instances) == 1
     engine_starter = instances[0]
+    assert engine_starter.kwargs["command"] is None
     assert engine_starter.kwargs["cwd"] == workspace.working_directory
     assert engine_starter.kwargs["entrypoint"] == workspace.runtime_entrypoint
     assert engine_starter.kwargs["env"]["WORKSPACE_TEST_ENV"] == "1"
     assert engine_starter.flow_run is flow_run
+
+
+async def test_workspace_resolving_starter_uses_uv_for_pyproject_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    workspace = _prepared_workspace(tmp_path)
+    assert workspace.project_root is not None
+    (workspace.project_root / "pyproject.toml").write_text(
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+    )
+    resolver = AsyncMock(return_value=workspace)
+    flow_run = MagicMock()
+    flow_run.id = uuid4()
+    instances: list[object] = []
+
+    class FakeEngineCommandStarter:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            instances.append(self)
+
+        async def start(self, flow_run_arg: object, task_status: object) -> None:
+            self.flow_run = flow_run_arg
+            self.task_status = task_status
+
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.resolve_workspace_in_subprocess", resolver
+    )
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.EngineCommandStarter",
+        FakeEngineCommandStarter,
+    )
+    monkeypatch.setattr(
+        "prefect.runner._workspace_starter.shutil.which",
+        lambda executable, path=None: "/opt/bin/uv" if executable == "uv" else None,
+    )
+
+    starter = WorkspaceResolvingEngineCommandStarter(
+        workspace_root=tmp_path / "workspace-root"
+    )
+    await starter.start(flow_run)
+
+    assert len(instances) == 1
+    command = instances[0].kwargs["command"]
+    assert command is not None
+    assert command_from_string(command) == [
+        "/opt/bin/uv",
+        "run",
+        "--project",
+        str(workspace.project_root),
+        "-m",
+        "prefect.flow_engine",
+        workspace.runtime_entrypoint,
+    ]
+    assert instances[0].kwargs["cwd"] == workspace.working_directory
 
 
 async def test_load_flow_from_prepared_workspace_does_not_change_parent_cwd(

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -43,6 +43,9 @@ from prefect.flow_engine import (
     MINIMUM_HEARTBEAT_INTERVAL,
     AsyncFlowRunEngine,
     FlowRunEngine,
+    _load_flow_from_runtime_entrypoint,
+    _main,
+    _run_flow_from_runtime_entrypoint,
     _run_serialized_call_with_control_bootstrap,
     _runtime_subprocess_env,
     _send_heartbeats,
@@ -2900,6 +2903,135 @@ class TestLoadFlowAndFlowRun:
         loaded_flow_run, flow = load_flow_and_flow_run(flow_run.id)
         assert loaded_flow_run.id == flow_run.id
         assert flow.fn() == "woof!"
+
+    def test_load_flow_from_runtime_entrypoint_converts_plain_function(self, tmp_path):
+        flow_code = """
+        def dog():
+            return "woof!"
+        """
+        fpath = tmp_path / "f.py"
+        fpath.write_text(dedent(flow_code))
+
+        flow = _load_flow_from_runtime_entrypoint(f"{fpath}:dog")
+
+        assert flow.name == "dog"
+        assert flow.fn() == "woof!"
+
+    def test_load_flow_from_runtime_entrypoint_supports_module_path(self, tmp_path):
+        package = tmp_path / "package"
+        package.mkdir()
+        (package / "__init__.py").write_text("")
+        (package / "flows.py").write_text(
+            dedent(
+                """
+                from prefect import flow
+
+                @flow
+                def dog():
+                    return "woof!"
+                """
+            )
+        )
+
+        with tmpchdir(tmp_path):
+            flow = _load_flow_from_runtime_entrypoint("package.flows:dog")
+
+        assert flow.name == "dog"
+        assert flow.fn() == "woof!"
+
+    def test_flow_engine_main_reads_flow_run_id_from_env(self, monkeypatch):
+        flow_run_id = uuid.uuid4()
+        captured: dict[str, object] = {}
+
+        def run_flow_from_runtime_entrypoint(flow_run_id_arg, entrypoint):
+            captured["flow_run_id"] = flow_run_id_arg
+            captured["entrypoint"] = entrypoint
+
+        monkeypatch.setenv("PREFECT__FLOW_RUN_ID", str(flow_run_id))
+        monkeypatch.setattr(
+            "prefect.flow_engine._run_flow_from_runtime_entrypoint",
+            run_flow_from_runtime_entrypoint,
+        )
+
+        assert _main(["package.flows:dog"]) == 0
+        assert captured == {
+            "flow_run_id": flow_run_id,
+            "entrypoint": "package.flows:dog",
+        }
+
+    @pytest.mark.parametrize("argv", [[], ["one", "two"]])
+    def test_flow_engine_main_requires_entrypoint_argument(self, monkeypatch, argv):
+        run_flow_from_runtime_entrypoint = MagicMock()
+        monkeypatch.setenv("PREFECT__FLOW_RUN_ID", str(uuid.uuid4()))
+        monkeypatch.setattr(
+            "prefect.flow_engine._run_flow_from_runtime_entrypoint",
+            run_flow_from_runtime_entrypoint,
+        )
+
+        assert _main(argv) == 1
+        run_flow_from_runtime_entrypoint.assert_not_called()
+
+    @pytest.mark.parametrize("flow_run_id", [None, "not-a-uuid"])
+    def test_flow_engine_main_requires_flow_run_id_env(self, monkeypatch, flow_run_id):
+        run_flow_from_runtime_entrypoint = MagicMock()
+        if flow_run_id is None:
+            monkeypatch.delenv("PREFECT__FLOW_RUN_ID", raising=False)
+        else:
+            monkeypatch.setenv("PREFECT__FLOW_RUN_ID", flow_run_id)
+        monkeypatch.setattr(
+            "prefect.flow_engine._run_flow_from_runtime_entrypoint",
+            run_flow_from_runtime_entrypoint,
+        )
+
+        assert _main(["package.flows:dog"]) == 1
+        run_flow_from_runtime_entrypoint.assert_not_called()
+
+    def test_run_flow_from_runtime_entrypoint_runs_loaded_flow(
+        self, monkeypatch, flow_run
+    ):
+        loaded_flow = MagicMock()
+        run_logger = MagicMock()
+        events: list[object] = []
+
+        @contextmanager
+        def run_metrics(flow_run_arg, flow_arg):
+            events.append(("metrics-enter", flow_run_arg, flow_arg))
+            yield
+            events.append("metrics-exit")
+
+        monkeypatch.setattr(
+            "prefect.flow_engine.configure_from_env",
+            lambda: events.append("configure"),
+        )
+        monkeypatch.setattr(
+            "prefect.flow_engine.load_flow_run", lambda flow_run_id: flow_run
+        )
+        monkeypatch.setattr(
+            "prefect.flow_engine._load_flow_from_runtime_entrypoint",
+            lambda entrypoint: loaded_flow,
+        )
+        monkeypatch.setattr(
+            "prefect.flow_engine.flow_run_logger",
+            lambda flow_run: run_logger,
+        )
+        monkeypatch.setattr("prefect.flow_engine.RunMetrics", run_metrics)
+        monkeypatch.setattr(
+            "prefect.flow_engine.run_flow",
+            lambda flow, flow_run, error_logger: "run-result",
+        )
+        monkeypatch.setattr(
+            "prefect.flow_engine._drive_run_flow_result",
+            lambda flow, run_result: events.append(("drive", flow, run_result)),
+        )
+
+        _run_flow_from_runtime_entrypoint(flow_run.id, "package.flows:dog")
+
+        assert events == [
+            "configure",
+            ("metrics-enter", flow_run, loaded_flow),
+            ("drive", loaded_flow, "run-result"),
+            "metrics-exit",
+        ]
 
     async def test_load_flow_from_script_with_module_level_sync_compatible_call(
         self, prefect_client: PrefectClient, tmp_path


### PR DESCRIPTION
refs #19321
depends on #21799

this PR makes prepared pyproject workspaces execute through `uv run`.

<details>
<summary>Details</summary>

- Updates `WorkspaceResolvingEngineCommandStarter` to select `uv run --project <project-root> -m prefect.flow_engine <entrypoint>` after workspace resolution.
- Only selects uv when no explicit command override is configured, a prepared `project_root` has `pyproject.toml`, and `uv` is discoverable from the prepared workspace environment.
- Preserves the existing `python -m prefect.engine` fallback when those conditions are not met.
- Keeps the child process cwd as the resolved workspace working directory while passing the project root explicitly to uv.

</details>
