### PR TITLE
Add worker work-pool snapshot handling

### DIFF
--- a/src/prefect/workers/_worker_channel/__init__.py
+++ b/src/prefect/workers/_worker_channel/__init__.py
@@ -9,6 +9,7 @@ from prefect.workers._worker_channel._state import (
     WorkerChannelState,
     WorkerChannelStatus,
     WorkerChannelTerminalError,
+    WorkPoolSnapshotState,
 )
 from prefect.workers._worker_channel._sync import WorkPoolWorkerChannel
 
@@ -21,5 +22,6 @@ __all__ = [
     "WorkerChannelState",
     "WorkerChannelStatus",
     "WorkerChannelTerminalError",
+    "WorkPoolSnapshotState",
     "WorkPoolWorkerChannel",
 ]

--- a/src/prefect/workers/_worker_channel/_protocol.py
+++ b/src/prefect/workers/_worker_channel/_protocol.py
@@ -27,6 +27,7 @@ from prefect.client.schemas.worker_channel import (
     WorkerHelloFrame,
     WorkerReadyFrame,
     WorkPoolSnapshotFrame,
+    WorkPoolSnapshotPayload,
     validate_worker_channel_frame,
 )
 from prefect.settings import get_current_settings
@@ -38,6 +39,7 @@ from prefect.workers._worker_channel._state import (
     WorkerChannelRetryableError,
     WorkerChannelSession,
     WorkerChannelTerminalError,
+    WorkPoolSnapshotState,
 )
 
 
@@ -77,6 +79,7 @@ class WorkerChannelProtocolHandler:
         self._current_session = CurrentWorkerChannelSession()
         self._worker_id: UUID | None = None
         self._worker_metadata_sent = False
+        self._work_pool_snapshots = WorkPoolSnapshotState()
 
     @property
     def worker_id(self) -> UUID | None:
@@ -85,6 +88,10 @@ class WorkerChannelProtocolHandler:
     @property
     def worker_metadata_sent(self) -> bool:
         return self._worker_metadata_sent
+
+    @property
+    def work_pool_snapshots_available(self) -> bool:
+        return self._work_pool_snapshots.snapshots_available
 
     async def handshake(
         self, websocket: websockets.asyncio.client.ClientConnection
@@ -175,12 +182,26 @@ class WorkerChannelProtocolHandler:
             )
 
     def _handle_ready(self, ready: WorkerReadyFrame) -> None:
-        self.handle_work_pool_snapshot(ready.payload.initial_snapshot.work_pool)
+        self.reset_work_pool_snapshot_sequence()
+        self.handle_work_pool_snapshot(ready.payload.initial_snapshot)
         worker_id = ready.payload.worker_id
         if worker_id is not None:
             self.record_worker_id(worker_id)
 
-    def handle_work_pool_snapshot(self, work_pool: WorkPool) -> None:
+    def reset_work_pool_snapshot_sequence(self) -> None:
+        self._work_pool_snapshots.reset_connection_sequence()
+
+    def handle_work_pool_snapshot(self, snapshot: WorkPoolSnapshotPayload) -> bool:
+        work_pool = self._work_pool_snapshots.apply_snapshot(snapshot)
+        if work_pool is None:
+            return False
+
+        if self._on_work_pool_snapshot is not None:
+            self._on_work_pool_snapshot(work_pool)
+        return True
+
+    def record_rest_work_pool_snapshot(self, work_pool: WorkPool) -> None:
+        work_pool = self._work_pool_snapshots.replace_from_rest(work_pool)
         if self._on_work_pool_snapshot is not None:
             self._on_work_pool_snapshot(work_pool)
 
@@ -299,7 +320,7 @@ class WorkerChannelProtocolHandler:
                 ) from exc
 
             if isinstance(frame, WorkPoolSnapshotFrame):
-                self.handle_work_pool_snapshot(frame.payload.work_pool)
+                self.handle_work_pool_snapshot(frame.payload)
                 continue
 
             if isinstance(frame, CleanupMessageFrame):

--- a/src/prefect/workers/_worker_channel/_state.py
+++ b/src/prefect/workers/_worker_channel/_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from dataclasses import dataclass
 from enum import Enum
 from typing import Protocol
