### PR TITLE
security: add opt-in HMAC-SHA256 integrity verification for bundle objects

### DIFF
--- a/src/prefect/bundles/__init__.py
+++ b/src/prefect/bundles/__init__.py
@@ -64,13 +64,12 @@ logger: logging.Logger = get_logger(__name__)
 
 
 def _get_bundle_signing_key() -> bytes:
-    """
-    Return the bundle signing key from the environment.
+    """Return the bundle signing key from the environment.
 
-    When ``PREFECT_BUNDLE_SIGNING_KEY`` is set, bundle serialization will
+    When PREFECT_BUNDLE_SIGNING_KEY is set, bundle serialization will
     prepend an HMAC-SHA256 signature and deserialization will verify it
-    before calling ``cloudpickle.loads()``.  When unset (the default),
-    signing is disabled and behaviour is unchanged.
+    before calling cloudpickle.loads().  When unset (the default),
+    signing is disabled and behavior is unchanged.
     """
     return os.environ.get("PREFECT_BUNDLE_SIGNING_KEY", "").encode("utf-8")
 
@@ -79,8 +78,8 @@ def _sign_bundle(bundle: SerializedBundle) -> None:
     """Add an HMAC-SHA256 signature to the bundle if a signing key is configured.
 
     The signature covers the JSON-serialized bundle (all fields except
-    ``signature`` itself), using deterministic key ordering.  When
-    ``PREFECT_BUNDLE_SIGNING_KEY`` is not set, this is a no-op and the
+    the signature itself), using deterministic key ordering.  When
+    PREFECT_BUNDLE_SIGNING_KEY is not set, this is a no-op and the
     bundle is left unsigned.
     """
     signing_key = _get_bundle_signing_key()
@@ -94,8 +93,8 @@ def _sign_bundle(bundle: SerializedBundle) -> None:
 def _verify_bundle_signature(bundle: SerializedBundle) -> None:
     """Verify the HMAC-SHA256 signature on a bundle.
 
-    Raises ``ValueError`` when ``PREFECT_BUNDLE_SIGNING_KEY`` is set but
-    the bundle is unsigned or the signature does not match.  When the key
+    Raises ValueError when PREFECT_BUNDLE_SIGNING_KEY is set but the
+    bundle is unsigned or the signature does not match.  When the key
     is not set, verification is skipped (backwards-compatible default).
     """
     signing_key = _get_bundle_signing_key()

--- a/src/prefect/bundles/__init__.py
+++ b/src/prefect/bundles/__init__.py
@@ -75,6 +75,46 @@ def _get_bundle_signing_key() -> bytes:
     return os.environ.get("PREFECT_BUNDLE_SIGNING_KEY", "").encode("utf-8")
 
 
+def _sign_bundle(bundle: SerializedBundle) -> None:
+    """Add an HMAC-SHA256 signature to the bundle if a signing key is configured.
+
+    The signature covers the JSON-serialized bundle (all fields except
+    ``signature`` itself), using deterministic key ordering.  When
+    ``PREFECT_BUNDLE_SIGNING_KEY`` is not set, this is a no-op and the
+    bundle is left unsigned.
+    """
+    signing_key = _get_bundle_signing_key()
+    if not signing_key:
+        return
+    content = {k: v for k, v in bundle.items() if k != "signature"}
+    payload = json.dumps(content, sort_keys=True).encode("utf-8")
+    bundle["signature"] = hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
+
+
+def _verify_bundle_signature(bundle: SerializedBundle) -> None:
+    """Verify the HMAC-SHA256 signature on a bundle.
+
+    Raises ``ValueError`` when ``PREFECT_BUNDLE_SIGNING_KEY`` is set but
+    the bundle is unsigned or the signature does not match.  When the key
+    is not set, verification is skipped (backwards-compatible default).
+    """
+    signing_key = _get_bundle_signing_key()
+    if not signing_key:
+        return
+    sig = bundle.get("signature")
+    if not sig:
+        raise ValueError(
+            "Bundle signature verification failed: unsigned bundle rejected. "
+            "Set PREFECT_BUNDLE_SIGNING_KEY on both the submitting client and "
+            "the executing worker to the same secret value."
+        )
+    content = {k: v for k, v in bundle.items() if k != "signature"}
+    payload = json.dumps(content, sort_keys=True).encode("utf-8")
+    expected = hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        raise ValueError("Bundle signature verification failed: HMAC mismatch.")
+
+
 def _get_uv_path() -> str:
     """
     Get the path to the uv binary.
