### PR TITLE
Add `cancelling_timeout_teardown.v1` cleanup handler

### DIFF
--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from prefect.client.schemas.worker_channel import (
+    CANCELLING_TIMEOUT_TEARDOWN,
+    CancellingTimeoutCleanupMessagePayload,
+    CleanupMessagePayload,
+)
+from prefect.exceptions import (
+    InfrastructureNotAvailable,
+    InfrastructureNotFound,
+    ObjectNotFound,
+)
+from prefect.workers._cleanup import CleanupExecutionResult
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.objects import FlowRun
+    from prefect.workers.base import BaseWorker
+
+
+class CancellingTimeoutTeardownHandler:
+    """
+    Cleanup handler for `cancelling_timeout_teardown.v1`.
+
+    Performs idempotent infrastructure teardown for a flow run after the
+    server has already committed the state-machine outcome that requires
+    cleanup. The handler uses stable target identifiers from the cleanup
+    payload (`target.flow_run_id`, `target.infrastructure_pid`) and reuses
+    the worker's existing `kill_infrastructure` semantics.
+
+    The handler is opt-in: capable worker types (those that implement
+    `kill_infrastructure`) should register it on their cleanup handler
+    registry, typically in their constructor:
+
+        class MyWorker(BaseWorker[...]):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._cleanup_handler_registry.register(
+                    CancellingTimeoutTeardownHandler(self)
+                )
+
+    Boundary contract:
+    - Does not propose or force flow-run state transitions; the server has
+      already crossed the timeout boundary by the time cleanup is enqueued.
+    - Does not require the current flow-run state to be `CANCELLING` and
+      does not skip teardown when the flow run has a `start_time`.
+    - Treats `InfrastructureNotFound` and an absent infrastructure handle
+      (when no actionable handle can be determined) as idempotent success.
+    - Treats `InfrastructureNotAvailable`, `NotImplementedError`, and
+      missing configuration context as stable release reasons rather than
+      generic errors so the cleanup executor can release with intent.
+    - Does not depend on an immutable submission-time job configuration
+      record; current worker configuration is used only for provider access.
+    """
+
+    cleanup_kind = CANCELLING_TIMEOUT_TEARDOWN
+
+    def __init__(
+        self,
+        worker: "BaseWorker[Any, Any, Any]",
+        *,
+        grace_seconds: int = 30,
+    ) -> None:
+        self._worker = worker
+        self._grace_seconds = grace_seconds
+
+    async def cleanup(
+        self, message: CleanupMessagePayload
+    ) -> CleanupExecutionResult | None:
+        if not isinstance(message, CancellingTimeoutCleanupMessagePayload):
+            return CleanupExecutionResult.release("unexpected_payload_kind")
+
+        flow_run_id = getattr(message.target, "flow_run_id", None)
+        if flow_run_id is None:
+            return CleanupExecutionResult.release("invalid_payload")
+
+        flow_run = await self._read_flow_run(flow_run_id)
+        if flow_run is None:
+            return CleanupExecutionResult.success()
+
+        infrastructure_pid = message.target.infrastructure_pid
+        if not infrastructure_pid:
+            stored_pid = getattr(flow_run, "infrastructure_pid", None)
+            if not stored_pid:
+                return CleanupExecutionResult.success()
+            return CleanupExecutionResult.release("missing_infrastructure_handle")
+
+        try:
+            configuration = await self._worker._get_configuration(flow_run)
+        except ObjectNotFound:
+            return CleanupExecutionResult.release("configuration_context_unavailable")
+
+        try:
+            await self._worker.kill_infrastructure(
+                infrastructure_pid=infrastructure_pid,
+                configuration=configuration,
+                grace_seconds=self._grace_seconds,
+            )
+        except InfrastructureNotFound:
+            return CleanupExecutionResult.success()
+        except NotImplementedError:
+            return CleanupExecutionResult.release("unsupported_worker_type")
+        except InfrastructureNotAvailable:
+            return CleanupExecutionResult.release("infrastructure_not_available")
+
+        return CleanupExecutionResult.success()
+
+    async def _read_flow_run(self, flow_run_id: UUID) -> "FlowRun | None":
+        try:
+            return await self._worker.client.read_flow_run(flow_run_id)
+        except ObjectNotFound:
+            return None
+
+
+__all__ = ["CancellingTimeoutTeardownHandler"]

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -75,8 +76,17 @@ class CancellingTimeoutTeardownHandler:
                 return CleanupExecutionResult.success()
             return CleanupExecutionResult.release("missing_infrastructure_handle")
 
+        # Freeze the worker's work-pool view so a mid-flight snapshot apply
+        # cannot retemplate the configuration we're handing to kill_infrastructure.
+        work_pool = copy.deepcopy(self._worker.work_pool)
         try:
-            configuration = await self._worker.get_configuration(flow_run)
+            configuration = await self._worker.job_configuration.resolve_for_flow_run(
+                flow_run,
+                client=self._worker.client,
+                work_pool=work_pool,
+                worker_name=self._worker.name,
+                worker_id=self._worker.backend_id,
+            )
         except ObjectNotFound:
             return CleanupExecutionResult.release("configuration_context_unavailable")
 

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -13,7 +13,10 @@ from prefect.exceptions import (
     InfrastructureNotFound,
     ObjectNotFound,
 )