@@ -10,10 +11,12 @@ import websockets.asyncio.client
 import websockets.exceptions
 
 from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.objects import WorkPool
 from prefect.client.schemas.worker_channel import (
     WorkerChannelCapability,
     WorkerChannelFrame,
     WorkerReadyFrame,
+    WorkPoolSnapshotPayload,
 )
 
 
@@ -75,6 +78,34 @@ class WorkerChannelState:
 
 
 WorkerChannelFallbackState = WorkerChannelState
+
+
+@dataclass
+class WorkPoolSnapshotState:
+    work_pool: WorkPool | None = None
+    last_applied_sequence: int | None = None
+
+    @property
+    def snapshots_available(self) -> bool:
+        return self.last_applied_sequence is not None
+
+    def reset_connection_sequence(self) -> None:
+        self.last_applied_sequence = None
+
+    def apply_snapshot(self, snapshot: WorkPoolSnapshotPayload) -> WorkPool | None:
+        if (
+            self.last_applied_sequence is not None
+            and snapshot.snapshot_sequence <= self.last_applied_sequence
+        ):
+            return None
+
+        self.last_applied_sequence = snapshot.snapshot_sequence
+        self.work_pool = copy.deepcopy(snapshot.work_pool)
+        return self.work_pool
+
+    def replace_from_rest(self, work_pool: WorkPool) -> WorkPool:
+        self.work_pool = copy.deepcopy(work_pool)
+        return self.work_pool
 
 
 @dataclass
@@ -145,6 +176,9 @@ class CurrentWorkerChannelSession:
 class WorkerChannel(Protocol):
     @property
     def rest_fallback_enabled(self) -> bool: ...
+
+    @property
+    def snapshots_available(self) -> bool: ...
 
     def set_client(self, client: PrefectClient) -> None: ...
 

--- a/src/prefect/workers/_worker_channel/_sync.py
+++ b/src/prefect/workers/_worker_channel/_sync.py
@@ -321,11 +321,25 @@ class WorkPoolWorkerChannel:
                     )
                 return
 
+        if self.state.healthy and self.snapshots_available:
+            self._logger.debug(
+                "Skipping REST work pool sync because the worker channel applied a "
+                "snapshot while REST sync was in flight."
+            )
+            return
+
         if not work_pool.base_job_template:
             await self._set_work_pool_template(
                 work_pool, self.default_base_job_template
             )
             work_pool.base_job_template = self.default_base_job_template
+
+        if self.state.healthy and self.snapshots_available:
+            self._logger.debug(
+                "Skipping REST work pool snapshot because the worker channel applied "
+                "a snapshot while REST sync was in flight."
+            )
+            return
 
         self._protocol.record_rest_work_pool_snapshot(work_pool)
 

--- a/src/prefect/workers/_worker_channel/_sync.py
+++ b/src/prefect/workers/_worker_channel/_sync.py
@@ -113,6 +113,10 @@ class WorkPoolWorkerChannel:
         return self.state.rest_fallback_enabled
 
     @property
+    def snapshots_available(self) -> bool:
+        return self._protocol.work_pool_snapshots_available
+
+    @property
     def worker_id(self) -> UUID | None:
         return self._protocol.worker_id
 
@@ -128,7 +132,7 @@ class WorkPoolWorkerChannel:
             self._run_scope.cancel()
 
     async def sync(self, task_group: anyio.abc.TaskGroup | None) -> None:
-        if self.state.healthy:
+        if self.state.healthy and self.snapshots_available:
             return
 
         if task_group is not None:
@@ -138,7 +142,7 @@ class WorkPoolWorkerChannel:
             if self.url is None:
                 self.state.mark_terminal("endpoint_unavailable")
 
-        if channel_started:
+        if channel_started and self.snapshots_available:
             return
 
         await self._sync_rest_work_pool()
@@ -323,7 +327,7 @@ class WorkPoolWorkerChannel:
             )
             work_pool.base_job_template = self.default_base_job_template
 
