### PR TITLE
Fix flow run suspension at orchestration boundaries

### DIFF
--- a/integration-tests/test_flow_suspension.py
+++ b/integration-tests/test_flow_suspension.py
@@ -1,0 +1,230 @@
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import uv
+
+import prefect
+from prefect import flow, get_client, task
+from prefect.client.schemas.objects import FlowRun
+from prefect.flow_runs import suspend_flow_run
+from prefect.settings import PREFECT_API_URL
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STARTED_MARKER = "flow-started"
+COMPLETED_MARKER = "flow-completed"
+TASK_MARKER_PREFIX = "task-"
+TASK_COUNT = 30
+
+
+@task
+def write_task_marker(marker_dir: str, index: int) -> None:
+    Path(marker_dir, f"{TASK_MARKER_PREFIX}{index}").write_text("done")
+    time.sleep(0.2)
+
+
+@flow(log_prints=True, persist_result=True)
+def externally_suspended_flow(marker_dir: str) -> None:
+    Path(marker_dir, STARTED_MARKER).write_text("started")
+    for index in range(TASK_COUNT):
+        write_task_marker(marker_dir, index)
+    Path(marker_dir, COMPLETED_MARKER).write_text("completed")
+
+
+def _worker_output(log_path: Path) -> str:
+    if not log_path.exists():
+        return "<no worker log>"
+    return log_path.read_text()[-4000:]
+
+
+def _wait_for(
+    predicate,
+    *,
+    timeout: float,
+    message: str,
+    interval: float = 0.2,
+):
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            result = predicate()
+        except Exception as exc:
+            last_error = exc
+            result = None
+
+        if result:
+            return result
+
+        time.sleep(interval)
+
+    if last_error is not None:
+        raise AssertionError(message) from last_error
+    raise AssertionError(message)
+
+
+def _read_flow_run(flow_run_id: UUID) -> FlowRun:
+    with get_client(sync_client=True) as client:
+        return client.read_flow_run(flow_run_id)
+
+
+def _task_marker_count(marker_dir: Path) -> int:
+    return len(list(marker_dir.glob(f"{TASK_MARKER_PREFIX}*")))
+
+
+def test_external_suspension_stops_flow_run_at_next_task_boundary(tmp_path: Path):
+    api_url = PREFECT_API_URL.value()
+    assert api_url, "PREFECT_API_URL must be configured for integration tests."
+    cli_env = {**os.environ, "PREFECT_API_URL": api_url}
+
+    work_pool_name = f"suspension-pool-{uuid4()}"
+    deployment_name = f"suspension-deployment-{uuid4()}"
+    marker_dir = tmp_path / "markers"
+    marker_dir.mkdir()
+    execution_log_path = tmp_path / "flow-run-execute.log"
+
+    work_pool_created = False
+    deployment_id: UUID | None = None
+    flow_run_id: UUID | None = None
+    execution_process: subprocess.Popen[str] | None = None
+    execution_log = None
+
+    try:
+        subprocess.check_call(
+            [
+                uv.find_uv_bin(),
+                "run",
+                "--isolated",
+                "prefect",
+                "work-pool",
+                "create",
+                work_pool_name,
+                "-t",
+                "process",
+            ],
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            cwd=REPO_ROOT,
+            env=cli_env,
+        )
+        work_pool_created = True
+
+        deployment_id = prefect.flow.from_source(
+            source=str(REPO_ROOT),
+            entrypoint="integration-tests/test_flow_suspension.py:externally_suspended_flow",
+        ).deploy(
+            name=deployment_name,
+            work_pool_name=work_pool_name,
+            parameters={"marker_dir": str(marker_dir)},
+            build=False,
+            push=False,
+            print_next_steps=False,
+            ignore_warnings=True,
+        )
+
+        with get_client(sync_client=True) as client:
+            flow_run = client.create_flow_run_from_deployment(deployment_id)
+            flow_run_id = flow_run.id
+
+        execution_log = execution_log_path.open("w")
+        execution_process = subprocess.Popen(
+            [
+                uv.find_uv_bin(),
+                "run",
+                "--isolated",
+                "prefect",
+                "flow-run",
+                "execute",
+                str(flow_run_id),
+            ],
+            stdout=execution_log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=REPO_ROOT,
+            env=cli_env,
+        )
+
+        _wait_for(
+            lambda: (
+                _task_marker_count(marker_dir)
+                if Path(marker_dir, STARTED_MARKER).exists()
+                and _task_marker_count(marker_dir) > 0
+                and (flow_run := _read_flow_run(flow_run_id)).state
+                and flow_run.state.is_running()
+                else None
+            ),
+            timeout=90,
+            message=(
+                "Flow run did not start and complete an initial task boundary.\n"
+                f"Execution log:\n{_worker_output(execution_log_path)}"
+            ),
+        )
+
+        suspend_flow_run(flow_run_id=flow_run_id)
+
+        return_code = execution_process.wait(timeout=120)
+        assert return_code == 0, (
+            f"`prefect flow-run execute` exited with code {return_code}.\n"
+            f"Execution log:\n{_worker_output(execution_log_path)}"
+        )
+
+        suspended_run = _wait_for(
+            lambda: (
+                flow_run
+                if (flow_run := _read_flow_run(flow_run_id)).state
+                and flow_run.state.is_paused()
+                and flow_run.state.name == "Suspended"
+                else None
+            ),
+            timeout=60,
+            message=(
+                "Flow run did not reach Suspended.\n"
+                f"Execution log:\n{_worker_output(execution_log_path)}"
+            ),
+        )
+
+        task_marker_count = _task_marker_count(marker_dir)
+        assert suspended_run.state and suspended_run.state.name == "Suspended"
+        assert 0 < task_marker_count < TASK_COUNT, (
+            f"Expected suspension before all tasks completed, got {task_marker_count}"
+            f" task markers.\nExecution log:\n{_worker_output(execution_log_path)}"
+        )
+        assert not Path(marker_dir, COMPLETED_MARKER).exists()
+
+    finally:
+        if execution_process is not None and execution_process.poll() is None:
+            execution_process.terminate()
+            try:
+                execution_process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                execution_process.kill()
+                execution_process.wait(timeout=20)
+
+        if execution_log is not None:
+            execution_log.close()
+
+        if deployment_id is not None:
+            with get_client(sync_client=True) as client:
+                client.delete_deployment(deployment_id)
+
+        if work_pool_created:
+            subprocess.check_call(
+                [
+                    uv.find_uv_bin(),
+                    "run",
+                    "--isolated",
+                    "prefect",
+                    "--no-prompt",
+                    "work-pool",
+                    "delete",
+                    work_pool_name,
+                ],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                cwd=REPO_ROOT,
+                env=cli_env,
+            )