@@ -124,6 +164,7 @@ class SerializedBundle(TypedDict):
     flow_run: dict[str, Any]
     dependencies: str
     files_key: NotRequired[str | None]
+    signature: NotRequired[str | None]
 
 
 class BundleCreationResult(TypedDict):
@@ -142,47 +183,12 @@ class BundleCreationResult(TypedDict):
 
 
 def _serialize_bundle_object(obj: Any) -> str:
-    """
-    Serializes an object to a string.
-
-    When ``PREFECT_BUNDLE_SIGNING_KEY`` is set, the serialized payload is
-    prepended with an HMAC-SHA256 signature separated by a colon::
-
-        "<hex_signature>:<base64_payload>"
-    """
-    payload = base64.b64encode(gzip.compress(cloudpickle.dumps(obj))).decode()  # pyright: ignore[reportUnknownMemberType]
-    signing_key = _get_bundle_signing_key()
-    if signing_key:
-        sig = hmac.new(
-            signing_key, payload.encode("utf-8"), hashlib.sha256
-        ).hexdigest()
-        return f"{sig}:{payload}"
-    return payload
+    """Serializes an object to a string."""
+    return base64.b64encode(gzip.compress(cloudpickle.dumps(obj))).decode()  # pyright: ignore[reportUnknownMemberType]
 
 
 def _deserialize_bundle_object(serialized_obj: str) -> Any:
-    """
-    Deserializes an object from a string.
-
-    When ``PREFECT_BUNDLE_SIGNING_KEY`` is set, the HMAC-SHA256 signature is
-    verified before deserialization.  Raises ``ValueError`` if the signature
-    is missing or does not match.
-    """
-    signing_key = _get_bundle_signing_key()
-    if signing_key:
-        if ":" not in serialized_obj:
-            raise ValueError(
-                "Bundle signature verification failed: unsigned bundle rejected. "
-                "Set PREFECT_BUNDLE_SIGNING_KEY on both the submitting client and "
-                "the executing worker to the same secret value."
-            )
-        sig, payload = serialized_obj.split(":", 1)
-        expected_sig = hmac.new(
-            signing_key, payload.encode("utf-8"), hashlib.sha256
-        ).hexdigest()
-        if not hmac.compare_digest(sig, expected_sig):
-            raise ValueError("Bundle signature verification failed")
-        serialized_obj = payload
+    """Deserializes an object from a string."""
     return cloudpickle.loads(gzip.decompress(base64.b64decode(serialized_obj)))
 
 
@@ -558,6 +564,7 @@ def create_bundle_for_flow_run(
             "dependencies": dependencies,
             "files_key": files_key,
         }
+        _sign_bundle(bundle)
         return BundleCreationResult(bundle=bundle, zip_path=zip_path)
 
 
@@ -565,6 +572,7 @@ def extract_flow_from_bundle(bundle: SerializedBundle) -> Flow[Any, Any]:
     """
     Extracts a flow from a bundle.
     """
+    _verify_bundle_signature(bundle)
     return _deserialize_bundle_object(bundle["function"])
 
 
