### PR TITLE
test: flip clear_db marker from opt-out to opt-in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,7 @@ python_functions = ["test_*", "bench_*"]
 markers = [
     "service(arg): a service integration test. For example 'docker'",
     "enable_api_log_handler: by default, sending logs to the API is disabled. Tests marked with this use the handler.",
-    "clear_db: marker to clear the database after test completion",
+    "clear_db: opt-in marker; clears all tables before the test runs. Apply when a test depends on a clean database (counts rows, lists 'all X', or asserts on absence). Run with --no-clear-db to audit whether a marked test still needs it.",
     "windows: tests that specifically test Windows-only behavior",
     "unix: tests that specifically test Unix-only behavior",
 ]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -30,6 +30,30 @@ Shared fixtures live in `fixtures/` (see fixtures/AGENTS.md) and root `conftest.
 
 ## Testing Guidelines
 
+### Database isolation
+
+Tests do not get a clean database by default. If a test depends on the DB starting empty — it counts rows, lists "all X", or asserts on the absence of records — opt in with `@pytest.mark.clear_db`:
+
+```python
+@pytest.mark.clear_db                # per-test
+async def test_count_flows(): ...
+
+class TestFlowAPI:                   # per-class
+    pytestmark = pytest.mark.clear_db
+
+pytestmark = pytest.mark.clear_db    # whole module
+```
+
+Tests that create resources with UUID-randomized names, filter by IDs they own, or only interact with responses they create themselves usually do not need this marker. Skipping the clear yields a 25–100% suite speedup, so prefer not adding it unless required.
+
+To check whether a marked file still needs the marker, run it with `--no-clear-db`:
+
+```bash
+uv run pytest tests/path/to/file.py --no-clear-db -x
+```
+
+If it passes, delete the `pytestmark` (or per-test marker) and commit.
+
 ### Type Hints
 - Full type hints on all test functions and fixtures (Python >=3.12 style: `dict[str, str]`)
 - Return type hints on fixtures, omit `-> None` on test functions

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -19,6 +19,8 @@ from prefect.settings import (
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def interactive_console(monkeypatch: pytest.MonkeyPatch):

--- a/tests/cli/deployment/test_deployment_run.py
+++ b/tests/cli/deployment/test_deployment_run.py
@@ -27,6 +27,8 @@ from prefect.types._datetime import (
 from prefect.types._datetime import now as now_fn
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def deployment_name(

--- a/tests/cli/test_api_command.py
+++ b/tests/cli/test_api_command.py
@@ -14,6 +14,8 @@ from prefect.settings import (
 )
 from prefect.testing.cli import invoke_and_assert
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def account_id() -> UUID:

--- a/tests/cli/test_artifact.py
+++ b/tests/cli/test_artifact.py
@@ -7,6 +7,8 @@ import pytest
 from prefect.server import models, schemas
 from prefect.testing.cli import invoke_and_assert
 
+pytestmark = pytest.mark.clear_db
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -18,6 +18,8 @@ from prefect.settings import (
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 TEST_BLOCK_CODE = """\
 from prefect.blocks.core import Block
 

--- a/tests/cli/test_cyclopts_runner.py
+++ b/tests/cli/test_cyclopts_runner.py
@@ -9,6 +9,8 @@ import sys
 
 import pytest
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def runner():

--- a/tests/cli/test_dashboard.py
+++ b/tests/cli/test_dashboard.py
@@ -9,6 +9,8 @@ from prefect.settings import (
 )
 from prefect.testing.cli import invoke_and_assert
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def mock_webbrowser(monkeypatch: pytest.MonkeyPatch) -> MagicMock:

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -63,6 +63,8 @@ from prefect.types._datetime import parse_datetime
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.filesystem import tmpchdir
 
+pytestmark = pytest.mark.clear_db
+
 if TYPE_CHECKING:
     from prefect.server.schemas.core import BlockDocument
 

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 import watchfiles
 
 import prefect
 import prefect.cli.dev
 from prefect.testing.cli import invoke_and_assert
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -7,6 +7,9 @@ import prefect
 import prefect.cli.dev
 from prefect.testing.cli import invoke_and_assert
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def _setup_ui_build_paths(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
     development_base_path = tmp_path / "repo"

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -12,6 +12,8 @@ from prefect.testing.cli import invoke_and_assert
 from prefect.testing.fixtures import Puppeteer
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def example_event_1() -> Event:

--- a/tests/cli/test_flow.py
+++ b/tests/cli/test_flow.py
@@ -11,6 +11,8 @@ from prefect.runner import Runner
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @flow(retries=2)
 def hello():

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -42,6 +42,8 @@ from prefect.testing.cli import invoke_and_assert
 from prefect.types._datetime import now
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @flow(name="hello")
 def hello_flow():

--- a/tests/cli/test_flow_run_watching.py
+++ b/tests/cli/test_flow_run_watching.py
@@ -14,7 +14,7 @@ from prefect.exceptions import FlowRunWaitTimeout
 from prefect.flow_engine import run_flow_async
 from prefect.states import Completed
 
-pytestmark = pytest.mark.usefixtures("hosted_api_server")
+pytestmark = [pytest.mark.usefixtures("hosted_api_server"), pytest.mark.clear_db]
 
 
 @flow

--- a/tests/cli/test_global_concurrency_limit.py
+++ b/tests/cli/test_global_concurrency_limit.py
@@ -13,6 +13,8 @@ from prefect.server.schemas.core import ConcurrencyLimitV2
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def interactive_console(monkeypatch):

--- a/tests/cli/test_prompts.py
+++ b/tests/cli/test_prompts.py
@@ -13,6 +13,8 @@ from prefect.settings import PREFECT_DEBUG_MODE, temporary_settings
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.filesystem import tmpchdir
 
+pytestmark = pytest.mark.clear_db
+
 TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
 

--- a/tests/cli/test_result_storage_cli.py
+++ b/tests/cli/test_result_storage_cli.py
@@ -6,6 +6,9 @@ from prefect.filesystems import LocalFileSystem
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_result_storage_cli_e2e(
     enable_ephemeral_server,

--- a/tests/cli/test_result_storage_cli.py
+++ b/tests/cli/test_result_storage_cli.py
@@ -1,12 +1,13 @@
 import json
 from uuid import uuid4
 
+import pytest
+
 from prefect.client.orchestration import PrefectClient
 from prefect.filesystems import LocalFileSystem
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/cli/test_sdk.py
+++ b/tests/cli/test_sdk.py
@@ -17,6 +17,9 @@ import prefect._sdk.generator  # noqa: F401
 import prefect.cli.sdk  # noqa: F401
 from prefect.testing.cli import invoke_and_assert
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 _GET_CLIENT_PATCH_TARGET = "prefect.cli.sdk.get_client"
 
 

--- a/tests/cli/test_sdk.py
+++ b/tests/cli/test_sdk.py
@@ -8,6 +8,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import pytest
+
 # Eagerly import modules that are mock.patch targets. Without this, the
 # autouse reset_sys_modules fixture can delete these lazily-imported modules
 # from sys.modules between tests.  mock.patch then resolves its target to a
@@ -17,7 +19,6 @@ import prefect._sdk.generator  # noqa: F401
 import prefect.cli.sdk  # noqa: F401
 from prefect.testing.cli import invoke_and_assert
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 _GET_CLIENT_PATCH_TARGET = "prefect.cli.sdk.get_client"

--- a/tests/cli/test_server_services.py
+++ b/tests/cli/test_server_services.py
@@ -9,6 +9,8 @@ from prefect.settings import PREFECT_HOME
 from prefect.settings.context import temporary_settings
 from prefect.testing.cli import invoke_and_assert
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def enable_all_services():

--- a/tests/cli/test_server_status.py
+++ b/tests/cli/test_server_status.py
@@ -7,6 +7,8 @@ from prefect.settings import PREFECT_API_URL
 from prefect.settings.context import temporary_settings
 from prefect.testing.cli import invoke_and_assert
 
+pytestmark = pytest.mark.clear_db
+
 _SERVER_MOD = "prefect.cli.server"
 
 

--- a/tests/cli/test_shell.py
+++ b/tests/cli/test_shell.py
@@ -1,11 +1,12 @@
 import os
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from prefect.cli.shell import run_shell_process
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/cli/test_shell.py
+++ b/tests/cli/test_shell.py
@@ -5,6 +5,9 @@ from prefect.cli.shell import run_shell_process
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_shell_serve(prefect_client):
     flow_name = "Flood Brothers"

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -38,6 +38,8 @@ from prefect.testing.fixtures import is_port_in_use
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.processutils import open_process
 
+pytestmark = pytest.mark.clear_db
+
 POLL_INTERVAL = 0.5
 STARTUP_TIMEOUT = 30
 SHUTDOWN_TIMEOUT = 20

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -1,10 +1,11 @@
 from unittest import mock
 
+import pytest
+
 from prefect import __development_base_path__
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 TEST_PROJECTS_DIR = __development_base_path__ / "tests" / "test-projects"

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -4,6 +4,9 @@ from prefect import __development_base_path__
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 TEST_PROJECTS_DIR = __development_base_path__ / "tests" / "test-projects"
 
 _TASK_SERVE_PATCH_TARGET = "prefect.cli.task.task_serve"

--- a/tests/cli/test_task_run.py
+++ b/tests/cli/test_task_run.py
@@ -23,6 +23,8 @@ from prefect.testing.cli import invoke_and_assert
 from prefect.types._datetime import now
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 @task(name="hello")
 def hello_task():

--- a/tests/cli/test_transfer.py
+++ b/tests/cli/test_transfer.py
@@ -17,6 +17,8 @@ from prefect.settings import Profile, ProfilesCollection
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 _PATCH_LOAD_PROFILES = "prefect.settings.load_profiles"
 _PATCH_USE_PROFILE = "prefect.context.use_profile"
 _PATCH_GET_CLIENT = "prefect.client.orchestration.get_client"

--- a/tests/cli/test_variable.py
+++ b/tests/cli/test_variable.py
@@ -7,6 +7,8 @@ from prefect.server.models.variables import create_variable
 from prefect.server.schemas.actions import VariableCreate
 from prefect.testing.cli import invoke_and_assert
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def interactive_console(monkeypatch):

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -37,6 +37,8 @@ from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.workers.base import BaseWorker
 from prefect.workers.process import ProcessWorker
 
+pytestmark = pytest.mark.clear_db
+
 MOCK_PREFECT_UI_URL = "https://api.prefect.io"
 
 FAKE_DEFAULT_BASE_JOB_TEMPLATE = {

--- a/tests/cli/test_work_queues.py
+++ b/tests/cli/test_work_queues.py
@@ -8,6 +8,8 @@ from prefect import flow
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 
 async def read_queue(prefect_client, name, pool=None):
     return await prefect_client.read_work_queue_by_name(name=name, work_pool_name=pool)

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -25,7 +25,7 @@ from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.processutils import open_process
 from prefect.workers.base import BaseJobConfiguration, BaseWorker
 
-pytestmark = pytest.mark.usefixtures("asserting_events_worker")
+pytestmark = [pytest.mark.usefixtures("asserting_events_worker"), pytest.mark.clear_db]
 
 
 class MockKubernetesWorker(BaseWorker):

--- a/tests/client/api/test_flow_runs.py
+++ b/tests/client/api/test_flow_runs.py
@@ -7,6 +7,8 @@ from prefect.client.schemas import filters
 from prefect.server import models, schemas
 from prefect.server.schemas import actions
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestReadFlowRuns:
     @pytest.fixture

--- a/tests/client/test_attribution.py
+++ b/tests/client/test_attribution.py
@@ -7,13 +7,13 @@ from unittest import mock
 from uuid import uuid4
 
 import httpx
+import pytest
 from httpx import Request, Response
 
 from prefect._internal.compatibility.starlette import status
 from prefect.client.attribution import get_attribution_headers
 from prefect.client.base import PrefectHttpxAsyncClient, PrefectHttpxSyncClient
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 RESPONSE_200 = Response(

--- a/tests/client/test_attribution.py
+++ b/tests/client/test_attribution.py
@@ -13,6 +13,9 @@ from prefect._internal.compatibility.starlette import status
 from prefect.client.attribution import get_attribution_headers
 from prefect.client.base import PrefectHttpxAsyncClient, PrefectHttpxSyncClient
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 RESPONSE_200 = Response(
     status.HTTP_200_OK,
     request=Request("a test request", "fake.url/fake/route"),

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -31,6 +31,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 now = datetime.now(timezone.utc)
 
 RESPONSE_429_RETRY_AFTER_0 = Response(

--- a/tests/client/test_client_routes.py
+++ b/tests/client/test_client_routes.py
@@ -1,9 +1,10 @@
 from typing import get_args
 
+import pytest
+
 from prefect.client.orchestration.routes import ServerRoutes
 from prefect.server.api.server import create_api_app
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/client/test_client_routes.py
+++ b/tests/client/test_client_routes.py
@@ -3,6 +3,9 @@ from typing import get_args
 from prefect.client.orchestration.routes import ServerRoutes
 from prefect.server.api.server import create_api_app
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def test_server_routes_match_openapi_schema():
     """Test that all ServerRoutes are present in the OpenAPI schema"""

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -12,6 +12,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 mock_work_pool_types_response = {
     "prefect": {
         "prefect-agent": {

--- a/tests/client/test_collections_metadata_client.py
+++ b/tests/client/test_collections_metadata_client.py
@@ -6,6 +6,9 @@ from prefect.client.collections import (
 )
 from prefect.client.orchestration import PrefectClient, ServerType
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestGetCollectionsMetadataClient:
     async def test_returns_cloud_client_when_server_type_is_cloud(self, monkeypatch):

--- a/tests/client/test_collections_metadata_client.py
+++ b/tests/client/test_collections_metadata_client.py
@@ -1,12 +1,13 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from prefect.client.cloud import CloudClient
 from prefect.client.collections import (
     get_collections_metadata_client,
 )
 from prefect.client.orchestration import PrefectClient, ServerType
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/client/test_events_client.py
+++ b/tests/client/test_events_client.py
@@ -5,6 +5,9 @@ import prefect.types._datetime
 from prefect.client.orchestration import get_client
 from prefect.events.filters import EventFilter, EventOccurredFilter
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 if TYPE_CHECKING:
     from prefect.testing.utilities import PrefectTestHarness
 

--- a/tests/client/test_events_client.py
+++ b/tests/client/test_events_client.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+import pytest
+
 import prefect.types._datetime
 from prefect.client.orchestration import get_client
 from prefect.events.filters import EventFilter, EventOccurredFilter
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 if TYPE_CHECKING:

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -102,6 +102,8 @@ from prefect.testing.utilities import exceptions_equal
 from prefect.types._datetime import DateTime, now
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def clear_api_version_check_cache():

--- a/tests/client/test_prefect_client_build.py
+++ b/tests/client/test_prefect_client_build.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 import toml
 
+pytestmark = pytest.mark.clear_db
+
 
 def get_dependencies_from_pyproject(pyproject_path: Path) -> dict[str, str]:
     pyproject_data = toml.load(pyproject_path)

--- a/tests/client/test_state_serialization.py
+++ b/tests/client/test_state_serialization.py
@@ -20,6 +20,8 @@ from pydantic._internal._mock_val_ser import MockValSer
 from prefect.client.schemas.objects import FlowRun, StateDetails, StateType
 from prefect.states import to_state_create
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestStateSerializationWithDeferBuild:
     """

--- a/tests/client/test_subscriptions.py
+++ b/tests/client/test_subscriptions.py
@@ -10,6 +10,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_subscription_uses_websocket_connect_with_ssl_for_wss():
     """Test that Subscription creates a connector with SSL context for wss:// URLs"""

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -6,6 +6,9 @@ from httpx import Response
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency._asyncio import aacquire_concurrency_slots
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_calls_increment_client_method():
     limits = [

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -1,12 +1,12 @@
 import uuid
 from unittest import mock
 
+import pytest
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency._asyncio import aacquire_concurrency_slots
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -21,6 +21,8 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.schemas.core import ConcurrencyLimitV2
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
     executed = False

--- a/tests/concurrency/test_concurrency_slot_acquisition_service.py
+++ b/tests/concurrency/test_concurrency_slot_acquisition_service.py
@@ -7,6 +7,8 @@ from httpx import HTTPStatusError, Request, Response
 from prefect.client.orchestration import get_client
 from prefect.concurrency.services import ConcurrencySlotAcquisitionService
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def mocked_client(test_database_connection_url):

--- a/tests/concurrency/test_concurrency_slot_acquisition_with_lease_service.py
+++ b/tests/concurrency/test_concurrency_slot_acquisition_with_lease_service.py
@@ -18,6 +18,8 @@ from prefect.concurrency.services import (
     _should_use_cache,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 class ClientWrapper:
     """Wrapper to make mocked client work with async context manager."""

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -18,6 +18,8 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.schemas.core import ConcurrencyLimitV2
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
     executed = False

--- a/tests/concurrency/test_context.py
+++ b/tests/concurrency/test_context.py
@@ -11,6 +11,8 @@ from prefect.server.schemas.core import ConcurrencyLimitV2
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.timeout import timeout, timeout_async
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_concurrency_context_releases_slots_async(
     concurrency_limit: ConcurrencyLimitV2, prefect_client: PrefectClient

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -6,6 +6,8 @@ import pytest
 
 from prefect.concurrency._leases import _lease_renewal_loop
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_lease_renewal_loop_renews_lease():
     mock_client = mock.AsyncMock()

--- a/tests/concurrency/test_raise_on_lease_renewal_failure.py
+++ b/tests/concurrency/test_raise_on_lease_renewal_failure.py
@@ -6,6 +6,9 @@ from uuid import uuid4
 
 from prefect.concurrency._sync import concurrency
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 @contextmanager
 def mock_concurrency_internals(*, limits_exist: bool = True):

--- a/tests/concurrency/test_raise_on_lease_renewal_failure.py
+++ b/tests/concurrency/test_raise_on_lease_renewal_failure.py
@@ -4,9 +4,10 @@ from contextlib import contextmanager
 from unittest import mock
 from uuid import uuid4
 
+import pytest
+
 from prefect.concurrency._sync import concurrency
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/concurrency/test_release_concurrency_slots.py
+++ b/tests/concurrency/test_release_concurrency_slots.py
@@ -1,12 +1,12 @@
 import uuid
 from unittest import mock
 
+import pytest
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency._asyncio import arelease_concurrency_slots
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/concurrency/test_release_concurrency_slots.py
+++ b/tests/concurrency/test_release_concurrency_slots.py
@@ -6,6 +6,9 @@ from httpx import Response
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency._asyncio import arelease_concurrency_slots
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_calls_release_client_method():
     limits = [

--- a/tests/concurrency/v1/test_concurrency_asyncio.py
+++ b/tests/concurrency/v1/test_concurrency_asyncio.py
@@ -15,6 +15,8 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.schemas.core import ConcurrencyLimit
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_concurrency_orchestrates_api(v1_concurrency_limit: ConcurrencyLimit):
     executed = False

--- a/tests/concurrency/v1/test_concurrency_limit_acquisition_service.py
+++ b/tests/concurrency/v1/test_concurrency_limit_acquisition_service.py
@@ -8,6 +8,8 @@ from httpx import HTTPStatusError, Request, Response
 from prefect.client.orchestration import get_client
 from prefect.concurrency.v1.services import ConcurrencySlotAcquisitionService
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def mocked_client(test_database_connection_url):

--- a/tests/concurrency/v1/test_concurrency_sync.py
+++ b/tests/concurrency/v1/test_concurrency_sync.py
@@ -17,6 +17,8 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.schemas.core import ConcurrencyLimit
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimit):
     executed = False

--- a/tests/concurrency/v1/test_context.py
+++ b/tests/concurrency/v1/test_context.py
@@ -12,6 +12,8 @@ from prefect.server.schemas.core import ConcurrencyLimit
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.timeout import timeout, timeout_async
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_concurrency_context_releases_slots_async(
     v1_concurrency_limit: ConcurrencyLimit, prefect_client: PrefectClient

--- a/tests/concurrency/v1/test_decrement_concurrency_slots.py
+++ b/tests/concurrency/v1/test_decrement_concurrency_slots.py
@@ -6,6 +6,9 @@ from httpx import Response
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency.v1._asyncio import release_concurrency_slots
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_calls_release_client_method():
     task_run_id = uuid.UUID("00000000-0000-0000-0000-000000000000")

--- a/tests/concurrency/v1/test_decrement_concurrency_slots.py
+++ b/tests/concurrency/v1/test_decrement_concurrency_slots.py
@@ -1,12 +1,12 @@
 import uuid
 from unittest import mock
 
+import pytest
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency.v1._asyncio import release_concurrency_slots
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/concurrency/v1/test_increment_concurrency_limits.py
+++ b/tests/concurrency/v1/test_increment_concurrency_limits.py
@@ -6,6 +6,9 @@ from httpx import Response
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency._asyncio import aacquire_concurrency_slots
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_calls_increment_client_method():
     limits = [

--- a/tests/concurrency/v1/test_increment_concurrency_limits.py
+++ b/tests/concurrency/v1/test_increment_concurrency_limits.py
@@ -1,12 +1,12 @@
 import uuid
 from unittest import mock
 
+import pytest
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.concurrency._asyncio import aacquire_concurrency_slots
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,84 +148,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
 
-
-# The following tests are excluded from the clear_db fixture because they are
-# are safe to run without first clearing the database. Not clearing the database
-# after each run generally results in a 25 to 100% speed up of the test suite, so
-# if you run across tests that don't rely on a clean database, you can add them
-# to this list to speed up the test suite.
-EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = [
-    "tests/utilities",
-    "tests/agent",
-    "tests/test_settings.py",
-    "tests/_internal",
-    "tests/server/orchestration/test_rules.py",
-    "tests/test_flows.py",
-    "tests/server/orchestration/api/ui/test_task_runs.py",
-    "tests/test_transactions.py",
-    "tests/test_types.py",
-    "tests/test_highlighters.py",
-    "tests/test_exceptions.py",
-    "tests/test_schedules.py",
-    "tests/test_plugins.py",
-    "tests/test_serializers.py",
-    "tests/test_cache_policies.py",
-    "tests/test_versioning.py",
-    "tests/custom_types",
-    "tests/test_states.py",
-    # Phase 2 additions
-    "tests/test_filesystems.py",
-    "tests/test_locking.py",
-    "tests/test_flows_compat.py",
-    "tests/logging",
-    "tests/scripts",
-    "tests/_sdk",
-    "tests/_experimental",
-    "tests/docker",
-    "tests/test_observers.py",
-    # Phase 3 additions
-    "tests/test_log_prints.py",
-    "tests/public",
-    "tests/test_task_runs.py",
-    "tests/assets",
-    "tests/test_flow_runs.py",
-    "tests/telemetry",
-    "tests/input",
-    "tests/deployment",
-    "tests/experimental",
-    "tests/results",
-    # Phase 4 - Part 1 (No changes needed)
-    "tests/engine",
-    "tests/client/schemas",
-    "tests/cli/test_config.py",
-    "tests/cli/test_profile.py",
-    "tests/cli/test_version.py",
-    # Phase 4 - Part 2
-    "tests/events/client",
-    "tests/infrastructure/provisioners/test_coiled.py",
-    "tests/infrastructure/provisioners/test_modal.py",
-    "tests/blocks",
-    "tests/test_task_runners.py",
-    "tests/test_variables.py",
-    "tests/test_futures.py",
-    "tests/test_logging.py",
-    # Phase 5 - Top-level test files with UUID-based randomization
-    "tests/test_artifacts.py",
-    "tests/test_assets.py",
-    "tests/test_automations.py",
-    "tests/test_background_tasks.py",
-    "tests/test_context.py",
-    "tests/test_flow_engine.py",
-    "tests/test_infrastructure_bound_flow.py",
-    "tests/test_task_engine.py",
-    "tests/test_task_worker.py",
-    "tests/test_tasks.py",
-    "tests/test_waiters.py",
-    # Phase 5 - CLI subdirectories with UUID-based randomization
-    "tests/cli/cloud/",
-    "tests/cli/deploy/",
-    "tests/cli/transfer/",
-]
+    parser.addoption(
+        "--no-clear-db",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the clear_db fixture even for tests marked @pytest.mark.clear_db. "
+            "Use to audit whether a test still requires a clean database; if it "
+            "passes with this flag, the marker can be removed."
+        ),
+    )
 
 
 def pytest_collection_modifyitems(
@@ -313,14 +245,6 @@ def pytest_collection_modifyitems(
                     pytest.mark.skip(only_running_blurb + " " + requires_blurb)
                 )
         return
-
-    for item in items:
-        # Check if the test file is not in the excluded list
-        if not any(
-            excluded in item.nodeid for excluded in EXCLUDE_FROM_CLEAR_DB_AUTO_MARK
-        ):
-            # Apply the custom mark to clear the database prior to the test
-            item.add_marker(pytest.mark.clear_db)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/events/jinja_filters/test_flow_run_id.py
+++ b/tests/events/jinja_filters/test_flow_run_id.py
@@ -1,5 +1,8 @@
 from prefect.server.events.jinja_filters import flow_run_id
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def test_flow_run_id_extraction():
     url = "https://app.prefect.cloud/account/abc/workspace/xyz/runs/flow-run/12345678-1234-5678-1234-567812345678"

--- a/tests/events/jinja_filters/test_flow_run_id.py
+++ b/tests/events/jinja_filters/test_flow_run_id.py
@@ -1,6 +1,7 @@
+import pytest
+
 from prefect.server.events.jinja_filters import flow_run_id
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/events/jinja_filters/test_ui_url.py
+++ b/tests/events/jinja_filters/test_ui_url.py
@@ -19,6 +19,8 @@ from prefect.server.schemas.responses import FlowRunResponse
 from prefect.settings import PREFECT_UI_URL, temporary_settings
 from prefect.types._datetime import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 template_environment = jinja2.Environment()
 template_environment.filters["ui_url"] = ui_url
 

--- a/tests/events/server/actions/test_actions_service.py
+++ b/tests/events/server/actions/test_actions_service.py
@@ -18,6 +18,8 @@ from prefect.server.utilities.messaging.memory import MemoryMessage
 from prefect.types import DateTime
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def message_handler(act: mock.AsyncMock) -> AsyncGenerator[MessageHandler, None]:

--- a/tests/events/server/actions/test_calling_webhook.py
+++ b/tests/events/server/actions/test_calling_webhook.py
@@ -39,6 +39,8 @@ from prefect.server.schemas.core import Deployment, Flow, FlowRun, WorkQueue
 from prefect.types import DateTime
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def snap_a_pic(

--- a/tests/events/server/actions/test_cancelling_flow_run.py
+++ b/tests/events/server/actions/test_cancelling_flow_run.py
@@ -20,6 +20,8 @@ from prefect.server.schemas.core import Deployment, Flow, FlowRun
 from prefect.server.schemas.states import Running, StateType
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def take_a_picture(

--- a/tests/events/server/actions/test_changing_flow_run_state.py
+++ b/tests/events/server/actions/test_changing_flow_run_state.py
@@ -20,6 +20,8 @@ from prefect.server.schemas.core import Deployment, Flow, FlowRun
 from prefect.server.schemas.states import Failed, Running, StateType
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def take_a_picture(

--- a/tests/events/server/actions/test_doing_nothing.py
+++ b/tests/events/server/actions/test_doing_nothing.py
@@ -3,6 +3,8 @@ import pytest
 from prefect.server.events import actions
 from prefect.server.events.schemas.automations import TriggeredAction
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_doing_nothing(
     caplog: pytest.LogCaptureFixture,

--- a/tests/events/server/actions/test_infinite_loops.py
+++ b/tests/events/server/actions/test_infinite_loops.py
@@ -14,6 +14,8 @@ from prefect.server.events.schemas.automations import (
     Posture,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_running_inferred_deployment_on_all_flow_run_state_changes():
     """It's never okay to run an inferred deployment from all flow run state changes."""

--- a/tests/events/server/actions/test_jinja_templated_action.py
+++ b/tests/events/server/actions/test_jinja_templated_action.py
@@ -49,6 +49,8 @@ from prefect.settings import PREFECT_UI_URL, temporary_settings
 from prefect.types import DateTime
 from prefect.types._datetime import now as now_fn
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def ui_url() -> Generator[str, None, None]:

--- a/tests/events/server/actions/test_pausing_resuming_automation.py
+++ b/tests/events/server/actions/test_pausing_resuming_automation.py
@@ -27,6 +27,8 @@ from prefect.types import DateTime
 from prefect.types._datetime import now
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def enable_automations():

--- a/tests/events/server/actions/test_pausing_resuming_deployment.py
+++ b/tests/events/server/actions/test_pausing_resuming_deployment.py
@@ -25,6 +25,8 @@ from prefect.types import DateTime
 from prefect.types._datetime import now
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_source_determines_if_deployment_id_is_required_or_allowed():
     with pytest.raises(ValidationError):

--- a/tests/events/server/actions/test_pausing_resuming_work_pool.py
+++ b/tests/events/server/actions/test_pausing_resuming_work_pool.py
@@ -23,6 +23,8 @@ from prefect.server.schemas.actions import WorkPoolCreate
 from prefect.types import DateTime
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 if TYPE_CHECKING:
     from prefect.server.database.orm_models import ORMWorkPool
 

--- a/tests/events/server/actions/test_pausing_resuming_work_queue.py
+++ b/tests/events/server/actions/test_pausing_resuming_work_queue.py
@@ -24,6 +24,8 @@ from prefect.types import DateTime
 from prefect.types._datetime import now
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_source_determines_if_work_queue_id_is_required_or_allowed():
     with pytest.raises(ValidationError):

--- a/tests/events/server/actions/test_resuming_flow_run.py
+++ b/tests/events/server/actions/test_resuming_flow_run.py
@@ -20,6 +20,8 @@ from prefect.server.schemas.core import Deployment, Flow, FlowRun
 from prefect.server.schemas.states import Paused, Running, StateType
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def paused_flow_run(session: AsyncSession) -> FlowRun:

--- a/tests/events/server/actions/test_running_deployment.py
+++ b/tests/events/server/actions/test_running_deployment.py
@@ -22,6 +22,8 @@ from prefect.server.schemas.actions import VariableCreate, WorkPoolCreate
 from prefect.server.schemas.core import CreatedBy, Deployment, Flow
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_action_can_omit_parameters():
     """Regression test for https://github.com/PrefectHQ/nebula/issues/2857, where

--- a/tests/events/server/actions/test_sending_notification.py
+++ b/tests/events/server/actions/test_sending_notification.py
@@ -25,6 +25,8 @@ from prefect.server.events.schemas.events import (
 )
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def TestNotificationBlock(

--- a/tests/events/server/actions/test_suspending_flow_run.py
+++ b/tests/events/server/actions/test_suspending_flow_run.py
@@ -20,6 +20,8 @@ from prefect.server.schemas.core import Deployment, Flow, FlowRun
 from prefect.server.schemas.states import Running, StateType
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def take_a_picture(session: AsyncSession) -> Deployment:

--- a/tests/events/server/gateway/test_gateway_in.py
+++ b/tests/events/server/gateway/test_gateway_in.py
@@ -14,6 +14,8 @@ from prefect.server.events.storage import database
 from prefect.settings import PREFECT_SERVER_API_AUTH_STRING, temporary_settings
 from prefect.types._datetime import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def publish(monkeypatch: pytest.MonkeyPatch) -> mock.AsyncMock:

--- a/tests/events/server/gateway/test_gateway_out.py
+++ b/tests/events/server/gateway/test_gateway_out.py
@@ -21,6 +21,8 @@ from prefect.server.events.storage import database
 from prefect.settings import PREFECT_SERVER_API_AUTH_STRING, temporary_settings
 from prefect.types._datetime import DateTime, now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def stream_mock(

--- a/tests/events/server/models/test_automation_notifications.py
+++ b/tests/events/server/models/test_automation_notifications.py
@@ -22,6 +22,8 @@ from prefect.server.events.triggers import listen_for_automation_changes
 from prefect.server.utilities.database import get_dialect
 from prefect.settings import PREFECT_API_SERVICES_TRIGGERS_ENABLED, temporary_settings
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def sample_automation() -> Automation:

--- a/tests/events/server/models/test_automations.py
+++ b/tests/events/server/models/test_automations.py
@@ -22,6 +22,8 @@ from prefect.server.events.schemas.automations import (
 from prefect.server.events.schemas.events import ResourceSpecification
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_reading_automations_by_workspace_empty(
     automations_session: AsyncSession,

--- a/tests/events/server/models/test_composite_trigger_child_firing.py
+++ b/tests/events/server/models/test_composite_trigger_child_firing.py
@@ -25,6 +25,8 @@ from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.triggers import load_automation
 from prefect.types import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def raise_the_alarm(automations_session: AsyncSession) -> Automation:

--- a/tests/events/server/schemas/test_automations.py
+++ b/tests/events/server/schemas/test_automations.py
@@ -10,6 +10,8 @@ from prefect.server.events.schemas.automations import (
     Posture,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_compound_trigger_requires_too_small():
     with pytest.raises(ValueError, match="require must be at least 1"):

--- a/tests/events/server/storage/test_database.py
+++ b/tests/events/server/storage/test_database.py
@@ -24,6 +24,8 @@ from prefect.server.events.storage.database import (
 )
 from prefect.types._datetime import DateTime, now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def event() -> ReceivedEvent:

--- a/tests/events/server/storage/test_event_persister.py
+++ b/tests/events/server/storage/test_event_persister.py
@@ -23,6 +23,8 @@ from prefect.server.utilities.messaging import CapturedMessage, Message, Message
 from prefect.types import DateTime
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @db_injector
 async def get_event(db: PrefectDBInterface, id: UUID) -> Optional[ReceivedEvent]:

--- a/tests/events/server/test_automations_api.py
+++ b/tests/events/server/test_automations_api.py
@@ -42,6 +42,8 @@ from prefect.types import DateTime
 from prefect.types._datetime import now as now_fn
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def enable_automations():

--- a/tests/events/server/test_clients.py
+++ b/tests/events/server/test_clients.py
@@ -14,6 +14,8 @@ from prefect.server.events.schemas.events import Event, ReceivedEvent, RelatedRe
 from prefect.server.utilities.messaging import CapturingPublisher
 from prefect.types import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def example_event(start_of_test: DateTime) -> Event:

--- a/tests/events/server/test_db_ordering.py
+++ b/tests/events/server/test_db_ordering.py
@@ -13,7 +13,7 @@ from prefect.server.events.ordering.db import CausalOrdering
 from prefect.server.events.schemas.events import ReceivedEvent, Resource
 from prefect.types._datetime import DateTime
 
-pytestmark = pytest.mark.usefixtures("cleared_automations")
+pytestmark = [pytest.mark.usefixtures("cleared_automations"), pytest.mark.clear_db]
 
 
 @pytest.fixture

--- a/tests/events/server/test_events_api.py
+++ b/tests/events/server/test_events_api.py
@@ -26,6 +26,8 @@ from prefect.server.events.storage import INTERACTIVE_PAGE_SIZE, InvalidTokenErr
 from prefect.types import DateTime
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def filter(frozen_time: DateTime) -> EventFilter:

--- a/tests/events/server/test_events_counts.py
+++ b/tests/events/server/test_events_counts.py
@@ -21,6 +21,8 @@ from prefect.server.events.storage.database import (
 )
 from prefect.types._datetime import Date, DateTime, Duration, end_of_period, now
 
+pytestmark = pytest.mark.clear_db
+
 # Note: the counts in this module are sensitive to the number and shape of events
 # we produce in conftest.py and may need to be adjusted if we make changes.
 

--- a/tests/events/server/test_events_queries.py
+++ b/tests/events/server/test_events_queries.py
@@ -28,6 +28,8 @@ from prefect.server.events.storage.database import (
 )
 from prefect.types._datetime import Date, now, start_of_day
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(scope="module")
 def known_dates() -> tuple[Date, ...]:

--- a/tests/events/server/test_events_schema.py
+++ b/tests/events/server/test_events_schema.py
@@ -15,6 +15,8 @@ from prefect.server.events.schemas.events import (
 from prefect.types import DateTime
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_client_events_do_not_have_defaults_for_the_fields_it_seems_they_should():
     """While it seems tempting to include a default for `occurred` or `id`, these

--- a/tests/events/server/test_in_memory_ordering.py
+++ b/tests/events/server/test_in_memory_ordering.py
@@ -17,6 +17,8 @@ from prefect.server.events.ordering.memory import CausalOrdering, EventBeingProc
 from prefect.server.events.schemas.events import ReceivedEvent, Resource
 from prefect.types._datetime import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def resource() -> Resource:

--- a/tests/events/server/test_messaging.py
+++ b/tests/events/server/test_messaging.py
@@ -13,6 +13,8 @@ from prefect.types._datetime import now
 
 from .conftest import assert_message_represents_event
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def event1() -> ReceivedEvent:

--- a/tests/events/server/test_resource_schema.py
+++ b/tests/events/server/test_resource_schema.py
@@ -19,6 +19,8 @@ from prefect.settings import (
 )
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_resource_openapi_schema() -> None:
     assert Resource.model_json_schema() == {

--- a/tests/events/server/test_stream.py
+++ b/tests/events/server/test_stream.py
@@ -14,6 +14,8 @@ from prefect.server.events.filters import (
 from prefect.server.events.schemas.events import Event, ReceivedEvent, Resource
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 async def anext_event(
     subscription: AsyncIterator[ReceivedEvent | None],

--- a/tests/events/server/triggers/test_basics.py
+++ b/tests/events/server/triggers/test_basics.py
@@ -23,6 +23,8 @@ from prefect.server.events.schemas.events import (
 from prefect.settings import PREFECT_EVENTS_EXPIRED_BUCKET_BUFFER
 from prefect.types import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_triggers_have_identifiers(arachnophobia: Automation):
     assert arachnophobia.id

--- a/tests/events/server/triggers/test_composite_triggers.py
+++ b/tests/events/server/triggers/test_composite_triggers.py
@@ -24,6 +24,8 @@ from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.types import DateTime
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def flow_run_events(

--- a/tests/events/server/triggers/test_flow_run_slas.py
+++ b/tests/events/server/triggers/test_flow_run_slas.py
@@ -19,6 +19,8 @@ from prefect.server.events.schemas.automations import (
 from prefect.server.events.schemas.events import Event, ReceivedEvent
 from prefect.types import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def stuck_flow_runs_sla(

--- a/tests/events/server/triggers/test_regressions.py
+++ b/tests/events/server/triggers/test_regressions.py
@@ -23,6 +23,8 @@ from prefect.server.schemas.actions import WorkQueueCreate
 from prefect.server.schemas.core import WorkQueue
 from prefect.types._datetime import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def act(monkeypatch: pytest.MonkeyPatch) -> mock.AsyncMock:

--- a/tests/events/server/triggers/test_service.py
+++ b/tests/events/server/triggers/test_service.py
@@ -25,6 +25,8 @@ from prefect.server.utilities.messaging.memory import MemoryMessage
 from prefect.types import DateTime
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_acting_publishes_an_action_message_from_a_reactive_event(
     frozen_time: DateTime,

--- a/tests/events/server/triggers/test_service_changes.py
+++ b/tests/events/server/triggers/test_service_changes.py
@@ -17,6 +17,8 @@ from prefect.server.events.schemas.automations import (
 )
 from prefect.settings import PREFECT_API_SERVICES_TRIGGERS_ENABLED, temporary_settings
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def enable_triggers():

--- a/tests/events/test_events_text_search.py
+++ b/tests/events/test_events_text_search.py
@@ -16,6 +16,8 @@ from prefect.server.events.filters import (
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.storage.database import query_events, write_events
 
+pytestmark = pytest.mark.clear_db
+
 # Define function types for our test variations
 QueryEventsFn = Callable[..., Awaitable[tuple[list[Event], int, Optional[str]]]]
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -96,9 +96,7 @@ async def clear_db(db, request):
     connection errors.
     """
 
-    if "clear_db" in request.keywords and not request.config.getoption(
-        "--no-clear-db"
-    ):
+    if "clear_db" in request.keywords and not request.config.getoption("--no-clear-db"):
         max_retries = 3
         retry_delay = 1
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -96,7 +96,9 @@ async def clear_db(db, request):
     connection errors.
     """
 
-    if "clear_db" in request.keywords:
+    if "clear_db" in request.keywords and not request.config.getoption(
+        "--no-clear-db"
+    ):
         max_retries = 3
         retry_delay = 1
 

--- a/tests/infrastructure/provisioners/test_cloud_run.py
+++ b/tests/infrastructure/provisioners/test_cloud_run.py
@@ -17,6 +17,8 @@ from prefect.settings import (
 )
 from prefect.types import SecretDict
 
+pytestmark = pytest.mark.clear_db
+
 default_cloud_run_push_base_job_template = {
     "job_configuration": {
         "command": "{{ command }}",

--- a/tests/infrastructure/provisioners/test_cloud_run_v2.py
+++ b/tests/infrastructure/provisioners/test_cloud_run_v2.py
@@ -17,6 +17,8 @@ from prefect.settings import (
 )
 from prefect.types import SecretDict
 
+pytestmark = pytest.mark.clear_db
+
 default_cloud_run_v2_push_base_job_template = {
     "job_configuration": {
         "command": "{{ command }}",

--- a/tests/infrastructure/provisioners/test_container_instance.py
+++ b/tests/infrastructure/provisioners/test_container_instance.py
@@ -13,6 +13,8 @@ from prefect.infrastructure.provisioners.container_instance import (
 )
 from prefect.types import SecretDict
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def existing_credentials_block(prefect_client: PrefectClient):

--- a/tests/infrastructure/provisioners/test_ecs.py
+++ b/tests/infrastructure/provisioners/test_ecs.py
@@ -23,6 +23,8 @@ from prefect.infrastructure.provisioners.ecs import (
     VpcResource,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def start_mocking_aws(monkeypatch):

--- a/tests/locking/test_filelock.py
+++ b/tests/locking/test_filelock.py
@@ -14,6 +14,8 @@ from prefect.locking._filelock import (
     _write_lock,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestIsPidAlive:
     def test_current_process_is_alive(self):

--- a/tests/plugins/test_compat.py
+++ b/tests/plugins/test_compat.py
@@ -16,6 +16,8 @@ import pytest
 
 import prefect.plugins as new_module
 
+pytestmark = pytest.mark.clear_db
+
 PUBLIC_NAMES = (
     "run_startup_hooks",
     "HookContext",

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -39,6 +39,8 @@ from prefect.settings import (
 )
 from prefect.settings.legacy import Settings, _get_settings_fields
 
+pytestmark = pytest.mark.clear_db
+
 
 def mock_entry_points(entry_points_list):
     """

--- a/tests/runner/test__cancellation_manager.py
+++ b/tests/runner/test__cancellation_manager.py
@@ -8,6 +8,8 @@ import pytest
 from prefect.client.schemas.objects import StateType
 from prefect.runner._cancellation_manager import CancellationManager
 
+pytestmark = pytest.mark.clear_db
+
 
 def _make_flow_run(*, has_state: bool = True) -> MagicMock:
     flow_run = MagicMock()

--- a/tests/runner/test__control_channel.py
+++ b/tests/runner/test__control_channel.py
@@ -10,6 +10,8 @@ import pytest
 
 from prefect.runner._control_channel import ControlChannel
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def channel():

--- a/tests/runner/test__deployment_registry.py
+++ b/tests/runner/test__deployment_registry.py
@@ -7,6 +7,9 @@ from cachetools import LRUCache
 
 from prefect.runner._deployment_registry import DeploymentRegistry
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestDeploymentRegistryIDs:
     def test_register_deployment_adds_to_set(self):

--- a/tests/runner/test__deployment_registry.py
+++ b/tests/runner/test__deployment_registry.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
 from cachetools import LRUCache
 
 from prefect.runner._deployment_registry import DeploymentRegistry
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/runner/test__event_emitter.py
+++ b/tests/runner/test__event_emitter.py
@@ -12,6 +12,8 @@ from prefect.client.schemas.responses import DeploymentResponse
 from prefect.events.clients import AssertingEventsClient, NullEventsClient
 from prefect.runner._event_emitter import EventEmitter
 
+pytestmark = pytest.mark.clear_db
+
 
 def _make_flow_run(
     deployment_id=None,

--- a/tests/runner/test__flow_resolver.py
+++ b/tests/runner/test__flow_resolver.py
@@ -9,6 +9,8 @@ from httpx import HTTPStatusError, Request, Response
 
 from prefect.runner._flow_resolver import FlowResolver
 
+pytestmark = pytest.mark.clear_db
+
 
 def _make_flow_run(deployment_id=None):
     flow_run = MagicMock()

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -13,6 +13,8 @@ from prefect._internal.infrastructure_exit_codes import get_infrastructure_exit_
 from prefect.runner._flow_run_executor import FlowRunExecutor, ProcessStarter
 from prefect.runner._process_manager import ProcessHandle
 
+pytestmark = pytest.mark.clear_db
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/runner/test__hook_runner.py
+++ b/tests/runner/test__hook_runner.py
@@ -4,11 +4,12 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import pytest
+
 from prefect import flows as flows_mod
 from prefect.flows import load_flow_from_flow_run
 from prefect.runner._hook_runner import HookRunner, _run_hooks
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/runner/test__hook_runner.py
+++ b/tests/runner/test__hook_runner.py
@@ -8,6 +8,9 @@ from prefect import flows as flows_mod
 from prefect.flows import load_flow_from_flow_run
 from prefect.runner._hook_runner import HookRunner, _run_hooks
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def _make_flow_run():
     flow_run = MagicMock()

--- a/tests/runner/test__limit_manager.py
+++ b/tests/runner/test__limit_manager.py
@@ -5,6 +5,8 @@ import pytest
 
 from prefect.runner._limit_manager import LimitManager
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestLimitManagerNoLimit:
     """Tests for limit=None behavior (sentinel path)."""

--- a/tests/runner/test__process_manager.py
+++ b/tests/runner/test__process_manager.py
@@ -10,6 +10,8 @@ import pytest
 
 from prefect.runner._process_manager import ProcessHandle, ProcessManager, _pid_is_alive
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestProcessHandle:
     def test_pid_from_anyio_process(self):

--- a/tests/runner/test__scheduled_run_poller.py
+++ b/tests/runner/test__scheduled_run_poller.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import anyio
+import pytest
 
 from prefect.runner._scheduled_run_poller import ScheduledRunPoller, StarterResolver
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 # ---------------------------------------------------------------------------

--- a/tests/runner/test__scheduled_run_poller.py
+++ b/tests/runner/test__scheduled_run_poller.py
@@ -8,6 +8,9 @@ import anyio
 
 from prefect.runner._scheduled_run_poller import ScheduledRunPoller, StarterResolver
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/runner/test__starter_bundle.py
+++ b/tests/runner/test__starter_bundle.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from prefect.runner._process_manager import ProcessHandle
 from prefect.runner._starter_bundle import BundleExecutionStarter
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/runner/test__starter_bundle.py
+++ b/tests/runner/test__starter_bundle.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock, patch
 from prefect.runner._process_manager import ProcessHandle
 from prefect.runner._starter_bundle import BundleExecutionStarter
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestBundleExecutionStarter:
     async def test_start_calls_execute_bundle_in_subprocess(self):

--- a/tests/runner/test__starter_direct.py
+++ b/tests/runner/test__starter_direct.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch
 from prefect.runner._process_manager import ProcessHandle
 from prefect.runner._starter_direct import DirectSubprocessStarter
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestDirectSubprocessStarter:
     async def test_start_calls_run_flow_in_subprocess(self):

--- a/tests/runner/test__starter_direct.py
+++ b/tests/runner/test__starter_direct.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from prefect.runner._process_manager import ProcessHandle
 from prefect.runner._starter_direct import DirectSubprocessStarter
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/runner/test__starter_engine.py
+++ b/tests/runner/test__starter_engine.py
@@ -10,6 +10,8 @@ from prefect.runner._process_manager import ProcessHandle
 from prefect.runner._starter_engine import EngineCommandStarter
 from prefect.utilities.processutils import command_to_string
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestEngineCommandStarter:
     async def test_start_calls_run_process_with_default_command(self):

--- a/tests/runner/test__state_proposer.py
+++ b/tests/runner/test__state_proposer.py
@@ -9,6 +9,8 @@ from prefect.exceptions import Abort, ObjectNotFound
 from prefect.runner._state_proposer import StateProposer
 from prefect.states import AwaitingRetry, Crashed, Pending, Running, Submitting
 
+pytestmark = pytest.mark.clear_db
+
 
 def _make_flow_run() -> MagicMock:
     flow_run = MagicMock()

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -17,6 +17,8 @@ from prefect.runner.storage import BlockStorageAdapter, RemoteStorage
 from prefect.settings import get_current_settings
 from prefect.utilities.filesystem import tmpchdir
 
+pytestmark = pytest.mark.clear_db
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CUSTOM_STEP_FQN = "tests.utilities.workspace_resolver_steps"
 

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -24,6 +24,8 @@ from prefect.runner._workspace_starter import (
 from prefect.utilities.filesystem import tmpchdir
 from prefect.utilities.processutils import command_from_string
 
+pytestmark = pytest.mark.clear_db
+
 
 def _prepared_workspace(tmp_path: Path) -> PreparedWorkspace:
     workspace_root = tmp_path / "workspace"

--- a/tests/runner/test_control_channel_e2e.py
+++ b/tests/runner/test_control_channel_e2e.py
@@ -30,6 +30,8 @@ import pytest
 
 from prefect.runner._control_channel import ControlChannel
 
+pytestmark = pytest.mark.clear_db
+
 CHILD_PROGRAM = textwrap.dedent(
     """
     import os

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -76,6 +76,8 @@ from prefect.utilities.filesystem import tmpchdir
 from prefect.utilities.processutils import command_to_string
 from prefect.utilities.slugify import slugify
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def suppress_deprecation_warnings() -> Generator[None, None, None]:

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -28,6 +28,8 @@ from prefect.runner.storage import (
 )
 from prefect.utilities.filesystem import tmpchdir
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def tmp_cwd(monkeypatch, tmp_path):

--- a/tests/runtime/test_deployment.py
+++ b/tests/runtime/test_deployment.py
@@ -4,6 +4,8 @@ from prefect import flow
 from prefect.flow_engine import run_flow_async
 from prefect.runtime import deployment
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def deployment_id(flow, prefect_client):

--- a/tests/runtime/test_flow_run.py
+++ b/tests/runtime/test_flow_run.py
@@ -14,6 +14,8 @@ from prefect.runtime import flow_run
 from prefect.settings import PREFECT_API_URL, PREFECT_UI_URL
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestAttributeAccessPatterns:
     async def test_access_unknown_attribute_fails(self):

--- a/tests/runtime/test_task_run.py
+++ b/tests/runtime/test_task_run.py
@@ -8,6 +8,8 @@ from prefect.runtime import task_run
 from prefect.settings import PREFECT_API_URL, PREFECT_UI_URL
 from prefect.tasks import Task
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestAttributeAccessPatterns:
     async def test_access_unknown_attribute_fails(self):

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -14,6 +14,9 @@ from prefect.server.models.block_registration import (
     register_block_type,
 )
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def create_server_block_document(
     session: AsyncSession,

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import httpx
+import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
@@ -14,7 +15,6 @@ from prefect.server.models.block_registration import (
     register_block_type,
 )
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/api/test_clients.py
+++ b/tests/server/api/test_clients.py
@@ -30,6 +30,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 if TYPE_CHECKING:
     from prefect.server.database.orm_models import ORMDeployment, ORMVariable
 

--- a/tests/server/api/test_csrf_token.py
+++ b/tests/server/api/test_csrf_token.py
@@ -9,6 +9,8 @@ from prefect.server import models, schemas
 from prefect.server.database import PrefectDBInterface
 from prefect.settings import PREFECT_SERVER_CSRF_PROTECTION_ENABLED, temporary_settings
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def enable_csrf_protection():

--- a/tests/server/api/test_dependencies.py
+++ b/tests/server/api/test_dependencies.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 
 from prefect.server.api.dependencies import get_prefect_client_version
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.mark.parametrize(
     "header,expected",

--- a/tests/server/api/test_docket_task_keys.py
+++ b/tests/server/api/test_docket_task_keys.py
@@ -25,6 +25,8 @@ from prefect.server import models, schemas
 from prefect.server.schemas.statuses import DeploymentStatus
 from prefect.settings import get_current_settings
 
+pytestmark = pytest.mark.clear_db
+
 
 @asynccontextmanager
 async def docket_without_worker_lifespan(

--- a/tests/server/api/test_flow_run_logs_download.py
+++ b/tests/server/api/test_flow_run_logs_download.py
@@ -5,6 +5,8 @@ import pytest
 from prefect._internal.compatibility.starlette import status
 from prefect.server import models, schemas
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.mark.parametrize("flow_run_name", ["🚀-production-logs", "simple-logs"])
 async def test_download_flow_run_logs_encoding_and_bom(

--- a/tests/server/api/test_logs.py
+++ b/tests/server/api/test_logs.py
@@ -20,6 +20,8 @@ from prefect.server.schemas.core import Log
 from prefect.server.schemas.filters import LogFilter
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 NOW = now("UTC")
 CREATE_LOGS_URL = "/logs/"
 READ_LOGS_URL = "/logs/filter"

--- a/tests/server/api/test_logs_text_search.py
+++ b/tests/server/api/test_logs_text_search.py
@@ -18,6 +18,8 @@ from prefect.server.schemas.filters import (
 )
 from prefect.server.schemas.sorting import LogSort
 
+pytestmark = pytest.mark.clear_db
+
 # Define function types for our test variations
 QueryLogsFn = Callable[..., Awaitable[list[Log]]]
 

--- a/tests/server/api/test_logs_websocket.py
+++ b/tests/server/api/test_logs_websocket.py
@@ -16,6 +16,8 @@ from prefect.server.schemas.filters import LogFilter, LogFilterLevel
 from prefect.settings import PREFECT_SERVER_API_AUTH_STRING, temporary_settings
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def stream_mock(

--- a/tests/server/api/test_middleware.py
+++ b/tests/server/api/test_middleware.py
@@ -15,6 +15,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 app = FastAPI()
 app.add_middleware(CsrfMiddleware)
 

--- a/tests/server/api/test_pagination.py
+++ b/tests/server/api/test_pagination.py
@@ -5,6 +5,8 @@ from httpx import ASGITransport, AsyncClient
 from prefect._internal.compatibility.starlette import status
 from prefect.server.api.dependencies import LimitBody
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def app():

--- a/tests/server/api/test_root.py
+++ b/tests/server/api/test_root.py
@@ -2,6 +2,9 @@ from unittest.mock import AsyncMock
 
 from starlette import status
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_hello_world(client):
     response = await client.get("/hello")

--- a/tests/server/api/test_root.py
+++ b/tests/server/api/test_root.py
@@ -1,8 +1,8 @@
 from unittest.mock import AsyncMock
 
+import pytest
 from starlette import status
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/api/test_saved_searches.py
+++ b/tests/server/api/test_saved_searches.py
@@ -7,6 +7,8 @@ from prefect.server import models, schemas
 from prefect.server.schemas.actions import SavedSearchCreate
 from prefect.types._datetime import now, parse_datetime
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateSavedSearch:
     async def test_create_saved_search(

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -49,6 +49,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_validation_error_handler_422(client):
     bad_flow_data = {"name": "my-flow", "tags": "this should be a list not a string"}

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -12,6 +12,8 @@ from prefect.server.concurrency.lease_storage.filesystem import (
 )
 from prefect.types._concurrency import ConcurrencyLeaseHolder
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestFilesystemConcurrencyLeaseStorage:
     @pytest.fixture

--- a/tests/server/concurrency/test_memory_lease_storage.py
+++ b/tests/server/concurrency/test_memory_lease_storage.py
@@ -10,6 +10,8 @@ from prefect.server.concurrency.lease_storage.memory import (
 from prefect.server.utilities.leasing import ResourceLease
 from prefect.types._concurrency import ConcurrencyLeaseHolder
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestMemoryConcurrencyLeaseStorage:
     def test_singleton_pattern(self):

--- a/tests/server/database/test_alembic_commands.py
+++ b/tests/server/database/test_alembic_commands.py
@@ -11,6 +11,8 @@ from prefect.server.database.alembic_commands import (
 )
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+pytestmark = pytest.mark.clear_db
+
 # These tests do not test the actual migration functionality, only that the commands are wrapped and called
 
 

--- a/tests/server/database/test_dependencies.py
+++ b/tests/server/database/test_dependencies.py
@@ -24,6 +24,8 @@ from prefect.server.database.query_components import (
 from prefect.server.schemas.graph import Graph
 from prefect.types._datetime import DateTime
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.mark.parametrize(
     "ConnectionConfig",

--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -22,7 +22,7 @@ from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL
 from prefect.types._datetime import now
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
-pytestmark = pytest.mark.service("database")
+pytestmark = [pytest.mark.service("database"), pytest.mark.clear_db]
 
 
 @pytest.fixture

--- a/tests/server/database/test_queries.py
+++ b/tests/server/database/test_queries.py
@@ -7,6 +7,8 @@ from prefect.server import models, schemas
 from prefect.server.database import PrefectDBInterface
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestGetRunsInQueueQuery:
     @pytest.fixture

--- a/tests/server/logs/test_messaging.py
+++ b/tests/server/logs/test_messaging.py
@@ -14,6 +14,8 @@ from prefect.settings import (
 )
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def sample_log():

--- a/tests/server/logs/test_settings.py
+++ b/tests/server/logs/test_settings.py
@@ -1,6 +1,7 @@
+import pytest
+
 from prefect.settings.models.server.logs import ServerLogsSettings
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/logs/test_settings.py
+++ b/tests/server/logs/test_settings.py
@@ -1,5 +1,8 @@
 from prefect.settings.models.server.logs import ServerLogsSettings
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def test_logs_settings_defaults():
     """Test that logs settings have correct defaults"""

--- a/tests/server/logs/test_stream.py
+++ b/tests/server/logs/test_stream.py
@@ -27,6 +27,8 @@ from prefect.server.schemas.filters import (
 from prefect.settings import PREFECT_SERVER_LOGS_STREAM_OUT_ENABLED, temporary_settings
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def sample_log1():

--- a/tests/server/models/deprecated/test_work_queues.py
+++ b/tests/server/models/deprecated/test_work_queues.py
@@ -13,6 +13,8 @@ from prefect.server.utilities.database import get_dialect
 from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def work_queue(session):

--- a/tests/server/models/test_artifacts.py
+++ b/tests/server/models/test_artifacts.py
@@ -5,6 +5,8 @@ import pytest
 from prefect.server import models, schemas
 from prefect.server.schemas import actions
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def artifact(session):

--- a/tests/server/models/test_block_documents.py
+++ b/tests/server/models/test_block_documents.py
@@ -13,6 +13,8 @@ from prefect.server.schemas.actions import BlockDocumentCreate
 from prefect.types import SecretDict
 from prefect.utilities.names import obfuscate, obfuscate_string
 
+pytestmark = pytest.mark.clear_db
+
 
 def long_string(s: str):
     return string.ascii_letters + s

--- a/tests/server/models/test_block_registration.py
+++ b/tests/server/models/test_block_registration.py
@@ -13,6 +13,8 @@ from prefect.server.models.block_types import read_block_type_by_slug, read_bloc
 from prefect.settings import PREFECT_API_BLOCKS_REGISTER_ON_START, temporary_settings
 from prefect.utilities.dispatch import get_registry_for_type
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(scope="module")
 async def expected_number_of_registered_block_types():

--- a/tests/server/models/test_block_schemas.py
+++ b/tests/server/models/test_block_schemas.py
@@ -22,6 +22,8 @@ from prefect.server.schemas.core import BlockSchema
 from prefect.server.schemas.filters import BlockSchemaFilter
 from prefect.utilities.collections import AutoEnum
 
+pytestmark = pytest.mark.clear_db
+
 EMPTY_OBJECT_CHECKSUM = Block._calculate_schema_checksum({})
 
 

--- a/tests/server/models/test_block_types.py
+++ b/tests/server/models/test_block_types.py
@@ -8,6 +8,8 @@ from prefect.blocks.core import Block
 from prefect.server import models, schemas
 from prefect.server.schemas.filters import BlockSchemaFilter, BlockTypeFilter
 
+pytestmark = pytest.mark.clear_db
+
 CODE_EXAMPLE = dedent(
     """\
         ```python