-        self._protocol.handle_work_pool_snapshot(work_pool)
+        self._protocol.record_rest_work_pool_snapshot(work_pool)
 
     async def _set_work_pool_template(
         self, work_pool: WorkPool, job_template: dict[str, Any]

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -653,6 +653,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
         return self._work_pool
 
+    def _get_work_pool_copy(self) -> WorkPool:
+        return copy.deepcopy(self.work_pool)
+
     @property
     def limiter(self) -> anyio.CapacityLimiter:
         if self._limiter is None:
@@ -957,12 +960,14 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             create_bundle_for_flow_run,
         )
 
+        work_pool = self._get_work_pool_copy()
+
         if (
-            self.work_pool.storage_configuration.bundle_upload_step is None
-            or self.work_pool.storage_configuration.bundle_execution_step is None
+            work_pool.storage_configuration.bundle_upload_step is None
+            or work_pool.storage_configuration.bundle_execution_step is None
         ):
             raise RuntimeError(
-                f"Storage is not configured for work pool {self.work_pool.name!r}. "
+                f"Storage is not configured for work pool {work_pool.name!r}. "
                 "Please configure storage for the work pool by running `prefect "
                 "work-pool storage configure`."
             )
@@ -982,11 +987,11 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         ):
             result_storage = None
             if (
-                self.work_pool.storage_configuration.default_result_storage_block_id
+                work_pool.storage_configuration.default_result_storage_block_id
                 is not None
             ):
                 result_storage = await aresolve_result_storage(
-                    self.work_pool.storage_configuration.default_result_storage_block_id
+                    work_pool.storage_configuration.default_result_storage_block_id
                 )
             else:
                 default_result_storage = await _aget_default_result_storage()
@@ -1010,12 +1015,12 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         bundle_key = str(uuid.uuid4())
         flow_launcher = getattr(flow, "launcher", None)
         upload_step = resolve_bundle_step_with_launcher(
-            self.work_pool.storage_configuration.bundle_upload_step,
+            work_pool.storage_configuration.bundle_upload_step,
             flow_launcher,
             "upload",
         )
         execute_step = resolve_bundle_step_with_launcher(
-            self.work_pool.storage_configuration.bundle_execution_step,
+            work_pool.storage_configuration.bundle_execution_step,
             flow_launcher,
             "execution",
         )
@@ -1051,7 +1056,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 parameters=flow.serialize_parameters(parameters),
                 state=Pending(),
                 job_variables=job_variables,
-                work_pool_name=self.work_pool.name,
+                work_pool_name=work_pool.name,
                 tags=TagsContext.get().current_tags,
                 parent_task_run_id=getattr(parent_task_run, "id", None),
             )
@@ -1073,14 +1078,14 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         logger = self.get_flow_run_logger(flow_run)
 
         configuration = await self.job_configuration.from_template_and_values(
-            base_job_template=self.work_pool.base_job_template,
+            base_job_template=work_pool.base_job_template,
             values=job_variables,
             client=self._client,
         )
         configuration.prepare_for_flow_run(
             flow_run=flow_run,
             flow=api_flow,
-            work_pool=self.work_pool,
+            work_pool=work_pool,
             worker_name=self.name,
             worker_id=self.backend_id,
         )
@@ -1261,6 +1266,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         return await self._submit_scheduled_flow_runs(flow_run_response=runs_response)
 
     def _record_work_pool_snapshot(self, work_pool: WorkPool) -> None:
+        work_pool = copy.deepcopy(work_pool)
+
         if not work_pool.base_job_template:
             work_pool.base_job_template = self.__class__.get_default_base_job_template()
 
@@ -1612,6 +1619,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         flow_run: "FlowRun",
         deployment: Optional["DeploymentResponse"] = None,
     ) -> C:
+        work_pool = self._get_work_pool_copy()
+
         if not deployment and flow_run.deployment_id:
             deployment = await self.client.read_deployment(flow_run.deployment_id)
 
@@ -1627,7 +1636,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         job_variables.update(flow_run_vars)
 
         configuration = await self.job_configuration.from_template_and_values(
-            base_job_template=self.work_pool.base_job_template,
+            base_job_template=work_pool.base_job_template,
             values=job_variables,
             client=self.client,
         )
@@ -1636,7 +1645,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 flow_run=flow_run,
                 deployment=deployment,
                 flow=flow,