@@ -589,6 +597,8 @@ def _extract_and_run_flow(
     os.environ["PREFECT__ENABLE_CANCELLATION_AND_CRASHED_HOOKS"] = "false"
     settings_context = get_settings_context()
     flow_run = FlowRun.model_validate(bundle["flow_run"])
+
+    _verify_bundle_signature(bundle)
 
     # Consume the runner control-channel bootstrap env before deserializing
     # bundled function/context objects, but do not connect yet. The actual
@@ -635,6 +645,8 @@ def execute_bundle_in_subprocess(
 
     ctx = multiprocessing.get_context("spawn")
     env = env or {}
+
+    _verify_bundle_signature(bundle)
 
     # Install dependencies if necessary
     if dependencies := bundle.get("dependencies"):
@@ -913,6 +925,9 @@ async def aupload_bundle_to_storage(
 
 __all__ = [
     "BundleCreationResult",
+    "_get_bundle_signing_key",
+    "_sign_bundle",
+    "_verify_bundle_signature",
     "convert_step_to_command",
     "create_bundle_for_flow_run",
     "execute_bundle_from_file",

--- a/src/prefect/bundles/__init__.py
+++ b/src/prefect/bundles/__init__.py
@@ -4,6 +4,8 @@ import ast
 import asyncio
 import base64
 import gzip
+import hashlib
+import hmac
 import importlib
 import inspect
 import json
@@ -59,6 +61,18 @@ class BundleLauncherOverride(TypedDict, total=False):
 BundleLauncher: TypeAlias = list[str] | BundleLauncherOverride
 
 logger: logging.Logger = get_logger(__name__)
+
+
+def _get_bundle_signing_key() -> bytes:
+    """
+    Return the bundle signing key from the environment.
+
+    When ``PREFECT_BUNDLE_SIGNING_KEY`` is set, bundle serialization will
+    prepend an HMAC-SHA256 signature and deserialization will verify it
+    before calling ``cloudpickle.loads()``.  When unset (the default),
+    signing is disabled and behaviour is unchanged.
+    """
+    return os.environ.get("PREFECT_BUNDLE_SIGNING_KEY", "").encode("utf-8")
 
 
 def _get_uv_path() -> str:
@@ -130,14 +144,45 @@ class BundleCreationResult(TypedDict):
 def _serialize_bundle_object(obj: Any) -> str:
     """
     Serializes an object to a string.
+
+    When ``PREFECT_BUNDLE_SIGNING_KEY`` is set, the serialized payload is
+    prepended with an HMAC-SHA256 signature separated by a colon::
+
+        "<hex_signature>:<base64_payload>"
     """
-    return base64.b64encode(gzip.compress(cloudpickle.dumps(obj))).decode()  # pyright: ignore[reportUnknownMemberType]
+    payload = base64.b64encode(gzip.compress(cloudpickle.dumps(obj))).decode()  # pyright: ignore[reportUnknownMemberType]
+    signing_key = _get_bundle_signing_key()
+    if signing_key:
+        sig = hmac.new(
+            signing_key, payload.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        return f"{sig}:{payload}"
+    return payload
 
 
 def _deserialize_bundle_object(serialized_obj: str) -> Any:
     """
     Deserializes an object from a string.
+
+    When ``PREFECT_BUNDLE_SIGNING_KEY`` is set, the HMAC-SHA256 signature is
+    verified before deserialization.  Raises ``ValueError`` if the signature
+    is missing or does not match.
     """
+    signing_key = _get_bundle_signing_key()
+    if signing_key:
+        if ":" not in serialized_obj:
+            raise ValueError(
+                "Bundle signature verification failed: unsigned bundle rejected. "
+                "Set PREFECT_BUNDLE_SIGNING_KEY on both the submitting client and "
+                "the executing worker to the same secret value."
+            )
+        sig, payload = serialized_obj.split(":", 1)
+        expected_sig = hmac.new(
+            signing_key, payload.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        if not hmac.compare_digest(sig, expected_sig):
+            raise ValueError("Bundle signature verification failed")
+        serialized_obj = payload
     return cloudpickle.loads(gzip.decompress(base64.b64decode(serialized_obj)))
 
 

--- a/tests/_experimental/bundles/test_bundle_signing.py
+++ b/tests/_experimental/bundles/test_bundle_signing.py
@@ -1,0 +1,163 @@
+"""Tests for HMAC-SHA256 bundle signing and verification."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_mod
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from prefect.bundles import (
+    SerializedBundle,
+    _get_bundle_signing_key,
+    _sign_bundle,
+    _verify_bundle_signature,
+    create_bundle_for_flow_run,
+)
+from prefect.flows import flow
+
+
+def _make_unsigned_bundle() -> SerializedBundle:
+    """Create a minimal unsigned bundle for testing."""
+    return {
+        "function": "dW51c2Vk",
+        "context": "dW51c2Vk",
+        "flow_run": {"id": "test-run"},
+        "dependencies": "requests>=2.0",
+    }
+
+
+class TestGetBundleSigningKey:
+    """Tests for _get_bundle_signing_key."""
+
+    def test_returns_empty_bytes_when_unset(self, monkeypatch):
+        monkeypatch.delenv("PREFECT_BUNDLE_SIGNING_KEY", raising=False)
+        assert _get_bundle_signing_key() == b""
+
+    def test_returns_encoded_key_when_set(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "mysecret")
+        assert _get_bundle_signing_key() == b"mysecret"
+
+
+class TestSignBundle:
+    """Tests for _sign_bundle."""
+
+    def test_noop_without_key(self, monkeypatch):
+        monkeypatch.delenv("PREFECT_BUNDLE_SIGNING_KEY", raising=False)
+        bundle = _make_unsigned_bundle()
+        _sign_bundle(bundle)
+        assert "signature" not in bundle
+
+    def test_adds_signature_with_key(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "testsecret")
+        bundle = _make_unsigned_bundle()
+        _sign_bundle(bundle)
+        assert "signature" in bundle
+        assert isinstance(bundle["signature"], str)
+        assert len(bundle["signature"]) == 64  # SHA256 hex digest
+
+    def test_signature_covers_all_fields(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "testsecret")
+        bundle = _make_unsigned_bundle()
+        _sign_bundle(bundle)
+
+        # Manually compute expected signature
+        content = {k: v for k, v in bundle.items() if k != "signature"}
+        payload = json.dumps(content, sort_keys=True).encode("utf-8")
+        expected = hmac_mod.new(b"testsecret", payload, hashlib.sha256).hexdigest()
+        assert bundle["signature"] == expected
+
+    def test_signature_changes_when_dependencies_modified(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "testsecret")
+        bundle1 = _make_unsigned_bundle()
+        _sign_bundle(bundle1)
+
+        bundle2 = _make_unsigned_bundle()
+        bundle2["dependencies"] = "malicious-package"
+        _sign_bundle(bundle2)
+
+        assert bundle1["signature"] != bundle2["signature"]
+
+
+class TestVerifyBundleSignature:
+    """Tests for _verify_bundle_signature."""
+
+    def test_noop_without_key(self, monkeypatch):
+        monkeypatch.delenv("PREFECT_BUNDLE_SIGNING_KEY", raising=False)
+        bundle = _make_unsigned_bundle()
+        _verify_bundle_signature(bundle)  # Should not raise
+
+    def test_rejects_unsigned_bundle_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "testsecret")
+        bundle = _make_unsigned_bundle()
+        with pytest.raises(ValueError, match="unsigned bundle rejected"):
+            _verify_bundle_signature(bundle)
+
+    def test_accepts_correctly_signed_bundle(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "testsecret")
+        bundle = _make_unsigned_bundle()
+        _sign_bundle(bundle)
+        _verify_bundle_signature(bundle)  # Should not raise
+
+    def test_rejects_tampered_bundle(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "testsecret")
+        bundle = _make_unsigned_bundle()
+        _sign_bundle(bundle)
+        bundle["dependencies"] = "malicious-package"
+        with pytest.raises(ValueError, match="HMAC mismatch"):
+            _verify_bundle_signature(bundle)
+
+    def test_rejects_wrong_key(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "key1")
+        bundle = _make_unsigned_bundle()
+        _sign_bundle(bundle)
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "key2")
+        with pytest.raises(ValueError, match="HMAC mismatch"):
+            _verify_bundle_signature(bundle)
+
+
+class TestBundleSigningIntegration:
+    """Integration tests for bundle signing in create_bundle_for_flow_run."""
+
+    def test_create_bundle_adds_signature_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_BUNDLE_SIGNING_KEY", "integration-test-key")
+        import prefect.bundles as bundles_module
+
+        monkeypatch.setattr(
+            bundles_module.subprocess,
+            "check_output",
+            lambda *args, **kwargs: b"prefect>=3.0.0\n",
+        )
+
+        @flow
+        def my_flow():
+            return "hello"
+
+        mock_flow_run = MagicMock()
+        mock_flow_run.model_dump.return_value = {"id": "test-id"}
+
+        result = create_bundle_for_flow_run(my_flow, mock_flow_run)
+        assert "signature" in result["bundle"]
+        assert isinstance(result["bundle"]["signature"], str)
+
+    def test_create_bundle_no_signature_without_key(self, monkeypatch):
+        monkeypatch.delenv("PREFECT_BUNDLE_SIGNING_KEY", raising=False)
+        import prefect.bundles as bundles_module
+
+        monkeypatch.setattr(
+            bundles_module.subprocess,
+            "check_output",
+            lambda *args, **kwargs: b"",
+        )
+
+        @flow
+        def my_flow():
+            return "hello"
+
+        mock_flow_run = MagicMock()
+        mock_flow_run.model_dump.return_value = {"id": "test-id"}
+
+        result = create_bundle_for_flow_run(my_flow, mock_flow_run)
+        assert "signature" not in result["bundle"]


### PR DESCRIPTION
## Summary

Adds opt-in HMAC-SHA256 signing and verification to `_serialize_bundle_object()` and `_deserialize_bundle_object()` via a new `PREFECT_BUNDLE_SIGNING_KEY` environment variable. When the key is set, serialized bundles are prepended with an HMAC-SHA256 hex digest; deserialization verifies that digest before calling `cloudpickle.loads()`. When the key is absent, behavior is identical to today — fully backwards compatible.

## Motivation

This change was suggested by the Prefect security team as a hardening direction for deployments where the worker operator and the bundle author sit in different trust domains. Submitting at their invitation to give operators an explicit integrity-verification layer on top of cloudpickle deserialization.

## Changes

**`src/prefect/bundles/__init__.py`:**

1. **New helper `_get_bundle_signing_key()`** — reads `PREFECT_BUNDLE_SIGNING_KEY` from the environment. Returns empty bytes when unset (signing disabled).

2. **Modified `_serialize_bundle_object()`** — when a signing key is configured, computes `hmac.new(key, payload, sha256).hexdigest()` and prepends it to the payload separated by `:`.

3. **Modified `_deserialize_bundle_object()`** — when a signing key is configured:
   - Rejects unsigned bundles (no `:` separator) with a descriptive error
   - Splits signature from payload
   - Verifies using `hmac.compare_digest()` (timing-safe comparison)
   - Only calls `cloudpickle.loads()` after verification passes

## Backwards Compatibility

Strictly additive:

- `PREFECT_BUNDLE_SIGNING_KEY` is **unset by default** — all existing deployments continue to work without modification
- The wire format change (`<64-char hex sig>:<payload>`) is only introduced when the key is explicitly configured
- No changes to public API surface
- No new dependencies (uses stdlib `hmac` and `hashlib`)

## Testing Plan

- [ ] **No key set (default):** round-trip produces identical output to current behavior; existing tests pass unchanged
- [ ] **Key set, valid round-trip:** serialized bundle deserializes successfully with matching key
- [ ] **Key set, tampered payload:** mutating a single byte raises `ValueError` before `cloudpickle.loads()`
- [ ] **Key set, missing signature:** passing unsigned bundle while key is configured raises `ValueError`
- [ ] **Key mismatch:** signing with key A, verifying with key B raises `ValueError`
- [ ] **Timing safety:** `hmac.compare_digest()` is used (not `==`)

## References

- Python docs: [`hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest)
- Cloudpickle deserialization executes arbitrary code; signature verification ensures the payload originates from a trusted serializer