### PR TITLE
Fix concurrency lease renewal starvation with thread-backed renewal

### DIFF
--- a/integration-tests/test_concurrency_leases.py
+++ b/integration-tests/test_concurrency_leases.py
@@ -14,7 +14,6 @@ import time
 import uuid
 from datetime import timedelta
 from multiprocessing import Process
-from typing import Any
 from unittest import mock
 
 import pytest
@@ -44,29 +43,17 @@ async def concurrency_limit():
 async def function_that_uses_async_concurrency_and_goes_belly_up(
     concurrency_limit_name: str,
 ):
-    original_sleep = asyncio.sleep
-
-    # Mock sleep so that the lease is renewed more quickly
-    async def mock_sleep(*args: Any, **kwargs: Any):
-        await original_sleep(0.1)
-
-    with mock.patch("asyncio.sleep", mock_sleep):
+    with mock.patch("prefect.concurrency._leases._RENEWAL_FRACTION", 0.01):
         async with concurrency(
             concurrency_limit_name, occupy=1, lease_duration=60, strict=True
         ):
-            await original_sleep(120)
+            await asyncio.sleep(120)
 
 
 def function_that_uses_sync_concurrency_and_goes_belly_up(
     concurrency_limit_name: str,
 ):
-    original_sleep = asyncio.sleep
-
-    # Mock sleep so that the lease is renewed more quickly
-    async def mock_sleep(*args: Any, **kwargs: Any):
-        await original_sleep(0.1)
-
-    with mock.patch("asyncio.sleep", mock_sleep):
+    with mock.patch("prefect.concurrency._leases._RENEWAL_FRACTION", 0.01):
         with sync_concurrency(
             concurrency_limit_name, occupy=1, lease_duration=60, strict=True
         ):

--- a/src/prefect/concurrency/AGENTS.md
+++ b/src/prefect/concurrency/AGENTS.md
@@ -4,15 +4,15 @@ Client-side concurrency limit enforcement: acquires and releases slots against s
 
 ## Purpose & Scope
 
-Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire -> maintain lease -> release, with both sync and async paths.
+Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire → maintain lease → release, with both sync and async paths.
 
 Does NOT define concurrency limits (server-side in `server/`). Does NOT handle task runner parallelism (separate concern).
 
 ## Entry Points & Contracts
 
 **Public API** (`asyncio.py`, `sync.py`):
-- `concurrency()` -> context manager that acquires slots on entry and releases on exit
-- `rate_limit()` -> one-shot acquire for decay-based limits (no release needed)
+- `concurrency()` — context manager that acquires slots on entry and releases on exit
+- `rate_limit()` — one-shot acquire for decay-based limits (no release needed)
 
 **`strict=False` (default):** logs a warning if the named limit doesn't exist, but proceeds. `strict=True` raises `ConcurrencySlotAcquisitionError`.
 
@@ -24,21 +24,21 @@ Does NOT define concurrency limits (server-side in `server/`). Does NOT handle t
 
 ## Architecture
 
-Layered -> public -> internal -> services, with leases and events as cross-cutting concerns:
+Layered — public → internal → services, with leases and events as cross-cutting concerns:
 
-- **Public** (`asyncio.py`, `sync.py`) -> user-facing context managers; `rate_limit()` emits events directly
-- **Internal** (`_asyncio.py`, `_sync.py`) -> orchestrates acquire -> lease -> release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
-- **Services** (`services.py`) -> serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
+- **Public** (`asyncio.py`, `sync.py`) — user-facing context managers; `rate_limit()` emits events directly
+- **Internal** (`_asyncio.py`, `_sync.py`) — orchestrates acquire → lease → release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
+- **Services** (`services.py`) — serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
 
 ## Anti-Patterns
 
-- **Don't call internal `_asyncio`/`_sync` functions directly** -> use the public `asyncio.py`/`sync.py` APIs. The internal modules skip event emission setup.
-- **Don't mix sync `concurrency()` in async code** -> use `asyncio.concurrency()` to avoid blocking the event loop.
-- **Don't rely on strict=False for correctness** -> in tests or scripts where the limit must exist, use `strict=True` so you catch misconfigurations early.
+- **Don't call internal `_asyncio`/`_sync` functions directly** — use the public `asyncio.py`/`sync.py` APIs. The internal modules skip event emission setup.
+- **Don't mix sync `concurrency()` in async code** — use `asyncio.concurrency()` to avoid blocking the event loop.
+- **Don't rely on strict=False for correctness** — in tests or scripts where the limit must exist, use `strict=True` so you catch misconfigurations early.
 
 ## Pitfalls
 
 - **Service singleton is keyed on `frozenset(names)`.** Passing the same names in different order reuses the same singleton; passing a strict subset creates a different singleton. Each unique name-set gets its own queue.
 - **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables so renewal sees the same settings/client context. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
-- **Cancellation during acquire or release** -> if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
+- **Cancellation during acquire or release** — if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
 - **`v1/` subdirectory** contains the legacy slot API (no lease model). New code should use the top-level `concurrency()` / `rate_limit()` APIs.

--- a/src/prefect/concurrency/AGENTS.md
+++ b/src/prefect/concurrency/AGENTS.md
@@ -18,7 +18,7 @@ Does NOT define concurrency limits (server-side in `server/`). Does NOT handle t
 
 **`raise_on_lease_renewal_failure` (public parameter):** Controls lease renewal failure behavior independently from `strict`. When `None` (default), falls back to the value of `strict` for backward compatibility. Set to `False` to let long-running tasks continue even if a transient renewal error occurs; set to `True` to terminate immediately on renewal failure regardless of `strict`. This means `strict=True, raise_on_lease_renewal_failure=False` gives strict slot acquisition but non-fatal renewal failures, and vice versa.
 
-**Lease renewal:** `_leases.py` starts a daemon thread that renews immediately on entry, then waits for 75% of `lease_duration` between renewals. The renewal thread creates a normal sync client with `get_client(sync_client=True)` and retries each renewal up to 3 times with exponential backoff. If all attempts fail, a shared failure handler either cancels execution with the existing sync/async cancel scope or logs a warning, depending on `raise_on_lease_renewal_failure`.
+**Lease renewal:** `_leases.py` starts a daemon thread that renews immediately on entry, then waits for 75% of `lease_duration` between renewals. The renewal thread uses the standard `get_client(sync_client=True)` path and retries each renewal up to 3 times with exponential backoff. If all attempts fail, a shared failure handler either cancels execution with the existing sync/async cancel scope or logs a warning, depending on `raise_on_lease_renewal_failure`.
 
 **Sync/async lockstep invariant:** `asyncio.py`/`sync.py` and `_asyncio.py`/`_sync.py` are parallel implementations. Any behavior change to one must be mirrored in the other.
 
