### PR TITLE
Fixes typing issues as ** accepts Any parameter, not just dicts

### DIFF
--- a/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
+++ b/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
@@ -198,9 +198,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
 
         return engine
 
-    def get_connection(
-        self, begin: bool = True, **connect_kwargs: Any
-    ) -> Connection:
+    def get_connection(self, begin: bool = True, **connect_kwargs: Any) -> Connection:
         """
         Returns a connection that can be used to query from databases.
 

--- a/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
+++ b/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
@@ -148,7 +148,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         if self._exit_stack is None:
             self._exit_stack = ExitStack()
 
-    def get_engine(self, **create_engine_kwargs: Dict[str, Any]) -> Engine:
+    def get_engine(self, **create_engine_kwargs: Any) -> Engine:
         """
         Returns an authenticated engine that can be
         used to query from databases.
@@ -199,7 +199,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         return engine
 
     def get_connection(
-        self, begin: bool = True, **connect_kwargs: Dict[str, Any]
+        self, begin: bool = True, **connect_kwargs: Any
     ) -> Connection:
         """
         Returns a connection that can be used to query from databases.
@@ -286,7 +286,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         connection: Connection,
         *execute_args: Tuple[Any],
         execute_commit: bool = True,
-        **execute_kwargs: Dict[str, Any],
+        **execute_kwargs: Any,
     ) -> CursorResult:
         """Execute the statement synchronously."""
         result_set = connection.execute(*execute_args, **execute_kwargs)
@@ -295,7 +295,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         return result_set
 
     def _get_result_set(
-        self, *execute_args: Tuple[Any], **execute_kwargs: Dict[str, Any]
+        self, *execute_args: Tuple[Any], **execute_kwargs: Any
     ) -> CursorResult:
         """
         Returns a new or existing result set.
@@ -365,7 +365,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> Tuple[Any]:
         """
         Fetch a single result from the database.
@@ -419,7 +419,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         size: Optional[int] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> List[Tuple[Any]]:
         """
         Fetch a limited number of results from the database.
@@ -475,7 +475,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> List[Tuple[Any]]:
         """
         Fetch all results from the database.
@@ -528,7 +528,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> CursorResult:
         """
         Executes an operation on the database.
@@ -572,7 +572,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         seq_of_parameters: List[Dict[str, Any]],
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> CursorResult:
         """
         Executes many operations on the database.
@@ -923,7 +923,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         connection: AsyncConnection,
         *execute_args: Tuple[Any],
         execute_commit: bool = True,
-        **execute_kwargs: Dict[str, Any],
+        **execute_kwargs: Any,
     ) -> CursorResult:
         """Execute the statement asynchronously."""
         result_set = await connection.execute(*execute_args, **execute_kwargs)
@@ -932,7 +932,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         return result_set
 
     async def _get_result_set(
-        self, *execute_args: Tuple[Any], **execute_kwargs: Dict[str, Any]
+        self, *execute_args: Tuple[Any], **execute_kwargs: Any
     ) -> CursorResult:
         """
         Returns a new or existing result set.
@@ -1008,7 +1008,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> Tuple[Any]:
         """
         Fetch a single result from the database.
@@ -1066,7 +1066,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         size: Optional[int] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> List[Tuple[Any]]:
         """
         Fetch a limited number of results from the database.
@@ -1126,7 +1126,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> List[Tuple[Any]]:
         """
         Fetch all results from the database.
@@ -1183,7 +1183,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> CursorResult:
         """
         Executes an operation on the database.
@@ -1231,7 +1231,7 @@ class AsyncSqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self,
         operation: str,
         seq_of_parameters: List[Dict[str, Any]],
-        **execution_options: Dict[str, Any],
+        **execution_options: Any,
     ) -> CursorResult:
         """
         Executes many operations on the database.


### PR DESCRIPTION
** doesn't need a Dict[str, Any] as it will accept Any directly

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
This is not a functional change, only impacting the typing of parameters. 

It fixes the following pyright error:
```
engine = sqlalchemy_connector.get_engine(echo=False)
```
```
error: Argument of type "Literal[False]" cannot be assigned to parameter "echo" of type "Dict[str, Any]" in function "get_engine" "Literal[False]" is not assignable to "Dict[str, Any]" (reportArgumentType)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