-from prefect.workers._cleanup import CleanupExecutionResult
+from prefect.workers._cleanup import (
+    CleanupExecutionResult,
+    WorkerCleanupHandlerRegistry,
+)
 
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
@@ -121,23 +124,21 @@ def _worker_implements_kill_infrastructure(
     return sum("kill_infrastructure" in vars(cls) for cls in type(worker).__mro__) > 1
 
 
-def register_default_cleanup_handlers(
+def build_cleanup_handler_registry(
     worker: "BaseWorker[Any, Any, Any]",
-) -> None:
+) -> "WorkerCleanupHandlerRegistry":
     """
-    Auto-register default cleanup handlers on a worker based on its
-    capabilities.
+    Build the cleanup handler registry for a worker.
 
-    Called from `BaseWorker.__init__` after the cleanup handler registry is
-    built, when the user has not explicitly supplied `_cleanup_handlers`.
+    Called from `BaseWorker.__init__`. Class-level `cleanup_handlers` are
+    registered first; per-instance default handlers are then added for
+    capabilities the worker exposes, but only when the class hasn't
+    already supplied a handler for the same cleanup kind.
 
-    Future cleanup kinds can hook in here without expanding conditionals in
-    `BaseWorker`. A handler is added only when:
-    - the worker exposes the capability it requires, AND
-    - no handler is already registered for that cleanup kind (so explicit
-      class-level `cleanup_handlers` or a custom strategy wins).
+    Future cleanup kinds can hook in here without expanding conditionals
+    in `BaseWorker`.
     """
-    registry = worker.cleanup_handler_registry
+    registry = WorkerCleanupHandlerRegistry(worker.__class__.cleanup_handlers)
 
     if (
         _worker_implements_kill_infrastructure(worker)
@@ -145,8 +146,10 @@ def register_default_cleanup_handlers(
     ):
         registry.register(CancellingTimeoutTeardownHandler(worker))
 
+    return registry
+
 
 __all__ = [
     "CancellingTimeoutTeardownHandler",
-    "register_default_cleanup_handlers",
+    "build_cleanup_handler_registry",
 ]

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -76,7 +76,7 @@ class CancellingTimeoutTeardownHandler:
             return CleanupExecutionResult.release("missing_infrastructure_handle")
 
         try:
-            configuration = await self._worker._get_configuration(flow_run)
+            configuration = await self._worker.get_configuration(flow_run)
         except ObjectNotFound:
             return CleanupExecutionResult.release("configuration_context_unavailable")
 

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -24,33 +25,22 @@ if TYPE_CHECKING:
 
 
 class CancellingTimeoutTeardownHandler:
-    """
-    Cleanup handler for `cancelling_timeout_teardown.v1`.
+    """Idempotent infrastructure teardown for `cancelling_timeout_teardown.v1`.
 
-    Performs idempotent infrastructure teardown for a flow run after the
-    server has already committed the state-machine outcome that requires
-    cleanup. The handler uses stable target identifiers from the cleanup
-    payload (`target.flow_run_id`, `target.infrastructure_pid`) and reuses
-    the worker's existing `kill_infrastructure` semantics.
+    The cleanup message is enqueued after the server has already committed
+    the CANCELLING-timeout state outcome. Boundary contract:
 
-    Capable worker types — those that override `kill_infrastructure` —
-    are auto-registered by `BaseWorker` via
-    `build_cleanup_handler_registry`. A class-level `cleanup_handlers`
-    entry for the same cleanup kind takes precedence, letting workers
-    swap in a custom teardown strategy.
-
-    Boundary contract:
-    - Does not propose or force flow-run state transitions; the server has
-      already crossed the timeout boundary by the time cleanup is enqueued.
-    - Does not require the current flow-run state to be `CANCELLING` and
+    - Does not propose or force flow-run state transitions.
+    - Does not require the flow run to currently be in `CANCELLING` and
       does not skip teardown when the flow run has a `start_time`.
     - Treats `InfrastructureNotFound` and an absent infrastructure handle
       (when no actionable handle can be determined) as idempotent success.
-    - Treats `InfrastructureNotAvailable`, `NotImplementedError`, and
-      missing configuration context as stable release reasons rather than
-      generic errors so the cleanup executor can release with intent.
-    - Does not depend on an immutable submission-time job configuration
-      record; current worker configuration is used only for provider access.
+    - Maps `InfrastructureNotAvailable`, `NotImplementedError`, and missing
+      configuration context to stable release reasons rather than generic
+      errors so the executor can release with intent.
+    - Uses the cleanup payload's stable target identifiers; current worker
+      configuration is consulted only for provider access, not as proof of
+      submission-time configuration.
     """
 
     cleanup_kind = CANCELLING_TIMEOUT_TEARDOWN
@@ -112,36 +102,23 @@ class CancellingTimeoutTeardownHandler:
             return None
 
 
-def _worker_implements_kill_infrastructure(
-    worker: "BaseWorker[Any, Any, Any]",
-) -> bool:
-    """Return True when the worker subclass overrides `kill_infrastructure`.
-
-    Walks the worker's MRO and counts the classes that define the method
-    directly in their `__dict__`. The abstract base contributes one; any
-    additional class means the subclass overrides it.
-    """
-    return sum("kill_infrastructure" in vars(cls) for cls in type(worker).__mro__) > 1
+@lru_cache(maxsize=None)
+def _class_implements_kill_infrastructure(cls: type) -> bool:
+    return sum("kill_infrastructure" in vars(c) for c in cls.__mro__) > 1
 
 
 def build_cleanup_handler_registry(
     worker: "BaseWorker[Any, Any, Any]",
 ) -> "WorkerCleanupHandlerRegistry":
-    """
-    Build the cleanup handler registry for a worker.
+    """Build the cleanup handler registry for a worker.
 
-    Called from `BaseWorker.__init__`. Class-level `cleanup_handlers` are
-    registered first; per-instance default handlers are then added for
-    capabilities the worker exposes, but only when the class hasn't
-    already supplied a handler for the same cleanup kind.
-
-    Future cleanup kinds can hook in here without expanding conditionals
-    in `BaseWorker`.
+    Class-level `cleanup_handlers` for a given cleanup kind take precedence
+    over the per-instance default registered here.
     """
     registry = WorkerCleanupHandlerRegistry(worker.__class__.cleanup_handlers)
 
     if (
-        _worker_implements_kill_infrastructure(worker)
+        _class_implements_kill_infrastructure(type(worker))
         and registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
     ):
         registry.register(CancellingTimeoutTeardownHandler(worker))

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -30,16 +30,11 @@ class CancellingTimeoutTeardownHandler:
     payload (`target.flow_run_id`, `target.infrastructure_pid`) and reuses
     the worker's existing `kill_infrastructure` semantics.
 
-    The handler is opt-in: capable worker types (those that implement
-    `kill_infrastructure`) should register it on their cleanup handler
-    registry, typically in their constructor:
-
-        class MyWorker(BaseWorker[...]):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self._cleanup_handler_registry.register(
-                    CancellingTimeoutTeardownHandler(self)
-                )
+    Capable worker types — those that override `kill_infrastructure` —
+    are auto-registered by `BaseWorker` via
+    `register_default_cleanup_handlers`. Workers that need different
+    behavior (e.g., a custom teardown strategy, or opt-out) can pass
+    `_cleanup_handlers=` explicitly to skip the auto-registration.
 
     Boundary contract:
     - Does not propose or force flow-run state transitions; the server has
@@ -114,4 +109,41 @@ class CancellingTimeoutTeardownHandler:
             return None
 
 
-__all__ = ["CancellingTimeoutTeardownHandler"]
+def _worker_implements_kill_infrastructure(
+    worker: "BaseWorker[Any, Any, Any]",
+) -> bool:
+    """Return True when the worker subclass overrides `kill_infrastructure`."""
+    from prefect.workers.base import BaseWorker as _BaseWorker
+
+    return type(worker).kill_infrastructure is not _BaseWorker.kill_infrastructure
+
+
+def register_default_cleanup_handlers(
+    worker: "BaseWorker[Any, Any, Any]",
+) -> None:
+    """
+    Auto-register default cleanup handlers on a worker based on its
+    capabilities.
+
+    Called from `BaseWorker.__init__` after the cleanup handler registry is
+    built, when the user has not explicitly supplied `_cleanup_handlers`.
+
+    Future cleanup kinds can hook in here without expanding conditionals in
+    `BaseWorker`. A handler is added only when:
+    - the worker exposes the capability it requires, AND
+    - no handler is already registered for that cleanup kind (so explicit
+      class-level `cleanup_handlers` or a custom strategy wins).
+    """
+    registry = worker.cleanup_handler_registry
+
+    if (
+        _worker_implements_kill_infrastructure(worker)
+        and registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
+    ):
+        registry.register(CancellingTimeoutTeardownHandler(worker))
+
+
+__all__ = [
+    "CancellingTimeoutTeardownHandler",
+    "register_default_cleanup_handlers",
+]

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -35,9 +35,9 @@ class CancellingTimeoutTeardownHandler:
 
     Capable worker types — those that override `kill_infrastructure` —
     are auto-registered by `BaseWorker` via
-    `register_default_cleanup_handlers`. Workers that need different
-    behavior (e.g., a custom teardown strategy, or opt-out) can pass
-    `_cleanup_handlers=` explicitly to skip the auto-registration.
+    `build_cleanup_handler_registry`. A class-level `cleanup_handlers`
+    entry for the same cleanup kind takes precedence, letting workers
+    swap in a custom teardown strategy.
 
     Boundary contract:
     - Does not propose or force flow-run state transitions; the server has

--- a/src/prefect/workers/_cleanup_handlers.py
+++ b/src/prefect/workers/_cleanup_handlers.py
@@ -112,10 +112,13 @@ class CancellingTimeoutTeardownHandler:
 def _worker_implements_kill_infrastructure(
     worker: "BaseWorker[Any, Any, Any]",
 ) -> bool:
-    """Return True when the worker subclass overrides `kill_infrastructure`."""
-    from prefect.workers.base import BaseWorker as _BaseWorker
+    """Return True when the worker subclass overrides `kill_infrastructure`.
 
-    return type(worker).kill_infrastructure is not _BaseWorker.kill_infrastructure
+    Walks the worker's MRO and counts the classes that define the method
+    directly in their `__dict__`. The abstract base contributes one; any
+    additional class means the subclass overrides it.
+    """
+    return sum("kill_infrastructure" in vars(cls) for cls in type(worker).__mro__) > 1
 
 
 def register_default_cleanup_handlers(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1498,7 +1498,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         run_logger = self.get_flow_run_logger(flow_run)
 
         try:
-            configuration = await self._get_configuration(flow_run)
+            configuration = await self.get_configuration(flow_run)
             submitted_event = self._emit_flow_run_submitted_event(configuration)
             await self._give_worker_labels_to_flow_run(flow_run.id)
 
@@ -1595,7 +1595,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             },
         }
 
-    async def _get_configuration(
+    async def get_configuration(
         self,
         flow_run: "FlowRun",
         deployment: Optional["DeploymentResponse"] = None,
@@ -1790,7 +1790,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         # Get configuration and kill infrastructure
         try:
-            configuration = await self._get_configuration(flow_run)
+            configuration = await self.get_configuration(flow_run)
         except ObjectNotFound:
             run_logger.warning(
                 "Cannot kill infrastructure: deployment not found. "

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -109,6 +109,7 @@ from prefect.workers._cleanup import (
     WorkerCleanupHandler,
     WorkerCleanupHandlerRegistry,
 )
+from prefect.workers._cleanup_handlers import register_default_cleanup_handlers
 from prefect.workers._worker_channel import WorkerChannel, WorkPoolWorkerChannel
 
 if TYPE_CHECKING:
@@ -618,10 +619,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         # as an empty tuple) opts out of auto-registration so callers retain
         # full control over what the worker advertises.
         if _cleanup_handlers is None:
-            from prefect.workers._cleanup_handlers import (
-                register_default_cleanup_handlers,
-            )
-
             register_default_cleanup_handlers(self)
         if _max_cleanup_concurrency is not None and _max_cleanup_concurrency < 0:
             raise ValueError("Cleanup concurrency cannot be negative")

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -259,7 +259,7 @@ class BaseJobConfiguration(BaseModel):
         client: PrefectClient,
         work_pool: WorkPool,
         worker_name: str,
-        worker_id: Optional[UUID] = None,
+        worker_id: UUID | None = None,
         deployment: "DeploymentResponse | None" = None,
     ) -> Self:
         """Build a fully-prepared job configuration for an existing flow run.

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -612,6 +612,17 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             if _cleanup_handlers is not None
             else self.__class__.cleanup_handlers
         )
+        # When the caller did not pass an explicit handler list, auto-register
+        # default handlers (e.g., cancelling_timeout_teardown.v1) for workers
+        # that expose the required capability. Passing _cleanup_handlers (even
+        # as an empty tuple) opts out of auto-registration so callers retain
+        # full control over what the worker advertises.
+        if _cleanup_handlers is None:
+            from prefect.workers._cleanup_handlers import (
+                register_default_cleanup_handlers,
+            )
+
+            register_default_cleanup_handlers(self)
         if _max_cleanup_concurrency is not None and _max_cleanup_concurrency < 0:
             raise ValueError("Cleanup concurrency cannot be negative")
         self._max_cleanup_concurrency_override = _max_cleanup_concurrency

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -108,7 +108,7 @@ from prefect.workers._cleanup import (
     WorkerCleanupHandler,
     WorkerCleanupHandlerRegistry,
 )
-from prefect.workers._cleanup_handlers import register_default_cleanup_handlers
+from prefect.workers._cleanup_handlers import build_cleanup_handler_registry
 from prefect.workers._worker_channel import WorkerChannel, WorkPoolWorkerChannel
 
 if TYPE_CHECKING:
@@ -605,13 +605,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         self._base_job_template = base_job_template
         self._work_pool_name = work_pool_name
         self._work_queues: set[str] = set(work_queues) if work_queues else set()
-        self._cleanup_handler_registry = WorkerCleanupHandlerRegistry(
-            self.__class__.cleanup_handlers
-        )
-        # Auto-register default handlers (e.g., cancelling_timeout_teardown.v1)
-        # for workers that expose the required capability. Class-level
-        # `cleanup_handlers` for the same cleanup kind take precedence.
-        register_default_cleanup_handlers(self)
+        self._cleanup_handler_registry = build_cleanup_handler_registry(self)
 
         self._prefetch_seconds: float = (
             prefetch_seconds or PREFECT_WORKER_PREFETCH_SECONDS.value()

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -252,6 +252,65 @@ class BaseJobConfiguration(BaseModel):
         return cls(**populated_configuration)
 
     @classmethod
+    async def resolve_for_flow_run(
+        cls,
+        flow_run: "FlowRun",
+        *,
+        client: PrefectClient,
+        work_pool: WorkPool,
+        worker_name: str,
+        worker_id: Optional[UUID] = None,
+        deployment: "DeploymentResponse | None" = None,
+    ) -> Self:
+        """Build a fully-prepared job configuration for an existing flow run.
+
+        Reads the flow run's deployment (when present) and flow, merges
+        deployment- and flow-run-level job variables over the work pool's
+        base template, instantiates the configuration, and stamps
+        attribution metadata via `prepare_for_flow_run`.
+        """
+        if not deployment and flow_run.deployment_id:
+            deployment = await client.read_deployment(flow_run.deployment_id)
+
+        flow = await client.read_flow(flow_run.flow_id)
+
+        deployment_vars = getattr(deployment, "job_variables", {}) or {}
+        flow_run_vars = flow_run.job_variables or {}
+        job_variables = {**deployment_vars}
+
+        # merge environment variables carefully, otherwise full override
+        if isinstance(job_variables.get("env"), dict):
+            job_variables["env"].update(flow_run_vars.pop("env", {}))
+        job_variables.update(flow_run_vars)
+
+        configuration = await cls.from_template_and_values(
+            base_job_template=work_pool.base_job_template,
+            values=job_variables,
+            client=client,
+        )
+        try:
+            configuration.prepare_for_flow_run(
+                flow_run=flow_run,
+                deployment=deployment,
+                flow=flow,
+                work_pool=work_pool,
+                worker_name=worker_name,
+                worker_id=worker_id,
+            )
+        except TypeError:
+            warnings.warn(
+                "This worker is missing the `work_pool`, `worker_name`, or `worker_id` arguments "
+                "in its JobConfiguration.prepare_for_flow_run method. Please update "
+                "the worker's JobConfiguration class to accept these arguments to "
+                "avoid this warning.",
+                category=PrefectDeprecationWarning,
+            )
+            configuration.prepare_for_flow_run(
+                flow_run=flow_run, deployment=deployment, flow=flow
+            )
+        return configuration
+
+    @classmethod
     def json_template(cls) -> dict[str, Any]:
         """Returns a dict with job configuration as keys and the corresponding templates as values
 
@@ -1498,7 +1557,16 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         run_logger = self.get_flow_run_logger(flow_run)
 
         try:
-            configuration = await self.get_configuration(flow_run)
+            # Freeze a local copy of the work pool so a mid-flight snapshot
+            # apply cannot retemplate the configuration we're building.
+            work_pool = copy.deepcopy(self.work_pool)
+            configuration = await self.job_configuration.resolve_for_flow_run(
+                flow_run,
+                client=self.client,
+                work_pool=work_pool,
+                worker_name=self.name,
+                worker_id=self.backend_id,
+            )
             submitted_event = self._emit_flow_run_submitted_event(configuration)
             await self._give_worker_labels_to_flow_run(flow_run.id)
 
@@ -1594,55 +1662,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 "prefetch_seconds": self._prefetch_seconds,
             },
         }
-
-    async def get_configuration(
-        self,
-        flow_run: "FlowRun",
-        deployment: Optional["DeploymentResponse"] = None,
-    ) -> C:
-        work_pool = copy.deepcopy(self.work_pool)
-
-        if not deployment and flow_run.deployment_id:
-            deployment = await self.client.read_deployment(flow_run.deployment_id)
-
-        flow = await self.client.read_flow(flow_run.flow_id)
-
-        deployment_vars = getattr(deployment, "job_variables", {}) or {}
-        flow_run_vars = flow_run.job_variables or {}
-        job_variables = {**deployment_vars}
-
-        # merge environment variables carefully, otherwise full override
-        if isinstance(job_variables.get("env"), dict):
-            job_variables["env"].update(flow_run_vars.pop("env", {}))
-        job_variables.update(flow_run_vars)
-
-        configuration = await self.job_configuration.from_template_and_values(
-            base_job_template=work_pool.base_job_template,
-            values=job_variables,
-            client=self.client,
-        )
-        try:
-            configuration.prepare_for_flow_run(
-                flow_run=flow_run,
-                deployment=deployment,
-                flow=flow,
-                work_pool=work_pool,
-                worker_name=self.name,
-                worker_id=self.backend_id,
-            )
-        except TypeError:
-            warnings.warn(
-                "This worker is missing the `work_pool`, `worker_name`, or `worker_id` arguments "
-                "in its JobConfiguration.prepare_for_flow_run method. Please update "
-                "the worker's JobConfiguration class to accept these arguments to "
-                "avoid this warning.",
-                category=PrefectDeprecationWarning,
-            )
-            # Handle older subclasses that don't accept work_pool, worker_name, and worker_id
-            configuration.prepare_for_flow_run(
-                flow_run=flow_run, deployment=deployment, flow=flow
-            )
-        return configuration
 
     async def _propose_pending_state(self, flow_run: "FlowRun") -> bool:
         run_logger = self.get_flow_run_logger(flow_run)
@@ -1788,9 +1807,17 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
             return
 
-        # Get configuration and kill infrastructure
+        # Get configuration and kill infrastructure. Freeze a local work
+        # pool copy so a mid-flight snapshot cannot retemplate the build.
         try:
-            configuration = await self.get_configuration(flow_run)
+            work_pool = copy.deepcopy(self.work_pool)
+            configuration = await self.job_configuration.resolve_for_flow_run(
+                flow_run,
+                client=self.client,
+                work_pool=work_pool,
+                worker_name=self.name,
+                worker_id=self.backend_id,
+            )
         except ObjectNotFound:
             run_logger.warning(
                 "Cannot kill infrastructure: deployment not found. "

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -17,7 +17,6 @@ from typing import (
     Callable,
     ClassVar,
     Generic,
-    Iterable,
     Optional,
     Type,
 )
@@ -568,8 +567,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         heartbeat_interval_seconds: int | None = None,
         *,
         base_job_template: dict[str, Any] | None = None,
-        _cleanup_handlers: Iterable[WorkerCleanupHandler] | None = None,
-        _max_cleanup_concurrency: int | None = None,
     ):
         """
         Base class for all Prefect workers.
@@ -609,20 +606,12 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         self._work_pool_name = work_pool_name
         self._work_queues: set[str] = set(work_queues) if work_queues else set()
         self._cleanup_handler_registry = WorkerCleanupHandlerRegistry(
-            _cleanup_handlers
-            if _cleanup_handlers is not None
-            else self.__class__.cleanup_handlers
+            self.__class__.cleanup_handlers
         )
-        # When the caller did not pass an explicit handler list, auto-register
-        # default handlers (e.g., cancelling_timeout_teardown.v1) for workers
-        # that expose the required capability. Passing _cleanup_handlers (even
-        # as an empty tuple) opts out of auto-registration so callers retain
-        # full control over what the worker advertises.
-        if _cleanup_handlers is None:
-            register_default_cleanup_handlers(self)
-        if _max_cleanup_concurrency is not None and _max_cleanup_concurrency < 0:
-            raise ValueError("Cleanup concurrency cannot be negative")
-        self._max_cleanup_concurrency_override = _max_cleanup_concurrency
+        # Auto-register default handlers (e.g., cancelling_timeout_teardown.v1)
+        # for workers that expose the required capability. Class-level
+        # `cleanup_handlers` for the same cleanup kind take precedence.
+        register_default_cleanup_handlers(self)
 
         self._prefetch_seconds: float = (
             prefetch_seconds or PREFECT_WORKER_PREFETCH_SECONDS.value()
@@ -695,15 +684,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
     def max_cleanup_concurrency(self) -> int:
         if not self._cleanup_handler_registry:
             return 0
-
-        concurrency = (
-            self._max_cleanup_concurrency_override
-            if self._max_cleanup_concurrency_override is not None
-            else self.__class__.cleanup_max_concurrency
-        )
-        if concurrency is None:
-            return 1
-        return concurrency
+        concurrency = self.__class__.cleanup_max_concurrency
+        return 1 if concurrency is None else concurrency
 
     def _cleanup_delivery_available(self) -> bool:
         return bool(self._cleanup_handler_registry) and self.max_cleanup_concurrency > 0

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -3245,7 +3245,7 @@ async def test_env_merge_logic_is_deep(
         work_pool_name=work_pool.name if work_pool_env else "test-work-pool",
     ) as worker:
         await worker.sync_with_backend()
-        config = await worker._get_configuration(
+        config = await worker.get_configuration(
             flow_run, schemas.responses.DeploymentResponse.model_validate(deployment)
         )
 
@@ -3319,7 +3319,7 @@ async def test_work_pool_env_from_job_configuration_merges_with_variable_default
         work_pool_name=work_pool.name,
     ) as worker:
         await worker.sync_with_backend()
-        config = await worker._get_configuration(
+        config = await worker.get_configuration(
             flow_run, schemas.responses.DeploymentResponse.model_validate(deployment)
         )
 
@@ -4535,7 +4535,7 @@ class TestBackwardsCompatibility:
         # Should warn and not raise an error
         with pytest.warns(PrefectDeprecationWarning):
             async with OldStyleWorker(work_pool_name=work_pool.name) as worker:
-                await worker._get_configuration(flow_run=flow_run)
+                await worker.get_configuration(flow_run=flow_run)
 
 
 class TestWorkerCancellationHandling:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -3245,8 +3245,13 @@ async def test_env_merge_logic_is_deep(
         work_pool_name=work_pool.name if work_pool_env else "test-work-pool",
     ) as worker:
         await worker.sync_with_backend()
-        config = await worker.get_configuration(
-            flow_run, schemas.responses.DeploymentResponse.model_validate(deployment)
+        config = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+            deployment=schemas.responses.DeploymentResponse.model_validate(deployment),
         )
 
     for key, value in expected_env.items():
@@ -3319,8 +3324,13 @@ async def test_work_pool_env_from_job_configuration_merges_with_variable_default
         work_pool_name=work_pool.name,
     ) as worker:
         await worker.sync_with_backend()
-        config = await worker.get_configuration(
-            flow_run, schemas.responses.DeploymentResponse.model_validate(deployment)
+        config = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+            deployment=schemas.responses.DeploymentResponse.model_validate(deployment),
         )
 
     # All env vars should be present: job_configuration + variable defaults + deployment
@@ -4535,7 +4545,13 @@ class TestBackwardsCompatibility:
         # Should warn and not raise an error
         with pytest.warns(PrefectDeprecationWarning):
             async with OldStyleWorker(work_pool_name=work_pool.name) as worker:
-                await worker.get_configuration(flow_run=flow_run)
+                await worker.job_configuration.resolve_for_flow_run(
+                    flow_run,
+                    client=worker.client,
+                    work_pool=worker.work_pool,
+                    worker_name=worker.name,
+                    worker_id=worker.backend_id,
+                )
 
 
 class TestWorkerCancellationHandling:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -3339,10 +3339,14 @@ async def test_work_pool_env_from_job_configuration_merges_with_variable_default
     assert config.env["DEPLOYMENT_VAR"] == "from-deployment"
 
 
-async def test_get_configuration_uses_stable_work_pool_copy(
+async def test_configuration_build_uses_stable_work_pool_copy(
     prefect_client: PrefectClient,
     work_pool: WorkPool,
 ):
+    """A mid-build snapshot apply must not retemplate the configuration the
+    worker is currently assembling. Callers deepcopy `self.work_pool` before
+    handing it to `BaseJobConfiguration.resolve_for_flow_run`."""
+
     @flow
     def test_flow():
         pass
@@ -3429,7 +3433,15 @@ async def test_get_configuration_uses_stable_work_pool_copy(
             default_queue_id=work_pool.default_queue_id,
         )
 
-        config = await worker._get_configuration(flow_run)
+        # Mirror the worker's internal call pattern: deepcopy then resolve.
+        frozen_work_pool = copy.deepcopy(worker.work_pool)
+        config = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=frozen_work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
 
         assert worker._work_pool.base_job_template == updated_template
 

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -36,8 +36,8 @@ from prefect.workers.base import (
 
 class TeardownTrackingWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
     """
-    Test worker that overrides `kill_infrastructure` so the handler has a
-    capable target to dispatch to.
+    Test worker that overrides `kill_infrastructure` so `BaseWorker` will
+    auto-register the cancelling-timeout cleanup handler.
     """
 
     type = "cleanup-handler-test-capable"
@@ -46,7 +46,6 @@ class TeardownTrackingWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerRes
         super().__init__(*args, **kwargs)
         self.kill_calls: list[dict[str, Any]] = []
         self.kill_side_effect: BaseException | None = None
-        self._cleanup_handler_registry.register(CancellingTimeoutTeardownHandler(self))
 
     async def run(  # type: ignore[override]
         self,
@@ -166,20 +165,28 @@ class TestHandlerRegistration:
 
         assert handler.cleanup_kind == CANCELLING_TIMEOUT_TEARDOWN
 
-    async def test_capable_worker_advertises_cancelling_timeout_kind(self):
+    async def test_capable_worker_auto_registers_handler(self):
+        """Overriding `kill_infrastructure` should auto-register the
+        cancelling-timeout cleanup handler via `BaseWorker.__init__`."""
         worker = TeardownTrackingWorker(work_pool_name="test")
 
         assert worker.handled_cleanup_kinds == (CANCELLING_TIMEOUT_TEARDOWN,)
         assert worker.max_cleanup_concurrency == 1
+        registered = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+        assert isinstance(registered, CancellingTimeoutTeardownHandler)
+        # The auto-registered handler is bound to this worker instance.
+        assert registered._worker is worker
 
     async def test_incapable_worker_does_not_advertise_cancelling_timeout_kind(self):
         worker = IncapableWorker(work_pool_name="test")
 
         assert worker.handled_cleanup_kinds == ()
         assert worker.max_cleanup_concurrency == 0
+        assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
 
     async def test_base_worker_does_not_register_handler_by_default(self):
-        """The base worker should not auto-register the cancelling timeout handler."""
+        """A subclass that inherits the base `kill_infrastructure` should not
+        get the handler auto-registered."""
 
         class NoCleanupWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
             type = "cleanup-handler-test-no-cleanup"
@@ -193,6 +200,62 @@ class TestHandlerRegistration:
 
         assert worker.handled_cleanup_kinds == ()
         assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
+
+    async def test_explicit_cleanup_handlers_opts_out_of_auto_registration(self):
+        """Passing `_cleanup_handlers` (even an empty tuple) should fully
+        override the auto-registration so callers retain control over what
+        the worker advertises."""
+        worker = TeardownTrackingWorker(
+            work_pool_name="test",
+            _cleanup_handlers=(),
+        )
+
+        assert worker.handled_cleanup_kinds == ()
+        assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
+
+    async def test_explicit_cleanup_handlers_replaces_default(self):
+        """A capable worker that supplies a custom handler for the cancelling
+        timeout kind should keep its custom handler instead of getting the
+        default auto-registered."""
+
+        class CustomHandler:
+            cleanup_kind = CANCELLING_TIMEOUT_TEARDOWN
+
+            async def cleanup(self, message):
+                return CleanupExecutionResult.success()
+
+        custom = CustomHandler()
+        worker = TeardownTrackingWorker(
+            work_pool_name="test",
+            _cleanup_handlers=(custom,),
+        )
+
+        assert (
+            worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is custom
+        )
+
+    async def test_class_level_cleanup_handlers_take_precedence(self):
+        """A capable subclass that sets `cleanup_handlers` to its own handler
+        for the cancelling timeout kind keeps that handler — the
+        auto-registration only fills in when the kind is unhandled."""
+
+        class CustomHandler:
+            cleanup_kind = CANCELLING_TIMEOUT_TEARDOWN
+
+            async def cleanup(self, message):
+                return CleanupExecutionResult.success()
+
+        custom = CustomHandler()
+
+        class CapableCustomWorker(TeardownTrackingWorker):
+            type = "cleanup-handler-test-capable-custom"
+            cleanup_handlers = (custom,)
+
+        worker = CapableCustomWorker(work_pool_name="test")
+
+        assert (
+            worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is custom
+        )
 
 
 class TestHandlerBehavior:

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -1,31 +1,28 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import AsyncMock, Mock
+from unittest import mock
+from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import pytest
 
-from prefect._internal.uuid7 import uuid7
-from prefect.client.schemas.objects import FlowRun
+from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.objects import FlowRun, WorkPool
 from prefect.client.schemas.worker_channel import (
     CANCELLING_TIMEOUT_TEARDOWN,
-    PENDING_CLAIM_TEARDOWN,
     CancellingTimeoutCleanupMessagePayload,
-    CleanupMessageFrame,
 )
 from prefect.exceptions import (
     InfrastructureNotAvailable,
     InfrastructureNotFound,
     ObjectNotFound,
 )
-from prefect.states import Cancelling, Pending, Running
-from prefect.types._datetime import now
-from prefect.workers._cleanup import (
-    CleanupExecutionResult,
-    WorkerCleanupExecutor,
-)
+from prefect.flows import flow
+from prefect.server.schemas.responses import DeploymentResponse
+from prefect.states import Pending, Running
+from prefect.workers._cleanup import CleanupExecutionResult
 from prefect.workers._cleanup_handlers import CancellingTimeoutTeardownHandler
 from prefect.workers.base import (
     BaseJobConfiguration,
@@ -86,6 +83,11 @@ class IncapableWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
         raise NotImplementedError
 
 
+@flow
+def _sample_flow():
+    pass
+
+
 def _cancelling_payload(
     *,
     flow_run_id: UUID | None = None,
@@ -102,7 +104,9 @@ def _cancelling_payload(
             "kind": CANCELLING_TIMEOUT_TEARDOWN,
             "message_id": str(uuid4()),
             "reservation_token": "token",
-            "lease_expires_at": (now("UTC") + timedelta(minutes=5)).isoformat(),
+            "lease_expires_at": (
+                datetime.now(timezone.utc) + timedelta(minutes=5)
+            ).isoformat(),
             "delivery_count": 1,
             "work_queue_id": None,
             "target": target,
@@ -111,71 +115,61 @@ def _cancelling_payload(
     )
 
 
-def _build_handler(
-    *,
-    flow_run: FlowRun | None,
-    configuration: BaseJobConfiguration | None = None,
-    configuration_error: BaseException | None = None,
-    kill_side_effect: BaseException | None = None,
-    grace_seconds: int = 30,
-) -> tuple[CancellingTimeoutTeardownHandler, Mock]:
-    worker = Mock(spec=BaseWorker)
-    client = Mock()
-    if flow_run is None:
-        client.read_flow_run = AsyncMock(
-            side_effect=ObjectNotFound(Exception("missing"))
-        )
-    else:
-        client.read_flow_run = AsyncMock(return_value=flow_run)
-    worker.client = client
-
-    if configuration_error is not None:
-        worker._get_configuration = AsyncMock(side_effect=configuration_error)
-    else:
-        worker._get_configuration = AsyncMock(
-            return_value=configuration or BaseJobConfiguration()
-        )
-
-    worker.kill_infrastructure = AsyncMock(side_effect=kill_side_effect)
-
-    handler = CancellingTimeoutTeardownHandler(worker, grace_seconds=grace_seconds)
-    return handler, worker
-
-
-def _flow_run(
+async def _create_flow_run(
+    prefect_client: PrefectClient,
+    work_pool: WorkPool,
     *,
     state=None,
     start_time=None,
     infrastructure_pid: str | None = None,
 ) -> FlowRun:
-    return FlowRun(
-        id=uuid4(),
-        flow_id=uuid4(),
-        name="test-flow-run",
-        state=state or Cancelling(),
-        start_time=start_time,
-        infrastructure_pid=infrastructure_pid,
+    flow_run = await prefect_client.create_flow_run(
+        _sample_flow, work_pool_name=work_pool.name, state=state
     )
+    updates: dict[str, Any] = {}
+    if infrastructure_pid is not None:
+        updates["infrastructure_pid"] = infrastructure_pid
+    if updates:
+        await prefect_client.update_flow_run(flow_run.id, **updates)
+    if start_time is not None or infrastructure_pid is not None:
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+    return flow_run
 
 
 class TestHandlerRegistration:
     async def test_handler_declares_cancelling_timeout_kind(self):
-        worker = Mock(spec=BaseWorker)
-        handler = CancellingTimeoutTeardownHandler(worker)
+        handler = CancellingTimeoutTeardownHandler(
+            TeardownTrackingWorker(work_pool_name="test")
+        )
 
         assert handler.cleanup_kind == CANCELLING_TIMEOUT_TEARDOWN
 
-    async def test_capable_worker_auto_registers_handler(self):
-        """Overriding `kill_infrastructure` should auto-register the
-        cancelling-timeout cleanup handler via `BaseWorker.__init__`."""
-        worker = TeardownTrackingWorker(work_pool_name="test")
+    async def test_capable_worker_auto_registers_handler(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        """A worker that overrides `kill_infrastructure` should advertise the
+        cancelling-timeout cleanup kind; the auto-registered handler should
+        dispatch to *this* worker instance."""
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
+        )
 
-        assert worker.handled_cleanup_kinds == (CANCELLING_TIMEOUT_TEARDOWN,)
-        assert worker.max_cleanup_concurrency == 1
-        registered = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-        assert isinstance(registered, CancellingTimeoutTeardownHandler)
-        # The auto-registered handler is bound to this worker instance.
-        assert registered._worker is worker
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            assert worker.handled_cleanup_kinds == (CANCELLING_TIMEOUT_TEARDOWN,)
+            assert worker.max_cleanup_concurrency == 1
+
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
+
+        assert result == CleanupExecutionResult.success()
+        assert len(worker.kill_calls) == 1
+        assert worker.kill_calls[0]["infrastructure_pid"] == "pid"
 
     async def test_incapable_worker_does_not_advertise_cancelling_timeout_kind(self):
         worker = IncapableWorker(work_pool_name="test")
@@ -259,22 +253,43 @@ class TestHandlerRegistration:
 
 
 class TestHandlerBehavior:
-    async def test_releases_unexpected_payload_kind(self):
-        handler, worker = _build_handler(flow_run=_flow_run())
+    """
+    Behavior tests for the handler against a real `BaseWorker` subclass.
 
-        wrong_payload = Mock(spec=[])  # No isinstance check matches
-        wrong_payload.kind = PENDING_CLAIM_TEARDOWN
+    Each test sets up the flow-run state it cares about via the
+    `prefect_client` and `work_pool` fixtures, then exercises the
+    auto-registered handler. The handler's only un-public hook into the
+    worker is the dependency on `_get_configuration`; tests that need to
+    control that path use `mock.patch.object` so the dependency is
+    explicit rather than mutating private attributes by hand.
+    """
 
-        result = await handler.cleanup(wrong_payload)
+    async def _handler_and_worker(
+        self, work_pool: WorkPool
+    ) -> tuple[CancellingTimeoutTeardownHandler, TeardownTrackingWorker]:
+        worker = TeardownTrackingWorker(work_pool_name=work_pool.name)
+        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+        assert isinstance(handler, CancellingTimeoutTeardownHandler)
+        return handler, worker
+
+    async def test_releases_unexpected_payload_kind(self, work_pool: WorkPool):
+        handler, worker = await self._handler_and_worker(work_pool)
+
+        class _UnexpectedPayload:
+            kind = "pending_claim_teardown.v1"
+
+        result = await handler.cleanup(_UnexpectedPayload())  # type: ignore[arg-type]
 
         assert result == CleanupExecutionResult.release("unexpected_payload_kind")
-        worker.client.read_flow_run.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_releases_invalid_payload_when_flow_run_id_missing(self):
+    async def test_releases_invalid_payload_when_flow_run_id_missing(
+        self, work_pool: WorkPool
+    ):
         """Defensive check: even though Pydantic validates flow_run_id, the
         handler releases with `invalid_payload` if it cannot find one on the
         target."""
-        handler, worker = _build_handler(flow_run=_flow_run())
+        handler, worker = await self._handler_and_worker(work_pool)
 
         payload = _cancelling_payload()
         payload.target.flow_run_id = None  # type: ignore[assignment]
@@ -282,415 +297,320 @@ class TestHandlerBehavior:
         result = await handler.cleanup(payload)
 
         assert result == CleanupExecutionResult.release("invalid_payload")
-        worker.client.read_flow_run.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_deleted_flow_run_is_idempotent_success(self):
-        handler, worker = _build_handler(flow_run=None)
+    async def test_deleted_flow_run_is_idempotent_success(self, work_pool: WorkPool):
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
 
-        result = await handler.cleanup(_cancelling_payload())
+            # Flow-run id that does not exist on the server.
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=uuid4(), infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_missing_pid_with_no_stored_pid_acks_as_noop(self):
-        flow_run = _flow_run(infrastructure_pid=None)
-        handler, worker = _build_handler(flow_run=flow_run)
+    async def test_missing_pid_with_no_stored_pid_acks_as_noop(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(prefect_client, work_pool)
 
-        result = await handler.cleanup(
-            _cancelling_payload(
-                flow_run_id=flow_run.id,
-                infrastructure_pid=None,
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid=None)
             )
-        )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_missing_pid_with_stored_pid_releases_missing_handle(self):
-        flow_run = _flow_run(infrastructure_pid="stored-pid")
-        handler, worker = _build_handler(flow_run=flow_run)
-
-        result = await handler.cleanup(
-            _cancelling_payload(
-                flow_run_id=flow_run.id,
-                infrastructure_pid=None,
-            )
+    async def test_missing_pid_with_stored_pid_releases_missing_handle(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="stored-pid"
         )
+
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid=None)
+            )
 
         assert result == CleanupExecutionResult.release("missing_infrastructure_handle")
-        worker.kill_infrastructure.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_empty_string_pid_treated_as_missing(self):
-        flow_run = _flow_run(infrastructure_pid=None)
-        handler, worker = _build_handler(flow_run=flow_run)
+    async def test_empty_string_pid_treated_as_missing(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(prefect_client, work_pool)
 
-        result = await handler.cleanup(
-            _cancelling_payload(
-                flow_run_id=flow_run.id,
-                infrastructure_pid="",
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="")
             )
-        )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_configuration_unavailable_releases_with_stable_reason(self):
-        flow_run = _flow_run(infrastructure_pid="stored-pid")
-        handler, worker = _build_handler(
-            flow_run=flow_run,
-            configuration_error=ObjectNotFound(Exception("deployment gone")),
+    async def test_configuration_unavailable_releases_with_stable_reason(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
         )
 
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            # Force the configuration lookup to fail like a deleted-deployment
+            # would. Patching the worker hook keeps the dependency explicit
+            # without mutating private attributes by hand.
+            with mock.patch.object(
+                worker,
+                "_get_configuration",
+                AsyncMock(side_effect=ObjectNotFound(Exception("deployment gone"))),
+            ):
+                result = await handler.cleanup(
+                    _cancelling_payload(
+                        flow_run_id=flow_run.id, infrastructure_pid="pid"
+                    )
+                )
 
         assert result == CleanupExecutionResult.release(
             "configuration_context_unavailable"
         )
-        worker.kill_infrastructure.assert_not_called()
+        assert worker.kill_calls == []
 
-    async def test_infrastructure_not_found_acks_as_idempotent_success(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        handler, worker = _build_handler(
-            flow_run=flow_run,
-            kill_side_effect=InfrastructureNotFound("gone"),
+    async def test_infrastructure_not_found_acks_as_idempotent_success(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
         )
 
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            worker.kill_side_effect = InfrastructureNotFound("gone")
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_awaited_once()
+        assert len(worker.kill_calls) == 1
 
-    async def test_not_implemented_releases_unsupported_worker_type(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        handler, worker = _build_handler(
-            flow_run=flow_run,
-            kill_side_effect=NotImplementedError("nope"),
+    async def test_not_implemented_releases_unsupported_worker_type(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        """A worker whose `kill_infrastructure` raises NotImplementedError at
+        call time (rather than at class-definition time) should release with
+        `unsupported_worker_type`."""
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
         )
 
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            worker.kill_side_effect = NotImplementedError("nope")
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.release("unsupported_worker_type")
 
-    async def test_infrastructure_unavailable_releases_with_stable_reason(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        handler, worker = _build_handler(
-            flow_run=flow_run,
-            kill_side_effect=InfrastructureNotAvailable("offline"),
+    async def test_infrastructure_unavailable_releases_with_stable_reason(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
         )
 
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            worker.kill_side_effect = InfrastructureNotAvailable("offline")
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.release("infrastructure_not_available")
 
-    async def test_successful_kill_acks(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        handler, worker = _build_handler(flow_run=flow_run)
-
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+    async def test_successful_kill_acks(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
         )
+
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_awaited_once()
-        call_kwargs = worker.kill_infrastructure.await_args.kwargs
-        assert call_kwargs["infrastructure_pid"] == "pid"
-        assert call_kwargs["grace_seconds"] == 30
+        assert len(worker.kill_calls) == 1
+        call = worker.kill_calls[0]
+        assert call["infrastructure_pid"] == "pid"
+        assert call["grace_seconds"] == 30
+        assert isinstance(call["configuration"], BaseJobConfiguration)
 
-    async def test_grace_seconds_is_configurable(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        handler, worker = _build_handler(flow_run=flow_run, grace_seconds=10)
-
-        await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+    async def test_grace_seconds_is_configurable(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="pid"
         )
 
-        assert worker.kill_infrastructure.await_args.kwargs["grace_seconds"] == 10
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            # Build a handler with a custom grace period instead of the
+            # auto-registered default.
+            handler = CancellingTimeoutTeardownHandler(worker, grace_seconds=10)
 
-    async def test_does_not_skip_when_start_time_is_set(self):
+            await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
+
+        assert worker.kill_calls[0]["grace_seconds"] == 10
+
+    async def test_does_not_skip_when_start_time_is_set(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
         """The cleanup message is emitted after the timeout boundary; the
         handler must NOT skip teardown when a `start_time` is present."""
-        flow_run = _flow_run(
+        flow_run = await _create_flow_run(
+            prefect_client,
+            work_pool,
             state=Running(),
-            start_time=now("UTC"),
             infrastructure_pid="pid",
         )
-        handler, worker = _build_handler(flow_run=flow_run)
+        assert flow_run.start_time is not None
 
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_awaited_once()
+        assert len(worker.kill_calls) == 1
 
-    async def test_does_not_skip_when_state_is_not_cancelling(self):
+    async def test_does_not_skip_when_state_is_not_cancelling(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
         """The handler must NOT require the flow run to currently be in the
         CANCELLING state — the server has already moved beyond it."""
-        flow_run = _flow_run(state=Pending(), infrastructure_pid="pid")
-        handler, worker = _build_handler(flow_run=flow_run)
-
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        flow_run = await _create_flow_run(
+            prefect_client,
+            work_pool,
+            state=Pending(),
+            infrastructure_pid="pid",
         )
+
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+            result = await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
 
         assert result == CleanupExecutionResult.success()
-        worker.kill_infrastructure.assert_awaited_once()
+        assert len(worker.kill_calls) == 1
 
-    async def test_does_not_mutate_flow_run_state(self):
+    async def test_does_not_mutate_flow_run_state(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
         """Verify the handler never proposes or forces a state transition."""
-        flow_run = _flow_run(state=Running(), infrastructure_pid="pid")
-        handler, worker = _build_handler(flow_run=flow_run)
-
-        await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        flow_run = await _create_flow_run(
+            prefect_client,
+            work_pool,
+            state=Running(),
+            infrastructure_pid="pid",
         )
+        assert flow_run.state is not None
+        original_state_id = flow_run.state.id
+        original_state_type = flow_run.state.type
 
-        worker.client.set_flow_run_state.assert_not_called()
-        # Any helper that would propose a transition should not have been used.
-        assert not hasattr(worker, "_propose_state_calls")
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
 
-    async def test_uses_payload_pid_not_flow_run_pid(self):
+            await handler.cleanup(
+                _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+            )
+
+        refreshed = await prefect_client.read_flow_run(flow_run.id)
+        assert refreshed.state is not None
+        assert refreshed.state.id == original_state_id
+        assert refreshed.state.type == original_state_type
+
+    async def test_uses_payload_pid_not_flow_run_pid(
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+    ):
         """Per the protocol contract, target identifiers come from the payload,
         not from current flow-run state."""
-        flow_run = _flow_run(infrastructure_pid="flow-run-pid")
-        handler, worker = _build_handler(flow_run=flow_run)
-
-        await handler.cleanup(
-            _cancelling_payload(
-                flow_run_id=flow_run.id,
-                infrastructure_pid="payload-pid",
-            )
+        flow_run = await _create_flow_run(
+            prefect_client, work_pool, infrastructure_pid="flow-run-pid"
         )
 
-        worker.kill_infrastructure.assert_awaited_once()
-        assert (
-            worker.kill_infrastructure.await_args.kwargs["infrastructure_pid"]
-            == "payload-pid"
-        )
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+            assert isinstance(handler, CancellingTimeoutTeardownHandler)
 
-
-class TestExecutorIntegration:
-    """Verify the handler integrates correctly with WorkerCleanupExecutor."""
-
-    async def _build_executor_with_handler(
-        self,
-        *,
-        flow_run: FlowRun | None,
-        infrastructure_pid: str | None = "pid",
-        kill_side_effect: BaseException | None = None,
-    ) -> tuple[WorkerCleanupExecutor, Mock, list[Any]]:
-        sent: list[Any] = []
-
-        async def send(frame):
-            sent.append(frame)
-            from prefect.client.schemas.worker_channel import (
-                CleanupOperationResultFrame,
+            await handler.cleanup(
+                _cancelling_payload(
+                    flow_run_id=flow_run.id, infrastructure_pid="payload-pid"
+                )
             )
 
-            return CleanupOperationResultFrame.model_validate(
-                {
-                    "type": "cleanup.operation_result.v1",
-                    "id": str(uuid7()),
-                    "sent_at": now("UTC").isoformat(),
-                    "payload": {
-                        "request_frame_id": str(frame.id),
-                        "message_id": str(frame.payload.message_id),
-                        "operation": frame.payload.message_id
-                        and (
-                            "ack"
-                            if frame.type == "cleanup.ack.v1"
-                            else "release"
-                            if frame.type == "cleanup.release.v1"
-                            else "renew"
-                        ),
-                        "status": "accepted",
-                        "reason": None,
-                        "detail": None,
-                    },
-                }
-            )
-
-        handler, worker = _build_handler(
-            flow_run=flow_run,
-            kill_side_effect=kill_side_effect,
-        )
-        executor = WorkerCleanupExecutor([handler], send_operation=send)
-
-        message = CleanupMessageFrame.model_validate(
-            {
-                "type": "cleanup.message.v1",
-                "id": str(uuid7()),
-                "sent_at": now("UTC").isoformat(),
-                "payload": _cancelling_payload(
-                    flow_run_id=flow_run.id if flow_run else uuid4(),
-                    infrastructure_pid=infrastructure_pid,
-                ).model_dump(mode="json"),
-            }
-        )
-
-        await executor.execute(message)
-        return executor, worker, sent
-
-    async def test_successful_teardown_results_in_ack_frame(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        _, worker, sent = await self._build_executor_with_handler(flow_run=flow_run)
-
-        worker.kill_infrastructure.assert_awaited_once()
-        assert len(sent) == 1
-        assert sent[0].type == "cleanup.ack.v1"
-
-    async def test_missing_handle_results_in_release_frame(self):
-        flow_run = _flow_run(infrastructure_pid="stored-pid")
-        _, worker, sent = await self._build_executor_with_handler(
-            flow_run=flow_run,
-            infrastructure_pid=None,
-        )
-
-        worker.kill_infrastructure.assert_not_called()
-        assert len(sent) == 1
-        assert sent[0].type == "cleanup.release.v1"
-        assert sent[0].payload.reason == "missing_infrastructure_handle"
-
-    async def test_unsupported_worker_results_in_release_frame(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        _, _worker, sent = await self._build_executor_with_handler(
-            flow_run=flow_run,
-            kill_side_effect=NotImplementedError("nope"),
-        )
-
-        assert len(sent) == 1
-        assert sent[0].type == "cleanup.release.v1"
-        assert sent[0].payload.reason == "unsupported_worker_type"
-
-    async def test_infrastructure_not_found_results_in_ack_frame(self):
-        flow_run = _flow_run(infrastructure_pid="pid")
-        _, _worker, sent = await self._build_executor_with_handler(
-            flow_run=flow_run,
-            kill_side_effect=InfrastructureNotFound("gone"),
-        )
-
-        assert len(sent) == 1
-        assert sent[0].type == "cleanup.ack.v1"
-
-    async def test_unsupported_cleanup_kind_releases_via_executor(self):
-        """When a worker only registers cancelling_timeout_teardown but receives
-        a pending_claim_teardown message, the executor handles the release
-        without invoking the handler."""
-        sent: list[Any] = []
-
-        async def send(frame):
-            sent.append(frame)
-            from prefect.client.schemas.worker_channel import (
-                CleanupOperationResultFrame,
-            )
-
-            return CleanupOperationResultFrame.model_validate(
-                {
-                    "type": "cleanup.operation_result.v1",
-                    "id": str(uuid7()),
-                    "sent_at": now("UTC").isoformat(),
-                    "payload": {
-                        "request_frame_id": str(frame.id),
-                        "message_id": str(frame.payload.message_id),
-                        "operation": "release",
-                        "status": "accepted",
-                        "reason": None,
-                        "detail": None,
-                    },
-                }
-            )
-
-        handler, _worker = _build_handler(flow_run=_flow_run(infrastructure_pid="pid"))
-        executor = WorkerCleanupExecutor([handler], send_operation=send)
-
-        pending_payload = {
-            "kind": PENDING_CLAIM_TEARDOWN,
-            "message_id": str(uuid4()),
-            "reservation_token": "token",
-            "lease_expires_at": (now("UTC") + timedelta(minutes=5)).isoformat(),
-            "delivery_count": 1,
-            "work_queue_id": None,
-            "target": {
-                "flow_run_id": str(uuid4()),
-                "claim_id": str(uuid7()),
-            },
-            "data": {},
-        }
-        message = CleanupMessageFrame.model_validate(
-            {
-                "type": "cleanup.message.v1",
-                "id": str(uuid7()),
-                "sent_at": now("UTC").isoformat(),
-                "payload": pending_payload,
-            }
-        )
-
-        await executor.execute(message)
-
-        assert len(sent) == 1
-        assert sent[0].type == "cleanup.release.v1"
-        assert sent[0].payload.reason == "unsupported_cleanup_kind"
-
-
-class TestRealWorkerIntegration:
-    """End-to-end smoke tests using a real BaseWorker subclass and fixtures."""
-
-    async def test_handler_against_real_capable_worker(self, work_pool):
-        worker = TeardownTrackingWorker(
-            work_pool_name=work_pool.name,
-            name="cleanup-handler-test",
-        )
-        flow_run = _flow_run(infrastructure_pid="pid")
-
-        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-        assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
-        worker._get_configuration = AsyncMock(  # type: ignore[method-assign]
-            return_value=BaseJobConfiguration()
-        )
-        worker._client = Mock()
-        worker._client.read_flow_run = AsyncMock(return_value=flow_run)
-
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
-
-        assert result == CleanupExecutionResult.success()
-        assert worker.kill_calls == [
-            {
-                "infrastructure_pid": "pid",
-                "configuration": worker._get_configuration.return_value,
-                "grace_seconds": 30,
-            }
-        ]
-
-    async def test_handler_treats_not_implemented_from_base_as_unsupported(self):
-        """Direct check against an incapable BaseWorker subclass — kill
-        raises NotImplementedError, which the handler maps to a stable
-        release reason."""
-        worker = IncapableWorker(work_pool_name="test")
-        flow_run = _flow_run(infrastructure_pid="pid")
-
-        worker._client = Mock()
-        worker._client.read_flow_run = AsyncMock(return_value=flow_run)
-        worker._get_configuration = AsyncMock(  # type: ignore[method-assign]
-            return_value=BaseJobConfiguration()
-        )
-
-        handler = CancellingTimeoutTeardownHandler(worker)
-        result = await handler.cleanup(
-            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-        )
-
-        assert result == CleanupExecutionResult.release("unsupported_worker_type")
+        assert len(worker.kill_calls) == 1
+        assert worker.kill_calls[0]["infrastructure_pid"] == "payload-pid"
 
 
 @pytest.mark.parametrize(
@@ -701,16 +621,48 @@ class TestRealWorkerIntegration:
     ],
 )
 async def test_typed_kill_exceptions_map_to_stable_release_reasons(
+    prefect_client: PrefectClient,
+    work_pool: WorkPool,
     kill_side_effect: BaseException,
     expected_reason: str,
 ):
-    flow_run = _flow_run(infrastructure_pid="pid")
-    handler, _worker = _build_handler(
-        flow_run=flow_run, kill_side_effect=kill_side_effect
+    flow_run = await _create_flow_run(
+        prefect_client, work_pool, infrastructure_pid="pid"
     )
 
-    result = await handler.cleanup(
-        _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
-    )
+    async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+        worker.kill_side_effect = kill_side_effect
+        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+        assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
 
     assert result == CleanupExecutionResult.release(expected_reason)
+
+
+async def test_cleanup_handler_works_with_unrelated_deployment_context(
+    prefect_client: PrefectClient,
+    work_pool: WorkPool,
+    deployment: DeploymentResponse,
+):
+    """Verify the handler successfully tears down a flow run created from a
+    real deployment — exercises the full `_get_configuration` path against
+    fixtures that mirror production usage."""
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        deployment_id=deployment.id,
+    )
+    await prefect_client.update_flow_run(flow_run.id, infrastructure_pid="pid")
+
+    async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+        assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+    assert result == CleanupExecutionResult.success()
+    assert len(worker.kill_calls) == 1
+    assert worker.kill_calls[0]["infrastructure_pid"] == "pid"

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -307,8 +307,8 @@ class TestHandlerBehavior:
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
             handler = _handler_for(worker)
             with mock.patch.object(
-                worker,
-                "get_configuration",
+                worker.job_configuration,
+                "resolve_for_flow_run",
                 AsyncMock(side_effect=ObjectNotFound(Exception("deployment gone"))),
             ):
                 result = await handler.cleanup(

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -1,0 +1,653 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+from uuid import UUID, uuid4
+
+import pytest
+
+from prefect._internal.uuid7 import uuid7
+from prefect.client.schemas.objects import FlowRun
+from prefect.client.schemas.worker_channel import (
+    CANCELLING_TIMEOUT_TEARDOWN,
+    PENDING_CLAIM_TEARDOWN,
+    CancellingTimeoutCleanupMessagePayload,
+    CleanupMessageFrame,
+)
+from prefect.exceptions import (
+    InfrastructureNotAvailable,
+    InfrastructureNotFound,
+    ObjectNotFound,
+)
+from prefect.states import Cancelling, Pending, Running
+from prefect.types._datetime import now
+from prefect.workers._cleanup import (
+    CleanupExecutionResult,
+    WorkerCleanupExecutor,
+)
+from prefect.workers._cleanup_handlers import CancellingTimeoutTeardownHandler
+from prefect.workers.base import (
+    BaseJobConfiguration,
+    BaseWorker,
+    BaseWorkerResult,
+)
+
+
+class TeardownTrackingWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
+    """
+    Test worker that overrides `kill_infrastructure` so the handler has a
+    capable target to dispatch to.
+    """
+
+    type = "cleanup-handler-test-capable"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.kill_calls: list[dict[str, Any]] = []
+        self.kill_side_effect: BaseException | None = None
+        self._cleanup_handler_registry.register(CancellingTimeoutTeardownHandler(self))
+
+    async def run(  # type: ignore[override]
+        self,
+        flow_run: Any = None,
+        configuration: Any = None,
+        task_status: Any = None,
+    ) -> BaseWorkerResult:
+        raise NotImplementedError
+
+    async def kill_infrastructure(  # type: ignore[override]
+        self,
+        infrastructure_pid: str,
+        configuration: BaseJobConfiguration,
+        grace_seconds: int = 30,
+    ) -> None:
+        self.kill_calls.append(
+            {
+                "infrastructure_pid": infrastructure_pid,
+                "configuration": configuration,
+                "grace_seconds": grace_seconds,
+            }
+        )
+        if self.kill_side_effect is not None:
+            raise self.kill_side_effect
+
+
+class IncapableWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
+    """Test worker without `kill_infrastructure` to verify the base default."""
+
+    type = "cleanup-handler-test-incapable"
+
+    async def run(  # type: ignore[override]
+        self,
+        flow_run: Any = None,
+        configuration: Any = None,
+        task_status: Any = None,
+    ) -> BaseWorkerResult:
+        raise NotImplementedError
+
+
+def _cancelling_payload(
+    *,
+    flow_run_id: UUID | None = None,
+    infrastructure_pid: str | None = "infra-pid",
+) -> CancellingTimeoutCleanupMessagePayload:
+    target: dict[str, str | None] = {
+        "flow_run_id": str(flow_run_id or uuid4()),
+    }
+    if infrastructure_pid is not None:
+        target["infrastructure_pid"] = infrastructure_pid
+
+    return CancellingTimeoutCleanupMessagePayload.model_validate(
+        {
+            "kind": CANCELLING_TIMEOUT_TEARDOWN,
+            "message_id": str(uuid4()),
+            "reservation_token": "token",
+            "lease_expires_at": (now("UTC") + timedelta(minutes=5)).isoformat(),
+            "delivery_count": 1,
+            "work_queue_id": None,
+            "target": target,
+            "data": {},
+        }
+    )
+
+
+def _build_handler(
+    *,
+    flow_run: FlowRun | None,
+    configuration: BaseJobConfiguration | None = None,
+    configuration_error: BaseException | None = None,
+    kill_side_effect: BaseException | None = None,
+    grace_seconds: int = 30,
+) -> tuple[CancellingTimeoutTeardownHandler, Mock]:
+    worker = Mock(spec=BaseWorker)
+    client = Mock()
+    if flow_run is None:
+        client.read_flow_run = AsyncMock(
+            side_effect=ObjectNotFound(Exception("missing"))
+        )
+    else:
+        client.read_flow_run = AsyncMock(return_value=flow_run)
+    worker.client = client
+
+    if configuration_error is not None:
+        worker._get_configuration = AsyncMock(side_effect=configuration_error)
+    else:
+        worker._get_configuration = AsyncMock(
+            return_value=configuration or BaseJobConfiguration()
+        )
+
+    worker.kill_infrastructure = AsyncMock(side_effect=kill_side_effect)
+
+    handler = CancellingTimeoutTeardownHandler(worker, grace_seconds=grace_seconds)
+    return handler, worker
+
+
+def _flow_run(
+    *,
+    state=None,
+    start_time=None,
+    infrastructure_pid: str | None = None,
+) -> FlowRun:
+    return FlowRun(
+        id=uuid4(),
+        flow_id=uuid4(),
+        name="test-flow-run",
+        state=state or Cancelling(),
+        start_time=start_time,
+        infrastructure_pid=infrastructure_pid,
+    )
+
+
+class TestHandlerRegistration:
+    async def test_handler_declares_cancelling_timeout_kind(self):
+        worker = Mock(spec=BaseWorker)
+        handler = CancellingTimeoutTeardownHandler(worker)
+
+        assert handler.cleanup_kind == CANCELLING_TIMEOUT_TEARDOWN
+
+    async def test_capable_worker_advertises_cancelling_timeout_kind(self):
+        worker = TeardownTrackingWorker(work_pool_name="test")
+
+        assert worker.handled_cleanup_kinds == (CANCELLING_TIMEOUT_TEARDOWN,)
+        assert worker.max_cleanup_concurrency == 1
+
+    async def test_incapable_worker_does_not_advertise_cancelling_timeout_kind(self):
+        worker = IncapableWorker(work_pool_name="test")
+
+        assert worker.handled_cleanup_kinds == ()
+        assert worker.max_cleanup_concurrency == 0
+
+    async def test_base_worker_does_not_register_handler_by_default(self):
+        """The base worker should not auto-register the cancelling timeout handler."""
+
+        class NoCleanupWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
+            type = "cleanup-handler-test-no-cleanup"
+
+            async def run(  # type: ignore[override]
+                self, flow_run=None, configuration=None, task_status=None
+            ):
+                raise NotImplementedError
+
+        worker = NoCleanupWorker(work_pool_name="test")
+
+        assert worker.handled_cleanup_kinds == ()
+        assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
+
+
+class TestHandlerBehavior:
+    async def test_releases_unexpected_payload_kind(self):
+        handler, worker = _build_handler(flow_run=_flow_run())
+
+        wrong_payload = Mock(spec=[])  # No isinstance check matches
+        wrong_payload.kind = PENDING_CLAIM_TEARDOWN
+
+        result = await handler.cleanup(wrong_payload)
+
+        assert result == CleanupExecutionResult.release("unexpected_payload_kind")
+        worker.client.read_flow_run.assert_not_called()
+
+    async def test_releases_invalid_payload_when_flow_run_id_missing(self):
+        """Defensive check: even though Pydantic validates flow_run_id, the
+        handler releases with `invalid_payload` if it cannot find one on the
+        target."""
+        handler, worker = _build_handler(flow_run=_flow_run())
+
+        payload = _cancelling_payload()
+        payload.target.flow_run_id = None  # type: ignore[assignment]
+
+        result = await handler.cleanup(payload)
+
+        assert result == CleanupExecutionResult.release("invalid_payload")
+        worker.client.read_flow_run.assert_not_called()
+
+    async def test_deleted_flow_run_is_idempotent_success(self):
+        handler, worker = _build_handler(flow_run=None)
+
+        result = await handler.cleanup(_cancelling_payload())
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_not_called()
+
+    async def test_missing_pid_with_no_stored_pid_acks_as_noop(self):
+        flow_run = _flow_run(infrastructure_pid=None)
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(
+                flow_run_id=flow_run.id,
+                infrastructure_pid=None,
+            )
+        )
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_not_called()
+
+    async def test_missing_pid_with_stored_pid_releases_missing_handle(self):
+        flow_run = _flow_run(infrastructure_pid="stored-pid")
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(
+                flow_run_id=flow_run.id,
+                infrastructure_pid=None,
+            )
+        )
+
+        assert result == CleanupExecutionResult.release("missing_infrastructure_handle")
+        worker.kill_infrastructure.assert_not_called()
+
+    async def test_empty_string_pid_treated_as_missing(self):
+        flow_run = _flow_run(infrastructure_pid=None)
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(
+                flow_run_id=flow_run.id,
+                infrastructure_pid="",
+            )
+        )
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_not_called()
+
+    async def test_configuration_unavailable_releases_with_stable_reason(self):
+        flow_run = _flow_run(infrastructure_pid="stored-pid")
+        handler, worker = _build_handler(
+            flow_run=flow_run,
+            configuration_error=ObjectNotFound(Exception("deployment gone")),
+        )
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.release(
+            "configuration_context_unavailable"
+        )
+        worker.kill_infrastructure.assert_not_called()
+
+    async def test_infrastructure_not_found_acks_as_idempotent_success(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        handler, worker = _build_handler(
+            flow_run=flow_run,
+            kill_side_effect=InfrastructureNotFound("gone"),
+        )
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_awaited_once()
+
+    async def test_not_implemented_releases_unsupported_worker_type(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        handler, worker = _build_handler(
+            flow_run=flow_run,
+            kill_side_effect=NotImplementedError("nope"),
+        )
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.release("unsupported_worker_type")
+
+    async def test_infrastructure_unavailable_releases_with_stable_reason(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        handler, worker = _build_handler(
+            flow_run=flow_run,
+            kill_side_effect=InfrastructureNotAvailable("offline"),
+        )
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.release("infrastructure_not_available")
+
+    async def test_successful_kill_acks(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_awaited_once()
+        call_kwargs = worker.kill_infrastructure.await_args.kwargs
+        assert call_kwargs["infrastructure_pid"] == "pid"
+        assert call_kwargs["grace_seconds"] == 30
+
+    async def test_grace_seconds_is_configurable(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        handler, worker = _build_handler(flow_run=flow_run, grace_seconds=10)
+
+        await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert worker.kill_infrastructure.await_args.kwargs["grace_seconds"] == 10
+
+    async def test_does_not_skip_when_start_time_is_set(self):
+        """The cleanup message is emitted after the timeout boundary; the
+        handler must NOT skip teardown when a `start_time` is present."""
+        flow_run = _flow_run(
+            state=Running(),
+            start_time=now("UTC"),
+            infrastructure_pid="pid",
+        )
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_awaited_once()
+
+    async def test_does_not_skip_when_state_is_not_cancelling(self):
+        """The handler must NOT require the flow run to currently be in the
+        CANCELLING state — the server has already moved beyond it."""
+        flow_run = _flow_run(state=Pending(), infrastructure_pid="pid")
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.success()
+        worker.kill_infrastructure.assert_awaited_once()
+
+    async def test_does_not_mutate_flow_run_state(self):
+        """Verify the handler never proposes or forces a state transition."""
+        flow_run = _flow_run(state=Running(), infrastructure_pid="pid")
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        worker.client.set_flow_run_state.assert_not_called()
+        # Any helper that would propose a transition should not have been used.
+        assert not hasattr(worker, "_propose_state_calls")
+
+    async def test_uses_payload_pid_not_flow_run_pid(self):
+        """Per the protocol contract, target identifiers come from the payload,
+        not from current flow-run state."""
+        flow_run = _flow_run(infrastructure_pid="flow-run-pid")
+        handler, worker = _build_handler(flow_run=flow_run)
+
+        await handler.cleanup(
+            _cancelling_payload(
+                flow_run_id=flow_run.id,
+                infrastructure_pid="payload-pid",
+            )
+        )
+
+        worker.kill_infrastructure.assert_awaited_once()
+        assert (
+            worker.kill_infrastructure.await_args.kwargs["infrastructure_pid"]
+            == "payload-pid"
+        )
+
+
+class TestExecutorIntegration:
+    """Verify the handler integrates correctly with WorkerCleanupExecutor."""
+
+    async def _build_executor_with_handler(
+        self,
+        *,
+        flow_run: FlowRun | None,
+        infrastructure_pid: str | None = "pid",
+        kill_side_effect: BaseException | None = None,
+    ) -> tuple[WorkerCleanupExecutor, Mock, list[Any]]:
+        sent: list[Any] = []
+
+        async def send(frame):
+            sent.append(frame)
+            from prefect.client.schemas.worker_channel import (
+                CleanupOperationResultFrame,
+            )
+
+            return CleanupOperationResultFrame.model_validate(
+                {
+                    "type": "cleanup.operation_result.v1",
+                    "id": str(uuid7()),
+                    "sent_at": now("UTC").isoformat(),
+                    "payload": {
+                        "request_frame_id": str(frame.id),
+                        "message_id": str(frame.payload.message_id),
+                        "operation": frame.payload.message_id
+                        and (
+                            "ack"
+                            if frame.type == "cleanup.ack.v1"
+                            else "release"
+                            if frame.type == "cleanup.release.v1"
+                            else "renew"
+                        ),
+                        "status": "accepted",
+                        "reason": None,
+                        "detail": None,
+                    },
+                }
+            )
+
+        handler, worker = _build_handler(
+            flow_run=flow_run,
+            kill_side_effect=kill_side_effect,
+        )
+        executor = WorkerCleanupExecutor([handler], send_operation=send)
+
+        message = CleanupMessageFrame.model_validate(
+            {
+                "type": "cleanup.message.v1",
+                "id": str(uuid7()),
+                "sent_at": now("UTC").isoformat(),
+                "payload": _cancelling_payload(
+                    flow_run_id=flow_run.id if flow_run else uuid4(),
+                    infrastructure_pid=infrastructure_pid,
+                ).model_dump(mode="json"),
+            }
+        )
+
+        await executor.execute(message)
+        return executor, worker, sent
+
+    async def test_successful_teardown_results_in_ack_frame(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        _, worker, sent = await self._build_executor_with_handler(flow_run=flow_run)
+
+        worker.kill_infrastructure.assert_awaited_once()
+        assert len(sent) == 1
+        assert sent[0].type == "cleanup.ack.v1"
+
+    async def test_missing_handle_results_in_release_frame(self):
+        flow_run = _flow_run(infrastructure_pid="stored-pid")
+        _, worker, sent = await self._build_executor_with_handler(
+            flow_run=flow_run,
+            infrastructure_pid=None,
+        )
+
+        worker.kill_infrastructure.assert_not_called()
+        assert len(sent) == 1
+        assert sent[0].type == "cleanup.release.v1"
+        assert sent[0].payload.reason == "missing_infrastructure_handle"
+
+    async def test_unsupported_worker_results_in_release_frame(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        _, _worker, sent = await self._build_executor_with_handler(
+            flow_run=flow_run,
+            kill_side_effect=NotImplementedError("nope"),
+        )
+
+        assert len(sent) == 1
+        assert sent[0].type == "cleanup.release.v1"
+        assert sent[0].payload.reason == "unsupported_worker_type"
+
+    async def test_infrastructure_not_found_results_in_ack_frame(self):
+        flow_run = _flow_run(infrastructure_pid="pid")
+        _, _worker, sent = await self._build_executor_with_handler(
+            flow_run=flow_run,
+            kill_side_effect=InfrastructureNotFound("gone"),
+        )
+
+        assert len(sent) == 1
+        assert sent[0].type == "cleanup.ack.v1"
+
+    async def test_unsupported_cleanup_kind_releases_via_executor(self):
+        """When a worker only registers cancelling_timeout_teardown but receives
+        a pending_claim_teardown message, the executor handles the release
+        without invoking the handler."""
+        sent: list[Any] = []
+
+        async def send(frame):
+            sent.append(frame)
+            from prefect.client.schemas.worker_channel import (
+                CleanupOperationResultFrame,
+            )
+
+            return CleanupOperationResultFrame.model_validate(
+                {
+                    "type": "cleanup.operation_result.v1",
+                    "id": str(uuid7()),
+                    "sent_at": now("UTC").isoformat(),
+                    "payload": {
+                        "request_frame_id": str(frame.id),
+                        "message_id": str(frame.payload.message_id),
+                        "operation": "release",
+                        "status": "accepted",
+                        "reason": None,
+                        "detail": None,
+                    },
+                }
+            )
+
+        handler, _worker = _build_handler(flow_run=_flow_run(infrastructure_pid="pid"))
+        executor = WorkerCleanupExecutor([handler], send_operation=send)
+
+        pending_payload = {
+            "kind": PENDING_CLAIM_TEARDOWN,
+            "message_id": str(uuid4()),
+            "reservation_token": "token",
+            "lease_expires_at": (now("UTC") + timedelta(minutes=5)).isoformat(),
+            "delivery_count": 1,
+            "work_queue_id": None,
+            "target": {
+                "flow_run_id": str(uuid4()),
+                "claim_id": str(uuid7()),
+            },
+            "data": {},
+        }
+        message = CleanupMessageFrame.model_validate(
+            {
+                "type": "cleanup.message.v1",
+                "id": str(uuid7()),
+                "sent_at": now("UTC").isoformat(),
+                "payload": pending_payload,
+            }
+        )
+
+        await executor.execute(message)
+
+        assert len(sent) == 1
+        assert sent[0].type == "cleanup.release.v1"
+        assert sent[0].payload.reason == "unsupported_cleanup_kind"
+
+
+class TestRealWorkerIntegration:
+    """End-to-end smoke tests using a real BaseWorker subclass and fixtures."""
+
+    async def test_handler_against_real_capable_worker(self, work_pool):
+        worker = TeardownTrackingWorker(
+            work_pool_name=work_pool.name,
+            name="cleanup-handler-test",
+        )
+        flow_run = _flow_run(infrastructure_pid="pid")
+
+        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+        assert isinstance(handler, CancellingTimeoutTeardownHandler)
+
+        worker._get_configuration = AsyncMock(  # type: ignore[method-assign]
+            return_value=BaseJobConfiguration()
+        )
+        worker._client = Mock()
+        worker._client.read_flow_run = AsyncMock(return_value=flow_run)
+
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.success()
+        assert worker.kill_calls == [
+            {
+                "infrastructure_pid": "pid",
+                "configuration": worker._get_configuration.return_value,
+                "grace_seconds": 30,
+            }
+        ]
+
+    async def test_handler_treats_not_implemented_from_base_as_unsupported(self):
+        """Direct check against an incapable BaseWorker subclass — kill
+        raises NotImplementedError, which the handler maps to a stable
+        release reason."""
+        worker = IncapableWorker(work_pool_name="test")
+        flow_run = _flow_run(infrastructure_pid="pid")
+
+        worker._client = Mock()
+        worker._client.read_flow_run = AsyncMock(return_value=flow_run)
+        worker._get_configuration = AsyncMock(  # type: ignore[method-assign]
+            return_value=BaseJobConfiguration()
+        )
+
+        handler = CancellingTimeoutTeardownHandler(worker)
+        result = await handler.cleanup(
+            _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+        )
+
+        assert result == CleanupExecutionResult.release("unsupported_worker_type")
+
+
+@pytest.mark.parametrize(
+    "kill_side_effect,expected_reason",
+    [
+        (InfrastructureNotAvailable("offline"), "infrastructure_not_available"),
+        (NotImplementedError("nope"), "unsupported_worker_type"),
+    ],
+)
+async def test_typed_kill_exceptions_map_to_stable_release_reasons(
+    kill_side_effect: BaseException,
+    expected_reason: str,
+):
+    flow_run = _flow_run(infrastructure_pid="pid")
+    handler, _worker = _build_handler(
+        flow_run=flow_run, kill_side_effect=kill_side_effect
+    )
+
+    result = await handler.cleanup(
+        _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
+    )
+
+    assert result == CleanupExecutionResult.release(expected_reason)

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -308,7 +308,7 @@ class TestHandlerBehavior:
             handler = _handler_for(worker)
             with mock.patch.object(
                 worker,
-                "_get_configuration",
+                "get_configuration",
                 AsyncMock(side_effect=ObjectNotFound(Exception("deployment gone"))),
             ):
                 result = await handler.cleanup(

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -32,10 +32,7 @@ from prefect.workers.base import (
 
 
 class TeardownTrackingWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
-    """
-    Test worker that overrides `kill_infrastructure` so `BaseWorker` will
-    auto-register the cancelling-timeout cleanup handler.
-    """
+    """Worker that overrides `kill_infrastructure` so auto-registration triggers."""
 
     type = "cleanup-handler-test-capable"
 
@@ -70,8 +67,6 @@ class TeardownTrackingWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerRes
 
 
 class IncapableWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
-    """Test worker without `kill_infrastructure` to verify the base default."""
-
     type = "cleanup-handler-test-incapable"
 
     async def run(  # type: ignore[override]
@@ -120,20 +115,24 @@ async def _create_flow_run(
     work_pool: WorkPool,
     *,
     state=None,
-    start_time=None,
     infrastructure_pid: str | None = None,
 ) -> FlowRun:
     flow_run = await prefect_client.create_flow_run(
         _sample_flow, work_pool_name=work_pool.name, state=state
     )
-    updates: dict[str, Any] = {}
     if infrastructure_pid is not None:
-        updates["infrastructure_pid"] = infrastructure_pid
-    if updates:
-        await prefect_client.update_flow_run(flow_run.id, **updates)
-    if start_time is not None or infrastructure_pid is not None:
-        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        await prefect_client.update_flow_run(
+            flow_run.id, infrastructure_pid=infrastructure_pid
+        )
     return flow_run
+
+
+def _handler_for(
+    worker: TeardownTrackingWorker,
+) -> CancellingTimeoutTeardownHandler:
+    handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
+    assert isinstance(handler, CancellingTimeoutTeardownHandler)
+    return handler
 
 
 class TestHandlerRegistration:
@@ -149,9 +148,6 @@ class TestHandlerRegistration:
         prefect_client: PrefectClient,
         work_pool: WorkPool,
     ):
-        """A worker that overrides `kill_infrastructure` should advertise the
-        cancelling-timeout cleanup kind; the auto-registered handler should
-        dispatch to *this* worker instance."""
         flow_run = await _create_flow_run(
             prefect_client, work_pool, infrastructure_pid="pid"
         )
@@ -179,9 +175,6 @@ class TestHandlerRegistration:
         assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
 
     async def test_base_worker_does_not_register_handler_by_default(self):
-        """A subclass that inherits the base `kill_infrastructure` should not
-        get the handler auto-registered."""
-
         class NoCleanupWorker(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
             type = "cleanup-handler-test-no-cleanup"
 
@@ -196,10 +189,6 @@ class TestHandlerRegistration:
         assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
 
     async def test_class_level_cleanup_handlers_take_precedence(self):
-        """A capable subclass that sets `cleanup_handlers` to its own handler
-        for the cancelling timeout kind keeps that handler — the
-        auto-registration only fills in when the kind is unhandled."""
-
         class CustomHandler:
             cleanup_kind = CANCELLING_TIMEOUT_TEARDOWN
 
@@ -220,32 +209,13 @@ class TestHandlerRegistration:
 
 
 class TestHandlerBehavior:
-    """
-    Behavior tests for the handler against a real `BaseWorker` subclass.
-
-    Each test sets up the flow-run state it cares about via the
-    `prefect_client` and `work_pool` fixtures, then exercises the
-    auto-registered handler. The handler's only un-public hook into the
-    worker is the dependency on `_get_configuration`; tests that need to
-    control that path use `mock.patch.object` so the dependency is
-    explicit rather than mutating private attributes by hand.
-    """
-
-    async def _handler_and_worker(
-        self, work_pool: WorkPool
-    ) -> tuple[CancellingTimeoutTeardownHandler, TeardownTrackingWorker]:
-        worker = TeardownTrackingWorker(work_pool_name=work_pool.name)
-        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-        assert isinstance(handler, CancellingTimeoutTeardownHandler)
-        return handler, worker
-
     async def test_releases_unexpected_payload_kind(self, work_pool: WorkPool):
-        handler, worker = await self._handler_and_worker(work_pool)
-
         class _UnexpectedPayload:
             kind = "pending_claim_teardown.v1"
 
-        result = await handler.cleanup(_UnexpectedPayload())  # type: ignore[arg-type]
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = _handler_for(worker)
+            result = await handler.cleanup(_UnexpectedPayload())  # type: ignore[arg-type]
 
         assert result == CleanupExecutionResult.release("unexpected_payload_kind")
         assert worker.kill_calls == []
@@ -253,25 +223,21 @@ class TestHandlerBehavior:
     async def test_releases_invalid_payload_when_flow_run_id_missing(
         self, work_pool: WorkPool
     ):
-        """Defensive check: even though Pydantic validates flow_run_id, the
-        handler releases with `invalid_payload` if it cannot find one on the
-        target."""
-        handler, worker = await self._handler_and_worker(work_pool)
-
+        # Pydantic enforces `flow_run_id` at the protocol layer; this exercises
+        # the handler's defense-in-depth path by mutating it post-validation.
         payload = _cancelling_payload()
         payload.target.flow_run_id = None  # type: ignore[assignment]
 
-        result = await handler.cleanup(payload)
+        async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
+            handler = _handler_for(worker)
+            result = await handler.cleanup(payload)
 
         assert result == CleanupExecutionResult.release("invalid_payload")
         assert worker.kill_calls == []
 
     async def test_deleted_flow_run_is_idempotent_success(self, work_pool: WorkPool):
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
-            # Flow-run id that does not exist on the server.
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=uuid4(), infrastructure_pid="pid")
             )
@@ -287,9 +253,7 @@ class TestHandlerBehavior:
         flow_run = await _create_flow_run(prefect_client, work_pool)
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid=None)
             )
@@ -307,9 +271,7 @@ class TestHandlerBehavior:
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid=None)
             )
@@ -325,9 +287,7 @@ class TestHandlerBehavior:
         flow_run = await _create_flow_run(prefect_client, work_pool)
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="")
             )
@@ -345,12 +305,7 @@ class TestHandlerBehavior:
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
-            # Force the configuration lookup to fail like a deleted-deployment
-            # would. Patching the worker hook keeps the dependency explicit
-            # without mutating private attributes by hand.
+            handler = _handler_for(worker)
             with mock.patch.object(
                 worker,
                 "_get_configuration",
@@ -378,9 +333,7 @@ class TestHandlerBehavior:
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
             worker.kill_side_effect = InfrastructureNotFound("gone")
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -393,18 +346,13 @@ class TestHandlerBehavior:
         prefect_client: PrefectClient,
         work_pool: WorkPool,
     ):
-        """A worker whose `kill_infrastructure` raises NotImplementedError at
-        call time (rather than at class-definition time) should release with
-        `unsupported_worker_type`."""
         flow_run = await _create_flow_run(
             prefect_client, work_pool, infrastructure_pid="pid"
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
             worker.kill_side_effect = NotImplementedError("nope")
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -422,9 +370,7 @@ class TestHandlerBehavior:
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
             worker.kill_side_effect = InfrastructureNotAvailable("offline")
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -441,9 +387,7 @@ class TestHandlerBehavior:
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -465,10 +409,7 @@ class TestHandlerBehavior:
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            # Build a handler with a custom grace period instead of the
-            # auto-registered default.
             handler = CancellingTimeoutTeardownHandler(worker, grace_seconds=10)
-
             await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -480,8 +421,6 @@ class TestHandlerBehavior:
         prefect_client: PrefectClient,
         work_pool: WorkPool,
     ):
-        """The cleanup message is emitted after the timeout boundary; the
-        handler must NOT skip teardown when a `start_time` is present."""
         flow_run = await _create_flow_run(
             prefect_client,
             work_pool,
@@ -491,9 +430,7 @@ class TestHandlerBehavior:
         assert flow_run.start_time is not None
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -506,8 +443,6 @@ class TestHandlerBehavior:
         prefect_client: PrefectClient,
         work_pool: WorkPool,
     ):
-        """The handler must NOT require the flow run to currently be in the
-        CANCELLING state — the server has already moved beyond it."""
         flow_run = await _create_flow_run(
             prefect_client,
             work_pool,
@@ -516,9 +451,7 @@ class TestHandlerBehavior:
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             result = await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -531,7 +464,6 @@ class TestHandlerBehavior:
         prefect_client: PrefectClient,
         work_pool: WorkPool,
     ):
-        """Verify the handler never proposes or forces a state transition."""
         flow_run = await _create_flow_run(
             prefect_client,
             work_pool,
@@ -543,9 +475,7 @@ class TestHandlerBehavior:
         original_state_type = flow_run.state.type
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             await handler.cleanup(
                 _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
             )
@@ -560,16 +490,12 @@ class TestHandlerBehavior:
         prefect_client: PrefectClient,
         work_pool: WorkPool,
     ):
-        """Per the protocol contract, target identifiers come from the payload,
-        not from current flow-run state."""
         flow_run = await _create_flow_run(
             prefect_client, work_pool, infrastructure_pid="flow-run-pid"
         )
 
         async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-            handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-            assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+            handler = _handler_for(worker)
             await handler.cleanup(
                 _cancelling_payload(
                     flow_run_id=flow_run.id, infrastructure_pid="payload-pid"
@@ -599,9 +525,7 @@ async def test_typed_kill_exceptions_map_to_stable_release_reasons(
 
     async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
         worker.kill_side_effect = kill_side_effect
-        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-        assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+        handler = _handler_for(worker)
         result = await handler.cleanup(
             _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
         )
@@ -614,18 +538,13 @@ async def test_cleanup_handler_works_with_unrelated_deployment_context(
     work_pool: WorkPool,
     deployment: DeploymentResponse,
 ):
-    """Verify the handler successfully tears down a flow run created from a
-    real deployment — exercises the full `_get_configuration` path against
-    fixtures that mirror production usage."""
     flow_run = await prefect_client.create_flow_run_from_deployment(
         deployment_id=deployment.id,
     )
     await prefect_client.update_flow_run(flow_run.id, infrastructure_pid="pid")
 
     async with TeardownTrackingWorker(work_pool_name=work_pool.name) as worker:
-        handler = worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN)
-        assert isinstance(handler, CancellingTimeoutTeardownHandler)
-
+        handler = _handler_for(worker)
         result = await handler.cleanup(
             _cancelling_payload(flow_run_id=flow_run.id, infrastructure_pid="pid")
         )

--- a/tests/workers/test_cleanup_handlers.py
+++ b/tests/workers/test_cleanup_handlers.py
@@ -195,39 +195,6 @@ class TestHandlerRegistration:
         assert worker.handled_cleanup_kinds == ()
         assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
 
-    async def test_explicit_cleanup_handlers_opts_out_of_auto_registration(self):
-        """Passing `_cleanup_handlers` (even an empty tuple) should fully
-        override the auto-registration so callers retain control over what
-        the worker advertises."""
-        worker = TeardownTrackingWorker(
-            work_pool_name="test",
-            _cleanup_handlers=(),
-        )
-
-        assert worker.handled_cleanup_kinds == ()
-        assert worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is None
-
-    async def test_explicit_cleanup_handlers_replaces_default(self):
-        """A capable worker that supplies a custom handler for the cancelling
-        timeout kind should keep its custom handler instead of getting the
-        default auto-registered."""
-
-        class CustomHandler:
-            cleanup_kind = CANCELLING_TIMEOUT_TEARDOWN
-
-            async def cleanup(self, message):
-                return CleanupExecutionResult.success()
-
-        custom = CustomHandler()
-        worker = TeardownTrackingWorker(
-            work_pool_name="test",
-            _cleanup_handlers=(custom,),
-        )
-
-        assert (
-            worker.cleanup_handler_registry.get(CANCELLING_TIMEOUT_TEARDOWN) is custom
-        )
-
     async def test_class_level_cleanup_handlers_take_precedence(self):
         """A capable subclass that sets `cleanup_handlers` to its own handler
         for the cancelling timeout kind keeps that handler — the

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -220,7 +220,13 @@ async def test_worker_process_run_flow_run(
     ) as worker:
         result = await worker.run(
             flow_run,
-            configuration=await worker.get_configuration(flow_run),
+            configuration=await worker.job_configuration.resolve_for_flow_run(
+                flow_run,
+                client=worker.client,
+                work_pool=worker.work_pool,
+                worker_name=worker.name,
+                worker_id=worker.backend_id,
+            ),
         )
 
         assert isinstance(result, ProcessWorkerResult)
@@ -242,7 +248,13 @@ async def test_worker_process_run_flow_run_with_env_variables_job_config_default
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        configuration = await worker.get_configuration(flow_run)
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         assert configuration.working_dir is None, (
             "This test assumes no configured working_dir"
         )
@@ -281,8 +293,12 @@ async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        configuration = await worker.get_configuration(
-            flow_run_with_deployment_overrides
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run_with_deployment_overrides,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
         )
         result = await worker.run(
             flow_run_with_deployment_overrides,
@@ -317,8 +333,12 @@ async def test_flow_run_without_job_vars(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        configuration = await worker.get_configuration(
-            flow_run_with_deployment_overrides
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run_with_deployment_overrides,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
         )
         assert str(configuration.working_dir) == deployment.job_variables["working_dir"]
 
@@ -342,7 +362,13 @@ async def test_flow_run_vars_take_precedence(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        config = await worker.get_configuration(flow_run_with_overrides)
+        config = await worker.job_configuration.resolve_for_flow_run(
+            flow_run_with_overrides,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         assert (
             str(config.working_dir)
             == flow_run_with_overrides.job_variables["working_dir"]
@@ -368,7 +394,13 @@ async def test_flow_run_vars_and_deployment_vars_get_merged(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        config = await worker.get_configuration(flow_run_with_overrides)
+        config = await worker.job_configuration.resolve_for_flow_run(
+            flow_run_with_overrides,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         assert (
             str(config.working_dir)
             == flow_run_with_overrides.job_variables["working_dir"]
@@ -386,7 +418,13 @@ async def test_process_worker_working_dir_override(
 
     # Check default is not the mock_path
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker.get_configuration(flow_run)
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -407,7 +445,13 @@ async def test_process_worker_working_dir_override(
         ),
     )
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker.get_configuration(flow_run)
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -427,7 +471,13 @@ async def test_process_worker_stream_output_override(
     prefect_client: PrefectClient,
 ):
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker.get_configuration(flow_run)
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -446,7 +496,13 @@ async def test_process_worker_stream_output_override(
     )
 
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker.get_configuration(flow_run)
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -464,7 +520,13 @@ async def test_process_worker_executes_flow_run_with_runner(
     monkeypatch: pytest.MonkeyPatch,
 ):
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker.get_configuration(flow_run)
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
+        )
         assert configuration.working_dir is None, (
             "This test assumes no configured working_dir"
         )
@@ -498,8 +560,12 @@ async def test_process_worker_command_override(
 ):
     override_command = deployment_with_overrides.job_variables["command"]
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker.get_configuration(
-            flow_run_with_deployment_overrides
+        configuration = await worker.job_configuration.resolve_for_flow_run(
+            flow_run_with_deployment_overrides,
+            client=worker.client,
+            work_pool=worker.work_pool,
+            worker_name=worker.name,
+            worker_id=worker.backend_id,
         )
         result = await worker.run(
             flow_run=flow_run_with_deployment_overrides,
@@ -526,7 +592,13 @@ async def test_task_status_receives_pid(
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
         result = await worker.run(
             flow_run=flow_run,
-            configuration=await worker.get_configuration(flow_run),
+            configuration=await worker.job_configuration.resolve_for_flow_run(
+                flow_run,
+                client=worker.client,
+                work_pool=worker.work_pool,
+                worker_name=worker.name,
+                worker_id=worker.backend_id,
+            ),
             task_status=fake_status,
         )
 

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -220,7 +220,7 @@ async def test_worker_process_run_flow_run(
     ) as worker:
         result = await worker.run(
             flow_run,
-            configuration=await worker._get_configuration(flow_run),
+            configuration=await worker.get_configuration(flow_run),
         )
 
         assert isinstance(result, ProcessWorkerResult)
@@ -242,7 +242,7 @@ async def test_worker_process_run_flow_run_with_env_variables_job_config_default
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        configuration = await worker._get_configuration(flow_run)
+        configuration = await worker.get_configuration(flow_run)
         assert configuration.working_dir is None, (
             "This test assumes no configured working_dir"
         )
@@ -281,7 +281,7 @@ async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        configuration = await worker._get_configuration(
+        configuration = await worker.get_configuration(
             flow_run_with_deployment_overrides
         )
         result = await worker.run(
@@ -317,7 +317,7 @@ async def test_flow_run_without_job_vars(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        configuration = await worker._get_configuration(
+        configuration = await worker.get_configuration(
             flow_run_with_deployment_overrides
         )
         assert str(configuration.working_dir) == deployment.job_variables["working_dir"]
@@ -342,7 +342,7 @@ async def test_flow_run_vars_take_precedence(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        config = await worker._get_configuration(flow_run_with_overrides)
+        config = await worker.get_configuration(flow_run_with_overrides)
         assert (
             str(config.working_dir)
             == flow_run_with_overrides.job_variables["working_dir"]
@@ -368,7 +368,7 @@ async def test_flow_run_vars_and_deployment_vars_get_merged(
     async with ProcessWorker(
         work_pool_name=work_pool_with_default_env.name,
     ) as worker:
-        config = await worker._get_configuration(flow_run_with_overrides)
+        config = await worker.get_configuration(flow_run_with_overrides)
         assert (
             str(config.working_dir)
             == flow_run_with_overrides.job_variables["working_dir"]
@@ -386,7 +386,7 @@ async def test_process_worker_working_dir_override(
 
     # Check default is not the mock_path
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker._get_configuration(flow_run)
+        configuration = await worker.get_configuration(flow_run)
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -407,7 +407,7 @@ async def test_process_worker_working_dir_override(
         ),
     )
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker._get_configuration(flow_run)
+        configuration = await worker.get_configuration(flow_run)
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -427,7 +427,7 @@ async def test_process_worker_stream_output_override(
     prefect_client: PrefectClient,
 ):
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker._get_configuration(flow_run)
+        configuration = await worker.get_configuration(flow_run)
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -446,7 +446,7 @@ async def test_process_worker_stream_output_override(
     )
 
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker._get_configuration(flow_run)
+        configuration = await worker.get_configuration(flow_run)
         result = await worker.run(
             flow_run=flow_run,
             configuration=configuration,
@@ -464,7 +464,7 @@ async def test_process_worker_executes_flow_run_with_runner(
     monkeypatch: pytest.MonkeyPatch,
 ):
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker._get_configuration(flow_run)
+        configuration = await worker.get_configuration(flow_run)
         assert configuration.working_dir is None, (
             "This test assumes no configured working_dir"
         )
@@ -498,7 +498,7 @@ async def test_process_worker_command_override(
 ):
     override_command = deployment_with_overrides.job_variables["command"]
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
-        configuration = await worker._get_configuration(
+        configuration = await worker.get_configuration(
             flow_run_with_deployment_overrides
         )
         result = await worker.run(
@@ -526,7 +526,7 @@ async def test_task_status_receives_pid(
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
         result = await worker.run(
             flow_run=flow_run,
-            configuration=await worker._get_configuration(flow_run),
+            configuration=await worker.get_configuration(flow_run),
             task_status=fake_status,
         )
 


### PR DESCRIPTION
related to https://github.com/PrefectHQ/prefect/issues/21860

## Summary
- Adds `CancellingTimeoutTeardownHandler` in `src/prefect/workers/_cleanup_handlers.py`, a `cancelling_timeout_teardown.v1` cleanup handler that plugs into the generic cleanup handler registry from the worker cleanup executor.
- The handler performs idempotent infrastructure teardown after the server has crossed the CANCELLING-timeout boundary: it uses stable target identifiers from the cleanup payload (`target.flow_run_id`, `target.infrastructure_pid`) and reuses the worker's existing `kill_infrastructure` semantics.
- Registration is opt-in. `BaseWorker` does not auto-register the handler, so workers that don't implement `kill_infrastructure` don't advertise the cleanup kind. Capable workers register the handler in their constructor.

## Boundary contract preserved
- Does not propose or force flow-run state transitions; the server has already committed the state outcome.
- Does not require the flow run to currently be in `CANCELLING`; does not skip teardown because the flow run has a `start_time`.
- Maps existing exceptions intentionally:
  - `InfrastructureNotFound` → ack (idempotent success)
  - `NotImplementedError` → release `unsupported_worker_type`
  - `InfrastructureNotAvailable` → release `infrastructure_not_available`
  - Configuration lookup (`ObjectNotFound`) → release `configuration_context_unavailable`
- Treats a missing `target.infrastructure_pid` as idempotent success only when the handler can determine that there is no actionable infrastructure handle; otherwise releases with `missing_infrastructure_handle`.
- Defensive `invalid_payload` release if `target.flow_run_id` cannot be read.
- Uses payload identifiers, not flow-run state, as the source of truth for what to tear down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)