@@ -39,6 +39,6 @@ Layered — public → internal → services, with leases and events as cross-cu
 ## Pitfalls
 
 - **Service singleton is keyed on `frozenset(names)`.** Passing the same names in different order reuses the same singleton; passing a strict subset creates a different singleton. Each unique name-set gets its own queue.
-- **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables for settings and logging context, but opens its own normal sync client instead of reusing or cloning async client state. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
+- **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables for settings and logging context, then uses the standard `get_client(sync_client=True)` path instead of lease-specific async-client cloning. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
 - **Cancellation during acquire or release** — if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
 - **`v1/` subdirectory** contains the legacy slot API (no lease model). New code should use the top-level `concurrency()` / `rate_limit()` APIs.

--- a/src/prefect/concurrency/AGENTS.md
+++ b/src/prefect/concurrency/AGENTS.md
@@ -4,41 +4,41 @@ Client-side concurrency limit enforcement: acquires and releases slots against s
 
 ## Purpose & Scope
 
-Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire → maintain lease → release, with both sync and async paths.
+Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire  maintain lease  release, with both sync and async paths.
 
 Does NOT define concurrency limits (server-side in `server/`). Does NOT handle task runner parallelism (separate concern).
 
 ## Entry Points & Contracts
 
 **Public API** (`asyncio.py`, `sync.py`):
-- `concurrency()` — context manager that acquires slots on entry and releases on exit
-- `rate_limit()` — one-shot acquire for decay-based limits (no release needed)
+- `concurrency()`  context manager that acquires slots on entry and releases on exit
+- `rate_limit()`  one-shot acquire for decay-based limits (no release needed)
 
 **`strict=False` (default):** logs a warning if the named limit doesn't exist, but proceeds. `strict=True` raises `ConcurrencySlotAcquisitionError`.
 
 **`raise_on_lease_renewal_failure` (public parameter):** Controls lease renewal failure behavior independently from `strict`. When `None` (default), falls back to the value of `strict` for backward compatibility. Set to `False` to let long-running tasks continue even if a transient renewal error occurs; set to `True` to terminate immediately on renewal failure regardless of `strict`. This means `strict=True, raise_on_lease_renewal_failure=False` gives strict slot acquisition but non-fatal renewal failures, and vice versa.
 
-**Lease renewal:** `_leases.py` runs a background loop that renews immediately on entry, then sleeps for 75% of `lease_duration` between renewals. Each renewal call uses `@retry_async_fn(max_attempts=3)` for transient failures. If all 3 attempts fail, the background task raises and a done-callback either cancels execution or logs a warning, depending on `raise_on_lease_renewal_failure`.
+**Lease renewal:** `_leases.py` starts a daemon thread that renews immediately on entry, then waits for 75% of `lease_duration` between renewals. The renewal thread uses a sync client and retries each renewal up to 3 times with exponential backoff. If all attempts fail, a shared failure handler either cancels execution with the existing sync/async cancel scope or logs a warning, depending on `raise_on_lease_renewal_failure`.
 
 **Sync/async lockstep invariant:** `asyncio.py`/`sync.py` and `_asyncio.py`/`_sync.py` are parallel implementations. Any behavior change to one must be mirrored in the other.
 
 ## Architecture
 
-Layered — public → internal → services, with leases and events as cross-cutting concerns:
+Layered  public  internal  services, with leases and events as cross-cutting concerns:
 
-- **Public** (`asyncio.py`, `sync.py`) — user-facing context managers; `rate_limit()` emits events directly
-- **Internal** (`_asyncio.py`, `_sync.py`) — orchestrates acquire → lease → release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
-- **Services** (`services.py`) — serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
+- **Public** (`asyncio.py`, `sync.py`)  user-facing context managers; `rate_limit()` emits events directly
+- **Internal** (`_asyncio.py`, `_sync.py`)  orchestrates acquire  lease  release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
+- **Services** (`services.py`)  serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
 
 ## Anti-Patterns
 
-- **Don't call internal `_asyncio`/`_sync` functions directly** — use the public `asyncio.py`/`sync.py` APIs. The internal modules skip event emission setup.
-- **Don't mix sync `concurrency()` in async code** — use `asyncio.concurrency()` to avoid blocking the event loop.
-- **Don't rely on strict=False for correctness** — in tests or scripts where the limit must exist, use `strict=True` so you catch misconfigurations early.
+- **Don't call internal `_asyncio`/`_sync` functions directly**  use the public `asyncio.py`/`sync.py` APIs. The internal modules skip event emission setup.
+- **Don't mix sync `concurrency()` in async code**  use `asyncio.concurrency()` to avoid blocking the event loop.
+- **Don't rely on strict=False for correctness**  in tests or scripts where the limit must exist, use `strict=True` so you catch misconfigurations early.
 
 ## Pitfalls
 
 - **Service singleton is keyed on `frozenset(names)`.** Passing the same names in different order reuses the same singleton; passing a strict subset creates a different singleton. Each unique name-set gets its own queue.
-- **Lease renewal runs on the global event loop** (sync path). If the global loop is blocked or torn down, renewal silently fails — you'll see the renewal failure callback fire after `max_attempts` retries are exhausted.
-- **Cancellation during acquire or release** — if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
+- **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables so renewal sees the same settings/client context. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
+- **Cancellation during acquire or release**  if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
 - **`v1/` subdirectory** contains the legacy slot API (no lease model). New code should use the top-level `concurrency()` / `rate_limit()` APIs.

--- a/src/prefect/concurrency/AGENTS.md
+++ b/src/prefect/concurrency/AGENTS.md
@@ -4,15 +4,15 @@ Client-side concurrency limit enforcement: acquires and releases slots against s
 
 ## Purpose & Scope
 
-Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire  maintain lease  release, with both sync and async paths.
+Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire -> maintain lease -> release, with both sync and async paths.
 
 Does NOT define concurrency limits (server-side in `server/`). Does NOT handle task runner parallelism (separate concern).
 
 ## Entry Points & Contracts
 
 **Public API** (`asyncio.py`, `sync.py`):
-- `concurrency()`  context manager that acquires slots on entry and releases on exit
-- `rate_limit()`  one-shot acquire for decay-based limits (no release needed)
+- `concurrency()` -> context manager that acquires slots on entry and releases on exit
+- `rate_limit()` -> one-shot acquire for decay-based limits (no release needed)
 
 **`strict=False` (default):** logs a warning if the named limit doesn't exist, but proceeds. `strict=True` raises `ConcurrencySlotAcquisitionError`.
 
@@ -24,21 +24,21 @@ Does NOT define concurrency limits (server-side in `server/`). Does NOT handle t
 
 ## Architecture
 
-Layered  public  internal  services, with leases and events as cross-cutting concerns:
+Layered -> public -> internal -> services, with leases and events as cross-cutting concerns:
 
