### PR TITLE
[codex] Document published REST OpenAPI schema

### DIFF
--- a/docs/v3/api-ref/rest-api/index.mdx
+++ b/docs/v3/api-ref/rest-api/index.mdx
@@ -199,9 +199,9 @@ For example, to query for flows with the tag `"database"` and failed flow runs, 
 
 ## OpenAPI
 
-The Prefect REST API can be fully described with an OpenAPI 3.1 compliant document. [OpenAPI](https://swagger.io/docs/specification/about/) is a standard specification for describing REST APIs.
+The Prefect REST API can be described with an OpenAPI document. [OpenAPI](https://swagger.io/docs/specification/about/) is a standard specification for describing REST APIs.
 
-The published self-hosted Prefect server schema is available at [`/v3/api-ref/rest-api/server/schema.json`](/v3/api-ref/rest-api/server/schema.json). Agents, client generators, and API inspection tools can use this file without starting a local server.
+The published self-hosted Prefect server schema is available at [`/v3/api-ref/rest-api/server/schema.json`](/v3/api-ref/rest-api/server/schema.json). The generated schema currently declares `openapi: 3.1.0`. Agents, client generators, and API inspection tools can use this file without starting a local server.
 
 To generate self-hosted Prefect server's complete OpenAPI document, run the following commands in an interactive Python session:
 

--- a/docs/v3/api-ref/rest-api/index.mdx
+++ b/docs/v3/api-ref/rest-api/index.mdx
@@ -11,7 +11,9 @@ Prefect Cloud and self-hosted Prefect server each provide a REST API.
     - [Interactive Prefect Cloud REST API documentation](https://app.prefect.cloud/api/docs)
     - [Finding your Prefect Cloud details](#finding-your-prefect-cloud-details)
 - Self-hosted Prefect server:
+    - [Published OpenAPI schema](/v3/api-ref/rest-api/server/schema.json) for self-hosted Prefect server.
     - Interactive REST API documentation for self-hosted Prefect server is available under **Server API** on the sidebar navigation or at `http://localhost:4200/docs` or the `/docs` endpoint of the [PREFECT_API_URL](/v3/develop/settings-and-profiles/) you have configured to access the server. You must have the server running with `prefect server start` to access the interactive documentation.
+    - A running self-hosted Prefect server also serves its OpenAPI schema from the `/openapi.json` endpoint of the REST API app. For example, when using the default local server, the schema is available at `http://localhost:4200/api/openapi.json`.
 
 ## Interact with the REST API
 
@@ -197,7 +199,9 @@ For example, to query for flows with the tag `"database"` and failed flow runs, 
 
 ## OpenAPI
 
-The Prefect REST API can be fully described with an OpenAPI 3.0 compliant document. [OpenAPI](https://swagger.io/docs/specification/about/) is a standard specification for describing REST APIs.
+The Prefect REST API can be fully described with an OpenAPI 3.1 compliant document. [OpenAPI](https://swagger.io/docs/specification/about/) is a standard specification for describing REST APIs.
+
+The published self-hosted Prefect server schema is available at [`/v3/api-ref/rest-api/server/schema.json`](/v3/api-ref/rest-api/server/schema.json). Agents, client generators, and API inspection tools can use this file without starting a local server.
 
 To generate self-hosted Prefect server's complete OpenAPI document, run the following commands in an interactive Python session:
 

--- a/docs/v3/api-ref/rest-api/server/index.mdx
+++ b/docs/v3/api-ref/rest-api/server/index.mdx
@@ -7,3 +7,5 @@ The self-hosted Prefect server API is organized around REST.
 Select links in the left navigation menu to explore.
 
 Learn about [self-hosting Prefect server](/v3/how-to-guides/self-hosted/server-cli).
+
+The generated OpenAPI schema for the self-hosted Prefect server API is published at [`/v3/api-ref/rest-api/server/schema.json`](/v3/api-ref/rest-api/server/schema.json). A running Prefect server also serves its schema from the `/openapi.json` endpoint of the REST API app, such as `http://localhost:4200/api/openapi.json` when using the default local server.


### PR DESCRIPTION
## Summary

This PR documents the published self-hosted Prefect server OpenAPI schema from the REST API overview and server API overview pages.

## Why

External agent-readiness scans can report that Prefect has no OpenAPI specification when they only probe conventional discovery paths. The generated schema already exists at `/v3/api-ref/rest-api/server/schema.json`, but the REST API docs previously emphasized generating it locally instead of linking the published artifact directly.

## Changes

- Link the published self-hosted server OpenAPI schema from the REST API overview.
- Note that a running self-hosted server exposes its schema at `/api/openapi.json` by default.
- State that the generated schema currently declares `openapi: 3.1.0` without making a broad compliance promise in prose.
- Add the schema location to the Server API overview.

## Validation

- `python -m json.tool docs/v3/api-ref/rest-api/server/schema.json`
- `uv run --isolated --with openapi-spec-validator python - <<PY ... validate(schema) ... PY`
  - Result: `valid OpenAPI 3.1.0 schema: docs/v3/api-ref/rest-api/server/schema.json`
- `git diff --check`
- Commit/push hooks: codespell and branch checks passed; Python/UI hooks skipped because this is docs-only.