### PR TITLE
Add worker channel protocol contract

### DIFF
--- a/src/prefect/client/schemas/worker_channel.py
+++ b/src/prefect/client/schemas/worker_channel.py
@@ -59,6 +59,13 @@ CleanupOperationStatus: TypeAlias = Literal[
 ]
 _NonEmptyString: TypeAlias = Annotated[str, Field(min_length=1)]
 
+
+def _is_non_string_iterable(value: Any) -> bool:
+    return isinstance(value, Iterable) and not isinstance(
+        value, (str, bytes, bytearray, dict)
+    )
+
+
 WORKER_HEARTBEAT_CAPABILITY: Literal["worker_heartbeat.v1"] = "worker_heartbeat.v1"
 WORK_POOL_SNAPSHOT_CAPABILITY: Literal["work_pool_snapshot.v1"] = (
     "work_pool_snapshot.v1"
@@ -203,7 +210,7 @@ class _StrictProtocolModel(PrefectBaseModel):
 
 class WorkerChannelAuthRequest(_StrictProtocolModel):
     type: Literal["auth"]
-    token: str | None
+    token: str | None = None
 
 
 class WorkerChannelAuthSuccess(_StrictProtocolModel):
@@ -222,7 +229,7 @@ class WorkerHelloPayload(_StrictProtocolModel):
     worker_type: _NonEmptyString
     heartbeat_interval_seconds: PositiveInteger
     supported_channel_versions: list[_NonEmptyString] = Field(min_length=1)
-    requested_capabilities: list[WorkerChannelCapability] = Field(min_length=1)
+    requested_capabilities: list[_NonEmptyString] = Field(min_length=1)
     work_queue_names: list[_NonEmptyString] = Field(default_factory=list)
     handled_cleanup_kinds: list[CleanupKind] = Field(default_factory=list)
     max_cleanup_concurrency: NonNegativeInteger = 0
@@ -238,15 +245,26 @@ class WorkerHelloPayload(_StrictProtocolModel):
 
         requested = data.get("requested_capabilities", [])
         handled_cleanup_kinds = data.get("handled_cleanup_kinds", [])
-        if not isinstance(requested, list) or not isinstance(
-            handled_cleanup_kinds, list
+        if not _is_non_string_iterable(requested) or not _is_non_string_iterable(
+            handled_cleanup_kinds
         ):
             return data
 
-        if CLEANUP_DELIVERY_CAPABILITY in requested and handled_cleanup_kinds:
-            return {**data, "max_cleanup_concurrency": 1}
+        requested_values = tuple(requested)
+        handled_cleanup_kind_values = tuple(handled_cleanup_kinds)
+        normalized_data = {
+            **data,
+            "requested_capabilities": requested_values,
+            "handled_cleanup_kinds": handled_cleanup_kind_values,
+        }
 
-        return data
+        if (
+            CLEANUP_DELIVERY_CAPABILITY in requested_values
+            and handled_cleanup_kind_values
+        ):
+            return {**normalized_data, "max_cleanup_concurrency": 1}
+
+        return normalized_data
 
     @model_validator(mode="after")
     def required_capabilities_are_requested(self) -> WorkerHelloPayload:
@@ -298,7 +316,7 @@ class WorkerReadyPayload(_StrictProtocolModel):
     selected_channel_version: WorkerChannelVersion
     effective_heartbeat_interval_seconds: PositiveInteger
     accepted_capabilities: list[WorkerChannelCapability] = Field(min_length=1)
-    rejected_capabilities: list[WorkerChannelCapability] = Field(default_factory=list)
+    rejected_capabilities: list[_NonEmptyString] = Field(default_factory=list)
     effective_max_cleanup_concurrency: NonNegativeInteger = 0
     resolved_work_queues: list[ResolvedWorkQueue] = Field(default_factory=list)
     initial_snapshot: WorkPoolSnapshotPayload
@@ -329,6 +347,15 @@ class WorkerReadyPayload(_StrictProtocolModel):
             raise ValueError(
                 "`effective_max_cleanup_concurrency` must be 0 when "
                 "`cleanup_delivery.v1` is unavailable"
+            )
+
+        if (
+            CLEANUP_DELIVERY_CAPABILITY in accepted
+            and self.effective_max_cleanup_concurrency == 0
+        ):
+            raise ValueError(
+                "`effective_max_cleanup_concurrency` must be positive when "
+                "`cleanup_delivery.v1` is accepted"
             )
 
         if self.initial_snapshot.reason != "initial":

--- a/src/prefect/client/schemas/worker_channel.py
+++ b/src/prefect/client/schemas/worker_channel.py
@@ -1,10 +1,5 @@
 """
 Shared v1 worker-channel protocol contract.
-
-This module intentionally contains only wire models and implementation-facing
-constants. Worker, OSS server, and Cloud server implementations should conform
-to these shapes without importing Cloud-only authorization internals or backend
-endpoint code.
 """
 
 from __future__ import annotations
@@ -18,7 +13,7 @@ from pydantic import ConfigDict, Field, TypeAdapter, model_validator
 from typing_extensions import Literal, TypeAlias
 
 from prefect._internal.schemas.bases import PrefectBaseModel
-from prefect.client.schemas.objects import WorkPool
+from prefect.client.schemas.objects import WorkPool, WorkPoolStorageConfiguration
 from prefect.types import NonNegativeInteger, PositiveInteger
 from prefect.types._datetime import DateTime
 
@@ -235,6 +230,24 @@ class WorkerHelloPayload(_StrictProtocolModel):
     default_base_job_template: dict[str, Any] = Field(default_factory=dict)
     worker_metadata: dict[str, Any] | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def default_cleanup_concurrency(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or "max_cleanup_concurrency" in data:
+            return data
+
+        requested = data.get("requested_capabilities", [])
+        handled_cleanup_kinds = data.get("handled_cleanup_kinds", [])
+        if not isinstance(requested, list) or not isinstance(
+            handled_cleanup_kinds, list
+        ):
+            return data
+
+        if CLEANUP_DELIVERY_CAPABILITY in requested and handled_cleanup_kinds:
+            return {**data, "max_cleanup_concurrency": 1}
+
+        return data
+
     @model_validator(mode="after")
     def required_capabilities_are_requested(self) -> WorkerHelloPayload:
         requested = set(self.requested_capabilities)
@@ -265,10 +278,18 @@ class ResolvedWorkQueue(_StrictProtocolModel):
     name: str = Field(min_length=1)
 
 
+class WorkPoolSnapshot(WorkPool):
+    id: UUID
+    base_job_template: dict[str, Any]
+    is_paused: bool
+    storage_configuration: WorkPoolStorageConfiguration
+    default_queue_id: UUID
+
+
 class WorkPoolSnapshotPayload(_StrictProtocolModel):
     snapshot_sequence: PositiveInteger
     reason: str = Field(min_length=1)
-    work_pool: WorkPool
+    work_pool: WorkPoolSnapshot
 
 
 class WorkerReadyPayload(_StrictProtocolModel):
@@ -314,6 +335,9 @@ class WorkerReadyPayload(_StrictProtocolModel):
             raise ValueError(
                 "`worker.ready.v1` initial snapshot reason must be initial"
             )
+
+        if self.initial_snapshot.snapshot_sequence != 1:
+            raise ValueError("`worker.ready.v1` initial snapshot sequence must be 1")
 
         return self
 

--- a/src/prefect/client/schemas/worker_channel.py
+++ b/src/prefect/client/schemas/worker_channel.py
@@ -1,0 +1,539 @@
+"""
+Shared v1 worker-channel protocol contract.
+
+This module intentionally contains only wire models and implementation-facing
+constants. Worker, OSS server, and Cloud server implementations should conform
+to these shapes without importing Cloud-only authorization internals or backend
+endpoint code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import Enum
+from typing import Annotated, Any, ClassVar, Union
+from uuid import UUID
+
+from pydantic import ConfigDict, Field, TypeAdapter, model_validator
+from typing_extensions import Literal, TypeAlias
+
+from prefect._internal.schemas.bases import PrefectBaseModel
+from prefect.client.schemas.objects import WorkPool
+from prefect.types import NonNegativeInteger, PositiveInteger
+from prefect.types._datetime import DateTime
+
+WORK_POOL_WORKER_CHANNEL_ROUTE: Literal[
+    "/work_pools/{work_pool_name}/workers/connect"
+] = "/work_pools/{work_pool_name}/workers/connect"
+WORK_POOL_WORKER_CHANNEL_VERSION: Literal["work_pool_worker_channel.v1"] = (
+    "work_pool_worker_channel.v1"
+)
+WORKER_CHANNEL_SUBPROTOCOL: Literal["prefect"] = "prefect"
+
+WorkerChannelVersion: TypeAlias = Literal["work_pool_worker_channel.v1"]
+WorkerChannelCapability: TypeAlias = Literal[
+    "worker_heartbeat.v1",
+    "work_pool_snapshot.v1",
+    "cleanup_delivery.v1",
+]
+CleanupKind: TypeAlias = Literal[
+    "cancelling_timeout_teardown.v1",
+    "pending_claim_teardown.v1",
+]
+WorkerChannelFrameType: TypeAlias = Literal[
+    "worker.hello.v1",
+    "worker.ready.v1",
+    "worker.heartbeat.v1",
+    "work_pool.snapshot.v1",
+    "cleanup.message.v1",
+    "cleanup.ack.v1",
+    "cleanup.release.v1",
+    "cleanup.renew.v1",
+    "cleanup.operation_result.v1",
+]
+CleanupOperation: TypeAlias = Literal["ack", "release", "renew"]
+CleanupOperationStatus: TypeAlias = Literal[
+    "accepted",
+    "not_current",
+    "not_found",
+    "expired",
+    "invalid_token",
+    "unauthorized",
+    "dead_lettered",
+    "error",
+]
+_NonEmptyString: TypeAlias = Annotated[str, Field(min_length=1)]
+
+WORKER_HEARTBEAT_CAPABILITY: Literal["worker_heartbeat.v1"] = "worker_heartbeat.v1"
+WORK_POOL_SNAPSHOT_CAPABILITY: Literal["work_pool_snapshot.v1"] = (
+    "work_pool_snapshot.v1"
+)
+CLEANUP_DELIVERY_CAPABILITY: Literal["cleanup_delivery.v1"] = "cleanup_delivery.v1"
+
+REQUIRED_WORKER_CHANNEL_CAPABILITIES: frozenset[WorkerChannelCapability] = frozenset(
+    {
+        WORKER_HEARTBEAT_CAPABILITY,
+        WORK_POOL_SNAPSHOT_CAPABILITY,
+    }
+)
+OPTIONAL_WORKER_CHANNEL_CAPABILITIES: frozenset[WorkerChannelCapability] = frozenset(
+    {CLEANUP_DELIVERY_CAPABILITY}
+)
+SUPPORTED_WORKER_CHANNEL_CAPABILITIES: frozenset[WorkerChannelCapability] = (
+    REQUIRED_WORKER_CHANNEL_CAPABILITIES | OPTIONAL_WORKER_CHANNEL_CAPABILITIES
+)
+
+CANCELLING_TIMEOUT_TEARDOWN: Literal["cancelling_timeout_teardown.v1"] = (
+    "cancelling_timeout_teardown.v1"
+)
+PENDING_CLAIM_TEARDOWN: Literal["pending_claim_teardown.v1"] = (
+    "pending_claim_teardown.v1"
+)
+SUPPORTED_CLEANUP_KINDS: tuple[CleanupKind, ...] = (
+    CANCELLING_TIMEOUT_TEARDOWN,
+    PENDING_CLAIM_TEARDOWN,
+)
+
+
+class WorkerChannelCloseReason(str, Enum):
+    AUTHENTICATION_FAILED = "authentication_failed"
+    AUTHORIZATION_FAILED = "authorization_failed"
+    UNSUPPORTED_VERSION = "unsupported_version"
+    PROTOCOL_ERROR = "protocol_error"
+    HEARTBEAT_PERSISTENCE_FAILED = "heartbeat_persistence_failed"
+    TRANSIENT_SERVER_ERROR = "transient_server_error"
+
+
+class WorkerChannelClosePolicy(PrefectBaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+
+    reason: WorkerChannelCloseReason
+    websocket_code: int
+    terminal: bool
+    retryable: bool
+
+
+WORKER_CHANNEL_CLOSE_POLICIES: dict[
+    WorkerChannelCloseReason, WorkerChannelClosePolicy
+] = {
+    WorkerChannelCloseReason.AUTHENTICATION_FAILED: WorkerChannelClosePolicy(
+        reason=WorkerChannelCloseReason.AUTHENTICATION_FAILED,
+        websocket_code=1008,
+        terminal=True,
+        retryable=False,
+    ),
+    WorkerChannelCloseReason.AUTHORIZATION_FAILED: WorkerChannelClosePolicy(
+        reason=WorkerChannelCloseReason.AUTHORIZATION_FAILED,
+        websocket_code=1008,
+        terminal=True,
+        retryable=False,
+    ),
+    WorkerChannelCloseReason.UNSUPPORTED_VERSION: WorkerChannelClosePolicy(
+        reason=WorkerChannelCloseReason.UNSUPPORTED_VERSION,
+        websocket_code=1008,
+        terminal=True,
+        retryable=False,
+    ),
+    WorkerChannelCloseReason.PROTOCOL_ERROR: WorkerChannelClosePolicy(
+        reason=WorkerChannelCloseReason.PROTOCOL_ERROR,
+        websocket_code=1002,
+        terminal=True,
+        retryable=False,
+    ),
+    WorkerChannelCloseReason.HEARTBEAT_PERSISTENCE_FAILED: WorkerChannelClosePolicy(
+        reason=WorkerChannelCloseReason.HEARTBEAT_PERSISTENCE_FAILED,
+        websocket_code=1011,
+        terminal=False,
+        retryable=True,
+    ),
+    WorkerChannelCloseReason.TRANSIENT_SERVER_ERROR: WorkerChannelClosePolicy(
+        reason=WorkerChannelCloseReason.TRANSIENT_SERVER_ERROR,
+        websocket_code=1011,
+        terminal=False,
+        retryable=True,
+    ),
+}
+
+
+class WorkerChannelProtocolError(ValueError):
+    def __init__(self, close_reason: WorkerChannelCloseReason, message: str):
+        super().__init__(message)
+        self.close_reason = close_reason
+
+
+class WorkerChannelContract(PrefectBaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+
+    route: Literal["/work_pools/{work_pool_name}/workers/connect"]
+    version: WorkerChannelVersion
+    websocket_subprotocol: Literal["prefect"]
+    auth_setup_message_type: Literal["auth"]
+    auth_success_message_type: Literal["auth_success"]
+    first_application_frame_type: Literal["worker.hello.v1"]
+    required_capabilities: tuple[WorkerChannelCapability, ...]
+    optional_capabilities: tuple[WorkerChannelCapability, ...]
+    supported_cleanup_kinds: tuple[CleanupKind, ...]
+    scheduled_flow_run_acquisition: Literal["rest"]
+    worker_startup_rollout: Literal["opportunistic_without_user_setting"]
+    worker_side_cancellation_observation: Literal["event_subscription"]
+    cleanup_delivery_guarantee: Literal[
+        "at_least_once_one_active_reservation_per_message"
+    ]
+    cleanup_delivery_authority: Literal["reservation_token"]
+    cloud_authorization_internals: Literal["excluded_from_shared_contract"]
+
+
+WORK_POOL_WORKER_CHANNEL_CONTRACT = WorkerChannelContract(
+    route=WORK_POOL_WORKER_CHANNEL_ROUTE,
+    version=WORK_POOL_WORKER_CHANNEL_VERSION,
+    websocket_subprotocol=WORKER_CHANNEL_SUBPROTOCOL,
+    auth_setup_message_type="auth",
+    auth_success_message_type="auth_success",
+    first_application_frame_type="worker.hello.v1",
+    required_capabilities=tuple(sorted(REQUIRED_WORKER_CHANNEL_CAPABILITIES)),
+    optional_capabilities=tuple(sorted(OPTIONAL_WORKER_CHANNEL_CAPABILITIES)),
+    supported_cleanup_kinds=SUPPORTED_CLEANUP_KINDS,
+    scheduled_flow_run_acquisition="rest",
+    worker_startup_rollout="opportunistic_without_user_setting",
+    worker_side_cancellation_observation="event_subscription",
+    cleanup_delivery_guarantee="at_least_once_one_active_reservation_per_message",
+    cleanup_delivery_authority="reservation_token",
+    cloud_authorization_internals="excluded_from_shared_contract",
+)
+
+
+class _StrictProtocolModel(PrefectBaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+
+class WorkerChannelAuthRequest(_StrictProtocolModel):
+    type: Literal["auth"]
+    token: str | None
+
+
+class WorkerChannelAuthSuccess(_StrictProtocolModel):
+    type: Literal["auth_success"]
+
+
+class WorkerChannelFrame(_StrictProtocolModel):
+    type: WorkerChannelFrameType
+    id: UUID
+    sent_at: DateTime
+
+
+class WorkerHelloPayload(_StrictProtocolModel):
+    consumer_id: UUID
+    worker_name: _NonEmptyString
+    worker_type: _NonEmptyString
+    heartbeat_interval_seconds: PositiveInteger
+    supported_channel_versions: list[_NonEmptyString] = Field(min_length=1)
+    requested_capabilities: list[WorkerChannelCapability] = Field(min_length=1)
+    work_queue_names: list[_NonEmptyString] = Field(default_factory=list)
+    handled_cleanup_kinds: list[CleanupKind] = Field(default_factory=list)
+    max_cleanup_concurrency: NonNegativeInteger = 0
+    create_pool_if_not_found: bool = False
+    default_base_job_template: dict[str, Any] = Field(default_factory=dict)
+    worker_metadata: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def required_capabilities_are_requested(self) -> WorkerHelloPayload:
+        requested = set(self.requested_capabilities)
+        if not REQUIRED_WORKER_CHANNEL_CAPABILITIES.issubset(requested):
+            missing = sorted(REQUIRED_WORKER_CHANNEL_CAPABILITIES - requested)
+            raise ValueError(f"Missing required channel capabilities: {missing}")
+
+        if CLEANUP_DELIVERY_CAPABILITY not in requested:
+            if self.handled_cleanup_kinds:
+                raise ValueError(
+                    "`handled_cleanup_kinds` requires `cleanup_delivery.v1`"
+                )
+            if self.max_cleanup_concurrency:
+                raise ValueError(
+                    "`max_cleanup_concurrency` requires `cleanup_delivery.v1`"
+                )
+
+        return self
+
+
+class WorkerHelloFrame(WorkerChannelFrame):
+    type: Literal["worker.hello.v1"]
+    payload: WorkerHelloPayload
+
+
+class ResolvedWorkQueue(_StrictProtocolModel):
+    id: UUID
+    name: str = Field(min_length=1)
+
+
+class WorkPoolSnapshotPayload(_StrictProtocolModel):
+    snapshot_sequence: PositiveInteger
+    reason: str = Field(min_length=1)
+    work_pool: WorkPool
+
+
+class WorkerReadyPayload(_StrictProtocolModel):
+    consumer_id: UUID
+    worker_id: UUID | None
+    selected_channel_version: WorkerChannelVersion
+    effective_heartbeat_interval_seconds: PositiveInteger
+    accepted_capabilities: list[WorkerChannelCapability] = Field(min_length=1)
+    rejected_capabilities: list[WorkerChannelCapability] = Field(default_factory=list)
+    effective_max_cleanup_concurrency: NonNegativeInteger = 0
+    resolved_work_queues: list[ResolvedWorkQueue] = Field(default_factory=list)
+    initial_snapshot: WorkPoolSnapshotPayload
+
+    @model_validator(mode="after")
+    def validate_capability_decision(self) -> WorkerReadyPayload:
+        accepted = set(self.accepted_capabilities)
+        rejected = set(self.rejected_capabilities)
+
+        if overlap := accepted & rejected:
+            raise ValueError(
+                f"Capabilities cannot be both accepted and rejected: {sorted(overlap)}"
+            )
+
+        if not REQUIRED_WORKER_CHANNEL_CAPABILITIES.issubset(accepted):
+            missing = sorted(REQUIRED_WORKER_CHANNEL_CAPABILITIES - accepted)
+            raise ValueError(f"Missing accepted required capabilities: {missing}")
+
+        if required_rejected := REQUIRED_WORKER_CHANNEL_CAPABILITIES & rejected:
+            raise ValueError(
+                f"Required capabilities cannot be rejected: {sorted(required_rejected)}"
+            )
+
+        if (
+            CLEANUP_DELIVERY_CAPABILITY not in accepted
+            and self.effective_max_cleanup_concurrency != 0
+        ):
+            raise ValueError(
+                "`effective_max_cleanup_concurrency` must be 0 when "
+                "`cleanup_delivery.v1` is unavailable"
+            )
+
+        if self.initial_snapshot.reason != "initial":
+            raise ValueError(
+                "`worker.ready.v1` initial snapshot reason must be initial"
+            )
+
+        return self
+
+
+class WorkerReadyFrame(WorkerChannelFrame):
+    type: Literal["worker.ready.v1"]
+    payload: WorkerReadyPayload
+
+
+class WorkerHeartbeatPayload(_StrictProtocolModel):
+    consumer_id: UUID
+    worker_name: str = Field(min_length=1)
+    heartbeat_interval_seconds: PositiveInteger
+
+
+class WorkerHeartbeatFrame(WorkerChannelFrame):
+    type: Literal["worker.heartbeat.v1"]
+    payload: WorkerHeartbeatPayload
+
+
+class WorkPoolSnapshotFrame(WorkerChannelFrame):
+    type: Literal["work_pool.snapshot.v1"]
+    payload: WorkPoolSnapshotPayload
+
+
+class CancellingTimeoutTeardownTarget(PrefectBaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+
+    flow_run_id: UUID
+    infrastructure_pid: str | None = None
+
+
+class PendingClaimTeardownTarget(PrefectBaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+
+    flow_run_id: UUID
+    claim_id: UUID
+    execution_id: UUID | None = None
+    infrastructure_pid: str | None = None
+
+
+class _CleanupMessagePayloadBase(_StrictProtocolModel):
+    message_id: UUID
+    reservation_token: str = Field(min_length=1)
+    lease_expires_at: DateTime
+    delivery_count: PositiveInteger
+    work_queue_id: UUID | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class CancellingTimeoutCleanupMessagePayload(_CleanupMessagePayloadBase):
+    kind: Literal["cancelling_timeout_teardown.v1"]
+    target: CancellingTimeoutTeardownTarget
+
+
+class PendingClaimCleanupMessagePayload(_CleanupMessagePayloadBase):
+    kind: Literal["pending_claim_teardown.v1"]
+    target: PendingClaimTeardownTarget
+
+
+CleanupMessagePayload: TypeAlias = Annotated[
+    Union[PendingClaimCleanupMessagePayload, CancellingTimeoutCleanupMessagePayload],
+    Field(discriminator="kind"),
+]
+
+
+class CleanupMessageFrame(WorkerChannelFrame):
+    type: Literal["cleanup.message.v1"]
+    payload: CleanupMessagePayload
+
+
+class CleanupOperationPayload(_StrictProtocolModel):
+    message_id: UUID
+    reservation_token: str = Field(min_length=1)
+
+
+class CleanupReleasePayload(CleanupOperationPayload):
+    reason: str = Field(min_length=1)
+
+
+class CleanupAckFrame(WorkerChannelFrame):
+    type: Literal["cleanup.ack.v1"]
+    payload: CleanupOperationPayload
+
+
+class CleanupReleaseFrame(WorkerChannelFrame):
+    type: Literal["cleanup.release.v1"]
+    payload: CleanupReleasePayload
+
+
+class CleanupRenewFrame(WorkerChannelFrame):
+    type: Literal["cleanup.renew.v1"]
+    payload: CleanupOperationPayload
+
+
+class CleanupOperationResultPayload(_StrictProtocolModel):
+    request_frame_id: UUID
+    message_id: UUID
+    operation: CleanupOperation
+    status: CleanupOperationStatus
+    lease_expires_at: DateTime | None = None
+    reason: str | None = None
+    detail: str | None = None
+
+    @model_validator(mode="after")
+    def validate_result_contract(self) -> CleanupOperationResultPayload:
+        if self.status != "accepted" and not self.reason:
+            raise ValueError(
+                "`reason` is required for non-accepted cleanup operation results"
+            )
+
+        if self.lease_expires_at is not None and not (
+            self.status == "accepted" and self.operation == "renew"
+        ):
+            raise ValueError(
+                "`lease_expires_at` is only valid for accepted renew results"
+            )
+
+        if (
+            self.status == "accepted"
+            and self.operation == "renew"
+            and self.lease_expires_at is None
+        ):
+            raise ValueError("Accepted renew results require `lease_expires_at`")
+
+        return self
+
+
+class CleanupOperationResultFrame(WorkerChannelFrame):
+    type: Literal["cleanup.operation_result.v1"]
+    payload: CleanupOperationResultPayload
+
+
+WorkerChannelApplicationFrame: TypeAlias = Annotated[
+    Union[
+        WorkerHelloFrame,
+        WorkerReadyFrame,
+        WorkerHeartbeatFrame,
+        WorkPoolSnapshotFrame,
+        CleanupMessageFrame,
+        CleanupAckFrame,
+        CleanupReleaseFrame,
+        CleanupRenewFrame,
+        CleanupOperationResultFrame,
+    ],
+    Field(discriminator="type"),
+]
+
+WorkerChannelApplicationFrameAdapter: TypeAdapter[WorkerChannelApplicationFrame] = (
+    TypeAdapter(WorkerChannelApplicationFrame)
+)
+
+
+def validate_worker_channel_frame(frame: Any) -> WorkerChannelApplicationFrame:
+    return WorkerChannelApplicationFrameAdapter.validate_python(frame)
+
+
+def select_worker_channel_version(
+    supported_versions: Iterable[str],
+) -> WorkerChannelVersion:
+    if WORK_POOL_WORKER_CHANNEL_VERSION in set(supported_versions):
+        return WORK_POOL_WORKER_CHANNEL_VERSION
+
+    raise WorkerChannelProtocolError(
+        WorkerChannelCloseReason.UNSUPPORTED_VERSION,
+        "No mutually supported worker channel version",
+    )
+
+
+__all__ = [
+    "CANCELLING_TIMEOUT_TEARDOWN",
+    "CLEANUP_DELIVERY_CAPABILITY",
+    "OPTIONAL_WORKER_CHANNEL_CAPABILITIES",
+    "PENDING_CLAIM_TEARDOWN",
+    "REQUIRED_WORKER_CHANNEL_CAPABILITIES",
+    "SUPPORTED_CLEANUP_KINDS",
+    "SUPPORTED_WORKER_CHANNEL_CAPABILITIES",
+    "WORKER_CHANNEL_CLOSE_POLICIES",
+    "WORKER_CHANNEL_SUBPROTOCOL",
+    "WORKER_HEARTBEAT_CAPABILITY",
+    "WORK_POOL_SNAPSHOT_CAPABILITY",
+    "WORK_POOL_WORKER_CHANNEL_CONTRACT",
+    "WORK_POOL_WORKER_CHANNEL_ROUTE",
+    "WORK_POOL_WORKER_CHANNEL_VERSION",
+    "CancellingTimeoutCleanupMessagePayload",
+    "CancellingTimeoutTeardownTarget",
+    "CleanupAckFrame",
+    "CleanupKind",
+    "CleanupMessageFrame",
+    "CleanupMessagePayload",
+    "CleanupOperationPayload",
+    "CleanupOperationResultFrame",
+    "CleanupOperationResultPayload",
+    "CleanupOperationStatus",
+    "CleanupReleaseFrame",
+    "CleanupReleasePayload",
+    "CleanupRenewFrame",
+    "PendingClaimCleanupMessagePayload",
+    "PendingClaimTeardownTarget",
+    "ResolvedWorkQueue",
+    "WorkerChannelApplicationFrame",
+    "WorkerChannelApplicationFrameAdapter",
+    "WorkerChannelAuthRequest",
+    "WorkerChannelAuthSuccess",
+    "WorkerChannelCapability",
+    "WorkerChannelClosePolicy",
+    "WorkerChannelCloseReason",
+    "WorkerChannelContract",
+    "WorkerChannelFrame",
+    "WorkerChannelFrameType",
+    "WorkerChannelProtocolError",
+    "WorkerChannelVersion",
+    "WorkerHeartbeatFrame",
+    "WorkerHeartbeatPayload",
+    "WorkerHelloFrame",
+    "WorkerHelloPayload",
+    "WorkerReadyFrame",
+    "WorkerReadyPayload",
+    "WorkPoolSnapshotFrame",
+    "WorkPoolSnapshotPayload",
+    "select_worker_channel_version",
+    "validate_worker_channel_frame",
+]

--- a/tests/client/schemas/test_worker_channel.py
+++ b/tests/client/schemas/test_worker_channel.py
@@ -1,0 +1,433 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from prefect._internal.uuid7 import uuid7
+from prefect.client.schemas.worker_channel import (
+    CLEANUP_DELIVERY_CAPABILITY,
+    REQUIRED_WORKER_CHANNEL_CAPABILITIES,
+    SUPPORTED_CLEANUP_KINDS,
+    WORK_POOL_SNAPSHOT_CAPABILITY,
+    WORK_POOL_WORKER_CHANNEL_CONTRACT,
+    WORK_POOL_WORKER_CHANNEL_ROUTE,
+    WORK_POOL_WORKER_CHANNEL_VERSION,
+    WORKER_CHANNEL_CLOSE_POLICIES,
+    WORKER_HEARTBEAT_CAPABILITY,
+    CleanupAckFrame,
+    CleanupMessageFrame,
+    CleanupOperationResultFrame,
+    CleanupReleaseFrame,
+    CleanupRenewFrame,
+    WorkerChannelAuthRequest,
+    WorkerChannelAuthSuccess,
+    WorkerChannelCloseReason,
+    WorkerChannelProtocolError,
+    WorkerHelloFrame,
+    WorkerReadyFrame,
+    select_worker_channel_version,
+    validate_worker_channel_frame,
+)
+from prefect.types._datetime import now
+
+
+def _frame_base(frame_type: str) -> dict[str, object]:
+    return {
+        "type": frame_type,
+        "id": str(uuid7()),
+        "sent_at": now("UTC").isoformat(),
+    }
+
+
+def _work_pool_payload() -> dict[str, object]:
+    return {
+        "id": str(uuid4()),
+        "name": "default",
+        "type": "process",
+        "base_job_template": {},
+        "default_queue_id": str(uuid4()),
+    }
+
+
+def _hello_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "consumer_id": str(uuid7()),
+        "worker_name": "process-worker-1",
+        "worker_type": "process",
+        "heartbeat_interval_seconds": 30,
+        "supported_channel_versions": [WORK_POOL_WORKER_CHANNEL_VERSION],
+        "requested_capabilities": [
+            WORKER_HEARTBEAT_CAPABILITY,
+            WORK_POOL_SNAPSHOT_CAPABILITY,
+            CLEANUP_DELIVERY_CAPABILITY,
+        ],
+        "work_queue_names": ["default"],
+        "handled_cleanup_kinds": list(SUPPORTED_CLEANUP_KINDS),
+        "max_cleanup_concurrency": 1,
+        "create_pool_if_not_found": True,
+        "default_base_job_template": {},
+        "worker_metadata": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _hello_frame(**payload_overrides: object) -> dict[str, object]:
+    return {
+        **_frame_base("worker.hello.v1"),
+        "payload": _hello_payload(**payload_overrides),
+    }
+
+
+def _ready_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "consumer_id": str(uuid7()),
+        "worker_id": str(uuid4()),
+        "selected_channel_version": WORK_POOL_WORKER_CHANNEL_VERSION,
+        "effective_heartbeat_interval_seconds": 30,
+        "accepted_capabilities": [
+            WORKER_HEARTBEAT_CAPABILITY,
+            WORK_POOL_SNAPSHOT_CAPABILITY,
+            CLEANUP_DELIVERY_CAPABILITY,
+        ],
+        "rejected_capabilities": [],
+        "effective_max_cleanup_concurrency": 1,
+        "resolved_work_queues": [{"id": str(uuid4()), "name": "default"}],
+        "initial_snapshot": {
+            "snapshot_sequence": 1,
+            "reason": "initial",
+            "work_pool": _work_pool_payload(),
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _ready_frame(**payload_overrides: object) -> dict[str, object]:
+    return {
+        **_frame_base("worker.ready.v1"),
+        "payload": _ready_payload(**payload_overrides),
+    }
+
+
+def test_auth_setup_messages_are_outside_application_frame_envelope():
+    assert WorkerChannelAuthRequest(type="auth", token=None).token is None
+    assert WorkerChannelAuthSuccess(type="auth_success").type == "auth_success"
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame({"type": "auth", "token": None})
+
+    assert (
+        WORK_POOL_WORKER_CHANNEL_CONTRACT.first_application_frame_type
+        == "worker.hello.v1"
+    )
+
+
+def test_worker_hello_frame_validates_required_fields_and_capabilities():
+    frame = validate_worker_channel_frame(_hello_frame())
+
+    assert isinstance(frame, WorkerHelloFrame)
+    assert (
+        select_worker_channel_version(frame.payload.supported_channel_versions)
+        == WORK_POOL_WORKER_CHANNEL_VERSION
+    )
+    assert REQUIRED_WORKER_CHANNEL_CAPABILITIES.issubset(
+        set(frame.payload.requested_capabilities)
+    )
+
+    malformed = _hello_frame()
+    del malformed["payload"]["worker_name"]  # type: ignore[index]
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(malformed)
+
+
+def test_worker_hello_rejects_missing_required_capability():
+    with pytest.raises(ValidationError, match="Missing required channel capabilities"):
+        WorkerHelloFrame.model_validate(
+            _hello_frame(
+                requested_capabilities=[
+                    WORKER_HEARTBEAT_CAPABILITY,
+                    CLEANUP_DELIVERY_CAPABILITY,
+                ]
+            )
+        )
+
+
+def test_unsupported_channel_version_maps_to_close_reason():
+    frame = WorkerHelloFrame.model_validate(
+        _hello_frame(supported_channel_versions=["work_pool_worker_channel.v2"])
+    )
+
+    with pytest.raises(WorkerChannelProtocolError) as exc_info:
+        select_worker_channel_version(frame.payload.supported_channel_versions)
+
+    assert exc_info.value.close_reason == WorkerChannelCloseReason.UNSUPPORTED_VERSION
+
+
+def test_worker_ready_allows_optional_cleanup_delivery_rejection():
+    frame = WorkerReadyFrame.model_validate(
+        _ready_frame(
+            accepted_capabilities=[
+                WORKER_HEARTBEAT_CAPABILITY,
+                WORK_POOL_SNAPSHOT_CAPABILITY,
+            ],
+            rejected_capabilities=[CLEANUP_DELIVERY_CAPABILITY],
+            effective_max_cleanup_concurrency=0,
+        )
+    )
+
+    assert CLEANUP_DELIVERY_CAPABILITY in frame.payload.rejected_capabilities
+    assert frame.payload.effective_max_cleanup_concurrency == 0
+
+
+def test_worker_ready_rejects_required_capability_rejection():
+    with pytest.raises(ValidationError, match="Missing accepted required capabilities"):
+        WorkerReadyFrame.model_validate(
+            _ready_frame(
+                accepted_capabilities=[WORKER_HEARTBEAT_CAPABILITY],
+                rejected_capabilities=[WORK_POOL_SNAPSHOT_CAPABILITY],
+                effective_max_cleanup_concurrency=0,
+            )
+        )
+
+
+def test_worker_ready_rejects_cleanup_concurrency_when_cleanup_unavailable():
+    with pytest.raises(ValidationError, match="must be 0"):
+        WorkerReadyFrame.model_validate(
+            _ready_frame(
+                accepted_capabilities=[
+                    WORKER_HEARTBEAT_CAPABILITY,
+                    WORK_POOL_SNAPSHOT_CAPABILITY,
+                ],
+                rejected_capabilities=[CLEANUP_DELIVERY_CAPABILITY],
+                effective_max_cleanup_concurrency=1,
+            )
+        )
+
+
+def test_frame_validator_rejects_unknown_type_and_malformed_frames():
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(
+            {
+                **_frame_base("worker.goodbye.v1"),
+                "payload": {},
+            }
+        )
+
+    malformed = _hello_frame()
+    malformed["unexpected"] = True
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(malformed)
+
+
+def test_snapshot_frame_validates_full_work_pool_replacement_payload():
+    frame = validate_worker_channel_frame(
+        {
+            **_frame_base("work_pool.snapshot.v1"),
+            "payload": {
+                "snapshot_sequence": 2,
+                "reason": "work_pool_updated",
+                "work_pool": _work_pool_payload(),
+            },
+        }
+    )
+
+    assert frame.type == "work_pool.snapshot.v1"
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(
+            {
+                **_frame_base("work_pool.snapshot.v1"),
+                "payload": {
+                    "snapshot_sequence": 0,
+                    "reason": "work_pool_updated",
+                    "work_pool": _work_pool_payload(),
+                },
+            }
+        )
+
+
+def test_cleanup_message_validates_supported_kinds_and_kind_specific_targets():
+    cancelling = CleanupMessageFrame.model_validate(
+        {
+            **_frame_base("cleanup.message.v1"),
+            "payload": {
+                "message_id": str(uuid4()),
+                "kind": "cancelling_timeout_teardown.v1",
+                "reservation_token": "reservation-token",
+                "lease_expires_at": now("UTC").isoformat(),
+                "delivery_count": 1,
+                "work_queue_id": None,
+                "target": {
+                    "flow_run_id": str(uuid4()),
+                    "infrastructure_pid": "pid-123",
+                },
+                "data": {},
+            },
+        }
+    )
+
+    assert cancelling.payload.kind == "cancelling_timeout_teardown.v1"
+
+    pending_claim = CleanupMessageFrame.model_validate(
+        {
+            **_frame_base("cleanup.message.v1"),
+            "payload": {
+                "message_id": str(uuid4()),
+                "kind": "pending_claim_teardown.v1",
+                "reservation_token": "reservation-token",
+                "lease_expires_at": now("UTC").isoformat(),
+                "delivery_count": 1,
+                "work_queue_id": str(uuid4()),
+                "target": {
+                    "flow_run_id": str(uuid4()),
+                    "claim_id": str(uuid7()),
+                    "execution_id": str(uuid7()),
+                    "infrastructure_pid": None,
+                },
+                "data": {},
+            },
+        }
+    )
+
+    assert pending_claim.payload.kind == "pending_claim_teardown.v1"
+
+    with pytest.raises(ValidationError):
+        CleanupMessageFrame.model_validate(
+            {
+                **_frame_base("cleanup.message.v1"),
+                "payload": {
+                    "message_id": str(uuid4()),
+                    "kind": "pending_claim_teardown.v1",
+                    "reservation_token": "reservation-token",
+                    "lease_expires_at": now("UTC").isoformat(),
+                    "delivery_count": 1,
+                    "target": {"flow_run_id": str(uuid4())},
+                    "data": {},
+                },
+            }
+        )
+
+
+def test_cleanup_operation_frames_and_results_validate_reservation_contract():
+    operation_payload = {
+        "message_id": str(uuid4()),
+        "reservation_token": "reservation-token",
+    }
+
+    assert CleanupAckFrame.model_validate(
+        {**_frame_base("cleanup.ack.v1"), "payload": operation_payload}
+    )
+    assert CleanupRenewFrame.model_validate(
+        {**_frame_base("cleanup.renew.v1"), "payload": operation_payload}
+    )
+    assert CleanupReleaseFrame.model_validate(
+        {
+            **_frame_base("cleanup.release.v1"),
+            "payload": {**operation_payload, "reason": "cannot_act"},
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        CleanupReleaseFrame.model_validate(
+            {**_frame_base("cleanup.release.v1"), "payload": operation_payload}
+        )
+
+    accepted_renew = CleanupOperationResultFrame.model_validate(
+        {
+            **_frame_base("cleanup.operation_result.v1"),
+            "payload": {
+                "request_frame_id": str(uuid7()),
+                "message_id": operation_payload["message_id"],
+                "operation": "renew",
+                "status": "accepted",
+                "lease_expires_at": now("UTC").isoformat(),
+                "reason": None,
+                "detail": None,
+            },
+        }
+    )
+
+    assert accepted_renew.payload.status == "accepted"
+
+    with pytest.raises(ValidationError, match="reason"):
+        CleanupOperationResultFrame.model_validate(
+            {
+                **_frame_base("cleanup.operation_result.v1"),
+                "payload": {
+                    "request_frame_id": str(uuid7()),
+                    "message_id": operation_payload["message_id"],
+                    "operation": "ack",
+                    "status": "invalid_token",
+                },
+            }
+        )
+
+    with pytest.raises(ValidationError, match="lease_expires_at"):
+        CleanupOperationResultFrame.model_validate(
+            {
+                **_frame_base("cleanup.operation_result.v1"),
+                "payload": {
+                    "request_frame_id": str(uuid7()),
+                    "message_id": operation_payload["message_id"],
+                    "operation": "ack",
+                    "status": "accepted",
+                    "lease_expires_at": now("UTC").isoformat(),
+                },
+            }
+        )
+
+
+def test_close_reason_categories_match_protocol_spec():
+    assert set(WORKER_CHANNEL_CLOSE_POLICIES) == {
+        WorkerChannelCloseReason.AUTHENTICATION_FAILED,
+        WorkerChannelCloseReason.AUTHORIZATION_FAILED,
+        WorkerChannelCloseReason.UNSUPPORTED_VERSION,
+        WorkerChannelCloseReason.PROTOCOL_ERROR,
+        WorkerChannelCloseReason.HEARTBEAT_PERSISTENCE_FAILED,
+        WorkerChannelCloseReason.TRANSIENT_SERVER_ERROR,
+    }
+    assert (
+        WORKER_CHANNEL_CLOSE_POLICIES[
+            WorkerChannelCloseReason.AUTHENTICATION_FAILED
+        ].websocket_code
+        == 1008
+    )
+    assert (
+        WORKER_CHANNEL_CLOSE_POLICIES[
+            WorkerChannelCloseReason.PROTOCOL_ERROR
+        ].websocket_code
+        == 1002
+    )
+    assert (
+        WORKER_CHANNEL_CLOSE_POLICIES[
+            WorkerChannelCloseReason.TRANSIENT_SERVER_ERROR
+        ].websocket_code
+        == 1011
+    )
+    assert not WORKER_CHANNEL_CLOSE_POLICIES[
+        WorkerChannelCloseReason.UNSUPPORTED_VERSION
+    ].retryable
+    assert WORKER_CHANNEL_CLOSE_POLICIES[
+        WorkerChannelCloseReason.HEARTBEAT_PERSISTENCE_FAILED
+    ].retryable
+
+
+def test_contract_states_channel_boundaries_and_rollout_expectations():
+    contract = WORK_POOL_WORKER_CHANNEL_CONTRACT
+
+    assert contract.route == WORK_POOL_WORKER_CHANNEL_ROUTE
+    assert contract.scheduled_flow_run_acquisition == "rest"
+    assert contract.worker_startup_rollout == "opportunistic_without_user_setting"
+    assert contract.worker_side_cancellation_observation == "event_subscription"
+    assert (
+        contract.cleanup_delivery_guarantee
+        == "at_least_once_one_active_reservation_per_message"
+    )
+    assert contract.cleanup_delivery_authority == "reservation_token"
+    assert contract.cloud_authorization_internals == "excluded_from_shared_contract"
+    assert set(contract.required_capabilities) == REQUIRED_WORKER_CHANNEL_CAPABILITIES
+    assert contract.optional_capabilities == (CLEANUP_DELIVERY_CAPABILITY,)
+    assert contract.supported_cleanup_kinds == SUPPORTED_CLEANUP_KINDS

--- a/tests/client/schemas/test_worker_channel.py
+++ b/tests/client/schemas/test_worker_channel.py
@@ -45,6 +45,8 @@ def _work_pool_payload() -> dict[str, object]:
         "name": "default",
         "type": "process",
         "base_job_template": {},
+        "is_paused": False,
+        "storage_configuration": {},
         "default_queue_id": str(uuid4()),
     }
 
@@ -154,6 +156,43 @@ def test_worker_hello_rejects_missing_required_capability():
         )
 
 
+def test_worker_hello_defaults_cleanup_concurrency_when_cleanup_is_available():
+    hello = _hello_frame()
+    del hello["payload"]["max_cleanup_concurrency"]  # type: ignore[index]
+
+    frame = WorkerHelloFrame.model_validate(hello)
+
+    assert frame.payload.max_cleanup_concurrency == 1
+
+
+def test_worker_hello_defaults_cleanup_concurrency_to_zero_without_cleanup_kinds():
+    hello = _hello_frame(handled_cleanup_kinds=[])
+    del hello["payload"]["max_cleanup_concurrency"]  # type: ignore[index]
+
+    frame = WorkerHelloFrame.model_validate(hello)
+
+    assert frame.payload.max_cleanup_concurrency == 0
+
+
+@pytest.mark.parametrize("requested_capabilities", [None, 1])
+def test_worker_hello_rejects_malformed_capabilities_without_raw_type_error(
+    requested_capabilities: object,
+):
+    hello = _hello_frame(requested_capabilities=requested_capabilities)
+    del hello["payload"]["max_cleanup_concurrency"]  # type: ignore[index]
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(hello)
+
+
+def test_worker_hello_rejects_malformed_cleanup_kinds_without_raw_type_error():
+    hello = _hello_frame(handled_cleanup_kinds=1)
+    del hello["payload"]["max_cleanup_concurrency"]  # type: ignore[index]
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(hello)
+
+
 def test_unsupported_channel_version_maps_to_close_reason():
     frame = WorkerHelloFrame.model_validate(
         _hello_frame(supported_channel_versions=["work_pool_worker_channel.v2"])
@@ -206,6 +245,19 @@ def test_worker_ready_rejects_cleanup_concurrency_when_cleanup_unavailable():
         )
 
 
+def test_worker_ready_rejects_initial_snapshot_sequence_other_than_one():
+    with pytest.raises(ValidationError, match="initial snapshot sequence must be 1"):
+        WorkerReadyFrame.model_validate(
+            _ready_frame(
+                initial_snapshot={
+                    "snapshot_sequence": 2,
+                    "reason": "initial",
+                    "work_pool": _work_pool_payload(),
+                }
+            )
+        )
+
+
 def test_frame_validator_rejects_unknown_type_and_malformed_frames():
     with pytest.raises(ValidationError):
         validate_worker_channel_frame(
@@ -246,6 +298,79 @@ def test_snapshot_frame_validates_full_work_pool_replacement_payload():
                     "work_pool": _work_pool_payload(),
                 },
             }
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "id",
+        "base_job_template",
+        "is_paused",
+        "storage_configuration",
+        "default_queue_id",
+    ],
+)
+def test_snapshot_frame_requires_full_work_pool_replacement_state(field: str):
+    work_pool = _work_pool_payload()
+    del work_pool[field]
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(
+            {
+                **_frame_base("work_pool.snapshot.v1"),
+                "payload": {
+                    "snapshot_sequence": 2,
+                    "reason": "work_pool_updated",
+                    "work_pool": work_pool,
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize("field", ["default_queue_id", "storage_configuration"])
+def test_snapshot_frame_rejects_null_required_work_pool_state(field: str):
+    work_pool = _work_pool_payload()
+    work_pool[field] = None
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(
+            {
+                **_frame_base("work_pool.snapshot.v1"),
+                "payload": {
+                    "snapshot_sequence": 2,
+                    "reason": "work_pool_updated",
+                    "work_pool": work_pool,
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "id",
+        "base_job_template",
+        "is_paused",
+        "storage_configuration",
+        "default_queue_id",
+    ],
+)
+def test_worker_ready_initial_snapshot_requires_full_work_pool_replacement_state(
+    field: str,
+):
+    work_pool = _work_pool_payload()
+    del work_pool[field]
+
+    with pytest.raises(ValidationError):
+        validate_worker_channel_frame(
+            _ready_frame(
+                initial_snapshot={
+                    "snapshot_sequence": 1,
+                    "reason": "initial",
+                    "work_pool": work_pool,
+                }
+            )
         )
 
 

--- a/tests/client/schemas/test_worker_channel.py
+++ b/tests/client/schemas/test_worker_channel.py
@@ -114,6 +114,7 @@ def _ready_frame(**payload_overrides: object) -> dict[str, object]:
 
 def test_auth_setup_messages_are_outside_application_frame_envelope():
     assert WorkerChannelAuthRequest(type="auth", token=None).token is None
+    assert WorkerChannelAuthRequest.model_validate({"type": "auth"}).token is None
     assert WorkerChannelAuthSuccess(type="auth_success").type == "auth_success"
 
     with pytest.raises(ValidationError):
@@ -165,6 +166,22 @@ def test_worker_hello_defaults_cleanup_concurrency_when_cleanup_is_available():
     assert frame.payload.max_cleanup_concurrency == 1
 
 
+def test_worker_hello_defaults_cleanup_concurrency_for_tuple_inputs():
+    hello = _hello_frame(
+        requested_capabilities=(
+            WORKER_HEARTBEAT_CAPABILITY,
+            WORK_POOL_SNAPSHOT_CAPABILITY,
+            CLEANUP_DELIVERY_CAPABILITY,
+        ),
+        handled_cleanup_kinds=SUPPORTED_CLEANUP_KINDS,
+    )
+    del hello["payload"]["max_cleanup_concurrency"]  # type: ignore[index]
+
+    frame = WorkerHelloFrame.model_validate(hello)
+
+    assert frame.payload.max_cleanup_concurrency == 1
+
+
 def test_worker_hello_defaults_cleanup_concurrency_to_zero_without_cleanup_kinds():
     hello = _hello_frame(handled_cleanup_kinds=[])
     del hello["payload"]["max_cleanup_concurrency"]  # type: ignore[index]
@@ -191,6 +208,24 @@ def test_worker_hello_rejects_malformed_cleanup_kinds_without_raw_type_error():
 
     with pytest.raises(ValidationError):
         validate_worker_channel_frame(hello)
+
+
+def test_worker_hello_allows_unknown_optional_capability_requests():
+    future_capability = "future_optional_capability.v1"
+
+    frame = WorkerHelloFrame.model_validate(
+        _hello_frame(
+            requested_capabilities=[
+                WORKER_HEARTBEAT_CAPABILITY,
+                WORK_POOL_SNAPSHOT_CAPABILITY,
+                future_capability,
+            ],
+            handled_cleanup_kinds=[],
+            max_cleanup_concurrency=0,
+        )
+    )
+
+    assert future_capability in frame.payload.requested_capabilities
 
 
 def test_unsupported_channel_version_maps_to_close_reason():
@@ -220,6 +255,37 @@ def test_worker_ready_allows_optional_cleanup_delivery_rejection():
     assert frame.payload.effective_max_cleanup_concurrency == 0
 
 
+def test_worker_ready_allows_unknown_optional_capability_rejection():
+    future_capability = "future_optional_capability.v1"
+
+    frame = WorkerReadyFrame.model_validate(
+        _ready_frame(
+            accepted_capabilities=[
+                WORKER_HEARTBEAT_CAPABILITY,
+                WORK_POOL_SNAPSHOT_CAPABILITY,
+            ],
+            rejected_capabilities=[future_capability],
+            effective_max_cleanup_concurrency=0,
+        )
+    )
+
+    assert future_capability in frame.payload.rejected_capabilities
+
+
+def test_worker_ready_rejects_unknown_accepted_capability():
+    with pytest.raises(ValidationError):
+        WorkerReadyFrame.model_validate(
+            _ready_frame(
+                accepted_capabilities=[
+                    WORKER_HEARTBEAT_CAPABILITY,
+                    WORK_POOL_SNAPSHOT_CAPABILITY,
+                    "future_optional_capability.v1",
+                ],
+                effective_max_cleanup_concurrency=0,
+            )
+        )
+
+
 def test_worker_ready_rejects_required_capability_rejection():
     with pytest.raises(ValidationError, match="Missing accepted required capabilities"):
         WorkerReadyFrame.model_validate(
@@ -242,6 +308,13 @@ def test_worker_ready_rejects_cleanup_concurrency_when_cleanup_unavailable():
                 rejected_capabilities=[CLEANUP_DELIVERY_CAPABILITY],
                 effective_max_cleanup_concurrency=1,
             )
+        )
+
+
+def test_worker_ready_rejects_zero_cleanup_concurrency_when_cleanup_accepted():
+    with pytest.raises(ValidationError, match="must be positive"):
+        WorkerReadyFrame.model_validate(
+            _ready_frame(effective_max_cleanup_concurrency=0)
         )
 
 


### PR DESCRIPTION
related to: #21860

this PR adds the shared v1 work-pool worker communication channel protocol contract for workers, OSS backend implementations, and Cloud backend implementations to conform to.

<details>
<summary>Details</summary>

- Adds strict client-side protocol models for auth setup messages, typed application frames, worker hello/ready, heartbeat, work-pool snapshot, cleanup delivery, cleanup operations, and cleanup operation results.
- Defines shared capability, cleanup kind, close reason, route, version, and rollout/fallback contract constants without Cloud-only authorization internals.
- Adds contract-style tests covering required fields, unsupported versions, malformed frames, rejected capabilities, close categories, optional cleanup delivery, REST scheduled-run polling boundary, opportunistic rollout, and one-active-reservation cleanup delivery.

</details>