### PR TITLE
[codex] Remove archived quickstart repo references

### DIFF
--- a/docs/v3/get-started/quickstart.mdx
+++ b/docs/v3/get-started/quickstart.mdx
@@ -83,18 +83,18 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
       </Step>
       <Step title="Where should it run?">
         At this point, you've successfully run a Prefect `flow` locally. Let's get it running off of your machine! Again, for simplicity, 
-        we'll deploy this workflow to Prefect's Serverless Compute (so we don't have to wrangle any infrastructure). Push `01_getting_started.py` to a GitHub repository, then tell Prefect to clone your repository and invoke `01_getting_started.py:main`.
+        we'll deploy a hosted example workflow to Prefect's Serverless Compute (so we don't have to wrangle any infrastructure). We'll tell Prefect to clone the example from the active [`PrefectHQ/prefect-cloud`](https://github.com/PrefectHQ/prefect-cloud) repository and invoke `examples/hello.py:hello_world`.
         ```bash
-        uvx prefect-cloud deploy 01_getting_started.py:main \
+        uvx prefect-cloud deploy examples/hello.py:hello_world \
         --name my_first_deployment \
-        --from <github-account>/<repo-name>
+        --from PrefectHQ/prefect-cloud
         ```
         If all went well, you've created your first deployed workflow. 
         
         Since we now know what code to run and where to run it, this can now be invoked remotely. 
         To do that, run the following command and visit the returned link to see the run's status in the Prefect UI:
         ```bash 
-        uvx prefect-cloud run main/my_first_deployment
+        uvx prefect-cloud run hello_world/my_first_deployment
         ```
         Congrats! You've just run your first Prefect workflow remotely.
       </Step>
@@ -104,7 +104,7 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
         Let's schedule our workflow to run every day at 8:00 AM with [`cron`](https://en.wikipedia.org/wiki/Cron) syntax.
         
         ```bash
-        uvx prefect-cloud schedule main/my_first_deployment "0 8 * * *"
+        uvx prefect-cloud schedule hello_world/my_first_deployment "0 8 * * *"
         ```
 
         After running the command, your workflow will automatically execute remotely according to the schedule you've set. 

--- a/docs/v3/get-started/quickstart.mdx
+++ b/docs/v3/get-started/quickstart.mdx
@@ -24,7 +24,7 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
         ```
       </Step>
       <Step title="What code should run?">
-        Let's start with a boring Python script that fetches a list of customer ids and processes them all in parallel. You can find this code and other examples hosted in our [quickstart repository](https://github.com/PrefectHQ/quickstart/blob/main/01_getting_started.py). 
+        Let's start with a boring Python script that fetches a list of customer ids and processes them all in parallel. Save this code in a file named `01_getting_started.py`.
 
         ```python 01_getting_started.py [expandable]
         from prefect import flow, task
@@ -60,7 +60,6 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
         
         Let's run this code locally on your computer. To do that, run the following command in your terminal.
         ```bash
-        git clone https://github.com/PrefectHQ/quickstart && cd quickstart
         uv run 01_getting_started.py
         ```
         If all went well, you'll see a link to see its execution graph in the Prefect UI followed by a flurry of state changes and logs as Prefect dynamically discovers and executes your workflow.
@@ -84,12 +83,11 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
       </Step>
       <Step title="Where should it run?">
         At this point, you've successfully run a Prefect `flow` locally. Let's get it running off of your machine! Again, for simplicity, 
-        we'll deploy this workflow to Prefect's Serverless Compute (so we don't have to wrangle any infrastructure). We'll tell Prefect to clone
-        `https://github.com/PrefectHQ/quickstart` and invoke `01_getting_started.py:main`.
+        we'll deploy this workflow to Prefect's Serverless Compute (so we don't have to wrangle any infrastructure). Push `01_getting_started.py` to a GitHub repository, then tell Prefect to clone your repository and invoke `01_getting_started.py:main`.
         ```bash
         uvx prefect-cloud deploy 01_getting_started.py:main \
         --name my_first_deployment \
-        --from https://github.com/PrefectHQ/quickstart
+        --from <github-account>/<repo-name>
         ```
         If all went well, you've created your first deployed workflow. 
         
@@ -132,7 +130,7 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
         Both commands start a server at [`http://localhost:4200`](http://localhost:4200). Keep this process running for this tutorial.
       </Step>
       <Step title="What code should run?">
-        Let's start with a boring Python script that fetches a list of customer ids and processes them all in parallel. You can find this code and other examples hosted in our [quickstart repository](https://github.com/PrefectHQ/quickstart/blob/main/01_getting_started.py). 
+        Let's start with a boring Python script that fetches a list of customer ids and processes them all in parallel. Save this code in a file named `01_getting_started.py`.
 
         ```python 01_getting_started.py [expandable]
         from prefect import flow, task
@@ -168,7 +166,6 @@ In this tutorial, you'll deploy your first workflow to Prefect -- by specifying 
         
         Let's run this code locally on your computer. To do that, run the following command in your terminal (in a new terminal window, keeping the server running):
         ```bash
-        git clone https://github.com/PrefectHQ/quickstart && cd quickstart
         python 01_getting_started.py
         ```
         If all went well, you'll see a link to see its execution graph in the Prefect UI followed by a flurry of state changes and logs as Prefect dynamically discovers and executes your workflow.


### PR DESCRIPTION
closes #21850

## Summary

This PR removes references to the moved `PrefectHQ/quickstart` repository from the v3 quickstart while preserving a no-user-repo Cloud quickstart path.

## Why

The quickstart currently tells users to clone and deploy from `PrefectHQ/quickstart`. That repository now redirects to an archived repository, and the `prefect-cloud deploy --from` path fails on the GitHub API 301 redirect. A quickstart should not depend on an archived repository or require users to create their own repository just to get started.

## Changes

- Remove `git clone https://github.com/PrefectHQ/quickstart` commands from both Cloud and Open Source tabs.
- Change the Cloud deploy command to use the active `PrefectHQ/prefect-cloud` repository and its existing `examples/hello.py:hello_world` example.
- Update the run and schedule commands to use `hello_world/my_first_deployment`, matching the CLI output from the tested deploy command.

## Validation

Ran through the Cloud quickstart commands as documented after non-interactive `prefect-cloud login` setup:

- `uvx prefect-cloud deploy examples/hello.py:hello_world --name my_first_deployment --from PrefectHQ/prefect-cloud`
  - Result: deployment created successfully.
- `uvx prefect-cloud run hello_world/my_first_deployment`
  - Result: flow run started successfully.
- `uvx prefect-cloud schedule hello_world/my_first_deployment "0 8 * * *"`
  - Result: deployment scheduled successfully.
- Cleanup: `uvx prefect-cloud unschedule hello_world/my_first_deployment` and `uvx prefect-cloud delete hello_world/my_first_deployment` both succeeded.

Additional checks:

- Verified `PrefectHQ/prefect-cloud` is active and `examples/hello.py` exists.
- `rg -n "PrefectHQ/quickstart|prefect-archive|prefect-archives" docs src tests examples || true`
- `git diff --check`
- Commit/push hooks passed.