--- a/src/prefect/_flow_run_suspension.py
+++ b/src/prefect/_flow_run_suspension.py
@@ -123,7 +123,7 @@ def observe_flow_run_suspension(
 
     thread = threading.Thread(target=observer_thread, daemon=True)
     thread.start()
-    ready_event.wait(timeout=2)
+    ready_event.wait()
 
     try:
         yield

--- a/src/prefect/_flow_run_suspension.py
+++ b/src/prefect/_flow_run_suspension.py
@@ -41,6 +41,10 @@ class FlowRunSuspensionRequest:
             raise Pause(state=state)
 
 
+def is_suspended_flow_run_state(state: State | None) -> bool:
+    return bool(state and state.is_paused() and state.name == "Suspended")
+
+
 _active_flow_run_suspension_requests: dict[UUID, FlowRunSuspensionRequest] = {}
 _active_flow_run_suspension_requests_lock = threading.Lock()
 
@@ -94,8 +98,8 @@ def observe_flow_run_suspension(
     stop_event = threading.Event()
     ready_event = threading.Event()
 
-    def mark_suspended(observed_flow_run_id: UUID, state: State) -> None:
-        if not mark_flow_run_suspension_requested(observed_flow_run_id, state):
+    def mark_suspended(flow_run_id: UUID, state: State) -> None:
+        if not mark_flow_run_suspension_requested(flow_run_id, state):
             suspension_request.mark_requested(state)
 
     async def run_observer() -> None:

--- a/src/prefect/_flow_run_suspension.py
+++ b/src/prefect/_flow_run_suspension.py
@@ -12,57 +12,66 @@ from prefect.exceptions import Pause
 from prefect.logging.loggers import get_logger
 
 
-class FlowRunSuspensionSignal:
-    """Mutable in-process signal shared by flow, child flow, and task contexts."""
+class FlowRunSuspensionRequest:
+    """
+    Mutable in-process suspension request shared by flow, child flow, and task contexts.
+
+    The stored state is the server-accepted `Suspended` state that should be raised
+    through Prefect's existing `Pause` control-flow path at the next orchestration
+    boundary.
+    """
 
     def __init__(self) -> None:
-        self._state: State | None = None
+        self._suspended_state: State | None = None
         self._lock = threading.Lock()
 
-    def set(self, state: State) -> None:
+    def mark_requested(self, state: State) -> None:
         with self._lock:
-            self._state = state
+            self._suspended_state = state
 
-    def get(self) -> State | None:
+    def get_state(self) -> State | None:
         with self._lock:
-            return self._state
+            return self._suspended_state
 
-    def is_set(self) -> bool:
-        return self.get() is not None
+    def is_requested(self) -> bool:
+        return self.get_state() is not None
 
-    def raise_if_suspended(self) -> None:
-        if state := self.get():
+    def raise_if_requested(self) -> None:
+        if state := self.get_state():
             raise Pause(state=state)
 
 
-_active_flow_run_suspension_signals: dict[UUID, FlowRunSuspensionSignal] = {}
-_active_flow_run_suspension_signals_lock = threading.Lock()
+_active_flow_run_suspension_requests: dict[UUID, FlowRunSuspensionRequest] = {}
+_active_flow_run_suspension_requests_lock = threading.Lock()
 
 
 @contextmanager
-def register_flow_run_suspension_signal(
+def register_flow_run_suspension_request(
     flow_run_id: UUID,
-    signal: FlowRunSuspensionSignal,
+    suspension_request: FlowRunSuspensionRequest,
 ) -> Generator[None, None, None]:
-    with _active_flow_run_suspension_signals_lock:
-        _active_flow_run_suspension_signals[flow_run_id] = signal
+    with _active_flow_run_suspension_requests_lock:
+        _active_flow_run_suspension_requests[flow_run_id] = suspension_request
 
     try:
         yield
     finally:
-        with _active_flow_run_suspension_signals_lock:
-            if _active_flow_run_suspension_signals.get(flow_run_id) is signal:
-                _active_flow_run_suspension_signals.pop(flow_run_id, None)
+        with _active_flow_run_suspension_requests_lock:
+            if (
+                _active_flow_run_suspension_requests.get(flow_run_id)
+                is suspension_request
+            ):
+                _active_flow_run_suspension_requests.pop(flow_run_id, None)
 
 
-def signal_flow_run_suspension(flow_run_id: UUID, state: State) -> bool:
-    with _active_flow_run_suspension_signals_lock:
-        signal = _active_flow_run_suspension_signals.get(flow_run_id)
+def mark_flow_run_suspension_requested(flow_run_id: UUID, state: State) -> bool:
+    with _active_flow_run_suspension_requests_lock:
+        suspension_request = _active_flow_run_suspension_requests.get(flow_run_id)
 
-    if signal is None:
+    if suspension_request is None:
         return False
 
-    signal.set(state)
+    suspension_request.mark_requested(state)
     return True
 
 
@@ -70,13 +79,13 @@ def raise_if_flow_run_suspension_requested() -> None:
     from prefect.context import FlowRunContext
 
     if flow_run_context := FlowRunContext.get():
-        flow_run_context.flow_run_suspension_signal.raise_if_suspended()
+        flow_run_context.flow_run_suspension_request.raise_if_requested()
 
 
 @contextmanager
 def observe_flow_run_suspension(
     flow_run_id: UUID,
-    signal: FlowRunSuspensionSignal,
+    suspension_request: FlowRunSuspensionRequest,
     polling_interval: float = 10,
 ) -> Generator[None, None, None]:
     from prefect._observers import FlowRunSuspendingObserver
@@ -86,8 +95,8 @@ def observe_flow_run_suspension(
     ready_event = threading.Event()
 
     def mark_suspended(observed_flow_run_id: UUID, state: State) -> None:
-        if not signal_flow_run_suspension(observed_flow_run_id, state):
-            signal.set(state)
+        if not mark_flow_run_suspension_requested(observed_flow_run_id, state):
+            suspension_request.mark_requested(state)
 
     async def run_observer() -> None:
         async with FlowRunSuspendingObserver(

--- a/src/prefect/_flow_run_suspension.py
+++ b/src/prefect/_flow_run_suspension.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import threading
+from contextlib import contextmanager
+from typing import Generator
+from uuid import UUID
+
+from prefect.client.schemas.objects import State
+from prefect.exceptions import Pause
+from prefect.logging.loggers import get_logger
+
+
+class FlowRunSuspensionSignal:
+    """Mutable in-process signal shared by flow, child flow, and task contexts."""
+
+    def __init__(self) -> None:
+        self._state: State | None = None
+        self._lock = threading.Lock()
+
+    def set(self, state: State) -> None:
+        with self._lock:
+            self._state = state
+
+    def get(self) -> State | None:
+        with self._lock:
+            return self._state
+
+    def is_set(self) -> bool:
+        return self.get() is not None
+
+    def raise_if_suspended(self) -> None:
+        if state := self.get():
+            raise Pause(state=state)
+
+
+_active_flow_run_suspension_signals: dict[UUID, FlowRunSuspensionSignal] = {}
+_active_flow_run_suspension_signals_lock = threading.Lock()
+
+
+@contextmanager
+def register_flow_run_suspension_signal(
+    flow_run_id: UUID,
+    signal: FlowRunSuspensionSignal,
+) -> Generator[None, None, None]:
+    with _active_flow_run_suspension_signals_lock:
+        _active_flow_run_suspension_signals[flow_run_id] = signal
+
+    try:
+        yield
+    finally:
+        with _active_flow_run_suspension_signals_lock:
+            if _active_flow_run_suspension_signals.get(flow_run_id) is signal:
+                _active_flow_run_suspension_signals.pop(flow_run_id, None)
+
+
+def signal_flow_run_suspension(flow_run_id: UUID, state: State) -> bool:
+    with _active_flow_run_suspension_signals_lock:
+        signal = _active_flow_run_suspension_signals.get(flow_run_id)
+
+    if signal is None:
+        return False
+
+    signal.set(state)
+    return True
+
+
+def raise_if_flow_run_suspension_requested() -> None:
+    from prefect.context import FlowRunContext
+
+    if flow_run_context := FlowRunContext.get():
+        flow_run_context.flow_run_suspension_signal.raise_if_suspended()
+
+
+@contextmanager
+def observe_flow_run_suspension(
+    flow_run_id: UUID,
+    signal: FlowRunSuspensionSignal,
+    polling_interval: float = 10,
+) -> Generator[None, None, None]:
+    from prefect._observers import FlowRunSuspendingObserver
+
+    logger = get_logger("flow_run_suspension")
+    stop_event = threading.Event()
+    ready_event = threading.Event()
+
+    def mark_suspended(observed_flow_run_id: UUID, state: State) -> None:
+        if not signal_flow_run_suspension(observed_flow_run_id, state):
+            signal.set(state)
+
+    async def run_observer() -> None:
+        async with FlowRunSuspendingObserver(
+            on_suspended=mark_suspended,
+            polling_interval=polling_interval,
+        ) as observer:
+            await observer.watch_flow_run_id(flow_run_id)
+            ready_event.set()
+            while not stop_event.is_set():
+                await asyncio.sleep(0.2)
+
+    context = contextvars.copy_context()
+
+    def observer_thread() -> None:
+        try:
+            context.run(lambda: asyncio.run(run_observer()))
+        except Exception:
+            logger.debug(
+                "Flow run suspension observer exited with an exception",
+                exc_info=True,
+            )
+        finally:
+            ready_event.set()
+
+    thread = threading.Thread(target=observer_thread, daemon=True)
+    thread.start()
+    ready_event.wait(timeout=2)
+
+    try:
+        yield
+    finally:
+        stop_event.set()
+        thread.join(timeout=2)

--- a/src/prefect/_observers.py
+++ b/src/prefect/_observers.py
@@ -5,6 +5,7 @@ import uuid
 from contextlib import AsyncExitStack
 from typing import Any, Protocol
 
+from prefect._flow_run_suspension import is_suspended_flow_run_state
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.filters import (
     FlowRunFilter,
@@ -333,7 +334,7 @@ class FlowRunSuspendingObserver:
     def _notify_if_suspended_state(
         self, flow_run_id: uuid.UUID, state: State | None
     ) -> None:
-        if state and state.is_paused() and state.name == "Suspended":
+        if state is not None and is_suspended_flow_run_state(state):
             self._suspended_flow_run_ids.add(flow_run_id)
             self.on_suspended(flow_run_id, state)
 
@@ -370,21 +371,27 @@ class FlowRunSuspendingObserver:
                 )
 
     def _start_polling_task(self, task: asyncio.Task[None]):
-        if task.cancelled():
+        if task.cancelled() or self._is_shutting_down:
             return
+
         if exc := task.exception():
             self.logger.warning(
                 "The FlowRunSuspendingObserver websocket failed with an exception. Switching to polling mode.",
                 exc_info=exc,
             )
-            self._polling_task = asyncio.create_task(
-                critical_service_loop(
-                    workload=self._check_for_suspended_flow_runs,
-                    interval=self.polling_interval,
-                    jitter_range=0.3,
-                )
+        else:
+            self.logger.warning(
+                "The FlowRunSuspendingObserver websocket closed. Switching to polling mode.",
             )
-            self._polling_task.add_done_callback(self._handle_polling_task_done)
+
+        self._polling_task = asyncio.create_task(
+            critical_service_loop(
+                workload=self._check_for_suspended_flow_runs,
+                interval=self.polling_interval,
+                jitter_range=0.3,
+            )
+        )
+        self._polling_task.add_done_callback(self._handle_polling_task_done)
 
     def _handle_polling_task_done(self, task: asyncio.Task[None]):
         if task.exception():

--- a/src/prefect/_observers.py
+++ b/src/prefect/_observers.py
@@ -306,21 +306,29 @@ class FlowRunSuspendingObserver:
             raise RuntimeError(
                 "Client not initialized. Please use `async with` to initialize the observer."
             )
-        if flow_run_id in self._suspended_flow_run_ids:
-            return
+        retry_interval = max(min(self.polling_interval, 1.0), 0.01)
+        attempts = 0
 
-        try:
-            flow_run = await self._client.read_flow_run(flow_run_id)
-        except Exception:
-            self.logger.warning(
-                "Failed to check current state for flow run %s while starting"
-                " suspension observer. Continuing to watch for suspension events.",
-                flow_run_id,
-                exc_info=True,
-            )
-            return
+        while not self._is_shutting_down:
+            if flow_run_id in self._suspended_flow_run_ids:
+                return
 
-        self._notify_if_suspended_state(flow_run_id, flow_run.state)
+            try:
+                flow_run = await self._client.read_flow_run(flow_run_id)
+            except Exception:
+                attempts += 1
+                log = self.logger.warning if attempts == 1 else self.logger.debug
+                log(
+                    "Failed to check current state for flow run %s while starting"
+                    " suspension observer. Retrying before reporting observer ready.",
+                    flow_run_id,
+                    exc_info=True,
+                )
+                await asyncio.sleep(retry_interval)
+                continue
+
+            self._notify_if_suspended_state(flow_run_id, flow_run.state)
+            return
 
     def _notify_if_suspended_state(
         self, flow_run_id: uuid.UUID, state: State | None

--- a/src/prefect/_observers.py
+++ b/src/prefect/_observers.py
@@ -13,7 +13,7 @@ from prefect.client.schemas.filters import (
     FlowRunFilterStateName,
     FlowRunFilterStateType,
 )
-from prefect.client.schemas.objects import StateType
+from prefect.client.schemas.objects import State, StateType
 from prefect.events.clients import PrefectEventSubscriber, get_events_subscriber
 from prefect.events.filters import EventFilter, EventNameFilter
 from prefect.logging.loggers import get_logger
@@ -22,6 +22,10 @@ from prefect.utilities.services import critical_service_loop
 
 class OnCancellingCallback(Protocol):
     def __call__(self, flow_run_id: uuid.UUID) -> None: ...
+
+
+class OnSuspendedCallback(Protocol):
+    def __call__(self, flow_run_id: uuid.UUID, state: State) -> None: ...
 
 
 class OnFailureCallback(Protocol):
@@ -220,6 +224,236 @@ class FlowRunCancellingObserver:
 
     async def __aexit__(self, *exc_info: Any):
         self.logger.debug("Shutting down FlowRunCancellingObserver")
+        self._is_shutting_down = True
+        await self._exit_stack.__aexit__(*exc_info)
+        if self._consumer_task is not None:
+            self._consumer_task.cancel()
+            try:
+                await self._consumer_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                self.logger.warning(
+                    "Consumer task exited with exception", exc_info=True
+                )
+                pass
+
+        if self._polling_task is not None:
+            self._polling_task.cancel()
+            try:
+                await self._polling_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                self.logger.warning("Polling task exited with exception", exc_info=True)
+                pass
+
+
+class FlowRunSuspendingObserver:
+    def __init__(
+        self,
+        on_suspended: OnSuspendedCallback,
+        polling_interval: float = 10,
+        event_filter: EventFilter | None = None,
+        on_failure: OnFailureCallback | None = None,
+    ):
+        """
+        Observer that notices flow runs when they are marked as suspended.
+
+        Uses the events stream to listen for suspension events by default, with a
+        polling fallback when the websocket connection is unavailable or lost.
+        """
+        self.logger = get_logger("FlowRunSuspendingObserver")
+        self.on_suspended = on_suspended
+        self.on_failure = on_failure
+        self.polling_interval = polling_interval
+
+        if event_filter is not None:
+            if (
+                event_filter.event is None
+                or event_filter.event.name is None
+                or "prefect.flow-run.Suspended" not in event_filter.event.name
+            ):
+                raise ValueError(
+                    "event_filter must include 'prefect.flow-run.Suspended' in event.name"
+                )
+            self._event_filter = event_filter
+        else:
+            self._event_filter = EventFilter(
+                event=EventNameFilter(name=["prefect.flow-run.Suspended"])
+            )
+        self._in_flight_flow_run_ids: set[uuid.UUID] = set()
+        self._events_subscriber: PrefectEventSubscriber | None
+        self._exit_stack = AsyncExitStack()
+        self._consumer_task: asyncio.Task[None] | None = None
+        self._polling_task: asyncio.Task[None] | None = None
+        self._is_shutting_down = False
+        self._client: PrefectClient | None = None
+        self._suspended_flow_run_ids: set[uuid.UUID] = set()
+
+    def add_in_flight_flow_run_id(self, flow_run_id: uuid.UUID):
+        self.logger.debug("Adding in-flight flow run ID: %s", flow_run_id)
+        self._in_flight_flow_run_ids.add(flow_run_id)
+
+    def remove_in_flight_flow_run_id(self, flow_run_id: uuid.UUID):
+        self.logger.debug("Removing in-flight flow run ID: %s", flow_run_id)
+        self._in_flight_flow_run_ids.discard(flow_run_id)
+        self._suspended_flow_run_ids.discard(flow_run_id)
+
+    async def watch_flow_run_id(self, flow_run_id: uuid.UUID) -> None:
+        self.add_in_flight_flow_run_id(flow_run_id)
+        if self._client is None:
+            raise RuntimeError(
+                "Client not initialized. Please use `async with` to initialize the observer."
+            )
+        if flow_run_id in self._suspended_flow_run_ids:
+            return
+
+        try:
+            flow_run = await self._client.read_flow_run(flow_run_id)
+        except Exception:
+            self.logger.warning(
+                "Failed to check current state for flow run %s while starting"
+                " suspension observer. Continuing to watch for suspension events.",
+                flow_run_id,
+                exc_info=True,
+            )
+            return
+
+        self._notify_if_suspended_state(flow_run_id, flow_run.state)
+
+    def _notify_if_suspended_state(
+        self, flow_run_id: uuid.UUID, state: State | None
+    ) -> None:
+        if state and state.is_paused() and state.name == "Suspended":
+            self._suspended_flow_run_ids.add(flow_run_id)
+            self.on_suspended(flow_run_id, state)
+
+    async def _notify_if_suspended(self, flow_run_id: uuid.UUID) -> None:
+        if self._client is None:
+            raise RuntimeError(
+                "Client not initialized. Please use `async with` to initialize the observer."
+            )
+        if flow_run_id in self._suspended_flow_run_ids:
+            return
+
+        flow_run = await self._client.read_flow_run(flow_run_id)
+        self._notify_if_suspended_state(flow_run_id, flow_run.state)
+
+    async def _consume_events(self):
+        if self._events_subscriber is None:
+            raise RuntimeError(
+                "Events subscriber not initialized. Please use `async with` to initialize the observer."
+            )
+        async for event in self._events_subscriber:
+            try:
+                flow_run_id = uuid.UUID(
+                    event.resource["prefect.resource.id"].replace(
+                        "prefect.flow-run.", ""
+                    )
+                )
+                if flow_run_id not in self._in_flight_flow_run_ids:
+                    continue
+                await self._notify_if_suspended(flow_run_id)
+            except ValueError:
+                self.logger.warning(
+                    "Received event with invalid flow run ID: %s",
+                    event.resource["prefect.resource.id"],
+                )
+
+    def _start_polling_task(self, task: asyncio.Task[None]):
+        if task.cancelled():
+            return
+        if exc := task.exception():
+            self.logger.warning(
+                "The FlowRunSuspendingObserver websocket failed with an exception. Switching to polling mode.",
+                exc_info=exc,
+            )
+            self._polling_task = asyncio.create_task(
+                critical_service_loop(
+                    workload=self._check_for_suspended_flow_runs,
+                    interval=self.polling_interval,
+                    jitter_range=0.3,
+                )
+            )
+            self._polling_task.add_done_callback(self._handle_polling_task_done)
+
+    def _handle_polling_task_done(self, task: asyncio.Task[None]):
+        if task.exception():
+            self.logger.error(
+                "Suspension polling task failed. Execution will continue, but external flow run suspension will fail.",
+                exc_info=task.exception(),
+            )
+            if self.on_failure is not None:
+                self.on_failure(self._in_flight_flow_run_ids.copy())
+        else:
+            self.logger.debug("Polling task completed")
+
+    async def _check_for_suspended_flow_runs(self):
+        if self._is_shutting_down:
+            return
+        if self._client is None:
+            raise RuntimeError(
+                "Client not initialized. Please use `async with` to initialize the observer."
+            )
+
+        flow_run_ids = self._in_flight_flow_run_ids - self._suspended_flow_run_ids
+        if not flow_run_ids:
+            return
+
+        self.logger.debug("Checking for suspended flow runs")
+        suspended_flow_runs = await self._client.read_flow_runs(
+            flow_run_filter=FlowRunFilter(
+                state=FlowRunFilterState(
+                    type=FlowRunFilterStateType(any_=[StateType.PAUSED]),
+                    name=FlowRunFilterStateName(any_=["Suspended"]),
+                ),
+                id=FlowRunFilterId(any_=list(flow_run_ids)),
+            ),
+        )
+
+        if suspended_flow_runs:
+            self.logger.info(
+                "Found %s flow runs awaiting suspension.", len(suspended_flow_runs)
+            )
+
+        for flow_run in suspended_flow_runs:
+            if flow_run.state:
+                self._suspended_flow_run_ids.add(flow_run.id)
+                self.on_suspended(flow_run.id, flow_run.state)
+
+    async def __aenter__(self):
+        try:
+            self._events_subscriber = await self._exit_stack.enter_async_context(
+                get_events_subscriber(filter=self._event_filter)
+            )
+        except Exception as e:
+            self.logger.warning(
+                "Failed to connect to the events stream. Falling back to polling "
+                "for suspension events. Reason: %s",
+                str(e),
+            )
+            self._events_subscriber = None
+
+        self._client = await self._exit_stack.enter_async_context(get_client())
+
+        if self._events_subscriber is not None:
+            self._consumer_task = asyncio.create_task(self._consume_events())
+            self._consumer_task.add_done_callback(self._start_polling_task)
+        else:
+            self._polling_task = asyncio.create_task(
+                critical_service_loop(
+                    workload=self._check_for_suspended_flow_runs,
+                    interval=self.polling_interval,
+                    jitter_range=0.3,
+                )
+            )
+            self._polling_task.add_done_callback(self._handle_polling_task_done)
+
+        return self
+
+    async def __aexit__(self, *exc_info: Any):
+        self.logger.debug("Shutting down FlowRunSuspendingObserver")
         self._is_shutting_down = True
         await self._exit_stack.__aexit__(*exc_info)
         if self._consumer_task is not None:

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -30,6 +30,7 @@ from typing_extensions import Self
 
 import prefect.settings
 import prefect.types._datetime
+from prefect._flow_run_suspension import FlowRunSuspensionSignal
 from prefect._internal.compatibility.migration import getattr_migration
 from prefect.assets import Asset
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
@@ -469,6 +470,13 @@ class EngineContext(RunContext):
 
     # Counter for flow pauses
     observed_flow_pauses: dict[str, int] = Field(default_factory=dict)
+
+    # In-process signal used to stop execution at orchestration boundaries when
+    # the flow run is suspended externally.
+    flow_run_suspension_signal: FlowRunSuspensionSignal = Field(
+        default_factory=FlowRunSuspensionSignal,
+        exclude=True,
+    )
 
     # Tracking for result from task runs and sub flows in this flow run for
     # dependency tracking. Keyed by `id(obj)` of the result object. The

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -30,7 +30,7 @@ from typing_extensions import Self
 
 import prefect.settings
 import prefect.types._datetime
-from prefect._flow_run_suspension import FlowRunSuspensionSignal
+from prefect._flow_run_suspension import FlowRunSuspensionRequest
 from prefect._internal.compatibility.migration import getattr_migration
 from prefect.assets import Asset
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
@@ -471,10 +471,10 @@ class EngineContext(RunContext):
     # Counter for flow pauses
     observed_flow_pauses: dict[str, int] = Field(default_factory=dict)
 
-    # In-process signal used to stop execution at orchestration boundaries when
-    # the flow run is suspended externally.
-    flow_run_suspension_signal: FlowRunSuspensionSignal = Field(
-        default_factory=FlowRunSuspensionSignal,
+    # In-process suspension request used to stop execution at orchestration
+    # boundaries with the server-accepted Suspended state.
+    flow_run_suspension_request: FlowRunSuspensionRequest = Field(
+        default_factory=FlowRunSuspensionRequest,
         exclude=True,
     )
 

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -44,10 +44,10 @@ from typing_extensions import ParamSpec
 
 from prefect import Task, __version__
 from prefect._flow_run_suspension import (
-    FlowRunSuspensionSignal,
+    FlowRunSuspensionRequest,
     observe_flow_run_suspension,
     raise_if_flow_run_suspension_requested,
-    register_flow_run_suspension_signal,
+    register_flow_run_suspension_request,
 )
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.control_listener import Intent, configure_from_env, get_intent
@@ -1007,10 +1007,10 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         self.flow_run = client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
         parent_flow_run_context = FlowRunContext.get()
-        flow_run_suspension_signal = (
-            parent_flow_run_context.flow_run_suspension_signal
+        flow_run_suspension_request = (
+            parent_flow_run_context.flow_run_suspension_request
             if parent_flow_run_context
-            else FlowRunSuspensionSignal()
+            else FlowRunSuspensionRequest()
         )
 
         with ExitStack() as stack:
@@ -1036,18 +1036,18 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     result_store=result_store,
                     task_runner=task_runner,
                     persist_result=persist_result,
-                    flow_run_suspension_signal=flow_run_suspension_signal,
+                    flow_run_suspension_request=flow_run_suspension_request,
                 )
             )
             stack.enter_context(
-                register_flow_run_suspension_signal(
-                    self.flow_run.id, flow_run_suspension_signal
+                register_flow_run_suspension_request(
+                    self.flow_run.id, flow_run_suspension_request
                 )
             )
             if self.flow_run.deployment_id:
                 stack.enter_context(
                     observe_flow_run_suspension(
-                        self.flow_run.id, flow_run_suspension_signal
+                        self.flow_run.id, flow_run_suspension_request
                     )
                 )
             # Set deployment context vars only if this is the top-level deployment run
@@ -1695,10 +1695,10 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         self.flow_run = await client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
         parent_flow_run_context = FlowRunContext.get()
-        flow_run_suspension_signal = (
-            parent_flow_run_context.flow_run_suspension_signal
+        flow_run_suspension_request = (
+            parent_flow_run_context.flow_run_suspension_request
             if parent_flow_run_context
-            else FlowRunSuspensionSignal()
+            else FlowRunSuspensionRequest()
         )
 
         async with AsyncExitStack() as stack:
@@ -1724,18 +1724,18 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     result_store=result_store,
                     task_runner=task_runner,
                     persist_result=persist_result,
-                    flow_run_suspension_signal=flow_run_suspension_signal,
+                    flow_run_suspension_request=flow_run_suspension_request,
                 )
             )
             stack.enter_context(
-                register_flow_run_suspension_signal(
-                    self.flow_run.id, flow_run_suspension_signal
+                register_flow_run_suspension_request(
+                    self.flow_run.id, flow_run_suspension_request
                 )
             )
             if self.flow_run.deployment_id:
                 stack.enter_context(
                     observe_flow_run_suspension(
-                        self.flow_run.id, flow_run_suspension_signal
+                        self.flow_run.id, flow_run_suspension_request
                     )
                 )
             # Set deployment context vars only if this is the top-level deployment run

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -43,6 +43,12 @@ from opentelemetry import propagate, trace
 from typing_extensions import ParamSpec
 
 from prefect import Task, __version__
+from prefect._flow_run_suspension import (
+    FlowRunSuspensionSignal,
+    observe_flow_run_suspension,
+    raise_if_flow_run_suspension_requested,
+    register_flow_run_suspension_signal,
+)
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.control_listener import Intent, configure_from_env, get_intent
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
@@ -905,6 +911,8 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
 
         # this is a subflow run
         if flow_run_ctx:
+            raise_if_flow_run_suspension_requested()
+
             # add a task to a parent flow run that represents the execution of a subflow run
             parent_task = Task(
                 name=self.flow.name, fn=self.flow.fn, version=self.flow.version
@@ -998,6 +1006,12 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
 
         self.flow_run = client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
+        parent_flow_run_context = FlowRunContext.get()
+        flow_run_suspension_signal = (
+            parent_flow_run_context.flow_run_suspension_signal
+            if parent_flow_run_context
+            else FlowRunSuspensionSignal()
+        )
 
         with ExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
@@ -1022,8 +1036,20 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     result_store=result_store,
                     task_runner=task_runner,
                     persist_result=persist_result,
+                    flow_run_suspension_signal=flow_run_suspension_signal,
                 )
             )
+            stack.enter_context(
+                register_flow_run_suspension_signal(
+                    self.flow_run.id, flow_run_suspension_signal
+                )
+            )
+            if self.flow_run.deployment_id:
+                stack.enter_context(
+                    observe_flow_run_suspension(
+                        self.flow_run.id, flow_run_suspension_signal
+                    )
+                )
             # Set deployment context vars only if this is the top-level deployment run
             # (nested flows will inherit via ContextVar propagation)
             if self.flow_run.deployment_id and not _deployment_id.get():
@@ -1206,6 +1232,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         timeout_context = timeout_async if self.flow.isasync else timeout
         # reenter the run context to ensure it is up to date for every run
         with self.setup_run_context():
+            raise_if_flow_run_suspension_requested()
             try:
                 with timeout_context(
                     seconds=self.flow.timeout_seconds,
@@ -1574,6 +1601,8 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
 
         # this is a subflow run
         if flow_run_ctx:
+            raise_if_flow_run_suspension_requested()
+
             # add a task to a parent flow run that represents the execution of a subflow run
             parent_task = Task(
                 name=self.flow.name, fn=self.flow.fn, version=self.flow.version
@@ -1665,6 +1694,12 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
 
         self.flow_run = await client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
+        parent_flow_run_context = FlowRunContext.get()
+        flow_run_suspension_signal = (
+            parent_flow_run_context.flow_run_suspension_signal
+            if parent_flow_run_context
+            else FlowRunSuspensionSignal()
+        )
 
         async with AsyncExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
@@ -1689,8 +1724,20 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     result_store=result_store,
                     task_runner=task_runner,
                     persist_result=persist_result,
+                    flow_run_suspension_signal=flow_run_suspension_signal,
                 )
             )
+            stack.enter_context(
+                register_flow_run_suspension_signal(
+                    self.flow_run.id, flow_run_suspension_signal
+                )
+            )
+            if self.flow_run.deployment_id:
+                stack.enter_context(
+                    observe_flow_run_suspension(
+                        self.flow_run.id, flow_run_suspension_signal
+                    )
+                )
             # Set deployment context vars only if this is the top-level deployment run
             # (nested flows will inherit via ContextVar propagation)
             if self.flow_run.deployment_id and not _deployment_id.get():
@@ -1889,6 +1936,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         timeout_context = timeout_async if self.flow.isasync else timeout
         # reenter the run context to ensure it is up to date for every run
         async with self.setup_run_context():
+            raise_if_flow_run_suspension_requested()
             try:
                 with timeout_context(
                     seconds=self.flow.timeout_seconds,

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -45,6 +45,7 @@ from typing_extensions import ParamSpec
 from prefect import Task, __version__
 from prefect._flow_run_suspension import (
     FlowRunSuspensionRequest,
+    is_suspended_flow_run_state,
     observe_flow_run_suspension,
     raise_if_flow_run_suspension_requested,
     register_flow_run_suspension_request,
@@ -808,6 +809,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         msg: Optional[str] = None,
         result_store: Optional[ResultStore] = None,
     ) -> State:
+        self._get_flow_run_suspension_request().raise_if_requested()
         context = FlowRunContext.get()
         terminal_state = cast(
             State,
@@ -828,6 +830,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     f" state {terminal_state.name!r} and will attempt to run again..."
                 ),
             )
+            self._get_flow_run_suspension_request().raise_if_requested()
             state = self.set_state(Running())
         self._raised = exc
         self._telemetry.record_exception(exc)
@@ -843,6 +846,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         else:
             message = f"Flow run failed due to timeout: {exc!r}"
         self.logger.error(message)
+        self._get_flow_run_suspension_request().raise_if_requested()
         state = Failed(
             data=exc,
             message=message,
@@ -854,6 +858,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                 f"Received non-final state {self.state.name!r} when proposing final"
                 f" state {state.name!r} and will attempt to run again..."
             )
+            self._get_flow_run_suspension_request().raise_if_requested()
             self.set_state(Running())
             return
         self._raised = exc
@@ -1043,6 +1048,8 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         self.flow_run = client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
         flow_run_suspension_request = self._get_flow_run_suspension_request()
+        if (state := self.flow_run.state) and is_suspended_flow_run_state(state):
+            flow_run_suspension_request.mark_requested(state)
 
         with ExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
@@ -1487,6 +1494,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         msg: Optional[str] = None,
         result_store: Optional[ResultStore] = None,
     ) -> State:
+        self._get_flow_run_suspension_request().raise_if_requested()
         context = FlowRunContext.get()
         terminal_state = cast(
             State,
@@ -1505,6 +1513,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     f" state {terminal_state.name!r} and will attempt to run again..."
                 ),
             )
+            self._get_flow_run_suspension_request().raise_if_requested()
             state = await self.set_state(Running())
         self._raised = exc
         self._telemetry.record_exception(exc)
@@ -1520,6 +1529,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         else:
             message = f"Flow run failed due to timeout: {exc!r}"
         self.logger.error(message)
+        self._get_flow_run_suspension_request().raise_if_requested()
         state = Failed(
             data=exc,
             message=message,
@@ -1531,6 +1541,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                 f"Received non-final state {self.state.name!r} when proposing final"
                 f" state {state.name!r} and will attempt to run again..."
             )
+            self._get_flow_run_suspension_request().raise_if_requested()
             await self.set_state(Running())
             return
         self._raised = exc
@@ -1719,6 +1730,8 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         self.flow_run = await client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
         flow_run_suspension_request = self._get_flow_run_suspension_request()
+        if (state := self.flow_run.state) and is_suspended_flow_run_state(state):
+            flow_run_suspension_request.mark_requested(state)
 
         async with AsyncExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -419,6 +419,9 @@ class BaseFlowRunEngine(Generic[P, R]):
     _flow_run_name_set: bool = False
     _started_with_in_process_parent_flow_run_context: bool = False
     _telemetry: RunTelemetry = field(default_factory=RunTelemetry)
+    _flow_run_suspension_request: FlowRunSuspensionRequest = field(
+        default_factory=FlowRunSuspensionRequest
+    )
 
     def __post_init__(self) -> None:
         if self.flow is None and self.flow_run_id is None:
@@ -576,6 +579,36 @@ class BaseFlowRunEngine(Generic[P, R]):
             ).lower()
             == "true"
         )
+
+    def _get_flow_run_suspension_request(self) -> FlowRunSuspensionRequest:
+        parent_flow_run_context = FlowRunContext.get()
+        if parent_flow_run_context:
+            return parent_flow_run_context.flow_run_suspension_request
+        return self._flow_run_suspension_request
+
+    @contextmanager
+    def setup_flow_run_suspension_request(
+        self,
+    ) -> Generator[FlowRunSuspensionRequest, None, None]:
+        if not self.flow_run:
+            raise ValueError("Flow run not set")
+
+        flow_run_suspension_request = self._get_flow_run_suspension_request()
+        with ExitStack() as stack:
+            stack.enter_context(
+                register_flow_run_suspension_request(
+                    self.flow_run.id, flow_run_suspension_request
+                )
+            )
+            if self.flow_run.deployment_id:
+                stack.enter_context(
+                    observe_flow_run_suspension(
+                        self.flow_run.id, flow_run_suspension_request
+                    )
+                )
+
+            flow_run_suspension_request.raise_if_requested()
+            yield flow_run_suspension_request
 
 
 @dataclass
@@ -739,6 +772,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         return _result
 
     def handle_success(self, result: R) -> R:
+        raise_if_flow_run_suspension_requested()
         result_store = getattr(FlowRunContext.get(), "result_store", None)
         if result_store is None:
             raise ValueError("Result store is not set")
@@ -1006,12 +1040,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
 
         self.flow_run = client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
-        parent_flow_run_context = FlowRunContext.get()
-        flow_run_suspension_request = (
-            parent_flow_run_context.flow_run_suspension_request
-            if parent_flow_run_context
-            else FlowRunSuspensionRequest()
-        )
+        flow_run_suspension_request = self._get_flow_run_suspension_request()
 
         with ExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
@@ -1039,17 +1068,6 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     flow_run_suspension_request=flow_run_suspension_request,
                 )
             )
-            stack.enter_context(
-                register_flow_run_suspension_request(
-                    self.flow_run.id, flow_run_suspension_request
-                )
-            )
-            if self.flow_run.deployment_id:
-                stack.enter_context(
-                    observe_flow_run_suspension(
-                        self.flow_run.id, flow_run_suspension_request
-                    )
-                )
             # Set deployment context vars only if this is the top-level deployment run
             # (nested flows will inherit via ContextVar propagation)
             if self.flow_run.deployment_id and not _deployment_id.get():
@@ -1223,9 +1241,10 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                 if self._telemetry.span
                 else nullcontext()
             ):
