### PR TITLE
[codex] Document failed task memory retention

### DIFF
--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -244,6 +244,19 @@ def bar():
     return "pretend this is biiiig data"
 ```
 
+<Note>
+`cache_result_in_memory=False` controls whether committed task and flow results remain in Prefect's
+in-memory result cache. Failed task runs can still hold memory through the Python exception object
+that describes the failure. If an exception is raised while large local variables, such as DataFrames,
+are still in scope, Python traceback frames can keep references to those objects until the failed state
+and future are released.
+
+For long-running flows that submit many tasks with large in-memory objects, prefer writing large outputs
+inside the task and returning small metadata. If many failures are expected and the flow should continue,
+consider handling the exception inside the task and returning a small failure record. If the task should
+fail, release large local variables before re-raising the exception.
+</Note>
+
 ## Reading persisted results
 
 After a flow or task run completes, you can read the persisted result back using `ResultStore`.

--- a/docs/v3/concepts/task-runners.mdx
+++ b/docs/v3/concepts/task-runners.mdx
@@ -201,17 +201,19 @@ Prefect task) but do not need to use `.result()` if you are passing the value to
 
 When choosing how and when to achieve concurrency using task runners, consider the following:
 
-1. **Task granularity**: The "proper" size for tasks depends on the nature and complexity of the work you're doing, e.g. too many small tasks might create overhead - see [Writing tasks](/v3/develop/write-tasks) for more.
+1. **Task granularity**: The "proper" size for tasks depends on the nature and complexity of the work you're doing; for example, too many small tasks might create overhead - see [Writing tasks](/v3/develop/write-tasks) for more.
 
 2. **Resource constraints**: Be aware of environment limitations. Using `.map` can create many task instances very quickly, which might exceed your resource availability.
 
 3. **Data transfer**: Large data passed between tasks can impact performance. Consider passing references to external storage when dealing with large datasets.
 
-4. **Parallelism**: For true parallelism (rather than just concurrency), consider using a specialized task runner like the `DaskTaskRunner` or `RayTaskRunner` (or [propose a new task runner type](https://github.com/PrefectHQ/prefect/issues/new?template=2_feature_enhancement.yaml)).
+4. **Long-running submission loops**: If a flow submits many tasks over time, avoid retaining large lists of futures or task results for the entire flow run. Resolve futures in bounded groups and drop references when they are no longer needed. Failed tasks can also retain memory through Python tracebacks if large local variables are still in scope when the exception is raised; see [Caching results in memory](/v3/advanced/results#caching-results-in-memory).
 
-5. **Beware of unsafe global state**: Use of concurrency or parallelism features like `.submit` and `.map` must respect the underlying primitives to avoid unexpected behavior. For example, the default `ThreadPoolTaskRunner` runs each task in a separate thread, which means that any global state must be threadsafe. Similarly, `DaskTaskRunner` and `RayTaskRunner` are multi-process runners that require global state to be [picklable](https://docs.python.org/3/library/pickle.html).
+5. **Parallelism**: For true parallelism (rather than just concurrency), consider using a specialized task runner like the `DaskTaskRunner` or `RayTaskRunner` (or [propose a new task runner type](https://github.com/PrefectHQ/prefect/issues/new?template=2_feature_enhancement.yaml)).
 
-6. **Avoid blocking on child tasks submitted from within a task**: With a bounded `ThreadPoolTaskRunner`, submitting a child task from within a parent task and then calling `.result()` on the child can deadlock. If all worker threads are occupied by parent tasks blocked on `.result()`, no thread is free to execute the queued child tasks. Prefect emits a warning when it detects this condition. To resolve it, use one of:
+6. **Beware of unsafe global state**: Use of concurrency or parallelism features like `.submit` and `.map` must respect the underlying primitives to avoid unexpected behavior. For example, the default `ThreadPoolTaskRunner` runs each task in a separate thread, which means that any global state must be threadsafe. Similarly, `DaskTaskRunner` and `RayTaskRunner` are multi-process runners that require global state to be [picklable](https://docs.python.org/3/library/pickle.html).
+
+7. **Avoid blocking on child tasks submitted from within a task**: With a bounded `ThreadPoolTaskRunner`, submitting a child task from within a parent task and then calling `.result()` on the child can deadlock. If all worker threads are occupied by parent tasks blocked on `.result()`, no thread is free to execute the queued child tasks. Prefect emits a warning when it detects this condition. To resolve it, use one of:
    - Increase `max_workers` above your deepest synchronous nesting level: `ThreadPoolTaskRunner(max_workers=N)` or set `PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS=N`.
    - Restructure the flow so child tasks are submitted at the flow level rather than from within a parent task.
    - Use `.delay()` to dispatch child tasks to a task worker running in a separate process.


### PR DESCRIPTION
## Summary

This PR documents a memory-retention pattern for failure-heavy task runs that use large in-memory objects.

It adds guidance that Python exception tracebacks can keep large task-local objects alive after a task fails, clarifies that `cache_result_in_memory=False` only controls committed result caching, and points long-running `.submit()` loops toward bounded future handling and small task return values.

## Validation

- `uv run vale v3/advanced/results.mdx v3/concepts/task-runners.mdx` from `docs/`
- `git diff --check`
- `just links` from `docs/`
- `uv run --with pytest-markdown-docs pytest --markdown-docs docs/v3/advanced/results.mdx docs/v3/concepts/task-runners.mdx` currently fails on existing `results.mdx` code fences because the test environment is missing `prefect_kubernetes`; `task-runners.mdx` code fences are skipped by existing docs test configuration.