### PR TITLE
Clear default result storage when deleting block

### DIFF
--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -482,7 +482,14 @@ async def delete_block_document(
 ) -> bool:
     query = sa.delete(db.BlockDocument).where(db.BlockDocument.id == block_document_id)
     result = await session.execute(query)
-    return result.rowcount > 0
+    if result.rowcount <= 0:
+        return False
+
+    await models.storage_defaults.clear_server_default_result_storage_for_block(
+        session=session,
+        block_document_id=block_document_id,
+    )
+    return True
 
 
 @db_injector

--- a/src/prefect/server/models/block_schemas.py
+++ b/src/prefect/server/models/block_schemas.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import schemas
 from prefect.server.database import PrefectDBInterface, db_injector, orm_models
+from prefect.server.models import storage_defaults
 from prefect.server.models.block_types import read_block_type_by_slug
 from prefect.server.schemas.actions import BlockSchemaCreate
 from prefect.server.schemas.core import BlockSchema, BlockSchemaReference
@@ -297,10 +298,23 @@ async def delete_block_schema(
         bool: whether or not the block schema was deleted
     """
 
+    default_references_block_schema = (
+        await storage_defaults.server_default_result_storage_references_block_schema(
+            session=session,
+            block_schema_id=block_schema_id,
+        )
+    )
+
     result = await session.execute(
         delete(db.BlockSchema).where(db.BlockSchema.id == block_schema_id)
     )
-    return result.rowcount > 0
+    if result.rowcount <= 0:
+        return False
+
+    if default_references_block_schema:
+        await storage_defaults.clear_server_default_result_storage(session=session)
+
+    return True
 
 
 @db_injector

--- a/src/prefect/server/models/block_types.py
+++ b/src/prefect/server/models/block_types.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect.server import schemas
 from prefect.server.database import PrefectDBInterface, db_injector
 from prefect.server.database.orm_models import BlockType
+from prefect.server.models import storage_defaults
 
 if TYPE_CHECKING:
     from prefect.client.schemas import BlockType as ClientBlockType
@@ -202,7 +203,7 @@ async def update_block_type(
 
 @db_injector
 async def delete_block_type(
-    db: PrefectDBInterface, session: AsyncSession, block_type_id: str
+    db: PrefectDBInterface, session: AsyncSession, block_type_id: UUID
 ) -> bool:
     """
     Delete a block type by id.
@@ -215,7 +216,20 @@ async def delete_block_type(
         bool: True if the block type was updated
     """
 
+    default_references_block_type = (
+        await storage_defaults.server_default_result_storage_references_block_type(
+            session=session,
+            block_type_id=block_type_id,
+        )
+    )
+
     result = await session.execute(
         sa.delete(db.BlockType).where(db.BlockType.id == block_type_id)
     )
-    return result.rowcount > 0
+    if result.rowcount <= 0:
+        return False
+
+    if default_references_block_type:
+        await storage_defaults.clear_server_default_result_storage(session=session)
+
+    return True

--- a/src/prefect/server/models/storage_defaults.py
+++ b/src/prefect/server/models/storage_defaults.py
@@ -60,3 +60,14 @@ async def clear_server_default_result_storage(session: AsyncSession) -> bool:
         session=session,
         key=SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
     )
+
+
+async def clear_server_default_result_storage_for_block(
+    session: AsyncSession,
+    block_document_id: UUID,
+) -> bool:
+    storage_default = await read_server_default_result_storage(session=session)
+    if storage_default.default_result_storage_block_id != block_document_id:
+        return False
+
+    return await clear_server_default_result_storage(session=session)

--- a/src/prefect/server/models/storage_defaults.py
+++ b/src/prefect/server/models/storage_defaults.py
@@ -71,3 +71,37 @@ async def clear_server_default_result_storage_for_block(
         return False
 
     return await clear_server_default_result_storage(session=session)
+
+
+async def server_default_result_storage_references_block_schema(
+    session: AsyncSession,
+    block_schema_id: UUID,
+) -> bool:
+    storage_default = await read_server_default_result_storage(session=session)
+    block_document_id = storage_default.default_result_storage_block_id
+    if block_document_id is None:
+        return False
+
+    query = (
+        sa.select(orm_models.BlockDocument.id)
+        .where(orm_models.BlockDocument.id == block_document_id)
+        .where(orm_models.BlockDocument.block_schema_id == block_schema_id)
+    )
+    return await session.scalar(query) is not None
+
+
+async def server_default_result_storage_references_block_type(
+    session: AsyncSession,
+    block_type_id: UUID,
+) -> bool:
+    storage_default = await read_server_default_result_storage(session=session)
+    block_document_id = storage_default.default_result_storage_block_id
+    if block_document_id is None:
+        return False
+
+    query = (
+        sa.select(orm_models.BlockDocument.id)
+        .where(orm_models.BlockDocument.id == block_document_id)
+        .where(orm_models.BlockDocument.block_type_id == block_type_id)
+    )
+    return await session.scalar(query) is not None

--- a/tests/server/models/test_block_documents.py
+++ b/tests/server/models/test_block_documents.py
@@ -1083,6 +1083,77 @@ class TestDeleteBlockDocument:
             session=session, block_document_id=uuid4()
         )
 
+    async def test_delete_block_clears_server_default_result_storage(
+        self, session, block_schemas
+    ):
+        block = await models.block_documents.create_block_document(
+            session=session,
+            block_document=schemas.actions.BlockDocumentCreate(
+                name="server-default-result-storage",
+                data=dict(),
+                block_schema_id=block_schemas[0].id,
+                block_type_id=block_schemas[0].block_type_id,
+            ),
+        )
+        await models.storage_defaults.write_server_default_result_storage(
+            session=session,
+            storage_default=schemas.core.ServerDefaultResultStorage(
+                default_result_storage_block_id=block.id
+            ),
+        )
+
+        await models.block_documents.delete_block_document(
+            session=session,
+            block_document_id=block.id,
+        )
+
+        storage_default = (
+            await models.storage_defaults.read_server_default_result_storage(
+                session=session
+            )
+        )
+        assert storage_default.default_result_storage_block_id is None
+
+    async def test_delete_block_preserves_server_default_result_storage_for_other_block(
+        self, session, block_schemas
+    ):
+        default_block = await models.block_documents.create_block_document(
+            session=session,
+            block_document=schemas.actions.BlockDocumentCreate(
+                name="server-default-result-storage",
+                data=dict(),
+                block_schema_id=block_schemas[0].id,
+                block_type_id=block_schemas[0].block_type_id,
+            ),
+        )
+        other_block = await models.block_documents.create_block_document(
+            session=session,
+            block_document=schemas.actions.BlockDocumentCreate(
+                name="other-block",
+                data=dict(),
+                block_schema_id=block_schemas[0].id,
+                block_type_id=block_schemas[0].block_type_id,
+            ),
+        )
+        await models.storage_defaults.write_server_default_result_storage(
+            session=session,
+            storage_default=schemas.core.ServerDefaultResultStorage(
+                default_result_storage_block_id=default_block.id
+            ),
+        )
+
+        await models.block_documents.delete_block_document(
+            session=session,
+            block_document_id=other_block.id,
+        )
+
+        storage_default = (
+            await models.storage_defaults.read_server_default_result_storage(
+                session=session
+            )
+        )
+        assert storage_default.default_result_storage_block_id == default_block.id
+
 
 class TestUpdateBlockDocument:
     async def test_update_block_document_data(self, session, block_schemas):

--- a/tests/server/models/test_block_schemas.py
+++ b/tests/server/models/test_block_schemas.py
@@ -977,6 +977,36 @@ class TestDeleteBlockSchema:
             session=session, block_schema_id=block_schema_id
         )
 
+    async def test_delete_block_schema_clears_server_default_result_storage(
+        self, session, block_schema
+    ):
+        block = await models.block_documents.create_block_document(
+            session=session,
+            block_document=schemas.actions.BlockDocumentCreate(
+                name="server-default-result-storage",
+                data=dict(),
+                block_schema_id=block_schema.id,
+                block_type_id=block_schema.block_type_id,
+            ),
+        )
+        await models.storage_defaults.write_server_default_result_storage(
+            session=session,
+            storage_default=schemas.core.ServerDefaultResultStorage(
+                default_result_storage_block_id=block.id
+            ),
+        )
+
+        await models.block_schemas.delete_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+
+        storage_default = (
+            await models.storage_defaults.read_server_default_result_storage(
+                session=session
+            )
+        )
+        assert storage_default.default_result_storage_block_id is None
+
     async def test_delete_block_schema_fails_gracefully(self, session, block_schema):
         block_schema_id = block_schema.id
         assert await models.block_schemas.delete_block_schema(

--- a/tests/server/models/test_block_types.py
+++ b/tests/server/models/test_block_types.py
@@ -295,6 +295,36 @@ class TestDeleteBlockType:
             session=session, block_type_id=block_type_x.id
         )
 
+    async def test_delete_block_type_clears_server_default_result_storage(
+        self, session, block_type_x, block_schema
+    ):
+        block = await models.block_documents.create_block_document(
+            session=session,
+            block_document=schemas.actions.BlockDocumentCreate(
+                name="server-default-result-storage",
+                data=dict(),
+                block_schema_id=block_schema.id,
+                block_type_id=block_type_x.id,
+            ),
+        )
+        await models.storage_defaults.write_server_default_result_storage(
+            session=session,
+            storage_default=schemas.core.ServerDefaultResultStorage(
+                default_result_storage_block_id=block.id
+            ),
+        )
+
+        await models.block_types.delete_block_type(
+            session=session, block_type_id=block_type_x.id
+        )
+
+        storage_default = (
+            await models.storage_defaults.read_server_default_result_storage(
+                session=session
+            )
+        )
+        assert storage_default.default_result_storage_block_id is None
+
     async def test_delete_nonexistant_block_type(self, session):
         assert not await models.block_types.delete_block_type(
             session=session, block_type_id=uuid4()


### PR DESCRIPTION
this PR clears the server default result storage setting when the referenced block document is deleted. that prevents the server from returning a dangling default result storage block id after normal block deletion.

<details>
<summary>Details</summary>

- adds model-level cleanup after a block document delete succeeds
- clears only when the deleted block is the configured server default result storage block
- preserves the setting when unrelated blocks are deleted
- covers both deletion paths in model tests

</details>

Testing:
- `uv run pytest tests/server/models/test_block_documents.py::TestDeleteBlockDocument -q`
- `uv run pytest tests/server/models/test_storage_defaults.py -q`
- `uv run pytest tests/server/api/test_admin.py::TestServerDefaultResultStorage -q`
- `uv run ruff check src/prefect/server/models/block_documents.py src/prefect/server/models/storage_defaults.py tests/server/models/test_block_documents.py`