-- **Public** (`asyncio.py`, `sync.py`)  user-facing context managers; `rate_limit()` emits events directly
-- **Internal** (`_asyncio.py`, `_sync.py`)  orchestrates acquire  lease  release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
-- **Services** (`services.py`)  serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
+- **Public** (`asyncio.py`, `sync.py`) -> user-facing context managers; `rate_limit()` emits events directly
+- **Internal** (`_asyncio.py`, `_sync.py`) -> orchestrates acquire -> lease -> release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
+- **Services** (`services.py`) -> serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
 
 ## Anti-Patterns
 
-- **Don't call internal `_asyncio`/`_sync` functions directly**  use the public `asyncio.py`/`sync.py` APIs. The internal modules skip event emission setup.
-- **Don't mix sync `concurrency()` in async code**  use `asyncio.concurrency()` to avoid blocking the event loop.
-- **Don't rely on strict=False for correctness**  in tests or scripts where the limit must exist, use `strict=True` so you catch misconfigurations early.
+- **Don't call internal `_asyncio`/`_sync` functions directly** -> use the public `asyncio.py`/`sync.py` APIs. The internal modules skip event emission setup.
+- **Don't mix sync `concurrency()` in async code** -> use `asyncio.concurrency()` to avoid blocking the event loop.
+- **Don't rely on strict=False for correctness** -> in tests or scripts where the limit must exist, use `strict=True` so you catch misconfigurations early.
 
 ## Pitfalls
 
 - **Service singleton is keyed on `frozenset(names)`.** Passing the same names in different order reuses the same singleton; passing a strict subset creates a different singleton. Each unique name-set gets its own queue.
 - **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables so renewal sees the same settings/client context. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
-- **Cancellation during acquire or release**  if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
+- **Cancellation during acquire or release** -> if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
 - **`v1/` subdirectory** contains the legacy slot API (no lease model). New code should use the top-level `concurrency()` / `rate_limit()` APIs.

--- a/src/prefect/concurrency/AGENTS.md
+++ b/src/prefect/concurrency/AGENTS.md
@@ -4,7 +4,7 @@ Client-side concurrency limit enforcement: acquires and releases slots against s
 
 ## Purpose & Scope
 
-Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire -> maintain lease -> release, with both sync and async paths.
+Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire → maintain lease → release, with both sync and async paths.
 
 Does NOT define concurrency limits (server-side in `server/`). Does NOT handle task runner parallelism (separate concern).
 
@@ -24,10 +24,10 @@ Does NOT define concurrency limits (server-side in `server/`). Does NOT handle t
 
 ## Architecture
 
-Layered — public -> internal -> services, with leases and events as cross-cutting concerns:
+Layered — public → internal → services, with leases and events as cross-cutting concerns:
 
 - **Public** (`asyncio.py`, `sync.py`) — user-facing context managers; `rate_limit()` emits events directly
-- **Internal** (`_asyncio.py`, `_sync.py`) — orchestrates acquire -> lease -> release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
+- **Internal** (`_asyncio.py`, `_sync.py`) — orchestrates acquire → lease → release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
 - **Services** (`services.py`) — serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
 
 ## Anti-Patterns

--- a/src/prefect/concurrency/AGENTS.md
+++ b/src/prefect/concurrency/AGENTS.md
@@ -4,7 +4,7 @@ Client-side concurrency limit enforcement: acquires and releases slots against s
 
 ## Purpose & Scope
 
-Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire → maintain lease → release, with both sync and async paths.
+Manages concurrency slot acquisition/release for flows and tasks enforcing named concurrency limits. Handles the full lifecycle: acquire -> maintain lease -> release, with both sync and async paths.
 
 Does NOT define concurrency limits (server-side in `server/`). Does NOT handle task runner parallelism (separate concern).
 
@@ -18,16 +18,16 @@ Does NOT define concurrency limits (server-side in `server/`). Does NOT handle t
 
 **`raise_on_lease_renewal_failure` (public parameter):** Controls lease renewal failure behavior independently from `strict`. When `None` (default), falls back to the value of `strict` for backward compatibility. Set to `False` to let long-running tasks continue even if a transient renewal error occurs; set to `True` to terminate immediately on renewal failure regardless of `strict`. This means `strict=True, raise_on_lease_renewal_failure=False` gives strict slot acquisition but non-fatal renewal failures, and vice versa.
 
-**Lease renewal:** `_leases.py` starts a daemon thread that renews immediately on entry, then waits for 75% of `lease_duration` between renewals. The renewal thread uses a sync client and retries each renewal up to 3 times with exponential backoff. If all attempts fail, a shared failure handler either cancels execution with the existing sync/async cancel scope or logs a warning, depending on `raise_on_lease_renewal_failure`.
+**Lease renewal:** `_leases.py` starts a daemon thread that renews immediately on entry, then waits for 75% of `lease_duration` between renewals. The renewal thread creates a normal sync client with `get_client(sync_client=True)` and retries each renewal up to 3 times with exponential backoff. If all attempts fail, a shared failure handler either cancels execution with the existing sync/async cancel scope or logs a warning, depending on `raise_on_lease_renewal_failure`.
 
 **Sync/async lockstep invariant:** `asyncio.py`/`sync.py` and `_asyncio.py`/`_sync.py` are parallel implementations. Any behavior change to one must be mirrored in the other.
 
 ## Architecture
 
-Layered — public → internal → services, with leases and events as cross-cutting concerns:
+Layered — public -> internal -> services, with leases and events as cross-cutting concerns:
 
 - **Public** (`asyncio.py`, `sync.py`) — user-facing context managers; `rate_limit()` emits events directly
-- **Internal** (`_asyncio.py`, `_sync.py`) — orchestrates acquire → lease → release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
+- **Internal** (`_asyncio.py`, `_sync.py`) — orchestrates acquire -> lease -> release, emits events for `concurrency()`, handles cancellation cleanup via `ConcurrencyContext`
 - **Services** (`services.py`) — serializes API requests per `frozenset(names)` to prevent thundering herd; retries on HTTP 423 with `Retry-After` backoff
 
 ## Anti-Patterns
@@ -39,6 +39,6 @@ Layered — public → internal → services, with leases and events as cross-cu
 ## Pitfalls
 
 - **Service singleton is keyed on `frozenset(names)`.** Passing the same names in different order reuses the same singleton; passing a strict subset creates a different singleton. Each unique name-set gets its own queue.
-- **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables so renewal sees the same settings/client context. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
+- **Lease renewal runs on a daemon thread.** The thread copies the caller's context variables for settings and logging context, but opens its own normal sync client instead of reusing or cloning async client state. Sync callers join the thread briefly on exit; async callers only signal the thread to stop so the event loop is not blocked.
 - **Cancellation during acquire or release** — if a `CancelledError` is raised either during slot acquisition or during `release_concurrency_slots_with_lease` in the `finally` block, the lease ID is appended to `ConcurrencyContext.cleanup_lease_ids`. `ConcurrencyContext.__exit__` releases them via a sync client. If `ConcurrencyContext` is not active, those leases are abandoned until server-side expiry.
 - **`v1/` subdirectory** contains the legacy slot API (no lease model). New code should use the top-level `concurrency()` / `rate_limit()` APIs.