--- a/tests/server/models/test_concurrency_limits.py
+++ b/tests/server/models/test_concurrency_limits.py
@@ -3,6 +3,9 @@ from uuid import uuid4
 
 from prefect.server import models, schemas
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreatingConcurrencyLimits:
     async def test_creating_concurrency_limits(self, session):

--- a/tests/server/models/test_concurrency_limits.py
+++ b/tests/server/models/test_concurrency_limits.py
@@ -1,9 +1,10 @@
 import time
 from uuid import uuid4
 
+import pytest
+
 from prefect.server import models, schemas
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -29,6 +29,8 @@ from prefect.server.schemas.actions import (
 )
 from prefect.server.schemas.core import ConcurrencyLimitV2
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def concurrency_limit(session: AsyncSession) -> ConcurrencyLimitV2:

--- a/tests/server/models/test_configuration.py
+++ b/tests/server/models/test_configuration.py
@@ -1,6 +1,7 @@
+import pytest
+
 from prefect.server import models, schemas
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/models/test_configuration.py
+++ b/tests/server/models/test_configuration.py
@@ -1,5 +1,8 @@
 from prefect.server import models, schemas
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_write_and_read_new_configuration(session):
     new_config = schemas.core.Configuration(key="foo", value={"foo": "bar"})

--- a/tests/server/models/test_csrf_token.py
+++ b/tests/server/models/test_csrf_token.py
@@ -10,6 +10,8 @@ from prefect.server import models
 from prefect.server.database import orm_models
 from prefect.server.schemas import core
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def csrf_token(session: AsyncSession) -> core.CsrfToken:

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -17,6 +17,8 @@ from prefect.server.schemas.statuses import DeploymentStatus
 from prefect.settings import PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS
 from prefect.types._datetime import now, start_of_day
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateDeployment:
     async def test_create_deployment_succeeds(self, session, flow):

