### PR TITLE
Support PREFECT env values from files

### DIFF
--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -87,11 +87,28 @@ def _resolve_env_file_values(
     return resolved_env_vars
 
 
-def _resolved_os_environ() -> dict[str, str | None]:
-    return _resolve_env_file_values(
-        {key.lower(): value for key, value in os.environ.items()},
-        case_sensitive=False,
-    )
+def _get_env_value(name: str) -> str | None:
+    file_name = f"{name}__FILE"
+    value = os.getenv(name)
+    file_path = os.getenv(file_name)
+
+    if value is not None and file_path is not None:
+        raise SettingsError(
+            f"Both {name} and {file_name} are set, but they are mutually exclusive."
+        )
+
+    if file_path is None:
+        return value
+
+    if not file_path:
+        raise SettingsError(f"{file_name} must point to a readable file.")
+
+    try:
+        return _strip_single_trailing_newline(Path(file_path).read_text("utf-8"))
+    except OSError as exc:
+        raise SettingsError(
+            f"Could not read file referenced by {file_name}: {file_path}"
+        ) from exc
 
 
 def _read_toml_file(path: Path) -> dict[str, Any]:
@@ -224,9 +241,9 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
             active_profile = sys.argv[2]
 
         else:
-            active_profile = _resolved_os_environ().get(
-                "prefect_profile"
-            ) or all_profile_data.get("active")
+            active_profile = _get_env_value("PREFECT_PROFILE") or all_profile_data.get(
+                "active"
+            )
 
         profiles_data = all_profile_data.get("profiles", {})
 
@@ -401,22 +418,20 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSourceBase):
 
 def _is_test_mode() -> bool:
     """Check if the current process is in test mode."""
-    env_vars = _resolved_os_environ()
     return bool(
-        env_vars.get("prefect_test_mode")
-        or env_vars.get("prefect_unit_test_mode")
-        or env_vars.get("prefect_testing_unit_test_mode")
-        or env_vars.get("prefect_testing_test_mode")
+        _get_env_value("PREFECT_TEST_MODE")
+        or _get_env_value("PREFECT_UNIT_TEST_MODE")
+        or _get_env_value("PREFECT_TESTING_UNIT_TEST_MODE")
+        or _get_env_value("PREFECT_TESTING_TEST_MODE")
     )
 
 
 def _get_profiles_path() -> Path:
     """Helper to get the profiles path"""
-    env_vars = _resolved_os_environ()
 
     if _is_test_mode():
         return DEFAULT_PROFILES_PATH
-    if env_path := env_vars.get("prefect_profiles_path"):
+    if env_path := _get_env_value("PREFECT_PROFILES_PATH"):
         return Path(env_path)
     if Path(".env").is_file() and (
         dotenv_path := dotenv.dotenv_values(".env").get("PREFECT_PROFILES_PATH")
@@ -429,7 +444,7 @@ def _get_profiles_path() -> Path:
     ):
         return Path(pyproject_path)
 
-    if env_home := env_vars.get("prefect_home"):
+    if env_home := _get_env_value("PREFECT_HOME"):
         return Path(env_home) / "profiles.toml"
 
     if not (DEFAULT_PREFECT_HOME / "profiles.toml").exists():

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -87,6 +87,13 @@ def _resolve_env_file_values(
     return resolved_env_vars
 
 
+def _resolved_os_environ() -> dict[str, str | None]:
+    return _resolve_env_file_values(
+        {key.lower(): value for key, value in os.environ.items()},
+        case_sensitive=False,
+    )
+
+
 def _read_toml_file(path: Path) -> dict[str, Any]:
     """use ttl cache to cache toml files"""
     modified_time = path.stat().st_mtime
@@ -217,9 +224,9 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
             active_profile = sys.argv[2]
 
         else:
-            active_profile = os.environ.get("PREFECT_PROFILE") or all_profile_data.get(
-                "active"
-            )
+            active_profile = _resolved_os_environ().get(
+                "prefect_profile"
+            ) or all_profile_data.get("active")
 
         profiles_data = all_profile_data.get("profiles", {})
 
@@ -394,20 +401,22 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSourceBase):
 
 def _is_test_mode() -> bool:
     """Check if the current process is in test mode."""
+    env_vars = _resolved_os_environ()
     return bool(
-        os.getenv("PREFECT_TEST_MODE")
-        or os.getenv("PREFECT_UNIT_TEST_MODE")
-        or os.getenv("PREFECT_TESTING_UNIT_TEST_MODE")
-        or os.getenv("PREFECT_TESTING_TEST_MODE")
+        env_vars.get("prefect_test_mode")
+        or env_vars.get("prefect_unit_test_mode")
+        or env_vars.get("prefect_testing_unit_test_mode")
+        or env_vars.get("prefect_testing_test_mode")
     )
 
 
 def _get_profiles_path() -> Path:
     """Helper to get the profiles path"""