-                self.begin_run()
+                with self.setup_flow_run_suspension_request():
+                    self.begin_run()
 
-                yield
+                    yield
 
     @contextmanager
     def run_context(self):
@@ -1433,6 +1452,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         return await self.state.aresult(raise_on_failure=raise_on_failure)  # type: ignore
 
     async def handle_success(self, result: R) -> R:
+        raise_if_flow_run_suspension_requested()
         result_store = getattr(FlowRunContext.get(), "result_store", None)
         if result_store is None:
             raise ValueError("Result store is not set")
@@ -1694,12 +1714,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
 
         self.flow_run = await client.read_flow_run(self.flow_run.id)
         log_prints = should_log_prints(self.flow)
-        parent_flow_run_context = FlowRunContext.get()
-        flow_run_suspension_request = (
-            parent_flow_run_context.flow_run_suspension_request
-            if parent_flow_run_context
-            else FlowRunSuspensionRequest()
-        )
+        flow_run_suspension_request = self._get_flow_run_suspension_request()
 
         async with AsyncExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
@@ -1727,17 +1742,6 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     flow_run_suspension_request=flow_run_suspension_request,
                 )
             )
-            stack.enter_context(
-                register_flow_run_suspension_request(
-                    self.flow_run.id, flow_run_suspension_request
-                )
-            )
-            if self.flow_run.deployment_id:
-                stack.enter_context(
-                    observe_flow_run_suspension(
-                        self.flow_run.id, flow_run_suspension_request
-                    )
-                )
             # Set deployment context vars only if this is the top-level deployment run
             # (nested flows will inherit via ContextVar propagation)
             if self.flow_run.deployment_id and not _deployment_id.get():