-                work_pool=self.work_pool,
+                work_pool=work_pool,
                 worker_name=self.name,
                 worker_id=self.backend_id,
             )

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -653,9 +653,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
         return self._work_pool
 
-    def _get_work_pool_copy(self) -> WorkPool:
-        return copy.deepcopy(self.work_pool)
-
     @property
     def limiter(self) -> anyio.CapacityLimiter:
         if self._limiter is None:
@@ -960,7 +957,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             create_bundle_for_flow_run,
         )
 
-        work_pool = self._get_work_pool_copy()
+        work_pool = copy.deepcopy(self.work_pool)
 
         if (
             work_pool.storage_configuration.bundle_upload_step is None
@@ -1619,7 +1616,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         flow_run: "FlowRun",
         deployment: Optional["DeploymentResponse"] = None,
     ) -> C:
-        work_pool = self._get_work_pool_copy()
+        work_pool = copy.deepcopy(self.work_pool)
 
         if not deployment and flow_run.deployment_id:
             deployment = await self.client.read_deployment(flow_run.deployment_id)

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -51,6 +51,7 @@ from prefect.client.schemas.worker_channel import (
     WORKER_HEARTBEAT_CAPABILITY,
     WorkerChannelCloseReason,
     WorkerReadyFrame,
+    WorkPoolSnapshotPayload,
 )
 from prefect.context import FlowRunContext, TagsContext
 from prefect.exceptions import (
@@ -91,6 +92,7 @@ from prefect.workers._worker_channel import (
     WorkerChannelState,
     WorkerChannelStatus,
     WorkerChannelTerminalError,
+    WorkPoolSnapshotState,
     WorkPoolWorkerChannel,
 )
 from prefect.workers._worker_channel._protocol import WorkerChannelProtocolHandler
@@ -2285,6 +2287,31 @@ def worker_channel_ready_frame(
     }
 
 
+def worker_channel_snapshot_payload(
+    sequence: int,
+    *,
+    base_job_template: dict[str, Any] | None = None,
+    is_paused: bool = False,
+    name: str = "test-work-pool",
+    default_queue_id: uuid.UUID | None = None,
+) -> WorkPoolSnapshotPayload:
+    return WorkPoolSnapshotPayload.model_validate(
+        {
+            "snapshot_sequence": sequence,
+            "reason": "work_pool_updated" if sequence != 1 else "initial",
+            "work_pool": {
+                "id": str(uuid.uuid4()),
+                "name": name,
+                "type": "test",
+                "base_job_template": base_job_template or {},
+                "is_paused": is_paused,
+                "storage_configuration": {},
+                "default_queue_id": str(default_queue_id or uuid.uuid4()),
+            },
+        }
+    )
+
+
 async def no_worker_channel_metadata() -> WorkerMetadata | None:
     return None
 
@@ -2345,6 +2372,132 @@ class TestWorkerChannelClient:
         assert state.healthy is False
         assert state.terminal is True
         assert state.reason == "endpoint_unavailable"
+
+    def test_work_pool_snapshot_state_applies_full_replacements_by_sequence(self):
+        state = WorkPoolSnapshotState()
+        initial_template = {"job_configuration": {"env": {"A": "1"}}, "variables": {}}
+        updated_template = {"job_configuration": {"env": {"B": "2"}}, "variables": {}}
+
+        first = state.apply_snapshot(
+            worker_channel_snapshot_payload(
+                1, base_job_template=initial_template, is_paused=False
+            )
+        )
+        second = state.apply_snapshot(
+            worker_channel_snapshot_payload(
+                3, base_job_template=updated_template, is_paused=True
+            )
+        )
+
+        assert first is not None
+        assert second is not None
+        assert second is not first
+        assert state.last_applied_sequence == 3
+        assert state.work_pool is not None
+        assert state.work_pool.base_job_template == updated_template
+        assert state.work_pool.is_paused is True
+
+    def test_work_pool_snapshot_state_ignores_stale_and_duplicate_sequences(self):
+        state = WorkPoolSnapshotState()
+        current_template = {
+            "job_configuration": {"env": {"CURRENT": "1"}},
+            "variables": {},
+        }
+        stale_template = {"job_configuration": {"env": {"STALE": "1"}}, "variables": {}}
+
+        state.apply_snapshot(
+            worker_channel_snapshot_payload(3, base_job_template=current_template)
+        )
+
+        assert (
+            state.apply_snapshot(
+                worker_channel_snapshot_payload(3, base_job_template=stale_template)
+            )
+            is None
+        )
+        assert (
+            state.apply_snapshot(
+                worker_channel_snapshot_payload(2, base_job_template=stale_template)
+            )
+            is None
+        )
+        assert state.work_pool is not None
+        assert state.work_pool.base_job_template == current_template
+
+    def test_work_pool_snapshot_state_resets_sequence_tracking_for_reconnect(self):
+        state = WorkPoolSnapshotState()
+        original_template = {
+            "job_configuration": {"env": {"ORIGINAL": "1"}},
+            "variables": {},
+        }
+        reconnected_template = {
+            "job_configuration": {"env": {"RECONNECTED": "1"}},
+            "variables": {},
+        }
+
+        state.apply_snapshot(
+            worker_channel_snapshot_payload(5, base_job_template=original_template)
+        )
+        state.reset_connection_sequence()
+        state.apply_snapshot(
+            worker_channel_snapshot_payload(1, base_job_template=reconnected_template)
+        )
+
+        assert state.last_applied_sequence == 1
+        assert state.work_pool is not None
+        assert state.work_pool.base_job_template == reconnected_template
+
+    def test_protocol_applies_work_pool_snapshots_through_sequence_state(self):
+        consumer_id = uuid7()
+        snapshot = Mock()
+        protocol = WorkerChannelProtocolHandler(
+            consumer_id=consumer_id,
+            worker_name="test-worker",
+            worker_type="test",
+            heartbeat_interval_seconds=30,
+            work_queue_names=[],
+            create_pool_if_not_found=True,
+            default_base_job_template={},
+            worker_metadata=no_worker_channel_metadata,
+            classify_closed_connection=lambda exc: WorkerChannelTerminalError(
+                "connection_lost", str(exc)
+            ),
+            logger=logging.getLogger("test-worker-channel"),
+            on_work_pool_snapshot=snapshot,
+        )
+
+        protocol.handle_work_pool_snapshot(
+            worker_channel_snapshot_payload(
+                1,
+                base_job_template={
+                    "job_configuration": {"env": {"FIRST": "1"}},
+                    "variables": {},
+                },
+            )
+        )
+        protocol.handle_work_pool_snapshot(
+            worker_channel_snapshot_payload(
+                3,
+                base_job_template={
+                    "job_configuration": {"env": {"THIRD": "1"}},
+                    "variables": {},
+                },
+            )
+        )
+        protocol.handle_work_pool_snapshot(
+            worker_channel_snapshot_payload(
+                2,
+                base_job_template={
+                    "job_configuration": {"env": {"STALE": "1"}},
+                    "variables": {},
+                },
+            )
+        )
+
+        assert snapshot.call_count == 2
+        assert snapshot.call_args_list[-1].args[0].base_job_template[
+            "job_configuration"
+        ]["env"] == {"THIRD": "1"}
 
     async def test_transport_connects_with_auth_and_hello_payload(self):
         captured_connect_kwargs: dict[str, Any] = {}
@@ -2864,6 +3017,7 @@ class TestWorkerChannelClient:
             worker_metadata=no_worker_channel_metadata,
             logger=logging.getLogger("test-worker-channel"),
         )
