### PR TITLE
Handle concurrent work-pool creation in worker REST fallback

### DIFF
--- a/src/prefect/workers/_worker_channel/_sync.py
+++ b/src/prefect/workers/_worker_channel/_sync.py
@@ -308,9 +308,7 @@ class WorkPoolWorkerChannel:
 
                 try:
                     work_pool = await self._client.create_work_pool(work_pool=wp)
-                    self._logger.info(
-                        f"Work pool {self.work_pool_name!r} created."
-                    )
+                    self._logger.info(f"Work pool {self.work_pool_name!r} created.")
                 except ObjectAlreadyExists:
                     # Another worker created the pool between our read and
                     # create. Re-read so we can continue with the existing

--- a/src/prefect/workers/_worker_channel/_sync.py
+++ b/src/prefect/workers/_worker_channel/_sync.py
@@ -16,7 +16,7 @@ from prefect.client.base import ServerType
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.client.schemas.objects import WorkerMetadata, WorkPool
-from prefect.exceptions import ObjectNotFound
+from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 from prefect.workers._cleanup import WorkerCleanupExecutor
 from prefect.workers._worker_channel._protocol import WorkerChannelProtocolHandler
 from prefect.workers._worker_channel._state import (
@@ -306,8 +306,23 @@ class WorkPoolWorkerChannel:
                 if self.base_job_template is not None:
                     wp.base_job_template = self.base_job_template
 
-                work_pool = await self._client.create_work_pool(work_pool=wp)
-                self._logger.info(f"Work pool {self.work_pool_name!r} created.")
+                try:
+                    work_pool = await self._client.create_work_pool(work_pool=wp)
+                    self._logger.info(
+                        f"Work pool {self.work_pool_name!r} created."
+                    )
+                except ObjectAlreadyExists:
+                    # Another worker created the pool between our read and
+                    # create. Re-read so we can continue with the existing
+                    # pool rather than failing setup.
+                    self._logger.debug(
+                        "Work pool %r was created concurrently by another "
+                        "worker; re-reading.",
+                        self.work_pool_name,
+                    )
+                    work_pool = await self._client.read_work_pool(
+                        work_pool_name=self.work_pool_name
+                    )
             else:
                 self._logger.warning(f"Work pool {self.work_pool_name!r} not found!")
                 if self.base_job_template is not None:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -55,6 +55,7 @@ from prefect.client.schemas.worker_channel import (
 from prefect.context import FlowRunContext, TagsContext
 from prefect.exceptions import (
     CrashedRun,
+    ObjectAlreadyExists,
     ObjectNotFound,
 )
 from prefect.filesystems import WritableFileSystem
@@ -2648,6 +2649,53 @@ class TestWorkerChannelClient:
         client.send_worker_heartbeat.assert_awaited_once()
         snapshot.assert_called_once_with(work_pool)
         assert channel.worker_id == worker_id
+
+    async def test_sync_handles_concurrent_pool_creation_on_rest_fallback(self):
+        # When two workers start at the same time, both can see ObjectNotFound
+        # from read_work_pool before either has created the pool. One worker's
+        # create_work_pool call succeeds, and the other gets ObjectAlreadyExists.
+        # The losing worker should re-read the now-existing pool rather than
+        # bubble the exception up and fail setup.
+        work_pool = WorkPool(
+            name="test-work-pool",
+            type="test",
+            base_job_template={"job_configuration": {}, "variables": {}},
+            default_queue_id=uuid.uuid4(),
+        )
+        snapshot = Mock()
+        client = worker_channel_test_client()
+        # First read: pool doesn't exist yet.
+        # Second read (after the create race lost): pool now exists.
+        client.read_work_pool = AsyncMock(
+            side_effect=[ObjectNotFound("missing"), work_pool]
+        )
+        client.create_work_pool = AsyncMock(
+            side_effect=ObjectAlreadyExists(http_exc=Mock())
+        )
+        client.update_work_pool = AsyncMock()
+        channel = WorkPoolWorkerChannel(
+            client=client,
+            api_url=None,
+            work_pool_is_available=lambda: True,
+            work_pool_name="test-work-pool",
+            worker_name="test-worker",
+            worker_type="test",
+            heartbeat_interval_seconds=30,
+            work_queue_names=[],
+            create_pool_if_not_found=True,
+            default_base_job_template={"job_configuration": {}, "variables": {}},
+            worker_metadata=no_worker_channel_metadata,
+            logger=logging.getLogger("test-worker-channel"),
+            on_work_pool_snapshot=snapshot,
+        )
+
+        await channel.sync(None)
+
+        assert client.read_work_pool.await_count == 2
+        client.create_work_pool.assert_awaited_once()
+        client.update_work_pool.assert_not_awaited()
+        client.send_worker_heartbeat.assert_awaited_once()
+        snapshot.assert_called_once_with(work_pool)
 
     async def test_sync_repairs_missing_rest_work_pool_template(self):
         work_pool = WorkPool(


### PR DESCRIPTION
Closes #18085.

Two workers booting against the same backend can race on initial work-pool registration. Both call `read_work_pool` and get `ObjectNotFound`, both fall through to `create_work_pool`, one wins, and the other crashes with `ObjectAlreadyExists` during worker setup.

The issue reported the path in `BaseWorker._update_local_work_pool_info`. The worker-channel refactor since then moved the code to `WorkPoolWorkerChannel._sync_rest_work_pool` (`src/prefect/workers/_worker_channel/_sync.py:294`), but the bug shape is identical — `create_work_pool` still propagates the conflict.

The fix wraps the `create_work_pool` call in a try/except for `ObjectAlreadyExists` and re-reads on conflict. The "another worker just registered the same pool" outcome is the success path now, not a crash.

## Tests

`tests/workers/test_base_worker.py::TestWorkerChannelClient::test_sync_handles_concurrent_pool_creation_on_rest_fallback` — mocks `read_work_pool` to return `[ObjectNotFound, <work_pool>]` (first read misses, second hits because the other worker registered it in between) and `create_work_pool` to raise `ObjectAlreadyExists` (the race outcome). Asserts sync completes without raising and returns the work pool the other worker registered.

Fails on `main` with `ObjectAlreadyExists`; passes with this PR. The other 15 tests in `TestWorkerChannelClient` continue to pass.