### PR TITLE
fix: preserve trailing slash when redirecting neutral entry points to V2 UI

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -257,7 +257,13 @@ def _build_ui_path(base_url: str, relative_path: str) -> str:
         return normalized_relative_path
 
     if normalized_relative_path == "/":
-        return normalized_base_url
+        # Preserve the trailing slash so the redirect target falls inside
+        # the bundle's mount. Starlette's `Mount` only routes requests
+        # whose path starts with `{mount}/`; a bare `{mount}` falls through
+        # to whatever else matches, which in practice is the V1 SPA mount
+        # at "/" — that returns V1's index.html under the `/v2` URL and
+        # the V1 router can't resolve the route.
+        return f"{normalized_base_url}/"
 
     return f"{normalized_base_url}{normalized_relative_path}"
 

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -346,10 +346,13 @@ def test_create_ui_app_preserves_existing_v2_serve_base(
 @pytest.mark.parametrize(
     ("serve_base", "request_path", "cookie_value", "expected_location"),
     [
-        ("/", "/", "v2", "/v2"),
-        ("/prefect", "/prefect", "v2", "/prefect/v2"),
-        ("/v2", "/", "v2", "/v2"),
-        ("/prefect/v2", "/prefect", "v2", "/prefect/v2"),
+        # Trailing slash matters: Starlette's `Mount` only routes paths
+        # that start with `{mount}/`. A bare `/v2` falls through to the V1
+        # SPA mount at "/" and serves V1's index.html under the wrong URL.
+        ("/", "/", "v2", "/v2/"),
+        ("/prefect", "/prefect", "v2", "/prefect/v2/"),
+        ("/v2", "/", "v2", "/v2/"),
+        ("/prefect/v2", "/prefect", "v2", "/prefect/v2/"),
     ],
 )
 def test_create_ui_app_redirects_neutral_entrypoints_to_preferred_ui(
@@ -413,7 +416,68 @@ def test_create_ui_app_preserves_root_path_in_redirects(
     )
 
     assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
-    assert response.headers["location"].endswith("/proxy/prefect/v2")
+    assert response.headers["location"].endswith("/proxy/prefect/v2/")
+
+
+@pytest.mark.parametrize(
+    ("serve_base", "request_path", "expected_location"),
+    [
+        ("/", "/", "/v2/"),
+        ("/prefect", "/prefect", "/prefect/v2/"),
+        ("/v2", "/", "/v2/"),
+        ("/prefect/v2", "/prefect", "/prefect/v2/"),
+    ],
+)
+def test_create_ui_app_redirect_to_v2_lands_on_v2_bundle(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    serve_base: str,
+    request_path: str,
+    expected_location: str,
+):
+    """Regression test for the V2 redirect dropping its trailing slash.
+
+    Prior to the fix, navigating to a "neutral" entry point (e.g. `/`)
+    with V2 as the preferred UI 307'd the browser to `/v2` (no slash).
+    Starlette's `Mount` only routes requests whose path starts with
+    `{mount}/`, so a bare `/v2` fell through to the V1 SPA mount at "/"
+    and the V1 bundle was served at the `/v2` URL — leaving the browser
+    running V1's SPA with no matching route. This test follows the
+    redirect end-to-end and asserts the V2 bundle is actually returned.
+    """
+    v1_source = _write_fake_ui_bundle(tmp_path / "v1-source", "V1 UI")
+    v2_source = _write_fake_ui_bundle(tmp_path / "v2-source", "V2 UI")
+    monkeypatch.setattr(prefect, "__ui_static_path__", v1_source)
+    monkeypatch.setattr(prefect, "__ui_v2_static_path__", v2_source)
+
+    with temporary_settings(
+        {
+            PREFECT_UI_ENABLED: True,
+            PREFECT_UI_SERVE_BASE: serve_base,
+            PREFECT_UI_STATIC_DIRECTORY: str(tmp_path / "ui-static"),
+        }
+    ):
+        ui_app = create_ui_app(ephemeral=False)
+
+    client = TestClient(ui_app)
+    client.cookies.set("prefect_ui_version", "v2")
+
+    redirect_response = client.get(
+        request_path,
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert redirect_response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    assert redirect_response.headers["location"].endswith(expected_location)
+
+    followed_response = client.get(
+        request_path,
+        headers={"accept": "text/html"},
+        follow_redirects=True,
+    )
+    assert followed_response.status_code == 200
+    assert "V2 UI" in followed_response.text
+    assert "V1 UI" not in followed_response.text
 
 
 @pytest.mark.parametrize(
@@ -460,10 +524,10 @@ def test_create_ui_app_allows_explicit_v2_requests_without_saved_preference(
 @pytest.mark.parametrize(
     ("serve_base", "request_path", "expected_location"),
     [
-        ("/", "/", "/v2"),
-        ("/prefect", "/prefect", "/prefect/v2"),
-        ("/v2", "/", "/v2"),
-        ("/prefect/v2", "/prefect", "/prefect/v2"),
+        ("/", "/", "/v2/"),
+        ("/prefect", "/prefect", "/prefect/v2/"),
+        ("/v2", "/", "/v2/"),
+        ("/prefect/v2", "/prefect", "/prefect/v2/"),
     ],
 )
 def test_create_ui_app_uses_default_ui_for_neutral_entrypoints_without_saved_preference(


### PR DESCRIPTION
## Summary

`_build_ui_path` was dropping the trailing slash when the relative path was `/` and the bundle's base URL wasn't `/`. As a result, navigating to a neutral entry point (e.g. `/`) with V2 as the preferred UI 307'd the browser to `/v2` instead of `/v2/`.

Starlette's `Mount` only routes requests whose path starts with `{mount}/`. A bare `GET /v2` falls through to the V1 SPA mount at `/`, which returns V1's `index.html` under the `/v2` URL — the browser then runs V1's SPA at a route the V1 router can't resolve, showing a broken page.

Repro on a 3.7.0 server with `PREFECT_SERVER_UI_V2_ENABLED=true`:

```
GET /     → 200, ETag A (V1 index.html)
GET /v2   → 200, ETag A (V1 index.html — wrong, served by V1 catch-all)
GET /v2/  → 200, ETag B (V2 index.html — correct)
```

## Fix

One-line change in `_build_ui_path` (`src/prefect/server/api/server.py`) — when the relative path is `/`, return `{base_url}/` instead of `{base_url}`.

## Tests

- Existing redirect-target assertions in `test_create_ui_app_redirects_neutral_entrypoints_to_preferred_ui`, `test_create_ui_app_preserves_root_path_in_redirects`, and `test_create_ui_app_uses_default_ui_for_neutral_entrypoints_without_saved_preference` codified the broken (no-slash) behavior. Updated to expect a trailing slash.
- Added a regression test `test_create_ui_app_redirect_to_v2_lands_on_v2_bundle` that follows the redirect end-to-end and asserts the V2 bundle (not V1) is actually served. Without the fix, the followed redirect lands on V1's `index.html` and the assertion fails.

All 34 `tests/server/api/test_server.py -k ui_app` tests pass locally.

## Test plan
- [x] `uv run pytest tests/server/api/test_server.py -k ui_app` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)