--- a/tests/server/models/test_filters.py
+++ b/tests/server/models/test_filters.py
@@ -12,6 +12,8 @@ from prefect.server import models
 from prefect.server.schemas import actions, core, filters, schedules, states
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True, scope="module")
 async def clear_db(db):

--- a/tests/server/models/test_flow_run_input.py
+++ b/tests/server/models/test_flow_run_input.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.server.schemas as schemas
 from prefect.server import models
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateFlowRunInput:
     async def test_creates_flow_run_input(self, session: AsyncSession, flow_run):

--- a/tests/server/models/test_flow_run_states.py
+++ b/tests/server/models/test_flow_run_states.py
@@ -22,6 +22,8 @@ from prefect.server.orchestration.rules import (
 from prefect.server.schemas.states import Failed, Pending, Running, Scheduled, StateType
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestSetFlowRunState:
     async def test_throws_object_not_found_error_if_bad_id(self, session):

--- a/tests/server/models/test_flow_runs.py
+++ b/tests/server/models/test_flow_runs.py
@@ -12,6 +12,8 @@ from prefect.server.schemas.core import TaskRunResult
 from prefect.types import KeyValueLabels
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateFlowRun:
     async def test_create_flow_run(self, flow, session):

--- a/tests/server/models/test_flows.py
+++ b/tests/server/models/test_flows.py
@@ -4,6 +4,8 @@ import pytest
 
 from prefect.server import models, schemas
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateFlow:
     async def test_create_flow_succeeds(self, session):

--- a/tests/server/models/test_logs.py
+++ b/tests/server/models/test_logs.py
@@ -16,6 +16,8 @@ from prefect.server.schemas.filters import (
 from prefect.server.schemas.sorting import LogSort
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 NOW = now("UTC")
 
 

--- a/tests/server/models/test_orm.py
+++ b/tests/server/models/test_orm.py
@@ -8,6 +8,8 @@ import sqlalchemy as sa
 from prefect.server import models, schemas
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def many_flow_run_states(flow, session, db):

--- a/tests/server/models/test_saved_searches.py
+++ b/tests/server/models/test_saved_searches.py
@@ -4,6 +4,8 @@ import pytest
 
 from prefect.server import models, schemas
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateSavedSearch:
     async def test_create_saved_search_succeeds(self, session):

--- a/tests/server/models/test_storage_defaults.py
+++ b/tests/server/models/test_storage_defaults.py
@@ -8,6 +8,9 @@ from prefect.server.models.storage_defaults import (
     SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
 )
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 async def test_write_read_and_clear_server_default_result_storage(session):
     block_document_id = uuid4()

--- a/tests/server/models/test_storage_defaults.py
+++ b/tests/server/models/test_storage_defaults.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import pytest
 import sqlalchemy as sa
 
 from prefect.server import models, schemas
@@ -8,7 +9,6 @@ from prefect.server.models.storage_defaults import (
     SERVER_DEFAULT_RESULT_STORAGE_CONFIGURATION_KEY,
 )
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/models/test_task_run_states.py
+++ b/tests/server/models/test_task_run_states.py
@@ -20,6 +20,8 @@ from prefect.server.orchestration.rules import (
 from prefect.server.schemas.states import Failed, Running, Scheduled, StateType
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateTaskRunState:
     async def test_create_task_run_state_succeeds(self, task_run, session):

--- a/tests/server/models/test_task_runs.py
+++ b/tests/server/models/test_task_runs.py
@@ -11,6 +11,8 @@ from prefect.server.schemas.core import TaskRunResult
 from prefect.server.schemas.states import Failed, Pending, Running, Scheduled
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateTaskRun:
     async def test_create_task_run_succeeds(self, flow_run, session):

--- a/tests/server/models/test_task_workers.py
+++ b/tests/server/models/test_task_workers.py
@@ -2,6 +2,8 @@ import pytest
 
 from prefect.server.models.task_workers import InMemoryTaskWorkerTracker
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def tracker():

--- a/tests/server/models/test_variables.py
+++ b/tests/server/models/test_variables.py
@@ -24,6 +24,8 @@ from prefect.server.schemas.filters import (
 from prefect.server.schemas.sorting import VariableSort
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def variable(

--- a/tests/server/models/test_work_queues.py
+++ b/tests/server/models/test_work_queues.py
@@ -9,6 +9,8 @@ from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def work_queue(session):

--- a/tests/server/models/test_workers.py
+++ b/tests/server/models/test_workers.py
@@ -9,6 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect.server import models, schemas
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateWorkPool:
     async def test_create_work_pool(self, session: AsyncSession):

--- a/tests/server/orchestration/api/test_artifacts.py
+++ b/tests/server/orchestration/api/test_artifacts.py
@@ -11,6 +11,8 @@ from prefect.server.schemas import actions
 from prefect.types._datetime import now
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def artifact(flow_run, task_run, client):

--- a/tests/server/orchestration/api/test_block_capabilites.py
+++ b/tests/server/orchestration/api/test_block_capabilites.py
@@ -4,6 +4,8 @@ from starlette import status
 from prefect.blocks.core import Block
 from prefect.server import models
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def block_schemas(session):

--- a/tests/server/orchestration/api/test_block_documents.py
+++ b/tests/server/orchestration/api/test_block_documents.py
@@ -14,6 +14,8 @@ from prefect.types import SecretDict
 from prefect.utilities.names import obfuscate_string
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 def long_string(s: str):
     return string.ascii_letters + s

--- a/tests/server/orchestration/api/test_block_schemas.py
+++ b/tests/server/orchestration/api/test_block_schemas.py
@@ -10,6 +10,8 @@ from prefect.server.schemas.actions import BlockSchemaCreate
 from prefect.server.schemas.core import DEFAULT_BLOCK_SCHEMA_VERSION
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 EMPTY_OBJECT_CHECKSUM = Block._calculate_schema_checksum({})
 
 

--- a/tests/server/orchestration/api/test_block_types.py
+++ b/tests/server/orchestration/api/test_block_types.py
@@ -14,6 +14,8 @@ from prefect.server.schemas.core import BlockDocument, BlockType
 from prefect.utilities.pydantic import parse_obj_as
 from prefect.utilities.slugify import slugify
 
+pytestmark = pytest.mark.clear_db
+
 CODE_EXAMPLE = dedent(
     """\
         ```python

--- a/tests/server/orchestration/api/test_bulk_operations.py
+++ b/tests/server/orchestration/api/test_bulk_operations.py
@@ -19,6 +19,9 @@ from starlette import status
 from prefect._internal.testing import retry_asserts
 from prefect.server import models, schemas
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestFlowRunBulkDelete:
     """Tests for POST /flow_runs/bulk_delete endpoint."""

--- a/tests/server/orchestration/api/test_bulk_operations.py
+++ b/tests/server/orchestration/api/test_bulk_operations.py
@@ -14,12 +14,12 @@ These tests cover:
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+import pytest
 from starlette import status
 
 from prefect._internal.testing import retry_asserts
 from prefect.server import models, schemas
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/orchestration/api/test_collections.py
+++ b/tests/server/orchestration/api/test_collections.py
@@ -2,6 +2,8 @@ import pytest
 import respx
 from httpx import Response
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestReadCollectionViews:
     def collection_view_url(self, view):

--- a/tests/server/orchestration/api/test_concurrency_limits.py
+++ b/tests/server/orchestration/api/test_concurrency_limits.py
@@ -10,6 +10,8 @@ from prefect.server.api.concurrency_limits_v2 import MinimalConcurrencyLimitResp
 from prefect.server.schemas.actions import ConcurrencyLimitCreate
 from prefect.settings import PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestConcurrencyLimits:
     async def test_creating_concurrency_limits(self, session, client):

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -31,6 +31,8 @@ from prefect.settings import (
 )
 from prefect.settings.context import temporary_settings
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def use_filesystem_lease_storage():

--- a/tests/server/orchestration/api/test_deployment_schedules.py
+++ b/tests/server/orchestration/api/test_deployment_schedules.py
@@ -12,6 +12,8 @@ from prefect.server.database import PrefectDBInterface
 from prefect.types._datetime import now
 from tests.server import AsyncSessionGetter
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def schedules_url():

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -23,6 +23,8 @@ from prefect.types._datetime import now as now_fn
 from prefect.types._datetime import parse_datetime
 from prefect.utilities.callables import parameter_schema
 
+pytestmark = pytest.mark.clear_db
+
 
 def assert_status_events(deployment_name: str, events: List[str]):
     deployment_specific_events = [

--- a/tests/server/orchestration/api/test_flow_run_graph_v2.py
+++ b/tests/server/orchestration/api/test_flow_run_graph_v2.py
@@ -25,6 +25,8 @@ from prefect.settings import (
 )
 from prefect.types._datetime import DateTime, earliest_possible_datetime, now
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_reading_graph_for_nonexistant_flow_run(
     session: AsyncSession,

--- a/tests/server/orchestration/api/test_flow_run_states.py
+++ b/tests/server/orchestration/api/test_flow_run_states.py
@@ -4,6 +4,9 @@ from starlette import status
 
 from prefect.server import models, schemas
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestReadFlowRunStateById:
     async def test_read_flow_run_state(self, flow_run, client, session):

--- a/tests/server/orchestration/api/test_flow_run_states.py
+++ b/tests/server/orchestration/api/test_flow_run_states.py
@@ -1,10 +1,10 @@
 from uuid import uuid4
 
+import pytest
 from starlette import status
 
 from prefect.server import models, schemas
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/orchestration/api/test_flow_runs.py
+++ b/tests/server/orchestration/api/test_flow_runs.py
@@ -44,6 +44,8 @@ from prefect.states import (
 from prefect.types._datetime import now
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateFlowRun:
     async def test_create_flow_run(self, flow, client, session):

--- a/tests/server/orchestration/api/test_flows.py
+++ b/tests/server/orchestration/api/test_flows.py
@@ -8,6 +8,8 @@ from prefect.server import models, schemas
 from prefect.types._datetime import now, parse_datetime
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateFlow:
     async def test_create_flow(self, session, client):

--- a/tests/server/orchestration/api/test_infra_overrides.py
+++ b/tests/server/orchestration/api/test_infra_overrides.py
@@ -7,6 +7,8 @@ from prefect.blocks.core import Block
 from prefect.server import models, schemas
 from prefect.server.models import deployments
 
+pytestmark = pytest.mark.clear_db
+
 
 class MockKubernetesClusterConfig(Block):
     context_name: str

--- a/tests/server/orchestration/api/test_run_history.py
+++ b/tests/server/orchestration/api/test_run_history.py
@@ -12,6 +12,8 @@ from prefect.server import models
 from prefect.server.schemas import actions, core, responses, states
 from prefect.server.schemas.states import StateType
 
+pytestmark = pytest.mark.clear_db
+
 
 def datetime_range(
     start: datetime, end: datetime, interval: timedelta

--- a/tests/server/orchestration/api/test_task_run_states.py
+++ b/tests/server/orchestration/api/test_task_run_states.py
@@ -4,6 +4,9 @@ from starlette import status
 
 from prefect.server import models, schemas
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestReadTaskRunStateById:
     async def test_read_task_run_state(self, task_run, client, session):

--- a/tests/server/orchestration/api/test_task_run_states.py
+++ b/tests/server/orchestration/api/test_task_run_states.py
@@ -1,10 +1,10 @@
 from uuid import uuid4
 
+import pytest
 from starlette import status
 
 from prefect.server import models, schemas
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/orchestration/api/test_task_run_subscriptions.py
+++ b/tests/server/orchestration/api/test_task_run_subscriptions.py
@@ -18,6 +18,8 @@ from prefect.server.api import task_runs
 from prefect.server.schemas import states as server_states
 from prefect.server.schemas.core import TaskRun as ServerTaskRun
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def reset_task_queues() -> Generator[None, None, None]:

--- a/tests/server/orchestration/api/test_task_runs.py
+++ b/tests/server/orchestration/api/test_task_runs.py
@@ -18,6 +18,8 @@ from prefect.server.schemas.responses import OrchestrationResult
 from prefect.states import Pending
 from prefect.types._datetime import now as now_fn
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestCreateTaskRun:
     async def test_create_task_run(self, flow_run, client, session):

--- a/tests/server/orchestration/api/test_task_workers.py
+++ b/tests/server/orchestration/api/test_task_workers.py
@@ -2,6 +2,8 @@ import pytest
 
 from prefect.server.models.task_workers import observe_worker
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.mark.parametrize(
     "initial_workers,certain_tasks,expected_count",

--- a/tests/server/orchestration/api/test_validation.py
+++ b/tests/server/orchestration/api/test_validation.py
@@ -18,6 +18,8 @@ from prefect.server.schemas.actions import (
     DeploymentUpdate,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def deployment_with_work_queue(

--- a/tests/server/orchestration/api/test_variables.py
+++ b/tests/server/orchestration/api/test_variables.py
@@ -17,6 +17,8 @@ from prefect.server.schemas.filters import (
 from prefect.types import MAX_VARIABLE_NAME_LENGTH, MAX_VARIABLE_VALUE_LENGTH
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def variable(

--- a/tests/server/orchestration/api/test_work_queues.py
+++ b/tests/server/orchestration/api/test_work_queues.py
@@ -14,6 +14,8 @@ from prefect.server.schemas.actions import WorkQueueCreate, WorkQueueUpdate
 from prefect.server.schemas.statuses import WorkQueueStatus
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def patch_events_client(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/orchestration/api/test_workers.py
+++ b/tests/server/orchestration/api/test_workers.py
@@ -19,6 +19,8 @@ from prefect.server.schemas.core import WorkPoolStorageConfiguration
 from prefect.server.schemas.statuses import DeploymentStatus, WorkQueueStatus
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 RESERVED_POOL_NAMES = [
     "Prefect",
     "Prefect Pool",

--- a/tests/server/orchestration/api/ui/test_flow_runs.py
+++ b/tests/server/orchestration/api/ui/test_flow_runs.py
@@ -9,6 +9,8 @@ from prefect.server.database import orm_models
 from prefect.server.schemas import actions, states
 from prefect.utilities.pydantic import parse_obj_as
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def flow_runs(flow, session):

--- a/tests/server/orchestration/api/ui/test_flows.py
+++ b/tests/server/orchestration/api/ui/test_flows.py
@@ -7,6 +7,8 @@ from prefect.server.api.ui.flows import SimpleNextFlowRun
 from prefect.server.database import orm_models
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def flow_1(session):

--- a/tests/server/orchestration/api/ui/test_schemas.py
+++ b/tests/server/orchestration/api/ui/test_schemas.py
@@ -1,6 +1,6 @@
+import pytest
 from httpx import AsyncClient
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/orchestration/api/ui/test_schemas.py
+++ b/tests/server/orchestration/api/ui/test_schemas.py
@@ -1,5 +1,8 @@
 from httpx import AsyncClient
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestUISchemasValidate:
     async def test_empty_schema_and_values(

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -68,6 +68,8 @@ from prefect.settings import (
 )
 from prefect.types._datetime import DateTime, now, parse_datetime
 
+pytestmark = pytest.mark.clear_db
+
 # Convert constants from sets to lists for deterministic ordering of tests
 ALL_ORCHESTRATION_STATES = list(
     sorted(ALL_ORCHESTRATION_STATES, key=lambda item: str(item))

--- a/tests/server/orchestration/test_flow_run_instrumentation_policies.py
+++ b/tests/server/orchestration/test_flow_run_instrumentation_policies.py
@@ -45,6 +45,8 @@ from prefect.server.schemas.states import (
 from prefect.states import Cancelled, to_state_create
 from prefect.types._datetime import DateTime, now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def cleared_resource_data_cache():

--- a/tests/server/orchestration/test_global_policy.py
+++ b/tests/server/orchestration/test_global_policy.py
@@ -22,6 +22,8 @@ from prefect.server.orchestration.rules import TERMINAL_STATES
 from prefect.server.schemas import core, states
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 # Convert constants from sets to lists for deterministic ordering of tests
 TERMINAL_STATES = list(sorted(TERMINAL_STATES))
 

--- a/tests/server/orchestration/test_policies.py
+++ b/tests/server/orchestration/test_policies.py
@@ -5,6 +5,9 @@ from prefect.server.orchestration.rules import (
 )
 from prefect.server.schemas import states
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestPoliciesRespectOrdering:
     def test_policies_return_rules_in_priority_order(self):

--- a/tests/server/orchestration/test_policies.py
+++ b/tests/server/orchestration/test_policies.py
@@ -1,3 +1,5 @@
+import pytest
+
 from prefect.server.orchestration.policies import BaseOrchestrationPolicy
 from prefect.server.orchestration.rules import (
     ALL_ORCHESTRATION_STATES,
@@ -5,7 +7,6 @@ from prefect.server.orchestration.rules import (
 )
 from prefect.server.schemas import states
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/orchestration/test_task_concurrency_v2_integration.py
+++ b/tests/server/orchestration/test_task_concurrency_v2_integration.py
@@ -26,6 +26,8 @@ from prefect.server.orchestration.rules import (
 from prefect.server.schemas import actions, core, states
 from prefect.server.schemas.responses import SetStateStatus
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestSecureTaskConcurrencySlotsV2Integration:
     """Test SecureTaskConcurrencySlots with V2 Global Concurrency Limits."""

--- a/tests/server/orchestration/test_validate_deployment_concurrency_at_running.py
+++ b/tests/server/orchestration/test_validate_deployment_concurrency_at_running.py
@@ -6,6 +6,7 @@ import contextlib
 import datetime
 from uuid import UUID, uuid4
 
+import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.models as models
@@ -24,7 +25,6 @@ from prefect.server.schemas import states
 from prefect.server.schemas.core import ConcurrencyLimitStrategy
 from prefect.server.schemas.responses import SetStateStatus
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/orchestration/test_validate_deployment_concurrency_at_running.py
+++ b/tests/server/orchestration/test_validate_deployment_concurrency_at_running.py
@@ -24,6 +24,9 @@ from prefect.server.schemas import states
 from prefect.server.schemas.core import ConcurrencyLimitStrategy
 from prefect.server.schemas.responses import SetStateStatus
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestValidateDeploymentConcurrencyAtRunning:
     """Tests for ValidateDeploymentConcurrencyAtRunning orchestration rule."""

--- a/tests/server/schemas/test_actions.py
+++ b/tests/server/schemas/test_actions.py
@@ -21,6 +21,8 @@ from prefect.server.schemas.schedules import (
 )
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.mark.parametrize(
     "test_params,expected_dict",

--- a/tests/server/schemas/test_core.py
+++ b/tests/server/schemas/test_core.py
@@ -9,6 +9,8 @@ from prefect.server.utilities.schemas import PrefectBaseModel
 from prefect.settings import PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH, temporary_settings
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.mark.parametrize(
     "name",

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import pytest
 import sqlalchemy as sa
 
 from prefect.server.schemas.filters import (
@@ -10,7 +11,6 @@ from prefect.server.schemas.filters import (
 )
 from prefect.types._datetime import now
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 NOW = now("UTC")

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -10,6 +10,9 @@ from prefect.server.schemas.filters import (
 )
 from prefect.types._datetime import now
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 NOW = now("UTC")
 
 

--- a/tests/server/schemas/test_schedules.py
+++ b/tests/server/schemas/test_schedules.py
@@ -18,6 +18,8 @@ from prefect.server.schemas.schedules import (
 )
 from prefect.types._datetime import now, parse_datetime
 
+pytestmark = pytest.mark.clear_db
+
 dt = datetime(2020, 1, 1, tzinfo=ZoneInfo("UTC"))
 RRDaily = "FREQ=DAILY"
 

--- a/tests/server/schemas/test_states.py
+++ b/tests/server/schemas/test_states.py
@@ -20,6 +20,8 @@ from prefect.server.schemas.states import (
     Submitting,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestState:
     def test_state_takes_name_from_type(self):

--- a/tests/server/services/test_cancellation_cleanup.py
+++ b/tests/server/services/test_cancellation_cleanup.py
@@ -15,6 +15,8 @@ from prefect.server.services.cancellation_cleanup import (
 )
 from prefect.types._datetime import Duration, now
 
+pytestmark = pytest.mark.clear_db
+
 NON_TERMINAL_STATE_CONSTRUCTORS: dict[states.StateType, Any] = {
     states.StateType.SCHEDULED: states.Scheduled,
     states.StateType.PENDING: states.Pending,

--- a/tests/server/services/test_db_vacuum.py
+++ b/tests/server/services/test_db_vacuum.py
@@ -25,6 +25,8 @@ from prefect.server.services.db_vacuum import (
 from prefect.settings.context import get_current_settings
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture(autouse=True)
 def enable_db_vacuum(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/services/test_foreman.py
+++ b/tests/server/services/test_foreman.py
@@ -18,6 +18,8 @@ from prefect.settings import (
 )
 from prefect.settings.context import get_current_settings
 
+pytestmark = pytest.mark.clear_db
+
 if TYPE_CHECKING:
     from prefect.server.database.orm_models import (
         ORMDeployment,

--- a/tests/server/services/test_late_runs.py
+++ b/tests/server/services/test_late_runs.py
@@ -8,6 +8,8 @@ import pytest
 from prefect.server import models, schemas
 from prefect.server.services.late_runs import mark_flow_run_late
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def late_run(session, flow):

--- a/tests/server/services/test_pause_expirations.py
+++ b/tests/server/services/test_pause_expirations.py
@@ -7,6 +7,8 @@ import pytest
 from prefect.server import models, schemas
 from prefect.server.services.pause_expirations import fail_expired_pause
 
+pytestmark = pytest.mark.clear_db
+
 THE_PAST = datetime.now(timezone.utc) - timedelta(hours=5)
 THE_FUTURE = datetime.now(timezone.utc) + timedelta(days=5)
 

--- a/tests/server/services/test_perpetual_services.py
+++ b/tests/server/services/test_perpetual_services.py
@@ -1,12 +1,13 @@
 """Tests for the perpetual services registry and scheduling."""
 
+import pytest
+
 from prefect.server.services.perpetual_services import (
     _PERPETUAL_SERVICES,
     get_enabled_perpetual_services,
     get_perpetual_services,
 )
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/services/test_perpetual_services.py
+++ b/tests/server/services/test_perpetual_services.py
@@ -6,6 +6,9 @@ from prefect.server.services.perpetual_services import (
     get_perpetual_services,
 )
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def test_db_vacuum_service_registered():
     """Test that db vacuum perpetual service is registered."""

--- a/tests/server/services/test_repossessor.py
+++ b/tests/server/services/test_repossessor.py
@@ -21,6 +21,8 @@ from prefect.server.services.repossessor import (
     revoke_expired_lease,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestRevokeExpiredLease:
     @pytest.fixture

--- a/tests/server/services/test_scheduler.py
+++ b/tests/server/services/test_scheduler.py
@@ -24,6 +24,8 @@ from prefect.settings.context import get_current_settings
 from prefect.types._datetime import now
 from prefect.utilities.callables import parameter_schema
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 async def deployment_without_schedules(flow: schemas.core.Flow, session: AsyncSession):

--- a/tests/server/services/test_service_subsets.py
+++ b/tests/server/services/test_service_subsets.py
@@ -7,6 +7,9 @@ from prefect.server.logs.stream import LogDistributor
 from prefect.server.services.base import RunInEphemeralServers, RunInWebservers, Service
 from prefect.server.services.task_run_recorder import TaskRunRecorder
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 def test_the_all_service_subset():
     """The following services should be enabled on background servers or full-featured

--- a/tests/server/services/test_service_subsets.py
+++ b/tests/server/services/test_service_subsets.py
@@ -1,3 +1,5 @@
+import pytest
+
 from prefect.server.events.services.actions import Actions
 from prefect.server.events.services.event_logger import EventLogger
 from prefect.server.events.services.event_persister import EventPersister
@@ -7,7 +9,6 @@ from prefect.server.logs.stream import LogDistributor
 from prefect.server.services.base import RunInEphemeralServers, RunInWebservers, Service
 from prefect.server.services.task_run_recorder import TaskRunRecorder
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -25,6 +25,8 @@ from prefect.server.utilities.messaging import MessageHandler, create_publisher
 from prefect.server.utilities.messaging.memory import MemoryMessage
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 async def test_start_and_stop_service():
     service = task_run_recorder.TaskRunRecorder()

--- a/tests/server/services/test_telemetry.py
+++ b/tests/server/services/test_telemetry.py
@@ -11,6 +11,8 @@ from prefect.server.services.telemetry import (
     send_telemetry_heartbeat,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def sens_o_matic_mock():

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -15,6 +15,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_app_generates_correct_api_openapi_schema():
     """

--- a/tests/server/utilities/test_connection_leak_warnings.py
+++ b/tests/server/utilities/test_connection_leak_warnings.py
@@ -13,10 +13,13 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("TEST_CONNECTION_LEAK"),
-    reason="Skipping connection leak tests",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("TEST_CONNECTION_LEAK"),
+        reason="Skipping connection leak tests",
+    ),
+    pytest.mark.clear_db,
+]
 
 
 async def test_direct_connection_leak(database_engine: AsyncEngine):

--- a/tests/server/utilities/test_database.py
+++ b/tests/server/utilities/test_database.py
@@ -24,6 +24,8 @@ from prefect.server.utilities.database import (
     bindparams_from_clause,
 )
 
+pytestmark = pytest.mark.clear_db
+
 DBBase = declarative_base(type_annotation_map={datetime.datetime: Timestamp})
 
 

--- a/tests/server/utilities/test_messaging.py
+++ b/tests/server/utilities/test_messaging.py
@@ -42,6 +42,8 @@ from prefect.settings import (
     temporary_settings,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 @pytest.fixture
 def busted_cache_module():

--- a/tests/server/utilities/test_postgres_listener.py
+++ b/tests/server/utilities/test_postgres_listener.py
@@ -13,6 +13,8 @@ from prefect.server.utilities.postgres_listener import (
 )
 from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL, temporary_settings
 
+pytestmark = pytest.mark.clear_db
+
 
 def _parse_asyncpg_dsn(dsn: str) -> tuple[list[Any], Any]:
     addrs, params, _config = connect_utils._parse_connect_arguments(

--- a/tests/server/utilities/test_schemas.py
+++ b/tests/server/utilities/test_schemas.py
@@ -16,6 +16,8 @@ from prefect.server.utilities.schemas import (
 )
 from prefect.types._datetime import now
 
+pytestmark = pytest.mark.clear_db
+
 
 @contextmanager
 def reload_prefect_base_model(

--- a/tests/server/utilities/test_server.py
+++ b/tests/server/utilities/test_server.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 
 from prefect.server.utilities.server import PrefectRouter
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestParsing:
     @pytest.fixture

--- a/tests/server/utilities/test_text_search_parser.py
+++ b/tests/server/utilities/test_text_search_parser.py
@@ -16,6 +16,8 @@ from prefect.server.utilities.text_search_parser import (
     parse_text_search_query,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestBasicParsing:
     """Test basic query parsing functionality"""

--- a/tests/server/utilities/test_user_templates.py
+++ b/tests/server/utilities/test_user_templates.py
@@ -11,6 +11,8 @@ from prefect.server.utilities.user_templates import (
     render_user_template_sync,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 class NestedTemplateModel(BaseModel):
     when: datetime

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -14,6 +14,8 @@ import pytest
 
 from prefect.types._datetime import end_of_period, in_local_tz, now, start_of_day
 
+pytestmark = pytest.mark.clear_db
+
 # Saturday 2024-06-15 14:30:45 America/New_York (UTC-4, i.e. EDT)
 FIXED = datetime.datetime(2024, 6, 15, 14, 30, 45, tzinfo=ZoneInfo("America/New_York"))
 EDT = datetime.timedelta(hours=-4)

--- a/tests/test_subprocess_logging.py
+++ b/tests/test_subprocess_logging.py
@@ -10,6 +10,8 @@ from prefect.context import with_context
 from prefect.exceptions import MissingContextError
 from prefect.logging import get_run_logger
 
+pytestmark = pytest.mark.clear_db
+
 # ---------------------------------------------------------------------------
 # Helper functions executed in child processes
 # ---------------------------------------------------------------------------

--- a/tests/test_ui_build_validation.py
+++ b/tests/test_ui_build_validation.py
@@ -10,6 +10,8 @@ from hatch_build import (
     validate_packaged_ui_index_files,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 def test_validate_packaged_ui_index_files_passes_when_both_indexes_exist(
     tmp_path: pathlib.Path,

--- a/tests/testing/test_fixtures.py
+++ b/tests/testing/test_fixtures.py
@@ -10,6 +10,8 @@ import pytest
 
 from prefect.testing import fixtures
 
+pytestmark = pytest.mark.clear_db
+
 
 class TestHostedApiServerWindowsProcessHandling:
     """Tests for Windows-specific process handling in hosted_api_server fixture."""

--- a/tests/testing/test_utilites.py
+++ b/tests/testing/test_utilites.py
@@ -16,6 +16,8 @@ from prefect.settings import (
 )
 from prefect.testing.utilities import assert_does_not_warn, prefect_test_harness
 
+pytestmark = pytest.mark.clear_db
+
 
 def _multiprocessing_worker():
     """

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -105,7 +105,7 @@ from prefect.workers.base import (
     BaseWorkerResult,
 )
 
-pytestmark = pytest.mark.usefixtures("asserting_events_worker")
+pytestmark = [pytest.mark.usefixtures("asserting_events_worker"), pytest.mark.clear_db]
 
 
 class WorkerTestImpl(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -27,6 +27,8 @@ from prefect.workers.process import (
     ProcessWorkerResult,
 )
 
+pytestmark = pytest.mark.clear_db
+
 
 @flow
 def example_process_worker_flow():

--- a/tests/workers/test_utilities.py
+++ b/tests/workers/test_utilities.py
@@ -9,6 +9,8 @@ from prefect.workers.utilities import (
     get_default_base_job_template_for_infrastructure_type,
 )
 
+pytestmark = pytest.mark.clear_db
+
 FAKE_DEFAULT_BASE_JOB_TEMPLATE = {
     "job_configuration": {
         "fake": "{{ fake_var }}",

--- a/tests/workers/test_worker_attribution.py
+++ b/tests/workers/test_worker_attribution.py
@@ -8,9 +8,10 @@ import os
 from unittest import mock
 from uuid import uuid4
 
+import pytest
+
 from prefect.workers.base import BaseJobConfiguration, BaseWorker, BaseWorkerResult
 
-import pytest
 pytestmark = pytest.mark.clear_db
 
 

--- a/tests/workers/test_worker_attribution.py
+++ b/tests/workers/test_worker_attribution.py
@@ -10,6 +10,9 @@ from uuid import uuid4
 
 from prefect.workers.base import BaseJobConfiguration, BaseWorker, BaseWorkerResult
 
+import pytest
+pytestmark = pytest.mark.clear_db
+
 
 class TestBaseAttributionEnvironment:
     """Tests for the _base_attribution_environment method."""


### PR DESCRIPTION
## Overview

The `clear_db` autouse fixture in [tests/fixtures/database.py](tests/fixtures/database.py) runs ~40 `DELETE` statements before any test that carries the `clear_db` marker. Previously, [tests/conftest.py](tests/conftest.py) auto-applied the marker to every test whose path was *not* substring-matched by `EXCLUDE_FROM_CLEAR_DB_AUTO_MARK`. Skipping the clear yields a 25–100% suite speedup (per the comment that used to live at `tests/conftest.py:152`), so curating that exclusion list one path at a time was the only lever — and the work scaled with every new test added.

This change makes the marker **opt-in** so new tests default to no clearing.

## What changed

- Removed the `EXCLUDE_FROM_CLEAR_DB_AUTO_MARK` list and the auto-marking loop from `tests/conftest.py`.
- Added a `--no-clear-db` pytest option that suppresses the fixture even for marked tests — `uv run pytest path/to/file.py --no-clear-db -x` is now the one-command check for "does this test still need a clean DB?".
- Bulk-applied `pytestmark = pytest.mark.clear_db` to the 243 test files that were previously auto-marked, so behavior is unchanged at landing. Six of those files already had a different module-level `pytestmark` and were merged manually into a list.
- Updated the marker docstring in `pyproject.toml`.
- Documented the new opt-in pattern and the audit flag in `tests/AGENTS.md`.

## Why

The user's previous workflow was to identify tests that don't need DB clearing and append their paths to `EXCLUDE_FROM_CLEAR_DB_AUTO_MARK`. That's incremental, central, and unbounded — every new test starts paying the cost. After this flip, the audit work is the same per file but **additive only on files that still carry the marker**, and the steady-state default is fast.

## How to audit further

```bash
uv run pytest tests/some/file.py --no-clear-db -x
```

If it passes, delete the `pytestmark` (or per-test marker) and commit.

## Reviewer notes

- The migration mirrored the substring-matching semantics of the old hook, so any test previously auto-marked is now explicitly marked. Verified by running `tests/server/orchestration/api/test_flows.py` + `tests/server/orchestration/api/test_deployments.py` (212 pass), `tests/workers/test_base_worker.py` (124 pass), and previously-excluded `tests/utilities/test_callables.py` + `tests/test_logging.py` + `tests/test_states.py` (321 pass).
- `tests/cli/test_block.py` failures observed locally are pre-existing on `main` and unrelated to this change.
- Large diff is mechanical (243 single-line additions); the interesting changes are in `tests/conftest.py`, `tests/fixtures/database.py`, `pyproject.toml`, and `tests/AGENTS.md`.

### Checklist

- [x] If this pull request adds new functionality, it includes unit tests that cover the changes (n/a — test infrastructure change; verified via the existing suite)
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json` (n/a)
- [x] If this pull request adds functions or classes, it includes helpful docstrings (n/a)