@@ -1927,9 +1931,10 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                 if self._telemetry.span
                 else nullcontext()
             ):
-                await self.begin_run()
+                with self.setup_flow_run_suspension_request():
+                    await self.begin_run()
 
-                yield
+                    yield
 
     @asynccontextmanager
     async def run_context(self):

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -720,6 +720,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             self._flow_run_name_set = True
             self._telemetry.update_run_name(name=flow_run_name)
 
+        self._get_flow_run_suspension_request().raise_if_requested()
         new_state = Running()
         state = self.set_state(new_state)
         while state.is_pending():
@@ -784,6 +785,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                 write_result=should_persist_result(),
             )
         )
+        raise_if_flow_run_suspension_requested()
         self.set_state(terminal_state)
         self._return_value = resolved_result
 
@@ -1401,6 +1403,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             self._flow_run_name_set = True
             self._telemetry.update_run_name(name=flow_run_name)
 
+        self._get_flow_run_suspension_request().raise_if_requested()
         new_state = Running()
         state = await self.set_state(new_state)
         while state.is_pending():
@@ -1462,6 +1465,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             result_store=result_store,
             write_result=should_persist_result(),
         )
+        raise_if_flow_run_suspension_requested()
         await self.set_state(terminal_state)
         self._return_value = resolved_result
 

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -822,6 +822,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                 )
             ),
         )
+        self._get_flow_run_suspension_request().raise_if_requested()
         state = self.set_state(terminal_state)
         if self.state.is_scheduled():
             self.logger.info(
@@ -1505,6 +1506,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                 write_result=True,
             ),
         )