--- a/src/prefect/concurrency/_leases.py
+++ b/src/prefect/concurrency/_leases.py
@@ -1,7 +1,7 @@
 import contextvars
 import threading
 from contextlib import asynccontextmanager, contextmanager
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator
+from typing import TYPE_CHECKING, AsyncGenerator, Generator
 from uuid import UUID
 
 from prefect._internal.concurrency.cancellation import (
@@ -11,7 +11,6 @@ from prefect._internal.concurrency.cancellation import (
 from prefect._internal.retries import exponential_backoff_with_jitter
 from prefect.client.orchestration import get_client
 from prefect.logging.loggers import get_logger, get_run_logger
-from prefect.settings import PREFECT_API_AUTH_STRING, PREFECT_API_KEY
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import SyncPrefectClient
@@ -20,53 +19,6 @@ _RENEWAL_FRACTION = 0.75
 _RENEWAL_MAX_ATTEMPTS = 3
 _RENEWAL_RETRY_BASE_DELAY = 1
 _RENEWAL_RETRY_MAX_DELAY = 10
-
-
-@contextmanager
-def _get_lease_renewal_client() -> Generator["SyncPrefectClient", None, None]:
-    """
-    Return a sync client for lease renewal.
-
-    Renewal runs on an OS thread. If the caller is already in a sync client
-    context, reuse that client. If the caller is async-only, create an
-    independent sync client pointed at the async client's API URL and HTTPX
-    settings.
-    """
-    import prefect.context
-    from prefect.client.orchestration import SyncPrefectClient
-
-    if sync_ctx := prefect.context.SyncClientContext.get():
-        if sync_ctx.client:
-            yield sync_ctx.client
-            return
-
-    if async_ctx := prefect.context.AsyncClientContext.get():
-        if async_ctx.client:
-            if getattr(async_ctx.client, "_ephemeral_app", None):
-                raise RuntimeError(
-                    "Cannot renew a concurrency lease from an in-process async "
-                    "client on a background thread. Set PREFECT_API_URL to point "
-                    "at a running Prefect server."
-                )
-
-            ctx_settings: dict[str, Any] | None = getattr(
-                async_ctx, "_httpx_settings", None
-            )
-            inherited_settings = ctx_settings.copy() if ctx_settings else {}
-            inherited_settings.pop("transport", None)
-
-            with SyncPrefectClient(
-                str(async_ctx.client.api_url),
-                auth_string=PREFECT_API_AUTH_STRING.value(),
-                api_key=PREFECT_API_KEY.value(),
-                httpx_settings=inherited_settings or None,
-                server_type=async_ctx.client.server_type,
-            ) as client:
-                yield client
-            return
-
-    with get_client(sync_client=True) as client:
-        yield client
 
 
 def _renew_concurrency_lease_with_retries(
@@ -128,7 +80,7 @@ def _lease_renewal_loop(
         lease_duration: The duration of the lease in seconds.
         stop_event: Event set by the owning context manager on exit.
     """
-    with _get_lease_renewal_client() as client:
+    with get_client(sync_client=True) as client:
         while not stop_event.is_set():
             renewed = _renew_concurrency_lease_with_retries(
                 client, lease_id, lease_duration, stop_event

--- a/src/prefect/concurrency/_leases.py
+++ b/src/prefect/concurrency/_leases.py
@@ -1,44 +1,214 @@
-import asyncio
-import concurrent.futures
+import contextvars
+import threading
 from contextlib import asynccontextmanager, contextmanager
-from typing import AsyncGenerator, Generator
+from typing import TYPE_CHECKING, AsyncGenerator, Generator
 from uuid import UUID
 
-from prefect._internal.concurrency.api import create_call
 from prefect._internal.concurrency.cancellation import (
     AsyncCancelScope,
     WatcherThreadCancelScope,
 )
-from prefect._internal.concurrency.threads import get_global_loop
-from prefect._internal.retries import retry_async_fn
+from prefect._internal.retries import exponential_backoff_with_jitter
 from prefect.client.orchestration import get_client
 from prefect.logging.loggers import get_logger, get_run_logger
+from prefect.settings import PREFECT_API_AUTH_STRING, PREFECT_API_KEY
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import SyncPrefectClient
+
+_RENEWAL_FRACTION = 0.75
+_RENEWAL_MAX_ATTEMPTS = 3
+_RENEWAL_RETRY_BASE_DELAY = 1
+_RENEWAL_RETRY_MAX_DELAY = 10
 
 
-async def _lease_renewal_loop(
+@contextmanager
+def _get_lease_renewal_client() -> Generator["SyncPrefectClient", None, None]:
+    """
+    Return a sync client for lease renewal.
+
+    Renewal runs on an OS thread. If the caller is already in a sync client
+    context, reuse that client. If the caller is async-only, create an
+    independent sync client pointed at the async client's API URL and HTTPX
+    settings.
+    """
+    import prefect.context
+    from prefect.client.orchestration import SyncPrefectClient
+
+    if sync_ctx := prefect.context.SyncClientContext.get():
+        if sync_ctx.client:
+            yield sync_ctx.client
+            return
+
+    if async_ctx := prefect.context.AsyncClientContext.get():
+        if async_ctx.client:
+            if getattr(async_ctx.client, "_ephemeral_app", None):
+                raise RuntimeError(
+                    "Cannot renew a concurrency lease from an in-process async "
+                    "client on a background thread. Set PREFECT_API_URL to point "
+                    "at a running Prefect server."
+                )
+
+            ctx_settings = getattr(async_ctx, "_httpx_settings", None)
+            inherited_settings = dict(ctx_settings) if ctx_settings else {}
+            inherited_settings.pop("transport", None)
+
+            with SyncPrefectClient(
+                str(async_ctx.client.api_url),
+                auth_string=PREFECT_API_AUTH_STRING.value(),
+                api_key=PREFECT_API_KEY.value(),
+                httpx_settings=inherited_settings or None,
+                server_type=async_ctx.client.server_type,
+            ) as client:
+                yield client
+            return
+
+    with get_client(sync_client=True) as client:
+        yield client
+
+
+def _renew_concurrency_lease_with_retries(
+    client: "SyncPrefectClient",
     lease_id: UUID,
     lease_duration: float,
+    stop_event: threading.Event,
+) -> bool:
+    """
+    Renew a concurrency lease, retrying transient failures.
+
+    Returns `False` when shutdown is requested during retry backoff.
+    """
+    logger = get_logger("concurrency")
+
+    for attempt in range(_RENEWAL_MAX_ATTEMPTS):
+        try:
+            client.renew_concurrency_lease(
+                lease_id=lease_id, lease_duration=lease_duration
+            )
+            return True
+        except Exception as exc:
+            if attempt == _RENEWAL_MAX_ATTEMPTS - 1:
+                logger.exception(
+                    "Function 'concurrency lease renewal' failed after %s attempts",
+                    _RENEWAL_MAX_ATTEMPTS,
+                )
+                raise
+
+            delay = exponential_backoff_with_jitter(
+                attempt,
+                _RENEWAL_RETRY_BASE_DELAY,
+                _RENEWAL_RETRY_MAX_DELAY,
+            )
+            logger.warning(
+                "Attempt %s of function 'concurrency lease renewal' failed with "
+                "%s: %s. Retrying in %.2f seconds...",
+                attempt + 1,
+                type(exc).__name__,
+                exc,
+                delay,
+            )
+            if stop_event.wait(delay):
+                return False
+
+    return False
+
+
+def _lease_renewal_loop(
+    lease_id: UUID,
+    lease_duration: float,
+    stop_event: threading.Event,
 ) -> None:
     """
-    Maintain a concurrency lease by renewing it after the given interval.
+    Maintain a concurrency lease until stopped.
 
     Args:
         lease_id: The ID of the lease to maintain.
         lease_duration: The duration of the lease in seconds.
+        stop_event: Event set by the owning context manager on exit.
     """
-    async with get_client() as client:
-
-        @retry_async_fn(max_attempts=3, operation_name="concurrency lease renewal")
-        async def renew() -> None:
-            await client.renew_concurrency_lease(
-                lease_id=lease_id, lease_duration=lease_duration
+    with _get_lease_renewal_client() as client:
+        while not stop_event.is_set():
+            renewed = _renew_concurrency_lease_with_retries(
+                client, lease_id, lease_duration, stop_event
             )
+            if not renewed:
+                return
+            stop_event.wait(lease_duration * _RENEWAL_FRACTION)
 
-        while True:
-            await renew()
-            await asyncio.sleep(  # Renew the lease 3/4 of the way through the lease duration
-                lease_duration * 0.75
-            )
+
+def _handle_lease_renewal_failure(
+    exc: BaseException,
+    lease_id: UUID,
+    raise_on_lease_renewal_failure: bool,
+    suppress_warnings: bool,
+    cancel_scope: AsyncCancelScope | WatcherThreadCancelScope,
+) -> None:
+    try:
+        # Use a run logger if available
+        logger = get_run_logger()
+    except Exception:
+        logger = get_logger("concurrency")
+
+    if raise_on_lease_renewal_failure:
+        logger.error(
+            "Concurrency lease renewal failed - slots are no longer reserved. "
+            "Terminating execution to prevent over-allocation. "
+            "Lease ID: %s, exception: %s",
+            lease_id,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        cancel_scope.cancel()
+    elif suppress_warnings:
+        logger.debug(
+            "Concurrency lease renewal failed - slots are no longer reserved. "
+            "Execution will continue, but concurrency limits may be exceeded. "
+            "Lease ID: %s, exception: %s",
+            lease_id,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+    else:
+        logger.warning(
+            "Concurrency lease renewal failed - slots are no longer reserved. "
+            "Execution will continue, but concurrency limits may be exceeded. "
+            "Lease ID: %s, exception: %s",
+            lease_id,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+
+def _start_lease_renewal_thread(
+    lease_id: UUID,
+    lease_duration: float,
+    raise_on_lease_renewal_failure: bool,
+    suppress_warnings: bool,
+    cancel_scope: AsyncCancelScope | WatcherThreadCancelScope,
+) -> tuple[threading.Event, threading.Thread]:
+    stop_event = threading.Event()
+    renewal_ctx = contextvars.copy_context()
+
+    def renewal_loop() -> None:
+        try:
+            renewal_ctx.run(_lease_renewal_loop, lease_id, lease_duration, stop_event)
+        except Exception as exc:
+            if not stop_event.is_set():
+                _handle_lease_renewal_failure(
+                    exc,
+                    lease_id,
+                    raise_on_lease_renewal_failure,
+                    suppress_warnings,
+                    cancel_scope,
+                )
+
+    thread = threading.Thread(
+        target=renewal_loop,
+        daemon=True,
+        name=f"concurrency-lease-renewal-{lease_id}",
+    )
+    thread.start()
+    return stop_event, thread
 
 
 @contextmanager
@@ -56,64 +226,23 @@ def maintain_concurrency_lease(
         lease_duration: The duration of the lease in seconds.
         raise_on_lease_renewal_failure: A boolean specifying whether to raise an error if the lease renewal fails.
     """
-    # Start a loop to renew the lease on the global event loop to avoid blocking the main thread
-    global_loop = get_global_loop()
-    lease_renewal_call = create_call(
-        _lease_renewal_loop,
-        lease_id,
-        lease_duration,
-    )
-    global_loop.submit(lease_renewal_call)
-
     with WatcherThreadCancelScope() as cancel_scope:
-
-        def handle_lease_renewal_failure(future: concurrent.futures.Future[None]):
-            if future.cancelled():
-                return
-            exc = future.exception()
-            if exc:
-                try:
-                    # Use a run logger if available
-                    logger = get_run_logger()
-                except Exception:
-                    logger = get_logger("concurrency")
-                if raise_on_lease_renewal_failure:
-                    logger.error(
-                        "Concurrency lease renewal failed - slots are no longer reserved. "
-                        "Terminating execution to prevent over-allocation. "
-                        "Lease ID: %s, exception: %s",
-                        lease_id,
-                        exc,
-                        exc_info=(type(exc), exc, exc.__traceback__),
-                    )
-                    assert cancel_scope.cancel()
-                else:
-                    if suppress_warnings:
-                        logger.debug(
-                            "Concurrency lease renewal failed - slots are no longer reserved. "
-                            "Execution will continue, but concurrency limits may be exceeded. "
-                            "Lease ID: %s, exception: %s",
-                            lease_id,
-                            exc,
-                            exc_info=(type(exc), exc, exc.__traceback__),
-                        )
-                    else:
-                        logger.warning(
-                            "Concurrency lease renewal failed - slots are no longer reserved. "
-                            "Execution will continue, but concurrency limits may be exceeded. "
-                            "Lease ID: %s, exception: %s",
-                            lease_id,
-                            exc,
-                            exc_info=(type(exc), exc, exc.__traceback__),
-                        )
-
-        lease_renewal_call.future.add_done_callback(handle_lease_renewal_failure)
-
+        stop_event: threading.Event | None = None
+        thread: threading.Thread | None = None
         try:
+            stop_event, thread = _start_lease_renewal_thread(
+                lease_id,
+                lease_duration,
+                raise_on_lease_renewal_failure,
+                suppress_warnings,
+                cancel_scope,
+            )
             yield
         finally:
-            # Cancel the lease renewal loop
-            lease_renewal_call.cancel()
+            if stop_event is not None:
+                stop_event.set()
+            if thread is not None:
+                thread.join(timeout=2)
 
 
 @asynccontextmanager
@@ -131,60 +260,17 @@ async def amaintain_concurrency_lease(
         lease_duration: The duration of the lease in seconds.
         raise_on_lease_renewal_failure: A boolean specifying whether to raise an error if the lease renewal fails.
     """
-    lease_renewal_task = asyncio.create_task(
-        _lease_renewal_loop(lease_id, lease_duration)
-    )
     with AsyncCancelScope() as cancel_scope:
-
-        def handle_lease_renewal_failure(task: asyncio.Task[None]):
-            if task.cancelled():
-                # Cancellation is the expected way for this loop to stop
-                return
-            exc = task.exception()
-            if exc:
-                try:
-                    # Use a run logger if available
-                    logger = get_run_logger()
-                except Exception:
-                    logger = get_logger("concurrency")
-                if raise_on_lease_renewal_failure:
-                    logger.error(
-                        "Concurrency lease renewal failed - slots are no longer reserved. "
-                        "Terminating execution to prevent over-allocation. "
-                        "Lease ID: %s, exception: %s",
-                        lease_id,
-                        exc,
-                        exc_info=(type(exc), exc, exc.__traceback__),
-                    )
-                    cancel_scope.cancel()
-                else:
-                    if suppress_warnings:
-                        logger.debug(
-                            "Concurrency lease renewal failed - slots are no longer reserved. "
-                            "Execution will continue, but concurrency limits may be exceeded. "
-                            "Lease ID: %s, exception: %s",
-                            lease_id,
-                            exc,
-                            exc_info=(type(exc), exc, exc.__traceback__),
-                        )
-                    else:
-                        logger.warning(
-                            "Concurrency lease renewal failed - slots are no longer reserved. "
-                            "Execution will continue, but concurrency limits may be exceeded. "
-                            "Lease ID: %s, exception: %s",
-                            lease_id,
-                            exc,
-                            exc_info=(type(exc), exc, exc.__traceback__),
-                        )
-
-        # Add a callback to stop execution if the lease renewal fails and strict is True
-        lease_renewal_task.add_done_callback(handle_lease_renewal_failure)
+        stop_event: threading.Event | None = None
         try:
+            stop_event, _ = _start_lease_renewal_thread(
+                lease_id,
+                lease_duration,
+                raise_on_lease_renewal_failure,
+                suppress_warnings,
+                cancel_scope,
+            )
             yield
         finally:
-            lease_renewal_task.cancel()
-            try:
-                await lease_renewal_task
-            except (asyncio.CancelledError, Exception):
-                # Handling for errors will be done in the callback
-                pass
+            if stop_event is not None:
+                stop_event.set()

--- a/src/prefect/concurrency/_leases.py
+++ b/src/prefect/concurrency/_leases.py
@@ -1,7 +1,7 @@
 import contextvars
 import threading
 from contextlib import asynccontextmanager, contextmanager
-from typing import TYPE_CHECKING, AsyncGenerator, Generator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator
 from uuid import UUID
 
 from prefect._internal.concurrency.cancellation import (
@@ -49,8 +49,10 @@ def _get_lease_renewal_client() -> Generator["SyncPrefectClient", None, None]:
                     "at a running Prefect server."
                 )
 
-            ctx_settings = getattr(async_ctx, "_httpx_settings", None)
-            inherited_settings = dict(ctx_settings) if ctx_settings else {}
+            ctx_settings: dict[str, Any] | None = getattr(
+                async_ctx, "_httpx_settings", None
+            )
+            inherited_settings = ctx_settings.copy() if ctx_settings else {}
             inherited_settings.pop("transport", None)
 
             with SyncPrefectClient(

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -190,8 +190,9 @@ def test_lease_renewal_client_uses_async_client_api_url():
         mock.patch(
             "prefect.context.AsyncClientContext.get", return_value=mock_async_ctx
         ),
-        mock.patch("prefect.client.orchestration.SyncPrefectClient")
-        as mock_sync_client_cls,
+        mock.patch(
+            "prefect.client.orchestration.SyncPrefectClient"
+        ) as mock_sync_client_cls,
     ):
         mock_sync_client_cls.return_value.__enter__.return_value = mock.MagicMock()
 

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -82,6 +82,7 @@ def test_lease_renewal_logs_once_after_max_retries_non_strict(
     mock_client = mock.MagicMock()
     mock_client.renew_concurrency_lease.side_effect = RuntimeError("server down")
     continued_after_failure = False
+    failure_message = "Concurrency lease renewal failed - slots are no longer reserved."
 
     with _patch_renewal_client(mock_client):
         with caplog.at_level(logging.WARNING):
@@ -90,19 +91,12 @@ def test_lease_renewal_logs_once_after_max_retries_non_strict(
                 lease_duration=60,
                 raise_on_lease_renewal_failure=False,
             ):
-                assert _wait_for(
-                    lambda: mock_client.renew_concurrency_lease.call_count == 3
-                )
+                assert _wait_for(lambda: caplog.text.count(failure_message) == 1)
                 continued_after_failure = True
 
     assert continued_after_failure is True
     assert mock_client.renew_concurrency_lease.call_count == 3
-    assert (
-        caplog.text.count(
-            "Concurrency lease renewal failed - slots are no longer reserved."
-        )
-        == 1
-    )
+    assert caplog.text.count(failure_message) == 1
 
 
 @mock.patch(

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -9,7 +9,6 @@ import pytest
 
 from prefect._internal.concurrency.cancellation import CancelledError
 from prefect.concurrency._leases import (
-    _get_lease_renewal_client,
     amaintain_concurrency_lease,
     maintain_concurrency_lease,
 )
@@ -23,8 +22,8 @@ def _mock_client_context(mock_client: mock.MagicMock):
 @contextmanager
 def _patch_renewal_client(mock_client: mock.MagicMock):
     with mock.patch(
-        "prefect.concurrency._leases._get_lease_renewal_client",
-        side_effect=lambda: _mock_client_context(mock_client),
+        "prefect.concurrency._leases.get_client",
+        side_effect=lambda *, sync_client: _mock_client_context(mock_client),
     ) as patched:
         yield patched
 
@@ -46,12 +45,13 @@ def test_maintain_concurrency_lease_renews_lease():
     mock_client = mock.MagicMock()
     lease_id = uuid4()
 
-    with _patch_renewal_client(mock_client):
+    with _patch_renewal_client(mock_client) as patched_get_client:
         with maintain_concurrency_lease(lease_id=lease_id, lease_duration=0.05):
             assert _wait_for(
                 lambda: mock_client.renew_concurrency_lease.call_count >= 2
             )
 
+    patched_get_client.assert_called_once_with(sync_client=True)
     mock_client.renew_concurrency_lease.assert_called_with(
         lease_id=lease_id, lease_duration=0.05
     )
@@ -158,70 +158,3 @@ async def test_lease_renewal_fires_when_event_loop_blocked():
                 pass
 
     assert mock_client.renew_concurrency_lease.call_count >= 2
-
-
-def test_lease_renewal_client_prefers_sync_client_context():
-    mock_sync_ctx = mock.MagicMock()
-    mock_sync_ctx.client = mock.MagicMock()
-
-    with mock.patch(
-        "prefect.context.SyncClientContext.get", return_value=mock_sync_ctx
-    ):
-        with _get_lease_renewal_client() as client:
-            assert client is mock_sync_ctx.client
-
-
-def test_lease_renewal_client_uses_async_client_api_url():
-    mock_async_client = mock.MagicMock()
-    mock_async_client.api_url = "http://custom-server:4200/api"
-    mock_async_client.server_type = None
-    mock_async_client._ephemeral_app = None
-
-    mock_async_ctx = mock.MagicMock()
-    mock_async_ctx.client = mock_async_client
-    mock_async_ctx._httpx_settings = {
-        "headers": {"x-test": "value"},
-        "timeout": 30,
-        "transport": mock.MagicMock(),
-    }
-
-    with (
-        mock.patch("prefect.context.SyncClientContext.get", return_value=None),
-        mock.patch(
-            "prefect.context.AsyncClientContext.get", return_value=mock_async_ctx
-        ),
-        mock.patch(
-            "prefect.client.orchestration.SyncPrefectClient"
-        ) as mock_sync_client_cls,
-    ):
-        mock_sync_client_cls.return_value.__enter__.return_value = mock.MagicMock()
-
-        with _get_lease_renewal_client():
-            pass
-
-    mock_sync_client_cls.assert_called_once()
-    call_args, call_kwargs = mock_sync_client_cls.call_args
-    assert call_args == ("http://custom-server:4200/api",)
-    assert call_kwargs["httpx_settings"] == {
-        "headers": {"x-test": "value"},
-        "timeout": 30,
-    }
-    assert call_kwargs["server_type"] is None
-
-
-def test_lease_renewal_client_rejects_in_process_async_client():
-    mock_async_client = mock.MagicMock()
-    mock_async_client._ephemeral_app = mock.MagicMock()
-
-    mock_async_ctx = mock.MagicMock()
-    mock_async_ctx.client = mock_async_client
-
-    with (
-        mock.patch("prefect.context.SyncClientContext.get", return_value=None),
-        mock.patch(
-            "prefect.context.AsyncClientContext.get", return_value=mock_async_ctx
-        ),
-    ):
-        with pytest.raises(RuntimeError, match="Cannot renew a concurrency lease"):
-            with _get_lease_renewal_client():
-                pass

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -1,61 +1,225 @@
 import asyncio
+import logging
+import time
+from contextlib import contextmanager
 from unittest import mock
 from uuid import uuid4
 
 import pytest
 
-from prefect.concurrency._leases import _lease_renewal_loop
+from prefect._internal.concurrency.cancellation import CancelledError
+from prefect.concurrency._leases import (
+    _get_lease_renewal_client,
+    amaintain_concurrency_lease,
+    maintain_concurrency_lease,
+)
 
 
-async def test_lease_renewal_loop_renews_lease():
-    mock_client = mock.AsyncMock()
-    mock_client.renew_concurrency_lease.side_effect = [
-        None,
-        None,
-        asyncio.CancelledError(),
-    ]
-
-    with (
-        mock.patch("prefect.concurrency._leases.get_client") as mock_get_client,
-        mock.patch("asyncio.sleep", new_callable=mock.AsyncMock),
-    ):
-        mock_get_client.return_value.__aenter__.return_value = mock_client
-        with pytest.raises(asyncio.CancelledError):
-            await _lease_renewal_loop(lease_id=uuid4(), lease_duration=10.0)
-
-    assert mock_client.renew_concurrency_lease.call_count == 3
+@contextmanager
+def _mock_client_context(mock_client: mock.MagicMock):
+    yield mock_client
 
 
-async def test_lease_renewal_loop_retries_on_transient_failure():
-    mock_client = mock.AsyncMock()
-    mock_client.renew_concurrency_lease.side_effect = [
-        RuntimeError("transient"),
-        None,  # retry succeeds within first renew() call
-        asyncio.CancelledError(),
-    ]
-
-    with (
-        mock.patch("prefect.concurrency._leases.get_client") as mock_get_client,
-        mock.patch("asyncio.sleep", new_callable=mock.AsyncMock),
-    ):
-        mock_get_client.return_value.__aenter__.return_value = mock_client
-        with pytest.raises(asyncio.CancelledError):
-            await _lease_renewal_loop(lease_id=uuid4(), lease_duration=10.0)
-
-    assert mock_client.renew_concurrency_lease.call_count == 3
+@contextmanager
+def _patch_renewal_client(mock_client: mock.MagicMock):
+    with mock.patch(
+        "prefect.concurrency._leases._get_lease_renewal_client",
+        side_effect=lambda: _mock_client_context(mock_client),
+    ) as patched:
+        yield patched
 
 
-async def test_lease_renewal_loop_raises_after_max_retry_attempts():
-    mock_client = mock.AsyncMock()
+def _zero_backoff(attempt: int, base_delay: float, max_delay: float) -> float:
+    return 0.0
+
+
+def _wait_for(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def test_maintain_concurrency_lease_renews_lease():
+    mock_client = mock.MagicMock()
+    lease_id = uuid4()
+
+    with _patch_renewal_client(mock_client):
+        with maintain_concurrency_lease(lease_id=lease_id, lease_duration=0.05):
+            assert _wait_for(
+                lambda: mock_client.renew_concurrency_lease.call_count >= 2
+            )
+
+    mock_client.renew_concurrency_lease.assert_called_with(
+        lease_id=lease_id, lease_duration=0.05
+    )
+
+
+@mock.patch(
+    "prefect.concurrency._leases.exponential_backoff_with_jitter", _zero_backoff
+)
+def test_lease_renewal_retries_on_transient_failure():
+    mock_client = mock.MagicMock()
+    mock_client.renew_concurrency_lease.side_effect = [RuntimeError("transient"), None]
+
+    with _patch_renewal_client(mock_client):
+        with maintain_concurrency_lease(lease_id=uuid4(), lease_duration=60):
+            assert _wait_for(
+                lambda: mock_client.renew_concurrency_lease.call_count >= 2
+            )
+
+    assert mock_client.renew_concurrency_lease.call_count == 2
+
+
+@mock.patch(
+    "prefect.concurrency._leases.exponential_backoff_with_jitter", _zero_backoff
+)
+def test_lease_renewal_logs_once_after_max_retries_non_strict(
+    caplog: pytest.LogCaptureFixture,
+):
+    mock_client = mock.MagicMock()
     mock_client.renew_concurrency_lease.side_effect = RuntimeError("server down")
 
-    with (
-        mock.patch("prefect.concurrency._leases.get_client") as mock_get_client,
-        mock.patch("asyncio.sleep", new_callable=mock.AsyncMock),
-    ):
-        mock_get_client.return_value.__aenter__.return_value = mock_client
-        with pytest.raises(RuntimeError, match="server down"):
-            await _lease_renewal_loop(lease_id=uuid4(), lease_duration=10.0)
+    with _patch_renewal_client(mock_client):
+        with caplog.at_level(logging.WARNING):
+            with maintain_concurrency_lease(
+                lease_id=uuid4(),
+                lease_duration=60,
+                raise_on_lease_renewal_failure=False,
+            ):
+                assert _wait_for(
+                    lambda: mock_client.renew_concurrency_lease.call_count == 3
+                )
+                continued_after_failure = True
 
-    # retry_async_fn with max_attempts=3 tries exactly 3 times
+    assert continued_after_failure is True
     assert mock_client.renew_concurrency_lease.call_count == 3
+    assert (
+        caplog.text.count(
+            "Concurrency lease renewal failed - slots are no longer reserved."
+        )
+        == 1
+    )
+
+
+@mock.patch(
+    "prefect.concurrency._leases.exponential_backoff_with_jitter", _zero_backoff
+)
+def test_maintain_concurrency_lease_handles_failure_strict():
+    mock_client = mock.MagicMock()
+    mock_client.renew_concurrency_lease.side_effect = RuntimeError("server down")
+
+    with _patch_renewal_client(mock_client):
+        with pytest.raises(CancelledError):
+            with maintain_concurrency_lease(
+                lease_id=uuid4(),
+                lease_duration=60,
+                raise_on_lease_renewal_failure=True,
+            ):
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline:
+                    time.sleep(0.01)
+                raise AssertionError("Strict lease renewal failure did not cancel")
+
+
+@mock.patch(
+    "prefect.concurrency._leases.exponential_backoff_with_jitter", _zero_backoff
+)
+async def test_amaintain_concurrency_lease_handles_failure_strict():
+    mock_client = mock.MagicMock()
+    mock_client.renew_concurrency_lease.side_effect = RuntimeError("server down")
+
+    with _patch_renewal_client(mock_client):
+        with pytest.raises(asyncio.CancelledError):
+            async with amaintain_concurrency_lease(
+                lease_id=uuid4(),
+                lease_duration=60,
+                raise_on_lease_renewal_failure=True,
+            ):
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline:
+                    await asyncio.sleep(0.01)
+                raise AssertionError("Strict lease renewal failure did not cancel")
+
+
+async def test_lease_renewal_fires_when_event_loop_blocked():
+    mock_client = mock.MagicMock()
+
+    with _patch_renewal_client(mock_client):
+        async with amaintain_concurrency_lease(
+            lease_id=uuid4(),
+            lease_duration=0.05,
+        ):
+            deadline = time.monotonic() + 0.25
+            while time.monotonic() < deadline:
+                pass
+
+    assert mock_client.renew_concurrency_lease.call_count >= 2
+
+
+def test_lease_renewal_client_prefers_sync_client_context():
+    mock_sync_ctx = mock.MagicMock()
+    mock_sync_ctx.client = mock.MagicMock()
+
+    with mock.patch(
+        "prefect.context.SyncClientContext.get", return_value=mock_sync_ctx
+    ):
+        with _get_lease_renewal_client() as client:
+            assert client is mock_sync_ctx.client
+
+
+def test_lease_renewal_client_uses_async_client_api_url():
+    mock_async_client = mock.MagicMock()
+    mock_async_client.api_url = "http://custom-server:4200/api"
+    mock_async_client.server_type = None
+    mock_async_client._ephemeral_app = None
+
+    mock_async_ctx = mock.MagicMock()
+    mock_async_ctx.client = mock_async_client
+    mock_async_ctx._httpx_settings = {
+        "headers": {"x-test": "value"},
+        "timeout": 30,
+        "transport": mock.MagicMock(),
+    }
+
+    with (
+        mock.patch("prefect.context.SyncClientContext.get", return_value=None),
+        mock.patch(
+            "prefect.context.AsyncClientContext.get", return_value=mock_async_ctx
+        ),
+        mock.patch("prefect.client.orchestration.SyncPrefectClient")
+        as mock_sync_client_cls,
+    ):
+        mock_sync_client_cls.return_value.__enter__.return_value = mock.MagicMock()
+
+        with _get_lease_renewal_client():
+            pass
+
+    mock_sync_client_cls.assert_called_once()
+    call_args, call_kwargs = mock_sync_client_cls.call_args
+    assert call_args == ("http://custom-server:4200/api",)
+    assert call_kwargs["httpx_settings"] == {
+        "headers": {"x-test": "value"},
+        "timeout": 30,
+    }
+    assert call_kwargs["server_type"] is None
+
+
+def test_lease_renewal_client_rejects_in_process_async_client():
+    mock_async_client = mock.MagicMock()
+    mock_async_client._ephemeral_app = mock.MagicMock()
+
+    mock_async_ctx = mock.MagicMock()
+    mock_async_ctx.client = mock_async_client
+
+    with (
+        mock.patch("prefect.context.SyncClientContext.get", return_value=None),
+        mock.patch(
+            "prefect.context.AsyncClientContext.get", return_value=mock_async_ctx
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="Cannot renew a concurrency lease"):
+            with _get_lease_renewal_client():
+                pass

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -81,6 +81,7 @@ def test_lease_renewal_logs_once_after_max_retries_non_strict(
 ):
     mock_client = mock.MagicMock()
     mock_client.renew_concurrency_lease.side_effect = RuntimeError("server down")
+    continued_after_failure = False
 
     with _patch_renewal_client(mock_client):
         with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
Closes #20251
Closes #19068
Closes #18839
Supersedes #21308

## Summary

- Moves concurrency lease renewal off event-loop tasks and onto a daemon thread so renewal can continue while the caller's event loop is blocked by CPU-bound work.
- Keeps the existing `maintain_concurrency_lease` and `amaintain_concurrency_lease` APIs and preserves strict failure behavior by reusing `WatcherThreadCancelScope` / `AsyncCancelScope`.
- Keeps renewal client configuration simple: the background thread uses the standard `get_client(sync_client=True)` path instead of cloning async client state.
- Updates lease unit tests and filesystem lease integration helpers for the thread-backed cadence.