+    env_vars = _resolved_os_environ()
 
     if _is_test_mode():
         return DEFAULT_PROFILES_PATH
-    if env_path := os.getenv("PREFECT_PROFILES_PATH"):
+    if env_path := env_vars.get("prefect_profiles_path"):
         return Path(env_path)
     if Path(".env").is_file() and (
         dotenv_path := dotenv.dotenv_values(".env").get("PREFECT_PROFILES_PATH")
@@ -420,8 +429,8 @@ def _get_profiles_path() -> Path:
     ):
         return Path(pyproject_path)
 
-    if os.environ.get("PREFECT_HOME"):
-        return Path(os.environ["PREFECT_HOME"]) / "profiles.toml"
+    if env_home := env_vars.get("prefect_home"):
+        return Path(env_home) / "profiles.toml"
 
     if not (DEFAULT_PREFECT_HOME / "profiles.toml").exists():
         return DEFAULT_PROFILES_PATH

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -2,7 +2,17 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, get_origin
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    get_origin,
+)
 
 import dotenv
 from cachetools import TTLCache
@@ -14,6 +24,7 @@ from pydantic_settings import (
     EnvSettingsSource,
     PydanticBaseSettingsSource,
 )
+from pydantic_settings.exceptions import SettingsError
 from pydantic_settings.sources import (
     ENV_FILE_SENTINEL,
     ConfigFileSourceMixin,
@@ -25,6 +36,55 @@ from prefect.settings.constants import DEFAULT_PREFECT_HOME, DEFAULT_PROFILES_PA
 from prefect.utilities.collections import get_from_dict
 
 _file_cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=100, ttl=60)
+
+
+def _strip_single_trailing_newline(value: str) -> str:
+    if value.endswith("\r\n"):
+        return value[:-2]
+    if value.endswith(("\n", "\r")):
+        return value[:-1]
+    return value
+
+
+def _resolve_env_file_values(
+    env_vars: Mapping[str, str | None], case_sensitive: Optional[bool]
+) -> dict[str, str | None]:
+    resolved_env_vars = dict(env_vars)
+    suffix = "__FILE" if case_sensitive else "__file"
+    prefect_prefix = "PREFECT_" if case_sensitive else "prefect_"
+
+    for file_key, file_path in list(resolved_env_vars.items()):
+        if not file_key.endswith(suffix):
+            continue
+
+        env_key = file_key[: -len(suffix)]
+        if not env_key.startswith(prefect_prefix):
+            continue
+
+        if env_key in resolved_env_vars and resolved_env_vars[env_key] is not None:
+            env_name = env_key if case_sensitive else env_key.upper()
+            file_env_name = file_key if case_sensitive else file_key.upper()
+            raise SettingsError(
+                f"Both {env_name} and {file_env_name} are set, but they are mutually exclusive."
+            )
+
+        if not file_path:
+            file_env_name = file_key if case_sensitive else file_key.upper()
+            raise SettingsError(f"{file_env_name} must point to a readable file.")
+
+        try:
+            resolved_env_vars[env_key] = _strip_single_trailing_newline(
+                Path(file_path).read_text(encoding="utf-8")
+            )
+        except OSError as exc:
+            file_env_name = file_key if case_sensitive else file_key.upper()
+            raise SettingsError(
+                f"Could not read file referenced by {file_env_name}: {file_path}"
+            ) from exc
+
+        resolved_env_vars.pop(file_key, None)
+
+    return resolved_env_vars
 
 
 def _read_toml_file(path: Path) -> dict[str, Any]:
@@ -69,6 +129,10 @@ class EnvFilterSettingsSource(EnvSettingsSource):
             env_parse_enums=env_parse_enums,
         )
         self.env_vars: Mapping[str, str | None]
+        self.env_vars = _resolve_env_file_values(
+            self.env_vars,
+            case_sensitive=case_sensitive,
+        )
         if env_filter:
             if isinstance(self.env_vars, dict):
                 for key in env_filter:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2130,6 +2130,67 @@ class TestSettingsSources:
         assert Settings().profiles_path == profile_path
         assert (k := Settings().api.key) and k.get_secret_value() == "test_key"
 