+        self._get_flow_run_suspension_request().raise_if_requested()
         state = await self.set_state(terminal_state)
         if self.state.is_scheduled():
             self.logger.info(

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -11,6 +11,7 @@ from uuid import UUID, uuid4
 
 import anyio
 
+from prefect._flow_run_suspension import signal_flow_run_suspension
 from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
@@ -587,6 +588,8 @@ async def asuspend_flow_run(
         if wait_for_input:
             await wait_for_input.asave(run_input_keyset)
 
+    signal_flow_run_suspension(flow_run_id, state)
+
     if suspending_current_flow_run:
         # Exit this process so the run can be resubmitted later
         raise Pause(state=state)
@@ -711,6 +714,8 @@ def suspend_flow_run(
 
         if wait_for_input:
             wait_for_input.save(run_input_keyset)
+
+    signal_flow_run_suspension(flow_run_id, state)
 
     if suspending_current_flow_run:
         # Exit this process so the run can be resubmitted later

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -11,7 +11,7 @@ from uuid import UUID, uuid4
 
 import anyio
 
-from prefect._flow_run_suspension import signal_flow_run_suspension
+from prefect._flow_run_suspension import mark_flow_run_suspension_requested
 from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
@@ -588,7 +588,7 @@ async def asuspend_flow_run(
         if wait_for_input:
             await wait_for_input.asave(run_input_keyset)
 
-    signal_flow_run_suspension(flow_run_id, state)
+    mark_flow_run_suspension_requested(flow_run_id, state)
 
     if suspending_current_flow_run:
         # Exit this process so the run can be resubmitted later
@@ -715,7 +715,7 @@ def suspend_flow_run(
         if wait_for_input:
             wait_for_input.save(run_input_keyset)
 
-    signal_flow_run_suspension(flow_run_id, state)
+    mark_flow_run_suspension_requested(flow_run_id, state)
 
     if suspending_current_flow_run:
         # Exit this process so the run can be resubmitted later

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -237,6 +237,7 @@ class PrefectConcurrentFuture(PrefectWrappedFuture[R, concurrent.futures.Future[
         try:
             result = self._wrapped_future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
+            raise_if_flow_run_suspension_requested()
             return
         if isinstance(result, State):
             self._final_state = result
@@ -251,6 +252,7 @@ class PrefectConcurrentFuture(PrefectWrappedFuture[R, concurrent.futures.Future[
             try:
                 future_result = self._wrapped_future.result(timeout=timeout)
             except concurrent.futures.TimeoutError as exc:
+                raise_if_flow_run_suspension_requested()
                 raise TimeoutError(
                     f"Task run {self.task_run_id} did not complete within {timeout} seconds"
                 ) from exc
@@ -289,6 +291,7 @@ class PrefectDistributedFuture(PrefectTaskRunFuture[R]):
             logger.debug(
                 "Final state already set for %s. Returning...", self.task_run_id
             )
+            raise_if_flow_run_suspension_requested()
             return
 
         # Ask for the instance of TaskRunWaiter _now_ so that it's already running and
@@ -308,6 +311,7 @@ class PrefectDistributedFuture(PrefectTaskRunFuture[R]):
                     self.task_run_id,
                 )
                 self._final_state = task_run.state
+                raise_if_flow_run_suspension_requested()
                 return
 
             # If still running, wait for a completed event from the server
@@ -327,6 +331,7 @@ class PrefectDistributedFuture(PrefectTaskRunFuture[R]):
                     self.task_run_id,
                     state_from_event.type,
                 )
+            raise_if_flow_run_suspension_requested()
             return
 
     def result(
@@ -353,10 +358,12 @@ class PrefectDistributedFuture(PrefectTaskRunFuture[R]):
                     if task_run.state and task_run.state.is_final():
                         self._final_state = task_run.state
                     else:
+                        raise_if_flow_run_suspension_requested()
                         raise TimeoutError(
                             f"Task run {self.task_run_id} did not complete within {timeout} seconds"
                         )
 
+        raise_if_flow_run_suspension_requested()
         return await self._final_state.aresult(raise_on_failure=raise_on_failure)
 
     def add_done_callback(self, fn: Callable[[PrefectFuture[R]], None]) -> None:
@@ -419,6 +426,7 @@ class PrefectFlowRunFuture(PrefectFuture[R]):
             logger.debug(
                 "Final state already set for %s. Returning...", self.flow_run_id
             )
+            raise_if_flow_run_suspension_requested()
             return
 
         # Ask for the instance of FlowRunWaiter _now_ so that it's already running and
@@ -438,6 +446,7 @@ class PrefectFlowRunFuture(PrefectFuture[R]):
                     self.flow_run_id,
                 )
                 self._final_state = flow_run.state
+                raise_if_flow_run_suspension_requested()
                 return
 
             # If still running, wait for a completed event from the server
@@ -454,11 +463,13 @@ class PrefectFlowRunFuture(PrefectFuture[R]):
                 flow_run = await client.read_flow_run(flow_run_id=self._flow_run_id)
                 if flow_run.state and flow_run.state.is_final():
                     self._final_state = flow_run.state
+                    raise_if_flow_run_suspension_requested()
                     return
                 # Check if timeout has been exceeded
                 if timeout is not None:
                     elapsed = time.monotonic() - start_time
                     if elapsed >= timeout:
+                        raise_if_flow_run_suspension_requested()
                         return
                 # Brief sleep before polling again to avoid hammering the API
                 await asyncio.sleep(0.1)
@@ -480,10 +491,12 @@ class PrefectFlowRunFuture(PrefectFuture[R]):
         if not self._final_state:
             await self.wait_async(timeout=timeout)
             if not self._final_state:
+                raise_if_flow_run_suspension_requested()
                 raise TimeoutError(
                     f"Flow run {self.flow_run_id} did not complete within {timeout} seconds"
                 )
 
+        raise_if_flow_run_suspension_requested()
         return await self._final_state.aresult(raise_on_failure=raise_on_failure)
 
     def add_done_callback(self, fn: Callable[[PrefectFuture[R]], None]) -> None:
@@ -679,6 +692,7 @@ def wait(
     done = {f for f in _futures if f._final_state}
     not_done = _futures - done
     if len(done) == len(_futures):
+        raise_if_flow_run_suspension_requested()
         return DoneAndNotDoneFutures(done, not_done)
 
     # If no timeout, wait for all futures sequentially
@@ -687,6 +701,7 @@ def wait(
             future.wait()
             done.add(future)
             not_done.remove(future)
+        raise_if_flow_run_suspension_requested()
         return DoneAndNotDoneFutures(done, not_done)
 
     # With timeout, monitor all futures concurrently
@@ -729,9 +744,11 @@ def wait(
                         not_done.remove(future)
                         done.add(future)
 
+            raise_if_flow_run_suspension_requested()
             return DoneAndNotDoneFutures(done, not_done)
     except TimeoutError:
         logger.debug("Timed out waiting for all futures to complete.")
+        raise_if_flow_run_suspension_requested()
         return DoneAndNotDoneFutures(done, not_done)
 
 

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic
 
 from typing_extensions import NamedTuple, Self, TypeVar
 
+from prefect._flow_run_suspension import raise_if_flow_run_suspension_requested
 from prefect._waiters import FlowRunWaiter
 from prefect.client.orchestration import get_client
 from prefect.exceptions import ObjectNotFound
@@ -239,6 +240,7 @@ class PrefectConcurrentFuture(PrefectWrappedFuture[R, concurrent.futures.Future[
             return
         if isinstance(result, State):
             self._final_state = result
+        raise_if_flow_run_suspension_requested()
 
     def result(
         self,
@@ -257,8 +259,10 @@ class PrefectConcurrentFuture(PrefectWrappedFuture[R, concurrent.futures.Future[
                 self._final_state = future_result
 
             else:
+                raise_if_flow_run_suspension_requested()
                 return future_result
 
+        raise_if_flow_run_suspension_requested()
         _result = self._final_state.result(
             raise_on_failure=raise_on_failure, _sync=True
         )

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -1764,6 +1764,7 @@ def run_generator_task_sync(
                             # way to periodically clean it up (using
                             # weakrefs or similar) would be good
                             link_state_to_task_run_result(engine.state, gen_result)
+                            raise_if_flow_run_suspension_requested()
                             yield gen_result
                     except StopIteration as exc:
                         engine.handle_success(exc.value, transaction=txn)
@@ -1824,6 +1825,7 @@ async def run_generator_task_async(
                             # way to periodically clean it up (using
                             # weakrefs or similar) would be good
                             link_state_to_task_run_result(engine.state, gen_result)
+                            raise_if_flow_run_suspension_requested()
                             yield gen_result
                     except (StopAsyncIteration, GeneratorExit) as exc:
                         await engine.handle_success(None, transaction=txn)

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -653,6 +653,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         self._return_value = result
 
         self._telemetry.end_span_on_success()
+        raise_if_flow_run_suspension_requested()
 
     def handle_retry(self, exc_or_state: Exception | State[R]) -> bool:
         """Handle any task run retries.
@@ -1277,6 +1278,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         await self.set_state(terminal_state)
         self._return_value = result
         self._telemetry.end_span_on_success()
+        raise_if_flow_run_suspension_requested()
 
         return result
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -653,7 +653,6 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         self._return_value = result
 
         self._telemetry.end_span_on_success()
-        raise_if_flow_run_suspension_requested()
 
     def handle_retry(self, exc_or_state: Exception | State[R]) -> bool:
         """Handle any task run retries.
@@ -1278,7 +1277,6 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         await self.set_state(terminal_state)
         self._return_value = result
         self._telemetry.end_span_on_success()
-        raise_if_flow_run_suspension_requested()
 
         return result
 
@@ -1680,6 +1678,7 @@ def run_task_sync(
                 engine.transaction_context() as txn,
             ):
                 engine.call_task_fn(txn)
+            raise_if_flow_run_suspension_requested()
 
     return engine.state if return_type == "state" else engine.result()
 
@@ -1711,6 +1710,7 @@ async def run_task_async(
                 engine.transaction_context() as txn,
             ):
                 await engine.call_task_fn(txn)
+            raise_if_flow_run_suspension_requested()
 
     return engine.state if return_type == "state" else await engine.result()
 
@@ -1770,6 +1770,7 @@ def run_generator_task_sync(
                     except GeneratorExit as exc:
                         engine.handle_success(None, transaction=txn)
                         gen.throw(exc)
+            raise_if_flow_run_suspension_requested()
 
     return engine.result()
 
@@ -1828,6 +1829,7 @@ async def run_generator_task_async(
                         await engine.handle_success(None, transaction=txn)
                         if isinstance(exc, GeneratorExit):
                             gen.throw(exc)
+            raise_if_flow_run_suspension_requested()
 
     # async generators can't return, but we can raise failures here
     if engine.state.is_failed():

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -36,6 +36,7 @@ from typing_extensions import ParamSpec, Self
 
 import prefect.states
 import prefect.types._datetime
+from prefect._flow_run_suspension import raise_if_flow_run_suspension_requested
 from prefect._internal.compatibility import deprecated
 from prefect._internal.uuid7 import uuid7
 from prefect._states import (
@@ -819,6 +820,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         """
 
         with hydrated_context(self.context):
+            raise_if_flow_run_suspension_requested()
             with SyncClientContext.get_or_create() as client_ctx:
                 self._client = client_ctx.client
                 self._is_started = True
@@ -948,6 +950,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     lease_duration=60,
                     suppress_warnings=True,
                 ):
+                    raise_if_flow_run_suspension_requested()
                     self.begin_run()
                     try:
                         yield
@@ -1447,6 +1450,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         """
 
         with hydrated_context(self.context):
+            raise_if_flow_run_suspension_requested()
             async with AsyncClientContext.get_or_create():
                 self._client = get_client()
                 self._is_started = True
@@ -1577,6 +1581,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     lease_duration=60,
                     suppress_warnings=True,
                 ):
+                    raise_if_flow_run_suspension_requested()
                     await self.begin_run()
                     try:
                         yield

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -24,6 +24,7 @@ from typing import (
 
 from typing_extensions import ParamSpec, Self, TypeVar
 
+from prefect._flow_run_suspension import raise_if_flow_run_suspension_requested
 from prefect._internal.uuid7 import uuid7
 from prefect.client.schemas.objects import RunInput
 from prefect.events.schemas.events import Event
@@ -193,6 +194,8 @@ class TaskRunner(abc.ABC, Generic[F]):
 
         futures: list[PrefectFuture[Any]] = []
         for i in range(map_length):
+            raise_if_flow_run_suspension_requested()
+
             call_parameters: dict[str, Any] = {
                 key: value[i] for key, value in iterable_parameters.items()
             }

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -41,6 +41,7 @@ from typing_extensions import (
 )
 
 import prefect.states
+from prefect._flow_run_suspension import raise_if_flow_run_suspension_requested
 from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.uuid7 import uuid7
 from prefect.assets import Asset
@@ -1391,6 +1392,8 @@ class Task(Generic[P, R]):
                 "`task.submit()` is not currently supported by `flow.visualize()`"
             )
 
+        raise_if_flow_run_suspension_requested()
+
         task_runner = flow_run_context.task_runner
         future = task_runner.submit(self, parameters, wait_for)
         if return_state:
@@ -1613,6 +1616,8 @@ class Task(Generic[P, R]):
                 "`task.map()` is not currently supported by `flow.visualize()`"
             )
 
+        raise_if_flow_run_suspension_requested()
+
         if deferred:
             parameters_list = expand_mapping_parameters(self.fn, parameters)
             futures = [
@@ -1728,6 +1733,8 @@ class Task(Generic[P, R]):
 
         # Convert the call args/kwargs to a parameter dict
         parameters = get_call_parameters(self.fn, args, kwargs)
+
+        raise_if_flow_run_suspension_requested()
 
         task_run: TaskRun = run_coro_as_sync(
             self.create_run(

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -16,9 +16,13 @@ import anyio
 import pydantic
 import pytest
 
+import prefect.flow_engine as flow_engine_module
 import prefect.utilities.engine as engine_utils
 from prefect import Flow, __development_base_path__, flow, states, task
-from prefect._flow_run_suspension import FlowRunSuspensionRequest
+from prefect._flow_run_suspension import (
+    FlowRunSuspensionRequest,
+    mark_flow_run_suspension_requested,
+)
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter
 from prefect.client.schemas.objects import StateType
@@ -2792,6 +2796,72 @@ class TestSuspendFlowRun:
         assert flow_run.state.name == "Suspended"
 
     @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_begin_run_rechecks_suspension_before_running(
+        self,
+        prefect_client: PrefectClient,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+        engine_type: Literal["sync", "async"],
+    ):
+        flow_ran = False
+        suspended_state = states.Suspended()
+
+        def suspend_during_flow_run_name_resolution(
+            flow: Flow[Any, Any], parameters: dict[str, Any]
+        ) -> str:
+            _ = flow, parameters
+            flow_run_context = FlowRunContext.get()
+            assert flow_run_context
+            flow_run_id = flow_run_context.flow_run.id
+            sync_prefect_client.set_flow_run_state(
+                flow_run_id,
+                suspended_state,
+                force=True,
+            )
+            assert mark_flow_run_suspension_requested(flow_run_id, suspended_state)
+            return "suspended-before-running"
+
+        monkeypatch.setattr(
+            "prefect.flow_engine.resolve_custom_flow_run_name",
+            suspend_during_flow_run_name_resolution,
+        )
+
+        if engine_type == "sync":
+
+            @flow(
+                name=f"test_begin_run_rechecks_suspension_before_running_{uuid.uuid4()}",
+                flow_run_name="custom-name",
+            )
+            def suspendable_flow():
+                nonlocal flow_ran
+                flow_ran = True
+        else:
+
+            @flow(
+                name=f"test_begin_run_rechecks_suspension_before_running_{uuid.uuid4()}",
+                flow_run_name="custom-name",
+            )
+            async def suspendable_flow():
+                nonlocal flow_ran
+                flow_ran = True
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        assert not flow_ran
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
     async def test_completion_stops_at_suspension_boundary(
         self,
         prefect_client: PrefectClient,
@@ -2833,6 +2903,71 @@ class TestSuspendFlowRun:
         assert task_ran
 
         flow_run = await prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_handle_success_rechecks_suspension_before_final_state(
+        self,
+        prefect_client: PrefectClient,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+        engine_type: Literal["sync", "async"],
+    ):
+        suspended_state = states.Suspended()
+
+        original_return_value_to_state = flow_engine_module.return_value_to_state
+
+        async def suspend_during_terminal_state_preparation(*args: Any, **kwargs: Any):
+            terminal_state = await original_return_value_to_state(*args, **kwargs)
+            flow_run_context = FlowRunContext.get()
+            assert flow_run_context
+            flow_run_id = flow_run_context.flow_run.id
+            sync_prefect_client.set_flow_run_state(
+                flow_run_id,
+                suspended_state,
+                force=True,
+            )
+            assert mark_flow_run_suspension_requested(flow_run_id, suspended_state)
+            return terminal_state
+
+        monkeypatch.setattr(
+            "prefect.flow_engine.return_value_to_state",
+            suspend_during_terminal_state_preparation,
+        )
+
+        if engine_type == "sync":
+
+            @flow(
+                name=(
+                    "test_handle_success_rechecks_suspension_before_final_state_"
+                    f"{uuid.uuid4()}"
+                )
+            )
+            def suspendable_flow():
+                return "should-not-complete"
+        else:
+
+            @flow(
+                name=(
+                    "test_handle_success_rechecks_suspension_before_final_state_"
+                    f"{uuid.uuid4()}"
+                )
+            )
+            async def suspendable_flow():
+                return "should-not-complete"
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state.is_paused(), flow_run.state
         assert flow_run.state.name == "Suspended"
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -4,7 +4,7 @@ import signal
 import threading
 import time
 import uuid
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager, contextmanager, nullcontext
 from textwrap import dedent
 from types import SimpleNamespace
 from typing import Any, Literal, Optional
@@ -2966,6 +2966,141 @@ class TestSuspendFlowRun:
                 run_flow_sync(suspendable_flow, flow_run=flow_run)
             else:
                 await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_exception_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        if engine_type == "sync":
+
+            @flow(name=f"test_exception_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                raise ValueError("should pause instead of fail")
+        else:
+
+            @flow(name=f"test_exception_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                raise ValueError("should pause instead of fail")
+
+        flow_run_id = await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_timeout_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        if engine_type == "sync":
+
+            @flow(
+                name=f"test_timeout_stops_at_suspension_boundary_{uuid.uuid4()}",
+                timeout_seconds=0.5,
+            )
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                time.sleep(2)
+        else:
+
+            @flow(
+                name=f"test_timeout_stops_at_suspension_boundary_{uuid.uuid4()}",
+                timeout_seconds=0.5,
+            )
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                await asyncio.sleep(2)
+
+        flow_run_id = await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_setup_run_context_marks_refreshed_suspended_state(
+        self,
+        prefect_client: PrefectClient,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+        engine_type: Literal["sync", "async"],
+    ):
+        flow_ran = False
+
+        def suspend_after_running(flow_run_id: UUID) -> None:
+            sync_prefect_client.set_flow_run_state(
+                flow_run_id,
+                states.Suspended(),
+                force=True,
+            )
+
+        monkeypatch.setattr(
+            "prefect.flow_engine.observe_flow_run_suspension",
+            lambda *args, **kwargs: nullcontext(),
+        )
+
+        if engine_type == "sync":
+            original_begin_run = FlowRunEngine.begin_run
+
+            def suspend_after_sync_begin_run(engine):
+                state = original_begin_run(engine)
+                suspend_after_running(engine.flow_run.id)
+                return state
+
+            monkeypatch.setattr(
+                FlowRunEngine, "begin_run", suspend_after_sync_begin_run
+            )
+
+            @flow(name=f"test_setup_run_context_marks_suspended_state_{uuid.uuid4()}")
+            def suspendable_flow():
+                nonlocal flow_ran
+                flow_ran = True
+        else:
+            original_begin_run = AsyncFlowRunEngine.begin_run
+
+            async def suspend_after_async_begin_run(engine):
+                state = await original_begin_run(engine)
+                suspend_after_running(engine.flow_run.id)
+                return state
+
+            monkeypatch.setattr(
+                AsyncFlowRunEngine, "begin_run", suspend_after_async_begin_run
+            )
+
+            @flow(name=f"test_setup_run_context_marks_suspended_state_{uuid.uuid4()}")
+            async def suspendable_flow():
+                nonlocal flow_ran
+                flow_ran = True
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        assert not flow_ran
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state.is_paused(), flow_run.state

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -2972,6 +2972,73 @@ class TestSuspendFlowRun:
         assert flow_run.state.name == "Suspended"
 
     @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_handle_exception_rechecks_suspension_before_failed_state(
+        self,
+        prefect_client: PrefectClient,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+        engine_type: Literal["sync", "async"],
+    ):
+        suspended_state = states.Suspended()
+
+        original_exception_to_failed_state = (
+            flow_engine_module.exception_to_failed_state
+        )
+
+        async def suspend_during_failed_state_preparation(*args: Any, **kwargs: Any):
+            terminal_state = await original_exception_to_failed_state(*args, **kwargs)
+            flow_run_context = FlowRunContext.get()
+            assert flow_run_context
+            flow_run_id = flow_run_context.flow_run.id
+            sync_prefect_client.set_flow_run_state(
+                flow_run_id,
+                suspended_state,
+                force=True,
+            )
+            assert mark_flow_run_suspension_requested(flow_run_id, suspended_state)
+            return terminal_state
+
+        monkeypatch.setattr(
+            "prefect.flow_engine.exception_to_failed_state",
+            suspend_during_failed_state_preparation,
+        )
+
+        if engine_type == "sync":
+
+            @flow(
+                name=(
+                    "test_handle_exception_rechecks_suspension_before_failed_state_"
+                    f"{uuid.uuid4()}"
+                )
+            )
+            def suspendable_flow():
+                raise ValueError("should pause instead of fail")
+        else:
+
+            @flow(
+                name=(
+                    "test_handle_exception_rechecks_suspension_before_failed_state_"
+                    f"{uuid.uuid4()}"
+                )
+            )
+            async def suspendable_flow():
+                raise ValueError("should pause instead of fail")
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
     async def test_exception_stops_at_suspension_boundary(
         self,
         prefect_client: PrefectClient,

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -2599,7 +2599,7 @@ class TestSuspendFlowRun:
         prefect_client: PrefectClient,
         suspension_flow: Flow[Any, Any],
         engine_type: Literal["sync", "async"],
-    ) -> None:
+    ) -> UUID:
         flow_run = await self._create_deployment_backed_flow_run(
             prefect_client, suspension_flow
         )
@@ -2609,6 +2609,8 @@ class TestSuspendFlowRun:
                 run_flow_sync(suspension_flow, flow_run=flow_run)
             else:
                 await run_flow_async(suspension_flow, flow_run=flow_run)
+
+        return flow_run.id
 
     async def test_suspended_flow_runs_do_not_block_execution(
         self, prefect_client, deployment, session
@@ -2748,6 +2750,91 @@ class TestSuspendFlowRun:
         state = flow_run.state
         assert state.is_paused(), state
         assert state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_pre_start_suspension_stops_before_running(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        flow_ran = False
+
+        if engine_type == "sync":
+
+            @flow(name=f"test_pre_start_suspension_{uuid.uuid4()}")
+            def suspendable_flow():
+                nonlocal flow_ran
+                flow_ran = True
+        else:
+
+            @flow(name=f"test_pre_start_suspension_{uuid.uuid4()}")
+            async def suspendable_flow():
+                nonlocal flow_ran
+                flow_ran = True
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+        await prefect_client.set_flow_run_state(
+            flow_run.id, states.Suspended(), force=True
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        assert not flow_ran
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_completion_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        task_ran = False
+
+        if engine_type == "sync":
+
+            @task
+            def complete_task_boundary():
+                nonlocal task_ran
+                task_ran = True
+
+            @flow(name=f"test_completion_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                complete_task_boundary()
+                suspend_flow_run(flow_run_id=flow_run_id)
+                return "should-not-complete"
+        else:
+
+            @task
+            async def complete_task_boundary():
+                nonlocal task_ran
+                task_ran = True
+
+            @flow(name=f"test_completion_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await complete_task_boundary()
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                return "should-not-complete"
+
+        flow_run_id = await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
+
+        assert task_ran
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
 
     @pytest.mark.parametrize("engine_type", ["sync", "async"])
     async def test_task_call_stops_at_suspension_boundary(

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -18,6 +18,7 @@ import pytest
 
 import prefect.utilities.engine as engine_utils
 from prefect import Flow, __development_base_path__, flow, states, task
+from prefect._flow_run_suspension import FlowRunSuspensionRequest
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter
 from prefect.client.schemas.objects import StateType
@@ -2545,6 +2546,26 @@ class TestPauseFlowRun:
         assert len(sleep_intervals) == 6
 
 
+class TestFlowRunSuspensionRequest:
+    def test_raise_if_requested_uses_marked_suspended_state(self):
+        suspension_request = FlowRunSuspensionRequest()
+        suspended_state = states.Suspended(message="Suspend me")
+
+        assert not suspension_request.is_requested()
+        assert suspension_request.get_state() is None
+        suspension_request.raise_if_requested()
+
+        suspension_request.mark_requested(suspended_state)
+
+        assert suspension_request.is_requested()
+        assert suspension_request.get_state() is suspended_state
+
+        with pytest.raises(Pause) as exc_info:
+            suspension_request.raise_if_requested()
+
+        assert exc_info.value.state is suspended_state
+
+
 class TestSuspendFlowRun:
     async def _attach_deployment_to_current_flow_run(self, deployment, session) -> UUID:
         context = get_run_context()
@@ -2560,6 +2581,34 @@ class TestSuspendFlowRun:
         await session.commit()
 
         return context.flow_run.id
+
+    async def _create_deployment_backed_flow_run(
+        self,
+        prefect_client: PrefectClient,
+        suspension_flow: Flow[Any, Any],
+    ):
+        flow_id = await prefect_client.create_flow(suspension_flow)
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name=f"flow-run-suspension-{uuid.uuid4()}",
+        )
+        return await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+    async def _run_suspension_boundary_flow(
+        self,
+        prefect_client: PrefectClient,
+        suspension_flow: Flow[Any, Any],
+        engine_type: Literal["sync", "async"],
+    ) -> None:
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspension_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspension_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspension_flow, flow_run=flow_run)
 
     async def test_suspended_flow_runs_do_not_block_execution(
         self, prefect_client, deployment, session
@@ -2700,85 +2749,190 @@ class TestSuspendFlowRun:
         assert state.is_paused(), state
         assert state.name == "Suspended"
 
-    async def test_submit_stops_at_suspension_boundary(self, deployment, session):
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_task_call_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
         task_ran = False
 
-        @task
-        async def should_not_run():
-            nonlocal task_ran
-            task_ran = True
+        if engine_type == "sync":
 
-        @flow
-        async def suspendable_flow():
-            flow_run_id = await self._attach_deployment_to_current_flow_run(
-                deployment, session
-            )
+            @task
+            def should_not_run():
+                nonlocal task_ran
+                task_ran = True
 
-            await suspend_flow_run(flow_run_id=flow_run_id)
-            should_not_run.submit()
+            @flow(name=f"test_task_call_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_run()
+        else:
 
-        with pytest.raises(Pause):
-            await suspendable_flow()
+            @task
+            async def should_not_run():
+                nonlocal task_ran
+                task_ran = True
+
+            @flow(name=f"test_task_call_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                await should_not_run()
+
+        await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
 
         assert not task_ran
 
-    async def test_map_stops_at_suspension_boundary(self, deployment, session):
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_submit_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        task_ran = False
+
+        if engine_type == "sync":
+
+            @task
+            def should_not_run():
+                nonlocal task_ran
+                task_ran = True
+
+            @flow(name=f"test_submit_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_run.submit()
+        else:
+
+            @task
+            async def should_not_run():
+                nonlocal task_ran
+                task_ran = True
+
+            @flow(name=f"test_submit_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_run.submit()
+
+        await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
+
+        assert not task_ran
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_map_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
         task_runs = []
 
-        @task
-        async def should_not_run(value: int):
-            task_runs.append(value)
+        if engine_type == "sync":
 
-        @flow
-        async def suspendable_flow():
-            flow_run_id = await self._attach_deployment_to_current_flow_run(
-                deployment, session
-            )
+            @task
+            def should_not_run(value: int):
+                task_runs.append(value)
 
-            await suspend_flow_run(flow_run_id=flow_run_id)
-            should_not_run.map([1, 2, 3])
+            @flow(name=f"test_map_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_run.map([1, 2, 3])
+        else:
 
-        with pytest.raises(Pause):
-            await suspendable_flow()
+            @task
+            async def should_not_run(value: int):
+                task_runs.append(value)
+
+            @flow(name=f"test_map_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_run.map([1, 2, 3])
+
+        await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
 
         assert task_runs == []
 
-    async def test_apply_async_stops_at_suspension_boundary(self, deployment, session):
-        @task
-        async def should_not_schedule(value: int):
-            return value
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_apply_async_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        if engine_type == "sync":
 
-        @flow
-        async def suspendable_flow():
-            flow_run_id = await self._attach_deployment_to_current_flow_run(
-                deployment, session
-            )
+            @task
+            def should_not_schedule(value: int):
+                return value
 
-            await suspend_flow_run(flow_run_id=flow_run_id)
-            should_not_schedule.apply_async(kwargs={"value": 1})
+            @flow(name=f"test_apply_async_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_schedule.apply_async(kwargs={"value": 1})
+        else:
 
-        with pytest.raises(Pause):
-            await suspendable_flow()
+            @task
+            async def should_not_schedule(value: int):
+                return value
 
-    async def test_child_flow_stops_at_suspension_boundary(self, deployment, session):
+            @flow(name=f"test_apply_async_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                should_not_schedule.apply_async(kwargs={"value": 1})
+
+        await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_child_flow_stops_at_suspension_boundary(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
         child_ran = False
 
-        @flow
-        async def child_flow():
-            nonlocal child_ran
-            child_ran = True
+        if engine_type == "sync":
 
-        @flow
-        async def suspendable_flow():
-            flow_run_id = await self._attach_deployment_to_current_flow_run(
-                deployment, session
-            )
+            @flow(name=f"test_child_flow_boundary_child_{uuid.uuid4()}")
+            def child_flow():
+                nonlocal child_ran
+                child_ran = True
 
-            await suspend_flow_run(flow_run_id=flow_run_id)
-            await child_flow()
+            @flow(name=f"test_child_flow_stops_at_suspension_boundary_{uuid.uuid4()}")
+            def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                suspend_flow_run(flow_run_id=flow_run_id)
+                child_flow()
+        else:
 
-        with pytest.raises(Pause):
-            await suspendable_flow()
+            @flow(name=f"test_child_flow_boundary_child_{uuid.uuid4()}")
+            async def child_flow():
+                nonlocal child_ran
+                child_ran = True
+
+            @flow(name=f"test_child_flow_stops_at_suspension_boundary_{uuid.uuid4()}")
+            async def suspendable_flow():
+                flow_run_id = get_run_context().flow_run.id
+                await suspend_flow_run(flow_run_id=flow_run_id)
+                await child_flow()
+
+        await self._run_suspension_boundary_flow(
+            prefect_client, suspendable_flow, engine_type
+        )
 
         assert not child_ran
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -2546,6 +2546,21 @@ class TestPauseFlowRun:
 
 
 class TestSuspendFlowRun:
+    async def _attach_deployment_to_current_flow_run(self, deployment, session) -> UUID:
+        context = get_run_context()
+        assert context.flow_run
+
+        from prefect.server.models.flow_runs import update_flow_run
+
+        await update_flow_run(
+            session,
+            context.flow_run.id,
+            ServerFlowRun.model_construct(deployment_id=deployment.id),
+        )
+        await session.commit()
+
+        return context.flow_run.id
+
     async def test_suspended_flow_runs_do_not_block_execution(
         self, prefect_client, deployment, session
     ):
@@ -2629,7 +2644,6 @@ class TestSuspendFlowRun:
         with pytest.raises(RuntimeError, match="Cannot suspend subflows."):
             await main_flow()
 
-    @pytest.mark.xfail(reason="Brittle caused by 5xx from API")
     async def test_suspend_flow_run_by_id(self, prefect_client, deployment, session):
         flow_run_id = None
         task_completions = 0
@@ -2685,6 +2699,88 @@ class TestSuspendFlowRun:
         state = flow_run.state
         assert state.is_paused(), state
         assert state.name == "Suspended"
+
+    async def test_submit_stops_at_suspension_boundary(self, deployment, session):
+        task_ran = False
+
+        @task
+        async def should_not_run():
+            nonlocal task_ran
+            task_ran = True
+
+        @flow
+        async def suspendable_flow():
+            flow_run_id = await self._attach_deployment_to_current_flow_run(
+                deployment, session
+            )
+
+            await suspend_flow_run(flow_run_id=flow_run_id)
+            should_not_run.submit()
+
+        with pytest.raises(Pause):
+            await suspendable_flow()
+
+        assert not task_ran
+
+    async def test_map_stops_at_suspension_boundary(self, deployment, session):
+        task_runs = []
+
+        @task
+        async def should_not_run(value: int):
+            task_runs.append(value)
+
+        @flow
+        async def suspendable_flow():
+            flow_run_id = await self._attach_deployment_to_current_flow_run(
+                deployment, session
+            )
+
+            await suspend_flow_run(flow_run_id=flow_run_id)
+            should_not_run.map([1, 2, 3])
+
+        with pytest.raises(Pause):
+            await suspendable_flow()
+
+        assert task_runs == []
+
+    async def test_apply_async_stops_at_suspension_boundary(self, deployment, session):
+        @task
+        async def should_not_schedule(value: int):
+            return value
+
+        @flow
+        async def suspendable_flow():
+            flow_run_id = await self._attach_deployment_to_current_flow_run(
+                deployment, session
+            )
+
+            await suspend_flow_run(flow_run_id=flow_run_id)
+            should_not_schedule.apply_async(kwargs={"value": 1})
+
+        with pytest.raises(Pause):
+            await suspendable_flow()
+
+    async def test_child_flow_stops_at_suspension_boundary(self, deployment, session):
+        child_ran = False
+
+        @flow
+        async def child_flow():
+            nonlocal child_ran
+            child_ran = True
+
+        @flow
+        async def suspendable_flow():
+            flow_run_id = await self._attach_deployment_to_current_flow_run(
+                deployment, session
+            )
+
+            await suspend_flow_run(flow_run_id=flow_run_id)
+            await child_flow()
+
+        with pytest.raises(Pause):
+            await suspendable_flow()
+
+        assert not child_ran
 
     async def test_suspend_can_receive_input(self, deployment, session, prefect_client):
         flow_run_id = None

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -11,7 +11,8 @@ import pytest
 
 from prefect import flow, task
 from prefect.client.orchestration import PrefectClient
-from prefect.exceptions import MissingResult
+from prefect.context import FlowRunContext
+from prefect.exceptions import MissingResult, Pause
 from prefect.flow_engine import run_flow_async, run_flow_sync
 from prefect.futures import (
     PrefectConcurrentFuture,
@@ -26,7 +27,7 @@ from prefect.futures import (
     wait,
 )
 from prefect.server.events.pipeline import EventsPipeline
-from prefect.states import Completed, Failed
+from prefect.states import Completed, Failed, Suspended
 from prefect.task_engine import run_task_async, run_task_sync
 from prefect.task_runners import ThreadPoolTaskRunner
 
@@ -47,6 +48,12 @@ class MockFuture(PrefectWrappedFuture[Any, Future[Any]]):
         return self._final_state.result()
 
 
+def mark_flow_run_suspension_requested() -> None:
+    flow_run_context = FlowRunContext.get()
+    assert flow_run_context
+    flow_run_context.flow_run_suspension_request.mark_requested(Suspended())
+
+
 class TestUtilityFunctions:
     def test_wait(self):
         mock_futures = [MockFuture(data=i) for i in range(5)]
@@ -63,6 +70,19 @@ class TestUtilityFunctions:
         mock_futures.append(PrefectConcurrentFuture(uuid.uuid4(), hanging_future))
         futures = wait(mock_futures, timeout=0.01)
         assert futures.not_done == {mock_futures[-1]}
+
+    @pytest.mark.timeout(method="thread")
+    def test_wait_with_timeout_checks_flow_run_suspension(self):
+        @flow
+        def suspendable_flow():
+            hanging_future = Future()
+            future = PrefectConcurrentFuture(uuid.uuid4(), hanging_future)
+            mark_flow_run_suspension_requested()
+
+            wait([future], timeout=0.01)
+
+        with pytest.raises(Pause):
+            suspendable_flow()
 
     def test_wait_monitors_all_futures_concurrently_with_timeout(self):
         """Test that wait() with timeout monitors all futures concurrently, not sequentially."""
@@ -301,6 +321,22 @@ class TestPrefectConcurrentFuture:
         with pytest.raises(ValueError, match="oops"):
             future.result(raise_on_failure=True)
 
+    @pytest.mark.parametrize("method", ["wait", "result"])
+    def test_timeout_checks_flow_run_suspension(self, method: str):
+        @flow
+        def suspendable_flow():
+            wrapped_future = Future()
+            future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+            mark_flow_run_suspension_requested()
+
+            if method == "wait":
+                future.wait(timeout=0.01)
+            else:
+                future.result(timeout=0.01)
+
+        with pytest.raises(Pause):
+            suspendable_flow()
+
 
 class TestResolveFuturesToStates:
     async def test_resolve_futures_transforms_future(self):
@@ -458,6 +494,27 @@ class TestPrefectDistributedFuture:
         future = PrefectDistributedFuture(task_run_id=task_run.id)
         future.wait(timeout=0.25)
         assert future.state.is_pending()
+
+    @pytest.mark.parametrize("method", ["wait", "result"])
+    async def test_timeout_checks_flow_run_suspension(self, method: str):
+        @task
+        async def my_task():
+            return 42
+
+        task_run = await my_task.create_run()
+        future = PrefectDistributedFuture(task_run_id=task_run.id)
+
+        @flow
+        def suspendable_flow():
+            mark_flow_run_suspension_requested()
+
+            if method == "wait":
+                future.wait(timeout=0.01)
+            else:
+                future.result(timeout=0.01)
+
+        with pytest.raises(Pause):
+            suspendable_flow()
 
     async def test_wait_without_timeout(self, events_pipeline):
         @task
@@ -636,6 +693,34 @@ class TestPrefectFlowRunFuture:
         future = PrefectFlowRunFuture(flow_run_id=flow_run.id)
         future.wait(timeout=0.25)
         assert future.state.is_pending()
+
+    @pytest.mark.parametrize("method", ["wait", "result"])
+    async def test_timeout_checks_flow_run_suspension(
+        self,
+        prefect_client: PrefectClient,
+        method: str,
+    ):
+        @flow
+        async def my_flow():
+            return 42
+
+        flow_run = await prefect_client.create_flow_run(
+            flow=my_flow,
+            parameters={},
+        )
+        future = PrefectFlowRunFuture(flow_run_id=flow_run.id)
+
+        @flow
+        def suspendable_flow():
+            mark_flow_run_suspension_requested()
+
+            if method == "wait":
+                future.wait(timeout=0.01)
+            else:
+                future.result(timeout=0.01)
+
+        with pytest.raises(Pause):
+            suspendable_flow()
 
     async def test_wait_without_timeout(
         self, events_pipeline: EventsPipeline, prefect_client: PrefectClient

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import uuid
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -6,11 +7,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from prefect import flow
+from prefect._flow_run_suspension import (
+    FlowRunSuspensionSignal,
+    observe_flow_run_suspension,
+)
 from prefect._internal.testing import retry_asserts
-from prefect._observers import FlowRunCancellingObserver
+from prefect._observers import FlowRunCancellingObserver, FlowRunSuspendingObserver
 from prefect.client.schemas.objects import StateType
 from prefect.events.filters import EventAnyResourceFilter, EventFilter, EventNameFilter
 from prefect.events.utilities import emit_event
+from prefect.states import Running, Suspended
 
 
 @flow
@@ -525,3 +531,168 @@ class TestFlowRunCancellingObserver:
 
         # After exiting context, polling task should be cancelled/done
         assert polling_task.cancelled() or polling_task.done()
+
+
+class TestFlowRunSuspendingObserver:
+    async def test_observer_validates_event_filter_has_suspended_event(self):
+        callback = AsyncMock()
+
+        valid_filter = EventFilter(
+            event=EventNameFilter(name=["prefect.flow-run.Suspended"]),
+            any_resource=EventAnyResourceFilter(id=["prefect.work-pool.test-id"]),
+        )
+        observer = FlowRunSuspendingObserver(
+            on_suspended=callback, event_filter=valid_filter
+        )
+        assert observer._event_filter == valid_filter
+
+        with pytest.raises(
+            ValueError, match="must include 'prefect.flow-run.Suspended'"
+        ):
+            FlowRunSuspendingObserver(
+                on_suspended=callback,
+                event_filter=EventFilter(
+                    event=EventNameFilter(name=["prefect.flow-run.Running"])
+                ),
+            )
+
+    async def test_polling_with_mocked_suspended_flow_runs(self):
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(
+            on_suspended=callback, polling_interval=0.1
+        )
+
+        flow_run_id = uuid.uuid4()
+        state = Suspended()
+        mock_flow_run = mock.MagicMock()
+        mock_flow_run.id = flow_run_id
+        mock_flow_run.state = state
+
+        async with observer:
+            observer.add_in_flight_flow_run_id(flow_run_id)
+
+            with patch.object(
+                observer._client, "read_flow_runs", return_value=[mock_flow_run]
+            ):
+                await observer._check_for_suspended_flow_runs()
+
+            callback.assert_called_once_with(flow_run_id, state)
+            assert flow_run_id in observer._suspended_flow_run_ids
+
+    async def test_watch_flow_run_id_checks_current_state(self):
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+
+        flow_run_id = uuid.uuid4()
+        state = Suspended()
+        flow_run = mock.MagicMock(state=state)
+
+        async with observer:
+            with patch.object(
+                observer._client,
+                "read_flow_run",
+                return_value=flow_run,
+            ) as read_flow_run:
+                await observer.watch_flow_run_id(flow_run_id)
+
+            assert flow_run_id in observer._in_flight_flow_run_ids
+            read_flow_run.assert_called_once_with(flow_run_id)
+            callback.assert_called_once_with(flow_run_id, state)
+
+    async def test_watch_flow_run_id_keeps_watching_when_initial_check_fails(
+        self, caplog
+    ):
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+
+        flow_run_id = uuid.uuid4()
+        caplog.set_level("WARNING", logger="prefect.FlowRunSuspendingObserver")
+
+        async with observer:
+            with patch.object(
+                observer._client,
+                "read_flow_run",
+                side_effect=RuntimeError("boom"),
+            ) as read_flow_run:
+                await observer.watch_flow_run_id(flow_run_id)
+
+            assert flow_run_id in observer._in_flight_flow_run_ids
+            read_flow_run.assert_called_once_with(flow_run_id)
+            callback.assert_not_called()
+            assert "Failed to check current state" in caplog.text
+
+    async def test_event_consumer_reads_flow_run_before_callback(self):
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+
+        flow_run_id = uuid.uuid4()
+        suspended_state = Suspended()
+        running_flow_run = mock.MagicMock(state=Running())
+        suspended_flow_run = mock.MagicMock(state=suspended_state)
+
+        async with observer:
+            observer.add_in_flight_flow_run_id(flow_run_id)
+
+            with patch.object(
+                observer._client,
+                "read_flow_run",
+                side_effect=[running_flow_run, suspended_flow_run],
+            ):
+                await observer._notify_if_suspended(flow_run_id)
+                callback.assert_not_called()
+
+                await observer._notify_if_suspended(flow_run_id)
+
+            callback.assert_called_once_with(flow_run_id, suspended_state)
+
+    def test_observe_flow_run_suspension_waits_for_initial_check(self, monkeypatch):
+        flow_run_id = uuid.uuid4()
+        signal = FlowRunSuspensionSignal()
+        watch_started = threading.Event()
+        release_watch = threading.Event()
+        entered_context = threading.Event()
+        exit_context = threading.Event()
+        errors: list[BaseException] = []
+
+        class FakeFlowRunSuspendingObserver:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc_info):
+                pass
+
+            async def watch_flow_run_id(self, observed_flow_run_id):
+                assert observed_flow_run_id == flow_run_id
+                watch_started.set()
+                await asyncio.to_thread(release_watch.wait)
+
+        monkeypatch.setattr(
+            "prefect._observers.FlowRunSuspendingObserver",
+            FakeFlowRunSuspendingObserver,
+        )
+
+        def enter_observer_context():
+            try:
+                with observe_flow_run_suspension(flow_run_id, signal):
+                    entered_context.set()
+                    exit_context.wait(timeout=2)
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=enter_observer_context)
+        thread.start()
+
+        assert watch_started.wait(timeout=2)
+        assert not entered_context.wait(timeout=0.2)
+
+        release_watch.set()
+        assert entered_context.wait(timeout=2)
+
+        exit_context.set()
+        thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert not errors

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -8,7 +8,7 @@ import pytest
 
 from prefect import flow
 from prefect._flow_run_suspension import (
-    FlowRunSuspensionSignal,
+    FlowRunSuspensionRequest,
     observe_flow_run_suspension,
 )
 from prefect._internal.testing import retry_asserts
@@ -647,7 +647,7 @@ class TestFlowRunSuspendingObserver:
 
     def test_observe_flow_run_suspension_waits_for_initial_check(self, monkeypatch):
         flow_run_id = uuid.uuid4()
-        signal = FlowRunSuspensionSignal()
+        suspension_request = FlowRunSuspensionRequest()
         watch_started = threading.Event()
         release_watch = threading.Event()
         entered_context = threading.Event()
@@ -676,7 +676,7 @@ class TestFlowRunSuspendingObserver:
 
         def enter_observer_context():
             try:
-                with observe_flow_run_suspension(flow_run_id, signal):
+                with observe_flow_run_suspension(flow_run_id, suspension_request):
                     entered_context.set()
                     exit_context.wait(timeout=2)
             except BaseException as exc:

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -601,7 +601,9 @@ class TestFlowRunSuspendingObserver:
 
     async def test_watch_flow_run_id_retries_initial_check_until_success(self, caplog):
         callback = MagicMock()
-        observer = FlowRunSuspendingObserver(on_suspended=callback, polling_interval=0.01)
+        observer = FlowRunSuspendingObserver(
+            on_suspended=callback, polling_interval=0.01
+        )
 
         flow_run_id = uuid.uuid4()
         state = Suspended()

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 import uuid
+from contextlib import suppress
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -651,6 +652,58 @@ class TestFlowRunSuspendingObserver:
                 await observer._notify_if_suspended(flow_run_id)
 
             callback.assert_called_once_with(flow_run_id, suspended_state)
+
+    async def test_clean_event_consumer_completion_starts_polling(self):
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+
+        async def complete():
+            pass
+
+        async def never_finish(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        consumer_task = asyncio.create_task(complete())
+        await consumer_task
+
+        with patch(
+            "prefect._observers.critical_service_loop",
+            AsyncMock(side_effect=never_finish),
+        ) as critical_service_loop:
+            observer._start_polling_task(consumer_task)
+            await asyncio.sleep(0)
+
+            assert observer._polling_task is not None
+            critical_service_loop.assert_called_once()
+
+            observer._polling_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await observer._polling_task
+
+    @pytest.mark.parametrize("task_state", ["completed", "cancelled"])
+    async def test_event_consumer_completion_does_not_poll_during_shutdown(
+        self, task_state: str
+    ):
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+        observer._is_shutting_down = True
+
+        async def complete():
+            pass
+
+        consumer_task = asyncio.create_task(complete())
+        if task_state == "cancelled":
+            consumer_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await consumer_task
+        else:
+            await consumer_task
+
+        with patch("prefect._observers.critical_service_loop") as critical_service_loop:
+            observer._start_polling_task(consumer_task)
+
+        assert observer._polling_task is None
+        critical_service_loop.assert_not_called()
 
     def test_observe_flow_run_suspension_waits_for_initial_check(self, monkeypatch):
         flow_run_id = uuid.uuid4()

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -686,7 +686,7 @@ class TestFlowRunSuspendingObserver:
         thread.start()
 
         assert watch_started.wait(timeout=2)
-        assert not entered_context.wait(timeout=0.2)
+        assert not entered_context.wait(timeout=2.2)
 
         release_watch.set()
         assert entered_context.wait(timeout=2)

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -599,26 +599,31 @@ class TestFlowRunSuspendingObserver:
             read_flow_run.assert_called_once_with(flow_run_id)
             callback.assert_called_once_with(flow_run_id, state)
 
-    async def test_watch_flow_run_id_keeps_watching_when_initial_check_fails(
-        self, caplog
-    ):
+    async def test_watch_flow_run_id_retries_initial_check_until_success(self, caplog):
         callback = MagicMock()
-        observer = FlowRunSuspendingObserver(on_suspended=callback)
+        observer = FlowRunSuspendingObserver(on_suspended=callback, polling_interval=0.01)
 
         flow_run_id = uuid.uuid4()
+        state = Suspended()
+        flow_run = mock.MagicMock(state=state)
         caplog.set_level("WARNING", logger="prefect.FlowRunSuspendingObserver")
 
         async with observer:
             with patch.object(
                 observer._client,
                 "read_flow_run",
-                side_effect=RuntimeError("boom"),
+                side_effect=[
+                    RuntimeError("boom"),
+                    RuntimeError("still boom"),
+                    flow_run,
+                ],
             ) as read_flow_run:
                 await observer.watch_flow_run_id(flow_run_id)
 
             assert flow_run_id in observer._in_flight_flow_run_ids
-            read_flow_run.assert_called_once_with(flow_run_id)
-            callback.assert_not_called()
+            assert read_flow_run.call_count == 3
+            callback.assert_called_once_with(flow_run_id, state)
+            assert flow_run_id in observer._suspended_flow_run_ids
             assert "Failed to check current state" in caplog.text
 
     async def test_event_consumer_reads_flow_run_before_callback(self):

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import logging
 import os
 import random
@@ -31,11 +32,20 @@ from prefect.exceptions import CrashedRun, MissingResult, Pause
 from prefect.filesystems import LocalFileSystem
 from prefect.flow_engine import run_flow_async, run_flow_sync
 from prefect.flow_runs import suspend_flow_run
+from prefect.futures import PrefectConcurrentFuture
 from prefect.logging import get_run_logger
 from prefect.results import ResultRecord, ResultStore
 from prefect.server.schemas.core import ConcurrencyLimitV2
 from prefect.settings import PREFECT_TASK_DEFAULT_RETRIES, temporary_settings
-from prefect.states import AwaitingRetry, Completed, Failed, Pending, Running, State
+from prefect.states import (
+    AwaitingRetry,
+    Completed,
+    Failed,
+    Pending,
+    Running,
+    State,
+    Suspended,
+)
 from prefect.task_engine import (
     AsyncTaskRunEngine,
     SyncTaskRunEngine,
@@ -3575,6 +3585,8 @@ class TestTaskRunSuspension:
     ):
         task_ran = False
         flow_continued = False
+        commit_ran = False
+        rollback_ran = False
 
         if engine_type == "sync":
 
@@ -3609,6 +3621,16 @@ class TestTaskRunSuspension:
                 await suspending_task()
                 flow_continued = True
 
+        @suspending_task.on_commit
+        def commit_hook(_txn):
+            nonlocal commit_ran
+            commit_ran = True
+
+        @suspending_task.on_rollback
+        def rollback_hook(_txn):
+            nonlocal rollback_ran
+            rollback_ran = True
+
         flow_run = await self._create_deployment_backed_flow_run(
             prefect_client, suspendable_flow
         )
@@ -3620,11 +3642,39 @@ class TestTaskRunSuspension:
                 await run_flow_async(suspendable_flow, flow_run=flow_run)
 
         assert task_ran
+        assert commit_ran
+        assert not rollback_ran
         assert not flow_continued
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state.is_paused(), flow_run.state
         assert flow_run.state.name == "Suspended"
+
+    @pytest.mark.parametrize("method", ["wait", "result"])
+    def test_concurrent_future_resolution_checks_parent_flow_suspension(
+        self,
+        method: Literal["wait", "result"],
+    ):
+        @flow
+        def suspendable_flow():
+            wrapped_future: concurrent.futures.Future[str] = concurrent.futures.Future()
+            wrapped_future.set_result("done")
+            future = PrefectConcurrentFuture(
+                task_run_id=uuid4(),
+                wrapped_future=wrapped_future,
+            )
+
+            flow_run_context = FlowRunContext.get()
+            assert flow_run_context
+            flow_run_context.flow_run_suspension_request.mark_requested(Suspended())
+
+            if method == "wait":
+                future.wait()
+            else:
+                future.result()
+
+        with pytest.raises(Pause):
+            suspendable_flow()
 
 
 class TestWaitUntilReadySync:

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -3650,6 +3650,65 @@ class TestTaskRunSuspension:
         assert flow_run.state.is_paused(), flow_run.state
         assert flow_run.state.name == "Suspended"
 
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_generator_task_yield_checks_flow_run_suspension(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        task_ran = False
+        flow_loop_ran = False
+
+        if engine_type == "sync":
+
+            @task
+            def suspending_generator_task():
+                nonlocal task_ran
+                task_ran = True
+                flow_run_context = FlowRunContext.get()
+                assert flow_run_context
+                suspend_flow_run(flow_run_id=flow_run_context.flow_run.id)
+                yield "should-not-yield"
+
+            @flow(name=f"test_generator_task_yield_checks_suspension_{uuid4()}")
+            def suspendable_flow():
+                nonlocal flow_loop_ran
+                for _ in suspending_generator_task():
+                    flow_loop_ran = True
+        else:
+
+            @task
+            async def suspending_generator_task():
+                nonlocal task_ran
+                task_ran = True
+                flow_run_context = FlowRunContext.get()
+                assert flow_run_context
+                await suspend_flow_run(flow_run_id=flow_run_context.flow_run.id)
+                yield "should-not-yield"
+
+            @flow(name=f"test_generator_task_yield_checks_suspension_{uuid4()}")
+            async def suspendable_flow():
+                nonlocal flow_loop_ran
+                async for _ in suspending_generator_task():
+                    flow_loop_ran = True
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        assert task_ran
+        assert not flow_loop_ran
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
+
     @pytest.mark.parametrize("method", ["wait", "result"])
     def test_concurrent_future_resolution_checks_parent_flow_suspension(
         self,

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -5,7 +5,7 @@ import random
 import time
 from datetime import timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Literal, Optional
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 from uuid import UUID, uuid4
@@ -27,8 +27,10 @@ from prefect.context import (
     TaskRunContext,
     get_run_context,
 )
-from prefect.exceptions import CrashedRun, MissingResult
+from prefect.exceptions import CrashedRun, MissingResult, Pause
 from prefect.filesystems import LocalFileSystem
+from prefect.flow_engine import run_flow_async, run_flow_sync
+from prefect.flow_runs import suspend_flow_run
 from prefect.logging import get_run_logger
 from prefect.results import ResultRecord, ResultStore
 from prefect.server.schemas.core import ConcurrencyLimitV2
@@ -3550,6 +3552,79 @@ class TestTaskTagConcurrencyWarnings:
             f"but found {len(warning_records)}"
         )
         assert "nonexistent-limit" in warning_records[0].message
+
+
+class TestTaskRunSuspension:
+    async def _create_deployment_backed_flow_run(
+        self,
+        prefect_client: PrefectClient,
+        suspension_flow,
+    ):
+        flow_id = await prefect_client.create_flow(suspension_flow)
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name=f"task-run-suspension-{uuid4()}",
+        )
+        return await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+    @pytest.mark.parametrize("engine_type", ["sync", "async"])
+    async def test_task_completion_checks_flow_run_suspension(
+        self,
+        prefect_client: PrefectClient,
+        engine_type: Literal["sync", "async"],
+    ):
+        task_ran = False
+        flow_continued = False
+
+        if engine_type == "sync":
+
+            @task
+            def suspending_task():
+                nonlocal task_ran
+                task_ran = True
+                flow_run_context = FlowRunContext.get()
+                assert flow_run_context
+                suspend_flow_run(flow_run_id=flow_run_context.flow_run.id)
+                return "done"
+
+            @flow(name=f"test_task_completion_checks_suspension_{uuid4()}")
+            def suspendable_flow():
+                nonlocal flow_continued
+                suspending_task()
+                flow_continued = True
+        else:
+
+            @task
+            async def suspending_task():
+                nonlocal task_ran
+                task_ran = True
+                flow_run_context = FlowRunContext.get()
+                assert flow_run_context
+                await suspend_flow_run(flow_run_id=flow_run_context.flow_run.id)
+                return "done"
+
+            @flow(name=f"test_task_completion_checks_suspension_{uuid4()}")
+            async def suspendable_flow():
+                nonlocal flow_continued
+                await suspending_task()
+                flow_continued = True
+
+        flow_run = await self._create_deployment_backed_flow_run(
+            prefect_client, suspendable_flow
+        )
+
+        with pytest.raises(Pause):
+            if engine_type == "sync":
+                run_flow_sync(suspendable_flow, flow_run=flow_run)
+            else:
+                await run_flow_async(suspendable_flow, flow_run=flow_run)
+
+        assert task_ran
+        assert not flow_continued
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state.is_paused(), flow_run.state
+        assert flow_run.state.name == "Suspended"
 
 
 class TestWaitUntilReadySync:


### PR DESCRIPTION
closes #20388
closes #17822

Related to #14747.

This PR restores external flow run suspension behavior so an active deployment-backed flow exits at the next orchestration boundary after `suspend_flow_run(flow_run_id=...)` or a UI/API suspension request marks the run `Suspended`.

## Summary

- Adds a private in-process suspension signal shared through `FlowRunContext`
- Registers active flow runs for same-process suspension delivery
- Adds a `FlowRunSuspendingObserver` that watches `prefect.flow-run.Suspended` events with polling fallback
- Checks the signal before task submission, mapped/deferred task submission, task user-code execution, and child flow startup
- Closes the observer startup race with one initial server-authoritative state read before the observer reports ready
- Adds unit coverage and a live-server integration regression test

## Notes

This intentionally keeps distributed task runners best-effort: once the parent observes suspension it stops submitting new work, but already-submitted remote work may still start or finish.

Bundle-backed resumability is left for a follow-up PR; this keeps the existing deployment-backed resumability guard unchanged.