+        channel._protocol.handle_work_pool_snapshot(worker_channel_snapshot_payload(1))
         channel.state.mark_healthy()
 
         await channel.sync(None)
@@ -3086,6 +3240,106 @@ async def test_work_pool_env_from_job_configuration_merges_with_variable_default
     assert config.env["WORK_POOL_BASE_VAR"] == "from-job-config"
     assert config.env["WORK_POOL_DEFAULT_VAR"] == "from-variable-defaults"
     assert config.env["DEPLOYMENT_VAR"] == "from-deployment"
+
+
+async def test_get_configuration_uses_stable_work_pool_copy(
+    prefect_client: PrefectClient,
+    work_pool: WorkPool,
+):
+    @flow
+    def test_flow():
+        pass
+
+    flow_run = await prefect_client.create_flow_run(
+        test_flow,
+        work_pool_name=work_pool.name,
+    )
+    initial_template = {
+        "job_configuration": {"env": {"SNAPSHOT": "initial"}},
+        "variables": {"properties": {}},
+    }
+    updated_template = {
+        "job_configuration": {"env": {"SNAPSHOT": "updated"}},
+        "variables": {"properties": {}},
+    }
+    worker_ref: dict[str, BaseWorker[Any, Any, Any]] = {}
+    templates_used: list[dict[str, Any]] = []
+    prepared_work_pools: list[WorkPool | None] = []
+    worker_type = "stable-snapshot-test"
+
+    class StableSnapshotJobConfiguration(BaseJobConfiguration):
+        @classmethod
+        async def from_template_and_values(
+            cls,
+            base_job_template: dict[str, Any],
+            values: dict[str, Any],
+            client: PrefectClient | None = None,
+        ):
+            templates_used.append(copy.deepcopy(base_job_template))
+            worker_ref["worker"]._record_work_pool_snapshot(
+                WorkPool(
+                    name=work_pool.name,
+                    type=worker_type,
+                    base_job_template=updated_template,
+                    default_queue_id=work_pool.default_queue_id,
+                )
+            )
+            return await super().from_template_and_values(
+                base_job_template=base_job_template,
+                values=values,
+                client=client,
+            )
+
+        def prepare_for_flow_run(
+            self,
+            flow_run: FlowRun,
+            deployment: DeploymentResponse | None = None,
+            flow: Flow | None = None,
+            work_pool: WorkPool | None = None,
+            worker_name: str | None = None,
+            worker_id: uuid.UUID | None = None,
+        ) -> None:
+            prepared_work_pools.append(work_pool)
+            return super().prepare_for_flow_run(
+                flow_run=flow_run,
+                deployment=deployment,
+                flow=flow,
+                work_pool=work_pool,
+                worker_name=worker_name,
+                worker_id=worker_id,
+            )
+
+    class StableSnapshotWorker(
+        BaseWorker[StableSnapshotJobConfiguration, Any, BaseWorkerResult]
+    ):
+        type = worker_type
+        job_configuration = StableSnapshotJobConfiguration
+
+        async def run(
+            self,
+            flow_run: FlowRun,
+            configuration: StableSnapshotJobConfiguration,
+            task_status: anyio.abc.TaskStatus[int] | None = None,
+        ) -> BaseWorkerResult:
+            return BaseWorkerResult(identifier="test", status_code=0)
+
+    async with StableSnapshotWorker(work_pool_name=work_pool.name) as worker:
+        worker_ref["worker"] = worker
+        worker._work_pool = WorkPool(
+            name=work_pool.name,
+            type=worker_type,
+            base_job_template=initial_template,
+            default_queue_id=work_pool.default_queue_id,
+        )
+
+        config = await worker._get_configuration(flow_run)
+
+        assert worker._work_pool.base_job_template == updated_template
+
+    assert templates_used == [initial_template]
+    assert prepared_work_pools[0] is not None
+    assert prepared_work_pools[0].base_job_template == initial_template
+    assert config.env["SNAPSHOT"] == "initial"
 
 
 class TestBaseWorkerHeartbeat:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2840,6 +2840,93 @@ class TestWorkerChannelClient:
         assert work_pool.base_job_template == default_base_job_template
         snapshot.assert_called_once_with(work_pool)
 
