### PR TITLE
feat: Show active/paused status for deployment schedules

### DIFF
--- a/ui-v2/biome.json
+++ b/ui-v2/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -12,6 +12,8 @@
 			"**",
 			"!**/node_modules",
 			"!**/dist",
+			"!**/playwright-report",
+			"!**/test-results",
 			"!**/src/api/prefect.ts",
 			"!**/src/routeTree.gen.ts",
 			"!**/src/graphs",

--- a/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
+++ b/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
@@ -1,12 +1,12 @@
+import type { DeploymentSchedule } from "@/api/deployments";
+import { Card } from "@/components/ui/card";
+import { Icon } from "@/components/ui/icons";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { DeploymentSchedule } from "@/api/deployments";
-import { Card } from "@/components/ui/card";
-import { Icon } from "@/components/ui/icons";
 
 import { getScheduleTitle } from "./get-schedule-title";
 import { ScheduleActionMenu } from "./schedule-action-menu";

--- a/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
+++ b/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
@@ -24,6 +24,12 @@ export const DeploymentScheduleItem = ({
 	onEditSchedule,
 }: DeploymentScheduleItemProps) => {
 	const isActive = deploymentSchedule.active && !disabled;
+	const statusContainerClassName = isActive
+		? "bg-state-completed-100 text-state-completed-700"
+		: "bg-state-paused-100 text-state-paused-700";
+	const statusIconClassName = isActive
+		? "text-state-completed-600"
+		: "text-state-paused-600";
 
 	return (
 		<Card className="p-3">
@@ -32,20 +38,10 @@ export const DeploymentScheduleItem = ({
 					<TooltipProvider>
 						<Tooltip>
 							<TooltipTrigger asChild>
-								<div
-									className={`shrink-0 rounded-full p-1 ${
-										isActive
-											? "bg-green-100 dark:bg-green-900"
-											: "bg-yellow-100 dark:bg-yellow-900"
-									}`}
-								>
+								<div className={`shrink-0 rounded-full p-1 ${statusContainerClassName}`}>
 									<Icon
 										id={isActive ? "Check" : "Pause"}
-										className={`size-4 ${
-											isActive
-												? "text-green-600 dark:text-green-400"
-												: "text-yellow-600 dark:text-yellow-400"
-										}`}
+										className={`size-4 ${statusIconClassName}`}
 									/>
 								</div>
 							</TooltipTrigger>

--- a/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
+++ b/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
@@ -1,5 +1,12 @@
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { DeploymentSchedule } from "@/api/deployments";
 import { Card } from "@/components/ui/card";
+import { Icon } from "@/components/ui/icons";
 
 import { getScheduleTitle } from "./get-schedule-title";
 import { ScheduleActionMenu } from "./schedule-action-menu";
@@ -16,10 +23,39 @@ export const DeploymentScheduleItem = ({
 	disabled,
 	onEditSchedule,
 }: DeploymentScheduleItemProps) => {
+	const isActive = deploymentSchedule.active && !disabled;
+
 	return (
 		<Card className="p-3">
 			<div className="flex items-center justify-between gap-2">
-				<p className="text-base">{getScheduleTitle(deploymentSchedule)}</p>
+				<div className="flex items-center gap-2 flex-1">
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div
+									className={`shrink-0 rounded-full p-1 ${
+										isActive
+											? "bg-green-100 dark:bg-green-900"
+											: "bg-yellow-100 dark:bg-yellow-900"
+									}`}
+								>
+									<Icon
+										id={isActive ? "Check" : "Pause"}
+										className={`size-4 ${
+											isActive
+												? "text-green-600 dark:text-green-400"
+												: "text-yellow-600 dark:text-yellow-400"
+										}`}
+									/>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent>
+								{isActive ? "Schedule is active" : "Schedule is paused"}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+					<p className="text-base">{getScheduleTitle(deploymentSchedule)}</p>
+				</div>
 				<div className="flex items-baseline gap-2">
 					<ScheduleToggleSwitch
 						deploymentSchedule={deploymentSchedule}

--- a/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
+++ b/ui-v2/src/components/deployments/deployment-schedules/deployment-schedule-item.tsx
@@ -38,7 +38,9 @@ export const DeploymentScheduleItem = ({
 					<TooltipProvider>
 						<Tooltip>
 							<TooltipTrigger asChild>
-								<div className={`shrink-0 rounded-full p-1 ${statusContainerClassName}`}>
+								<div
+									className={`shrink-0 rounded-full p-1 ${statusContainerClassName}`}
+								>
 									<Icon
 										id={isActive ? "Check" : "Pause"}
 										className={`size-4 ${statusIconClassName}`}

--- a/ui-v2/src/components/ui/schedule-badge/index.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/index.tsx
@@ -71,13 +71,16 @@ const CronScheduleBadge = ({
 }) => {
 	const scheduleText = cronstrue.toString(schedule.cron);
 	const detailedScheduleText = `${active ? "" : "(Paused)"} ${scheduleText} (${schedule.timezone})`;
+	const badgeClass = active
+		? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+		: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+
 	return (
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
 					<Badge
-						variant="secondary"
-						className={`${!active ? "opacity-50" : ""}`}
+						className={badgeClass}
 						{...props}
 					>
 						<span className="truncate">{scheduleText}</span>
@@ -105,13 +108,16 @@ const IntervalScheduleBadge = ({
 			"MMM do, yyyy 'at' hh:mm:ss aa",
 		)} (${schedule.timezone}) as the anchor date`;
 	}
+	const badgeClass = active
+		? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+		: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+
 	return (
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
 					<Badge
-						variant="secondary"
-						className={`${!active ? "opacity-50" : ""}`}
+						className={badgeClass}
 						{...props}
 					>
 						<span className="truncate">{scheduleText}</span>
@@ -134,13 +140,16 @@ const RRuleScheduleBadge = ({
 	const scheduleText = rrulestr(schedule.rrule).toText();
 	const capitalizedScheduleText = capitalize(scheduleText);
 	const detailedScheduleText = `${active ? "" : "(Paused)"} ${capitalizedScheduleText} (${schedule.timezone})`;
+	const badgeClass = active
+		? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+		: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+
 	return (
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
 					<Badge
-						variant="secondary"
-						className={`${!active ? "opacity-50" : ""}`}
+						className={badgeClass}
 						{...props}
 					>
 						<span className="truncate">{capitalizedScheduleText}</span>

--- a/ui-v2/src/components/ui/schedule-badge/index.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/index.tsx
@@ -71,18 +71,13 @@ const CronScheduleBadge = ({
 }) => {
 	const scheduleText = cronstrue.toString(schedule.cron);
 	const detailedScheduleText = `${active ? "" : "(Paused)"} ${scheduleText} (${schedule.timezone})`;
-	const badgeClass = active
-		? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-		: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+	const badgeVariant = active ? "success" : "warning";
 
 	return (
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
-					<Badge
-						className={badgeClass}
-						{...props}
-					>
+					<Badge variant={badgeVariant} {...props}>
 						<span className="truncate">{scheduleText}</span>
 					</Badge>
 				</TooltipTrigger>
@@ -108,18 +103,13 @@ const IntervalScheduleBadge = ({
 			"MMM do, yyyy 'at' hh:mm:ss aa",
 		)} (${schedule.timezone}) as the anchor date`;
 	}
-	const badgeClass = active
-		? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-		: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+	const badgeVariant = active ? "success" : "warning";
 
 	return (
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
-					<Badge
-						className={badgeClass}
-						{...props}
-					>
+					<Badge variant={badgeVariant} {...props}>
 						<span className="truncate">{scheduleText}</span>
 					</Badge>
 				</TooltipTrigger>
@@ -140,18 +130,13 @@ const RRuleScheduleBadge = ({
 	const scheduleText = rrulestr(schedule.rrule).toText();
 	const capitalizedScheduleText = capitalize(scheduleText);
 	const detailedScheduleText = `${active ? "" : "(Paused)"} ${capitalizedScheduleText} (${schedule.timezone})`;
-	const badgeClass = active
-		? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-		: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+	const badgeVariant = active ? "success" : "warning";
 
 	return (
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
-					<Badge
-						className={badgeClass}
-						{...props}
-					>
+					<Badge variant={badgeVariant} {...props}>
 						<span className="truncate">{capitalizedScheduleText}</span>
 					</Badge>
 				</TooltipTrigger>

--- a/ui-v2/src/components/ui/schedule-badge/index.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/index.tsx
@@ -5,6 +5,7 @@ import { useRef } from "react";
 import { rrulestr } from "rrule";
 import type { components } from "@/api/prefect";
 import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { Icon } from "@/components/ui/icons";
 import {
 	HoverCard,
 	HoverCardContent,
@@ -27,6 +28,26 @@ type RRuleSchedule = components["schemas"]["RRuleSchedule"];
 type ScheduleBadgeProps = BadgeProps & {
 	schedule: DeploymentSchedule;
 };
+
+const getScheduleStatusLabel = (active: boolean) =>
+	active ? "Active" : "Paused";
+
+const ScheduleStatusPill = ({ active }: { active: boolean }) => (
+	<span
+		className={cn(
+			"inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium leading-none",
+			active
+				? "bg-state-completed-100 text-state-completed-700"
+				: "bg-state-paused-100 text-state-paused-700",
+		)}
+	>
+		<Icon id={active ? "Check" : "Pause"} className="size-3" aria-hidden="true" />
+		<span>{getScheduleStatusLabel(active)}</span>
+	</span>
+);
+
+const getScheduleBadgeClassName = (className?: string) =>
+	cn("gap-2 justify-start", className);
 
 export const ScheduleBadge = ({ schedule, ...props }: ScheduleBadgeProps) => {
 	const { schedule: innerSchedule } = schedule;
@@ -77,8 +98,13 @@ const CronScheduleBadge = ({
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
-					<Badge variant={badgeVariant} {...props}>
-						<span className="truncate">{scheduleText}</span>
+					<Badge
+						variant={badgeVariant}
+						{...props}
+						className={getScheduleBadgeClassName(props.className)}
+					>
+						<ScheduleStatusPill active={active} />
+						<span className="min-w-0 truncate">{scheduleText}</span>
 					</Badge>
 				</TooltipTrigger>
 				<TooltipContent>{detailedScheduleText}</TooltipContent>
@@ -109,8 +135,13 @@ const IntervalScheduleBadge = ({
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
-					<Badge variant={badgeVariant} {...props}>
-						<span className="truncate">{scheduleText}</span>
+					<Badge
+						variant={badgeVariant}
+						{...props}
+						className={getScheduleBadgeClassName(props.className)}
+					>
+						<ScheduleStatusPill active={active} />
+						<span className="min-w-0 truncate">{scheduleText}</span>
 					</Badge>
 				</TooltipTrigger>
 				<TooltipContent>{detailedScheduleText}</TooltipContent>
@@ -136,8 +167,13 @@ const RRuleScheduleBadge = ({
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger>
-					<Badge variant={badgeVariant} {...props}>
-						<span className="truncate">{capitalizedScheduleText}</span>
+					<Badge
+						variant={badgeVariant}
+						{...props}
+						className={getScheduleBadgeClassName(props.className)}
+					>
+						<ScheduleStatusPill active={active} />
+						<span className="min-w-0 truncate">{capitalizedScheduleText}</span>
 					</Badge>
 				</TooltipTrigger>
 				<TooltipContent>{detailedScheduleText}</TooltipContent>

--- a/ui-v2/src/components/ui/schedule-badge/index.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/index.tsx
@@ -5,12 +5,12 @@ import { useRef } from "react";
 import { rrulestr } from "rrule";
 import type { components } from "@/api/prefect";
 import { Badge, type BadgeProps } from "@/components/ui/badge";
-import { Icon } from "@/components/ui/icons";
 import {
 	HoverCard,
 	HoverCardContent,
 	HoverCardTrigger,
 } from "@/components/ui/hover-card";
+import { Icon } from "@/components/ui/icons";
 import {
 	Tooltip,
 	TooltipContent,
@@ -41,7 +41,11 @@ const ScheduleStatusPill = ({ active }: { active: boolean }) => (
 				: "bg-state-paused-100 text-state-paused-700",
 		)}
 	>
-		<Icon id={active ? "Check" : "Pause"} className="size-3" aria-hidden="true" />
+		<Icon
+			id={active ? "Check" : "Pause"}
+			className="size-3"
+			aria-hidden="true"
+		/>
 		<span>{getScheduleStatusLabel(active)}</span>
 	</span>
 );

--- a/ui-v2/src/components/ui/schedule-badge/schedule-badge.test.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/schedule-badge.test.tsx
@@ -22,6 +22,7 @@ describe("ScheduleBadge", () => {
 
 		render(<ScheduleBadge schedule={schedule} />);
 
+		expect(screen.getByText("Active")).toBeInTheDocument();
 		const badge = screen.getByText("At 12:00 AM");
 		expect(badge).toBeInTheDocument();
 		await user.hover(badge);
@@ -47,6 +48,7 @@ describe("ScheduleBadge", () => {
 		};
 		render(<ScheduleBadge schedule={schedule} />);
 
+		expect(screen.getByText("Paused")).toBeInTheDocument();
 		const badge = screen.getByText("At 12:00 AM");
 		expect(badge).toBeInTheDocument();
 		await user.hover(badge);
@@ -72,6 +74,7 @@ describe("ScheduleBadge", () => {
 		};
 		render(<ScheduleBadge schedule={schedule} />);
 
+		expect(screen.getByText("Active")).toBeInTheDocument();
 		const badge = screen.getByText("Every 1 hour, 1 minute, 1 second");
 		expect(badge).toBeInTheDocument();
 		await user.hover(badge);
@@ -99,6 +102,7 @@ describe("ScheduleBadge", () => {
 		};
 		render(<ScheduleBadge schedule={schedule} />);
 
+		expect(screen.getByText("Paused")).toBeInTheDocument();
 		const badge = screen.getByText("Every 1 hour, 1 minute, 1 second");
 		expect(badge).toBeInTheDocument();
 		await user.hover(badge);
@@ -123,6 +127,7 @@ describe("ScheduleBadge", () => {
 		};
 		render(<ScheduleBadge schedule={schedule} />);
 
+		expect(screen.getByText("Active")).toBeInTheDocument();
 		const badge = screen.getByText("Every weekday");
 		expect(badge).toBeInTheDocument();
 		await user.hover(badge);
@@ -147,6 +152,7 @@ describe("ScheduleBadge", () => {
 		};
 		render(<ScheduleBadge schedule={schedule} />);
 
+		expect(screen.getByText("Paused")).toBeInTheDocument();
 		const badge = screen.getByText("Every weekday");
 		expect(badge).toBeInTheDocument();
 		await user.hover(badge);
@@ -179,6 +185,8 @@ describe("ScheduleBadgeGroup", () => {
 
 		render(<ScheduleBadgeGroup schedules={schedules} />);
 
+		expect(screen.getByText("Active")).toBeInTheDocument();
+		expect(screen.getByText("Paused")).toBeInTheDocument();
 		const badges = screen.getAllByText("At 12:00 AM");
 		expect(badges).toHaveLength(2);
 	});


### PR DESCRIPTION
closes: #19037

- Adds explicit active/paused status indicators for deployment schedules in the deployment overview UI.
- Previously, schedules only displayed timing information, which could incorrectly imply that the schedule was actively creating runs even when paused.


<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