+    @pytest.mark.usefixtures("disable_hosted_api_server")
+    def test_prefect_profiles_path_file_is_used_to_load_profile_settings(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_PROFILES_PATH", raising=False)
+
+        profiles_path = tmp_path / "profiles.toml"
+        profiles_path.write_text(
+            textwrap.dedent(
+                """
+                active = "test"
+
+                [profiles.test]
+                PREFECT_API_KEY = "test_key"
+                """
+            )
+        )
+        profiles_path_file = tmp_path / "profiles-path"
+        profiles_path_file.write_text(f"{profiles_path}\n", encoding="utf-8")
+
+        monkeypatch.setenv("PREFECT_PROFILES_PATH__FILE", str(profiles_path_file))
+
+        assert Settings().profiles_path == profiles_path
+        assert (k := Settings().api.key) and k.get_secret_value() == "test_key"
+
+    @pytest.mark.usefixtures("disable_hosted_api_server")
+    def test_prefect_profile_file_selects_active_profile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_PROFILE", raising=False)
+
+        profiles_path = tmp_path / "profiles.toml"
+        profiles_path.write_text(
+            textwrap.dedent(
+                """
+                active = "default"
+
+                [profiles.default]
+                PREFECT_API_KEY = "default_key"
+
+                [profiles.test]
+                PREFECT_API_KEY = "test_key"
+                """
+            )
+        )
+        profile_file = tmp_path / "profile"
+        profile_file.write_text("test\n", encoding="utf-8")
+
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
+        monkeypatch.setenv("PREFECT_PROFILE__FILE", str(profile_file))
+
+        assert (k := Settings().api.key) and k.get_secret_value() == "test_key"
+
 
 class TestLoadProfiles:
     @pytest.fixture(autouse=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -705,6 +705,59 @@ class TestSettingsClass:
         assert PREFECT_TEST_MODE.value_from(new_settings) is False
 
     @pytest.mark.usefixtures("disable_hosted_api_server")
+    def test_settings_loads_environment_variables_from_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        secret_file = tmp_path / "prefect-api-key"
+        secret_file.write_text("test-key\n\n", encoding="utf-8")
+
+        monkeypatch.delenv("PREFECT_API_KEY", raising=False)
+        monkeypatch.setenv("PREFECT_API_KEY__FILE", str(secret_file))
+
+        settings = Settings()
+
+        assert settings.api.key is not None
+        assert settings.api.key.get_secret_value() == "test-key\n"
+
+    @pytest.mark.usefixtures("disable_hosted_api_server")
+    def test_settings_loads_nested_environment_variables_from_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        port_file = tmp_path / "api-port"
+        port_file.write_text("9999\n", encoding="utf-8")
+
+        monkeypatch.delenv("PREFECT_SERVER_API_PORT", raising=False)
+        monkeypatch.setenv("PREFECT_SERVER_API_PORT__FILE", str(port_file))
+
+        assert Settings().server.api.port == 9999
+
+    @pytest.mark.usefixtures("disable_hosted_api_server")
+    def test_settings_file_environment_variable_conflicts_with_value(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        secret_file = tmp_path / "prefect-api-key"
+        secret_file.write_text("file-key", encoding="utf-8")
+        monkeypatch.setenv("PREFECT_API_KEY", "env-key")
+        monkeypatch.setenv("PREFECT_API_KEY__FILE", str(secret_file))
+
+        from pydantic_settings.exceptions import SettingsError
+
+        with pytest.raises(SettingsError, match="mutually exclusive"):
+            Settings()
+
+    @pytest.mark.usefixtures("disable_hosted_api_server")
+    def test_settings_file_environment_variable_requires_readable_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.delenv("PREFECT_API_KEY", raising=False)
+        monkeypatch.setenv("PREFECT_API_KEY__FILE", str(tmp_path / "missing-api-key"))
+
+        from pydantic_settings.exceptions import SettingsError
+
+        with pytest.raises(SettingsError, match="Could not read file"):
+            Settings()
+
+    @pytest.mark.usefixtures("disable_hosted_api_server")
     def test_settings_to_environment_includes_all_settings_with_non_null_values(self):
         settings = get_current_settings()
         expected_names = {


### PR DESCRIPTION
## Summary

  Adds support for loading Prefect environment variable values from files
  using the `PREFECT_*__FILE` convention.
Fixes #21873
  For example:

  ```bash
  PREFECT_API_KEY__FILE=/run/secrets/prefect_api_key

  will load the file contents as PREFECT_API_KEY.


  ## What changed

  - Resolves PREFECT_*__FILE values in the settings environment source
  - Supports nested settings such as PREFECT_SERVER_API_PORT__FILE
  - Raises a clear error if both PREFECT_* and PREFECT_*__FILE are set
  - Raises a clear error if the referenced file cannot be read
  - Strips a single trailing newline from file contents

  ## Tests

  - uv run ruff check src/prefect/settings/sources.py tests/test_settings.py
  - uv run ruff format --check src/prefect/settings/sources.py tests/
    test_settings.py
  - Focused settings tests for file loading, nested settings, conflict
    handling, and missing files
