### PR TITLE
docs: mark server-side default result storage as beta

### DIFF
--- a/docs/v3/advanced/results.mdx
+++ b/docs/v3/advanced/results.mdx
@@ -184,6 +184,10 @@ Note that any explicit configuration of `result_storage` on either a flow or tas
 
 #### Specifying a default filesystem server-side
 
+<Warning>
+Server-side default result storage is currently in beta. APIs, CLI commands, and behaviors may change without notice. We encourage you to try it out and provide feedback through [GitHub issues](https://github.com/PrefectHQ/prefect/issues).
+</Warning>
+
 If many flow runs should use the same result storage, you can set a server-side default.
 This is useful when you want every client, worker, and deployment connected to the same Prefect Cloud
 workspace or self-hosted Prefect server to write persisted results to a shared location without setting
@@ -193,9 +197,9 @@ A configured server-side default result storage block also enables result persis
 flows and tasks that do not explicitly opt out. You do not need to set `PREFECT_RESULTS_PERSIST_BY_DEFAULT`
 in every worker environment when this default is configured.
 
-The `prefect experimental result-storage` commands use your active CLI profile and are subject to
-change while Prefect expands default storage configuration. Make sure the profile is connected to the
-API where you want to set the default. If you are running Prefect locally, start the server first:
+The `prefect experimental result-storage` commands use your active CLI profile. Make sure the profile
+is connected to the API where you want to set the default. If you are running Prefect locally, start
+the server first:
 
 {/* pmd-metadata: notest */}
 ```bash


### PR DESCRIPTION
this PR tags the new "Specifying a default filesystem server-side" subsection in `docs/v3/advanced/results.mdx` as beta, since the CLI surface is still under `prefect experimental result-storage ...` and the shape may change.

uses the canonical Prefect docs pattern — a `<Warning>` admonition right under the heading — matching how the MCP server doc and (previously) the infrastructure decorators doc marked themselves while in beta. also drops the now-redundant "subject to change while Prefect expands default storage configuration" hedge from the CLI sentence, since the `<Warning>` covers that.

<details>

scope is intentionally narrow: only the server-side default subsection, not the rest of `results.mdx`.

related: #21774 (the PR that introduced the section), #21532 / #21759 / #21771 (the underlying experimental work).

</details>

## Test plan
- [ ] `just docs` and visually confirm the `<Warning>` renders under the "Specifying a default filesystem server-side" heading
- [ ] confirm no other beta/experimental indicators were affected