+    async def test_sync_discards_rest_work_pool_if_snapshot_arrives_during_read(self):
+        stale_template = {"job_configuration": {"env": {"STALE": "true"}}}
+        fresh_template = {"job_configuration": {"env": {"FRESH": "true"}}}
+        stale_work_pool = WorkPool(
+            name="test-work-pool",
+            type="test",
+            base_job_template=stale_template,
+            default_queue_id=uuid.uuid4(),
+        )
+        snapshot = Mock()
+        client = worker_channel_test_client()
+
+        async def read_work_pool(work_pool_name: str) -> WorkPool:
+            assert work_pool_name == "test-work-pool"
+            channel._protocol.handle_work_pool_snapshot(
+                worker_channel_snapshot_payload(1, base_job_template=fresh_template)
+            )
+            channel.state.mark_healthy()
+            return stale_work_pool
+
+        client.read_work_pool = AsyncMock(side_effect=read_work_pool)
+        client.update_work_pool = AsyncMock()
+        channel = WorkPoolWorkerChannel(
+            client=client,
+            api_url="http://localhost:4200/api",
+            work_pool_is_available=lambda: True,
+            work_pool_name="test-work-pool",
+            worker_name="test-worker",
+            worker_type="test",
+            heartbeat_interval_seconds=30,
+            work_queue_names=[],
+            create_pool_if_not_found=True,
+            default_base_job_template={},
+            worker_metadata=no_worker_channel_metadata,
+            logger=logging.getLogger("test-worker-channel"),
+            on_work_pool_snapshot=snapshot,
+        )
+
+        await channel.sync(None)
+
+        client.update_work_pool.assert_not_awaited()
+        client.send_worker_heartbeat.assert_not_awaited()
+        snapshot.assert_called_once()
+        assert snapshot.call_args.args[0].base_job_template == fresh_template
+
+    async def test_sync_discards_rest_work_pool_if_snapshot_arrives_during_repair(self):
+        fresh_template = {"job_configuration": {"env": {"FRESH": "true"}}}
+        work_pool = WorkPool(
+            name="test-work-pool",
+            type="test",
+            base_job_template={},
+            default_queue_id=uuid.uuid4(),
+        )
+        snapshot = Mock()
+        client = worker_channel_test_client()
+        client.read_work_pool = AsyncMock(return_value=work_pool)
+
+        async def update_work_pool(*args: Any, **kwargs: Any) -> None:
+            channel._protocol.handle_work_pool_snapshot(
+                worker_channel_snapshot_payload(1, base_job_template=fresh_template)
+            )
+            channel.state.mark_healthy()
+
+        client.update_work_pool = AsyncMock(side_effect=update_work_pool)
+        channel = WorkPoolWorkerChannel(
+            client=client,
+            api_url="http://localhost:4200/api",
+            work_pool_is_available=lambda: True,
+            work_pool_name="test-work-pool",
+            worker_name="test-worker",
+            worker_type="test",
+            heartbeat_interval_seconds=30,
+            work_queue_names=[],
+            create_pool_if_not_found=True,
+            default_base_job_template={"job_configuration": {}, "variables": {}},
+            worker_metadata=no_worker_channel_metadata,
+            logger=logging.getLogger("test-worker-channel"),
+            on_work_pool_snapshot=snapshot,
+        )
+
+        await channel.sync(None)
+
+        client.update_work_pool.assert_awaited_once()
+        client.send_worker_heartbeat.assert_not_awaited()
+        snapshot.assert_called_once()
+        assert snapshot.call_args.args[0].base_job_template == fresh_template
+
     async def test_endpoint_unavailable_is_terminal_rest_fallback(self):
         client = worker_channel_test_client()
         client.read_work_pool = AsyncMock(


### PR DESCRIPTION
Related to #21860

this PR adds worker-side work-pool snapshot application for the worker channel. It keeps REST fallback active until the channel is healthy and has applied a snapshot, applies initial and subsequent snapshot payloads as full local replacements with connection-local sequence handling, and freezes a local work-pool copy while creating per-run job configuration so already-starting submissions are not reconfigured by later snapshots.

<details>
<summary>Details</summary>

- Adds sequence-aware `WorkPoolSnapshotState` for full replacement snapshots, stale/duplicate detection, tolerated gaps, and reconnect sequence resets.
- Routes `worker.ready.v1` initial snapshots and `work_pool.snapshot.v1` frames through the snapshot state before updating worker-local work-pool state.
- Suppresses REST work-pool sync only when the channel is healthy and a snapshot is available; REST fallback remains active otherwise.
- Uses a stable copied work-pool object while building launch configuration for scheduled and ad-hoc submissions.
- Adds focused worker tests for snapshot application, sequence handling, reconnect reset, REST fallback behavior, and stable launch configuration.

</details>