### PR TITLE
Ensure ECS observer ack waits for handlers

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -16,6 +16,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    Awaitable,
+    Callable,
     Literal,
     NamedTuple,
     Protocol,
@@ -192,6 +194,57 @@ OBSERVER_RESTART_BASE_DELAY = 30
 OBSERVER_MAX_RESTART_ATTEMPTS = 5
 
 
+class SqsMessage(NamedTuple):
+    message: "MessageTypeDef"
+    ack: Callable[[], Awaitable[bool]]
+
+
+class _SqsBackoffState:
+    def __init__(self, operation: str):
+        self.operation = operation
+        self.track_record: deque[bool] = deque(
+            [True] * SQS_CONSECUTIVE_FAILURES, maxlen=SQS_CONSECUTIVE_FAILURES
+        )
+        self.failures: deque[tuple[Exception, TracebackType | None]] = deque(
+            maxlen=SQS_MEMORY
+        )
+        self.backoff_count = 0
+
+    async def record_failure(self, e: Exception) -> None:
+        self.track_record.append(False)
+        self.failures.append((e, e.__traceback__))
+        logger.debug("Failed to %s messages from SQS", self.operation, exc_info=e)
+
+        if not any(self.track_record):
+            self.backoff_count += 1
+
+            if self.backoff_count > SQS_MAX_BACKOFF_ATTEMPTS:
+                logger.error(
+                    "SQS polling exceeded maximum backoff attempts (%s). "
+                    "Last %s errors: %s",
+                    SQS_MAX_BACKOFF_ATTEMPTS,
+                    len(self.failures),
+                    [str(e) for e, _ in self.failures],
+                )
+                raise RuntimeError(
+                    f"SQS polling failed after {SQS_MAX_BACKOFF_ATTEMPTS} backoff attempts"
+                ) from e
+
+            self.track_record.extend([True] * SQS_CONSECUTIVE_FAILURES)
+            self.failures.clear()
+            backoff_seconds = SQS_BACKOFF * 2**self.backoff_count
+            logger.debug(
+                "Backing off due to consecutive errors, using increased interval of %s seconds.",
+                backoff_seconds,
+            )
+            await asyncio.sleep(backoff_seconds)
+
+    def record_success(self) -> None:
+        self.backoff_count = 0
+        self.track_record.append(True)
+        self.failures.clear()
+
+
 class SqsSubscriber:
     def __init__(self, queue_name: str, queue_region: str | None = None):
         self.queue_name = queue_name
@@ -199,7 +252,7 @@ class SqsSubscriber:
 
     async def stream_messages(
         self,
-    ) -> AsyncGenerator["MessageTypeDef", None]:
+    ) -> AsyncGenerator[SqsMessage, None]:
         session = aiobotocore.session.get_session()
         async with session.create_client(
             "sqs", region_name=self.queue_region
@@ -229,46 +282,8 @@ class SqsSubscriber:
                     return
                 raise
 
-            track_record: deque[bool] = deque(
-                [True] * SQS_CONSECUTIVE_FAILURES, maxlen=SQS_CONSECUTIVE_FAILURES
-            )
-            failures: deque[tuple[Exception, TracebackType | None]] = deque(
-                maxlen=SQS_MEMORY
-            )
-            backoff_count = 0
-
-            async def handle_sqs_failure(e: Exception) -> None:
-                nonlocal backoff_count
-
-                track_record.append(False)
-                failures.append((e, e.__traceback__))
-                logger.debug(
-                    "Failed to receive or delete messages from SQS", exc_info=e
-                )
-
-                if not any(track_record):
-                    backoff_count += 1
-
-                    if backoff_count > SQS_MAX_BACKOFF_ATTEMPTS:
-                        logger.error(
-                            "SQS polling exceeded maximum backoff attempts (%s). "
-                            "Last %s errors: %s",
-                            SQS_MAX_BACKOFF_ATTEMPTS,
-                            len(failures),
-                            [str(e) for e, _ in failures],
-                        )
-                        raise RuntimeError(
-                            f"SQS polling failed after {SQS_MAX_BACKOFF_ATTEMPTS} backoff attempts"
-                        ) from e
-
-                    track_record.extend([True] * SQS_CONSECUTIVE_FAILURES)
-                    failures.clear()
-                    backoff_seconds = SQS_BACKOFF * 2**backoff_count
-                    logger.debug(
-                        "Backing off due to consecutive errors, using increased interval of %s seconds.",
-                        backoff_seconds,
-                    )
-                    await asyncio.sleep(backoff_seconds)
+            receive_backoff = _SqsBackoffState("receive")
+            delete_backoff = _SqsBackoffState("delete")
 
             while True:
                 try:
@@ -278,30 +293,29 @@ class SqsSubscriber:
                         WaitTimeSeconds=20,
                     )
                 except Exception as e:
-                    await handle_sqs_failure(e)
+                    await receive_backoff.record_failure(e)
                     continue
 
-                backoff_count = 0
-                track_record.append(True)
-                failures.clear()
+                receive_backoff.record_success()
 
                 for message in messages.get("Messages", []):
                     if not (receipt_handle := message.get("ReceiptHandle")):
                         continue
 
-                    yield message
+                    async def ack(receipt_handle: str = receipt_handle) -> bool:
+                        try:
+                            await sqs_client.delete_message(
+                                QueueUrl=queue_url,
+                                ReceiptHandle=receipt_handle,
+                            )
+                        except Exception as e:
+                            await delete_backoff.record_failure(e)
+                            return False
+                        else:
+                            delete_backoff.record_success()
+                            return True
 
-                    try:
-                        await sqs_client.delete_message(
-                            QueueUrl=queue_url,
-                            ReceiptHandle=receipt_handle,
-                        )
-                    except Exception as e:
-                        await handle_sqs_failure(e)
-                    else:
-                        backoff_count = 0
-                        track_record.append(True)
-                        failures.clear()
+                    yield SqsMessage(message=message, ack=ack)
 
 
 class EcsObserver:
@@ -331,12 +345,14 @@ class EcsObserver:
         async with AsyncExitStack() as stack:
             await stack.enter_async_context(self.ecs_tags_reader)
 
-            async for message in self.sqs_subscriber.stream_messages():
+            async for sqs_message in self.sqs_subscriber.stream_messages():
+                message = sqs_message.message
                 if not (body := message.get("Body")):
                     logger.debug(
                         "No body in message. Skipping.",
                         extra={"sqs_message": message},
                     )
+                    await sqs_message.ack()
                     continue
 
                 body = json.loads(body)
@@ -355,10 +371,12 @@ class EcsObserver:
                         "No event type in message. Skipping.",
                         extra={"sqs_message": message},
                     )
+                    await sqs_message.ack()
                     continue
 
                 if detail_type not in _ECS_EVENT_DETAIL_MAP:
                     logger.debug("Unknown event type: %s. Skipping.", detail_type)
+                    await sqs_message.ack()
                     continue
 
                 last_status = body.get("detail", {}).get("lastStatus")
@@ -378,11 +396,20 @@ class EcsObserver:
                         matching_handlers.append(handler)
 
                 if matching_handlers:
-                    async with anyio.create_task_group() as task_group:
-                        for handler in matching_handlers:
-                            task_group.start_soon(
-                                self._run_handler, handler, body, tags
-                            )
+                    try:
+                        async with anyio.create_task_group() as task_group:
+                            for handler in matching_handlers:
+                                task_group.start_soon(
+                                    self._run_handler, handler, body, tags
+                                )
+                    except Exception:
+                        logger.exception(
+                            "Failed to process ECS observer message",
+                            extra={"sqs_message": message},
+                        )
+                        continue
+
+                await sqs_message.ack()
 
     async def _run_handler(
         self,

--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -191,6 +191,7 @@ SQS_BACKOFF = 1
 SQS_MAX_BACKOFF_ATTEMPTS = 5
 SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS = 300
 SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS = 240
+SQS_VISIBILITY_EXTENSION_RETRY_INTERVAL_SECONDS = 5
 
 OBSERVER_RESTART_BASE_DELAY = 30
 OBSERVER_MAX_RESTART_ATTEMPTS = 5
@@ -295,6 +296,7 @@ class SqsSubscriber:
                         QueueUrl=queue_url,
                         MaxNumberOfMessages=1,
                         WaitTimeSeconds=20,
+                        VisibilityTimeout=SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS,
                     )
                 except Exception as e:
                     await receive_backoff.record_failure(e)
@@ -460,14 +462,22 @@ class EcsObserver:
         sqs_message: SqsMessage,
         message: "MessageTypeDef",
     ) -> None:
+        sleep_interval = SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS
         while True:
-            await asyncio.sleep(SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS)
+            await asyncio.sleep(sleep_interval)
             try:
-                await sqs_message.extend_visibility()
+                extended = await sqs_message.extend_visibility()
             except Exception:
                 logger.exception(
                     "Failed to extend ECS observer message visibility",
                     extra={"sqs_message": message},
+                )
+                sleep_interval = SQS_VISIBILITY_EXTENSION_RETRY_INTERVAL_SECONDS
+            else:
+                sleep_interval = (
+                    SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS
+                    if extended
+                    else SQS_VISIBILITY_EXTENSION_RETRY_INTERVAL_SECONDS
                 )
 
     def on_event(

--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import enum
+import inspect
 import json
 import logging
 import uuid
@@ -236,29 +237,14 @@ class SqsSubscriber:
             )
             backoff_count = 0
 
-            while True:
-                try:
-                    messages = await sqs_client.receive_message(
-                        QueueUrl=queue_url,
-                        MaxNumberOfMessages=10,
-                        WaitTimeSeconds=20,
-                    )
-                    for message in messages.get("Messages", []):
-                        if not (receipt_handle := message.get("ReceiptHandle")):
-                            continue
+            async def handle_sqs_failure(e: Exception) -> None:
+                nonlocal backoff_count
 
-                        yield message
-
-                        await sqs_client.delete_message(
-                            QueueUrl=queue_url,
-                            ReceiptHandle=receipt_handle,
-                        )
-
-                    backoff_count = 0
-                except Exception as e:
-                    track_record.append(False)
-                    failures.append((e, e.__traceback__))
-                    logger.debug("Failed to receive messages from SQS", exc_info=e)
+                track_record.append(False)
+                failures.append((e, e.__traceback__))
+                logger.debug(
+                    "Failed to receive or delete messages from SQS", exc_info=e
+                )
 
                 if not any(track_record):
                     backoff_count += 1
@@ -273,7 +259,7 @@ class SqsSubscriber:
                         )
                         raise RuntimeError(
                             f"SQS polling failed after {SQS_MAX_BACKOFF_ATTEMPTS} backoff attempts"
-                        )
+                        ) from e
 
                     track_record.extend([True] * SQS_CONSECUTIVE_FAILURES)
                     failures.clear()
@@ -283,6 +269,39 @@ class SqsSubscriber:
                         backoff_seconds,
                     )
                     await asyncio.sleep(backoff_seconds)
+
+            while True:
+                try:
+                    messages = await sqs_client.receive_message(
+                        QueueUrl=queue_url,
+                        MaxNumberOfMessages=10,
+                        WaitTimeSeconds=20,
+                    )
+                except Exception as e:
+                    await handle_sqs_failure(e)
+                    continue
+
+                backoff_count = 0
+                track_record.append(True)
+                failures.clear()
+
+                for message in messages.get("Messages", []):
+                    if not (receipt_handle := message.get("ReceiptHandle")):
+                        continue
+
+                    yield message
+
+                    try:
+                        await sqs_client.delete_message(
+                            QueueUrl=queue_url,
+                            ReceiptHandle=receipt_handle,
+                        )
+                    except Exception as e:
+                        await handle_sqs_failure(e)
+                    else:
+                        backoff_count = 0
+                        track_record.append(True)
+                        failures.clear()
 
 
 class EcsObserver:
@@ -310,7 +329,6 @@ class EcsObserver:
 
     async def run(self):
         async with AsyncExitStack() as stack:
-            task_group = await stack.enter_async_context(anyio.create_task_group())
             await stack.enter_async_context(self.ecs_tags_reader)
 
             async for message in self.sqs_subscriber.stream_messages():
@@ -345,6 +363,9 @@ class EcsObserver:
 
                 last_status = body.get("detail", {}).get("lastStatus")
                 event_type = _ECS_EVENT_DETAIL_MAP[detail_type]
+                matching_handlers: list[
+                    Union[EcsEventHandler, AsyncEcsEventHandler]
+                ] = []
                 for handler, filters in self.event_handlers[event_type]:
                     if filters["tags"].is_match(tags) and filters[
                         "last_status"
@@ -354,12 +375,25 @@ class EcsObserver:
                             handler.__name__,
                             extra={"sqs_message": message},
                         )
-                        if asyncio.iscoroutinefunction(handler):
-                            task_group.start_soon(handler, body, tags)
-                        else:
+                        matching_handlers.append(handler)
+
+                if matching_handlers:
+                    async with anyio.create_task_group() as task_group:
+                        for handler in matching_handlers:
                             task_group.start_soon(
-                                asyncio.to_thread, partial(handler, body, tags)
+                                self._run_handler, handler, body, tags
                             )
+
+    async def _run_handler(
+        self,
+        handler: Union[EcsEventHandler, AsyncEcsEventHandler],
+        event: dict[str, Any],
+        tags: dict[str, str],
+    ) -> None:
+        if inspect.iscoroutinefunction(handler):
+            await handler(event, tags)
+        else:
+            await asyncio.to_thread(partial(handler, event, tags))
 
     def on_event(
         self,
@@ -802,6 +836,7 @@ async def mark_runs_as_crashed(event: dict[str, Any], tags: dict[str, str]):
                     "Failed to propose Crashed state for flow run %s",
                     flow_run_id,
                 )
+                raise
 
         # Forward CloudWatch container logs for runs that never connected
         # to the Prefect server (never reached Running state). This runs

--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -274,7 +274,7 @@ class SqsSubscriber:
                 try:
                     messages = await sqs_client.receive_message(
                         QueueUrl=queue_url,
-                        MaxNumberOfMessages=10,
+                        MaxNumberOfMessages=1,
                         WaitTimeSeconds=20,
                     )
                 except Exception as e:

--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -467,6 +467,8 @@ class EcsObserver:
             await asyncio.sleep(sleep_interval)
             try:
                 extended = await sqs_message.extend_visibility()
+            except RuntimeError:
+                raise
             except Exception:
                 logger.exception(
                     "Failed to extend ECS observer message visibility",

--- a/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/observers/ecs.py
@@ -189,6 +189,8 @@ SQS_MEMORY = 10
 SQS_CONSECUTIVE_FAILURES = 3
 SQS_BACKOFF = 1
 SQS_MAX_BACKOFF_ATTEMPTS = 5
+SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS = 300
+SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS = 240
 
 OBSERVER_RESTART_BASE_DELAY = 30
 OBSERVER_MAX_RESTART_ATTEMPTS = 5
@@ -197,6 +199,7 @@ OBSERVER_MAX_RESTART_ATTEMPTS = 5
 class SqsMessage(NamedTuple):
     message: "MessageTypeDef"
     ack: Callable[[], Awaitable[bool]]
+    extend_visibility: Callable[[], Awaitable[bool]]
 
 
 class _SqsBackoffState:
@@ -284,6 +287,7 @@ class SqsSubscriber:
 
             receive_backoff = _SqsBackoffState("receive")
             delete_backoff = _SqsBackoffState("delete")
+            visibility_backoff = _SqsBackoffState("change visibility for")
 
             while True:
                 try:
@@ -315,7 +319,27 @@ class SqsSubscriber:
                             delete_backoff.record_success()
                             return True
 
-                    yield SqsMessage(message=message, ack=ack)
+                    async def extend_visibility(
+                        receipt_handle: str = receipt_handle,
+                    ) -> bool:
+                        try:
+                            await sqs_client.change_message_visibility(
+                                QueueUrl=queue_url,
+                                ReceiptHandle=receipt_handle,
+                                VisibilityTimeout=SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS,
+                            )
+                        except Exception as e:
+                            await visibility_backoff.record_failure(e)
+                            return False
+                        else:
+                            visibility_backoff.record_success()
+                            return True
+
+                    yield SqsMessage(
+                        message=message,
+                        ack=ack,
+                        extend_visibility=extend_visibility,
+                    )
 
 
 class EcsObserver:
@@ -397,11 +421,20 @@ class EcsObserver:
 
                 if matching_handlers:
                     try:
-                        async with anyio.create_task_group() as task_group:
-                            for handler in matching_handlers:
-                                task_group.start_soon(
-                                    self._run_handler, handler, body, tags
-                                )
+                        async with anyio.create_task_group() as visibility_group:
+                            visibility_group.start_soon(
+                                self._extend_message_visibility_while_processing,
+                                sqs_message,
+                                message,
+                            )
+                            try:
+                                async with anyio.create_task_group() as task_group:
+                                    for handler in matching_handlers:
+                                        task_group.start_soon(
+                                            self._run_handler, handler, body, tags
+                                        )
+                            finally:
+                                visibility_group.cancel_scope.cancel()
                     except Exception:
                         logger.exception(
                             "Failed to process ECS observer message",
@@ -421,6 +454,21 @@ class EcsObserver:
             await handler(event, tags)
         else:
             await asyncio.to_thread(partial(handler, event, tags))
+
+    async def _extend_message_visibility_while_processing(
+        self,
+        sqs_message: SqsMessage,
+        message: "MessageTypeDef",
+    ) -> None:
+        while True:
+            await asyncio.sleep(SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS)
+            try:
+                await sqs_message.extend_visibility()
+            except Exception:
+                logger.exception(
+                    "Failed to extend ECS observer message visibility",
+                    extra={"sqs_message": message},
+                )
 
     def on_event(
         self,

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -258,20 +258,23 @@ class TestSqsSubscriber:
         messages_batch_1 = {
             "Messages": [
                 {"Body": "message1", "ReceiptHandle": "handle1"},
-                {"Body": "message2", "ReceiptHandle": "handle2"},
             ]
         }
         messages_batch_2 = {
             "Messages": [
+                {"Body": "message2", "ReceiptHandle": "handle2"},
+            ]
+        }
+        messages_batch_3 = {
+            "Messages": [
                 {"Body": "message3", "ReceiptHandle": "handle3"},
             ]
         }
-        empty_batch = {"Messages": []}
 
         mock_sqs_client.receive_message.side_effect = [
             messages_batch_1,
             messages_batch_2,
-            empty_batch,
+            messages_batch_3,
         ]
 
         messages = []
@@ -287,6 +290,9 @@ class TestSqsSubscriber:
         assert messages[0]["Body"] == "message1"
         assert messages[1]["Body"] == "message2"
         assert messages[2]["Body"] == "message3"
+
+        for call in mock_sqs_client.receive_message.call_args_list:
+            assert call.kwargs["MaxNumberOfMessages"] == 1
 
         # Note: Only 2 deletes will be called because we break after the 3rd yield
         # but before its delete can execute
@@ -320,16 +326,17 @@ class TestSqsSubscriber:
         messages_batch = {
             "Messages": [
                 {"Body": "message1"},  # No ReceiptHandle, should be skipped
+            ]
+        }
+        messages_batch_2 = {
+            "Messages": [
                 {"Body": "message2", "ReceiptHandle": "handle2"},
             ]
         }
 
-        # Second batch to ensure we can break out
-        empty_batch = {"Messages": []}
-
         mock_sqs_client.receive_message.side_effect = [
             messages_batch,
-            empty_batch,
+            messages_batch_2,
         ]
 
         messages = []

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -13,6 +13,8 @@ from botocore.exceptions import ClientError
 from cachetools import LRUCache
 from prefect_aws.observers.ecs import (
     SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS,
+    SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS,
+    SQS_VISIBILITY_EXTENSION_RETRY_INTERVAL_SECONDS,
     EcsObserver,
     EcsTaskTagsReader,
     FilterCase,
@@ -296,6 +298,10 @@ class TestSqsSubscriber:
 
         for call in mock_sqs_client.receive_message.call_args_list:
             assert call.kwargs["MaxNumberOfMessages"] == 1
+            assert (
+                call.kwargs["VisibilityTimeout"]
+                == SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS
+            )
 
         # Only 2 deletes are called because this test acknowledges the first two
         # messages before breaking on the third.
@@ -840,6 +846,33 @@ class TestEcsObserver:
             await asyncio.wait_for(task, timeout=1)
         except asyncio.CancelledError:
             pass
+
+    async def test_message_visibility_extension_failures_retry_soon(self, observer):
+        extend_visibility = AsyncMock(side_effect=[False, asyncio.CancelledError()])
+        sqs_message = SqsMessage(
+            message={},
+            ack=AsyncMock(return_value=True),
+            extend_visibility=extend_visibility,
+        )
+        sleep_calls = []
+
+        async def sleep(interval):
+            sleep_calls.append(interval)
+
+        with (
+            patch("prefect_aws.observers.ecs.asyncio.sleep", sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await observer._extend_message_visibility_while_processing(
+                sqs_message,
+                sqs_message.message,
+            )
+
+        assert sleep_calls == [
+            SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS,
+            SQS_VISIBILITY_EXTENSION_RETRY_INTERVAL_SECONDS,
+        ]
+        assert extend_visibility.await_count == 2
 
     @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
     async def test_run_does_not_delete_message_when_handler_fails(

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -537,6 +537,35 @@ class TestEcsObserver:
             ecs_tags_reader=mock_tags_reader,
         )
 
+    def _setup_sqs_client(self, mock_get_session, receive_side_effect):
+        mock_session = Mock()
+        mock_sqs_client = AsyncMock()
+        mock_client_context = AsyncMock()
+        mock_client_context.__aenter__.return_value = mock_sqs_client
+        mock_session.create_client.return_value = mock_client_context
+        mock_get_session.return_value = mock_session
+
+        mock_sqs_client.get_queue_url.return_value = {
+            "QueueUrl": "https://sqs.us-east-1.amazonaws.com/123456789/test-queue"
+        }
+        mock_sqs_client.receive_message.side_effect = receive_side_effect
+        return mock_sqs_client
+
+    def _ecs_task_state_change_message(self):
+        return {
+            "Body": json.dumps(
+                {
+                    "detail-type": "ECS Task State Change",
+                    "detail": {
+                        "taskArn": "arn:aws:ecs:us-east-1:123456789:task/task-id",
+                        "clusterArn": "arn:aws:ecs:us-east-1:123456789:cluster/cluster",
+                        "lastStatus": "STOPPED",
+                    },
+                }
+            ),
+            "ReceiptHandle": "handle1",
+        }
+
     def test_init_with_defaults(self):
         observer = EcsObserver()
         assert isinstance(observer.settings, EcsObserverSettings)
@@ -617,6 +646,97 @@ class TestEcsObserver:
             await task
         except asyncio.CancelledError:
             pass
+
+    @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
+    async def test_run_waits_for_handlers_before_deleting_message(
+        self, mock_get_session, settings, mock_tags_reader
+    ):
+        message = self._ecs_task_state_change_message()
+        mock_sqs_client = self._setup_sqs_client(
+            mock_get_session,
+            [
+                {"Messages": [message]},
+                asyncio.CancelledError(),
+            ],
+        )
+
+        observer = EcsObserver(
+            settings=settings,
+            sqs_subscriber=SqsSubscriber("test-queue", "us-east-1"),
+            ecs_tags_reader=mock_tags_reader,
+        )
+
+        handler_started = asyncio.Event()
+        handler_finished = asyncio.Event()
+
+        async def handler(event, tags):
+            handler_started.set()
+            await handler_finished.wait()
+
+        observer.on_event("task", tags={"prefect": "test"})(handler)
+        mock_tags_reader.read_tags.return_value = {"prefect": "test"}
+
+        task = asyncio.create_task(observer.run())
+        await asyncio.wait_for(handler_started.wait(), timeout=1)
+        await asyncio.sleep(0.05)
+
+        mock_sqs_client.delete_message.assert_not_called()
+
+        handler_finished.set()
+        for _ in range(10):
+            if mock_sqs_client.delete_message.called:
+                break
+            await asyncio.sleep(0.05)
+
+        mock_sqs_client.delete_message.assert_called_once_with(
+            QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
+            ReceiptHandle="handle1",
+        )
+
+        try:
+            await asyncio.wait_for(task, timeout=1)
+        except asyncio.CancelledError:
+            pass
+
+    @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
+    async def test_run_does_not_delete_message_when_handler_fails(
+        self, mock_get_session, settings, mock_tags_reader
+    ):
+        message = self._ecs_task_state_change_message()
+        mock_sqs_client = self._setup_sqs_client(
+            mock_get_session,
+            [{"Messages": [message]}],
+        )
+
+        observer = EcsObserver(
+            settings=settings,
+            sqs_subscriber=SqsSubscriber("test-queue", "us-east-1"),
+            ecs_tags_reader=mock_tags_reader,
+        )
+
+        handler_started = asyncio.Event()
+        handler_finished = asyncio.Event()
+
+        async def handler(event, tags):
+            handler_started.set()
+            await handler_finished.wait()
+            raise RuntimeError("handler failed")
+
+        observer.on_event("task", tags={"prefect": "test"})(handler)
+        mock_tags_reader.read_tags.return_value = {"prefect": "test"}
+
+        task = asyncio.create_task(observer.run())
+        await asyncio.wait_for(handler_started.wait(), timeout=1)
+        await asyncio.sleep(0.05)
+
+        mock_sqs_client.delete_message.assert_not_called()
+
+        handler_finished.set()
+        done, _ = await asyncio.wait({task}, timeout=1)
+
+        assert task in done
+        assert task.exception() is not None
+        mock_sqs_client.delete_message.assert_not_called()
 
     async def test_run_skips_message_without_body(
         self, observer, mock_sqs_subscriber, mock_tags_reader
@@ -977,6 +1097,31 @@ class TestMarkRunsAsCrashed:
         assert proposed_state.name == "Crashed"
         assert call_args["flow_run_id"] == flow_run_id
         assert call_args["client"] == mock_client
+
+    @patch("prefect_aws.observers.ecs.prefect.get_client")
+    @patch("prefect_aws.observers.ecs.propose_state")
+    async def test_mark_runs_as_crashed_reraises_crash_proposal_errors(
+        self, mock_propose_state, mock_get_client, sample_event, sample_tags
+    ):
+        flow_run_id = uuid.UUID(sample_tags["prefect.io/flow-run-id"])
+        mock_client = AsyncMock()
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_context
+        mock_propose_state.side_effect = RuntimeError("api unavailable")
+
+        flow_run = FlowRun(
+            id=flow_run_id,
+            name="test-flow-run",
+            flow_id=uuid.uuid4(),
+            state=State(type="RUNNING", name="Running"),
+        )
+        mock_client.read_flow_run.return_value = flow_run
+
+        with pytest.raises(RuntimeError, match="api unavailable"):
+            await mark_runs_as_crashed(sample_event, sample_tags)
+
+        mock_propose_state.assert_called_once()
 
     @patch("prefect_aws.observers.ecs.prefect.get_client")
     @patch("prefect_aws.observers.ecs.propose_state")

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -12,6 +12,7 @@ import pytest
 from botocore.exceptions import ClientError
 from cachetools import LRUCache
 from prefect_aws.observers.ecs import (
+    SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS,
     EcsObserver,
     EcsTaskTagsReader,
     FilterCase,
@@ -296,8 +297,8 @@ class TestSqsSubscriber:
         for call in mock_sqs_client.receive_message.call_args_list:
             assert call.kwargs["MaxNumberOfMessages"] == 1
 
-        # Note: Only 2 deletes will be called because we break after the 3rd yield
-        # but before its delete can execute
+        # Only 2 deletes are called because this test acknowledges the first two
+        # messages before breaking on the third.
         assert mock_sqs_client.delete_message.call_count == 2
         delete_calls = mock_sqs_client.delete_message.call_args_list
 
@@ -353,8 +354,37 @@ class TestSqsSubscriber:
         assert messages[0]["Body"] == "message2"
         assert messages[0]["ReceiptHandle"] == "handle2"
 
-        # Note: delete may not be called if we break immediately after yield
-        # The generator is interrupted before the delete after yield can execute
+        mock_sqs_client.delete_message.assert_not_called()
+
+    @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
+    async def test_stream_messages_can_extend_message_visibility(
+        self, mock_get_session, subscriber
+    ):
+        mock_session = Mock()
+        mock_sqs_client = AsyncMock()
+        mock_client_context = AsyncMock()
+        mock_client_context.__aenter__.return_value = mock_sqs_client
+        mock_session.create_client.return_value = mock_client_context
+        mock_get_session.return_value = mock_session
+
+        mock_sqs_client.get_queue_url.return_value = {
+            "QueueUrl": "https://sqs.us-east-1.amazonaws.com/123456789/test-queue"
+        }
+        mock_sqs_client.receive_message.return_value = {
+            "Messages": [{"Body": "message1", "ReceiptHandle": "handle1"}],
+        }
+
+        message_generator = subscriber.stream_messages()
+        sqs_message = await anext(message_generator)
+
+        assert await sqs_message.extend_visibility() is True
+        mock_sqs_client.change_message_visibility.assert_awaited_once_with(
+            QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
+            ReceiptHandle="handle1",
+            VisibilityTimeout=SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS,
+        )
+
+        await message_generator.aclose()
 
     @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
     @patch("prefect_aws.observers.ecs.asyncio.sleep")
@@ -738,6 +768,70 @@ class TestEcsObserver:
             await asyncio.sleep(0.05)
 
         mock_sqs_client.delete_message.assert_called_once_with(
+            QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
+            ReceiptHandle="handle1",
+        )
+
+        try:
+            await asyncio.wait_for(task, timeout=1)
+        except asyncio.CancelledError:
+            pass
+
+    @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
+    async def test_run_extends_message_visibility_while_handlers_run(
+        self, mock_get_session, settings, mock_tags_reader
+    ):
+        message = self._ecs_task_state_change_message()
+        mock_sqs_client = self._setup_sqs_client(
+            mock_get_session,
+            [
+                {"Messages": [message]},
+                asyncio.CancelledError(),
+            ],
+        )
+
+        observer = EcsObserver(
+            settings=settings,
+            sqs_subscriber=SqsSubscriber("test-queue", "us-east-1"),
+            ecs_tags_reader=mock_tags_reader,
+        )
+
+        handler_started = asyncio.Event()
+        handler_finished = asyncio.Event()
+
+        async def handler(event, tags):
+            handler_started.set()
+            await handler_finished.wait()
+
+        observer.on_event("task", tags={"prefect": "test"})(handler)
+        mock_tags_reader.read_tags.return_value = {"prefect": "test"}
+
+        with patch(
+            "prefect_aws.observers.ecs.SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS", 0.01
+        ):
+            task = asyncio.create_task(observer.run())
+            await asyncio.wait_for(handler_started.wait(), timeout=1)
+
+            for _ in range(10):
+                if mock_sqs_client.change_message_visibility.await_count:
+                    break
+                await asyncio.sleep(0.01)
+
+            mock_sqs_client.change_message_visibility.assert_awaited()
+            mock_sqs_client.delete_message.assert_not_called()
+
+            handler_finished.set()
+            for _ in range(10):
+                if mock_sqs_client.delete_message.await_count:
+                    break
+                await asyncio.sleep(0.01)
+
+        mock_sqs_client.change_message_visibility.assert_any_await(
+            QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
+            ReceiptHandle="handle1",
+            VisibilityTimeout=SQS_MESSAGE_VISIBILITY_TIMEOUT_SECONDS,
+        )
+        mock_sqs_client.delete_message.assert_awaited_once_with(
             QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
             ReceiptHandle="handle1",
         )
@@ -2591,4 +2685,5 @@ async def async_generator_from_list(items: list) -> AsyncGenerator[Any, None]:
             yield item
         else:
             ack = AsyncMock(return_value=True)
-            yield SqsMessage(message=item, ack=ack)
+            extend_visibility = AsyncMock(return_value=True)
+            yield SqsMessage(message=item, ack=ack, extend_visibility=extend_visibility)

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -16,6 +16,7 @@ from prefect_aws.observers.ecs import (
     EcsTaskTagsReader,
     FilterCase,
     LastStatusFilter,
+    SqsMessage,
     SqsSubscriber,
     TagsFilter,
     _related_resources_from_tags,
@@ -279,12 +280,13 @@ class TestSqsSubscriber:
 
         messages = []
         message_generator = subscriber.stream_messages()
-        async for message in message_generator:
-            messages.append(message)
+        async for sqs_message in message_generator:
+            messages.append(sqs_message.message)
             if len(messages) >= 3:
                 # Close the generator properly to avoid pending task warning
                 await message_generator.aclose()
                 break
+            await sqs_message.ack()
 
         assert len(messages) == 3
         assert messages[0]["Body"] == "message1"
@@ -341,8 +343,8 @@ class TestSqsSubscriber:
 
         messages = []
         message_generator = subscriber.stream_messages()
-        async for message in message_generator:
-            messages.append(message)
+        async for sqs_message in message_generator:
+            messages.append(sqs_message.message)
             # Since message1 is skipped (no receipt handle), we only get message2
             await message_generator.aclose()
             break
@@ -382,8 +384,8 @@ class TestSqsSubscriber:
 
         messages = []
         message_generator = subscriber.stream_messages()
-        async for message in message_generator:
-            messages.append(message)
+        async for sqs_message in message_generator:
+            messages.append(sqs_message.message)
             await message_generator.aclose()
             break
 
@@ -429,8 +431,8 @@ class TestSqsSubscriber:
 
         messages = []
         message_generator = subscriber.stream_messages()
-        async for message in message_generator:
-            messages.append(message)
+        async for sqs_message in message_generator:
+            messages.append(sqs_message.message)
             await message_generator.aclose()
             break
 
@@ -475,6 +477,46 @@ class TestSqsSubscriber:
 
     @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
     @patch("prefect_aws.observers.ecs.asyncio.sleep")
+    async def test_stream_messages_delete_failures_backoff_independent_of_receive_success(
+        self, mock_sleep, mock_get_session, subscriber
+    ):
+        """Delete failures should back off even when receives keep succeeding."""
+        mock_session = Mock()
+        mock_sqs_client = AsyncMock()
+        mock_client_context = AsyncMock()
+        mock_client_context.__aenter__.return_value = mock_sqs_client
+        mock_session.create_client.return_value = mock_client_context
+        mock_get_session.return_value = mock_session
+
+        mock_sqs_client.get_queue_url.return_value = {
+            "QueueUrl": "https://sqs.us-east-1.amazonaws.com/123456789/test-queue"
+        }
+
+        mock_sqs_client.receive_message.side_effect = [
+            {
+                "Messages": [
+                    {"Body": f"message{i}", "ReceiptHandle": f"handle{i}"},
+                ]
+            }
+            for i in range(18)
+        ]
+        failure_exception = Exception("Persistent delete error")
+        mock_sqs_client.delete_message.side_effect = [failure_exception] * 18
+
+        message_generator = subscriber.stream_messages()
+
+        with pytest.raises(
+            RuntimeError, match="SQS polling failed after 5 backoff attempts"
+        ):
+            async for sqs_message in message_generator:
+                await sqs_message.ack()
+
+        assert mock_sleep.call_count == 5
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        assert sleep_calls == [2, 4, 8, 16, 32]
+
+    @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
+    @patch("prefect_aws.observers.ecs.asyncio.sleep")
     async def test_stream_messages_resets_backoff_on_success(
         self, mock_sleep, mock_get_session, subscriber
     ):
@@ -508,8 +550,8 @@ class TestSqsSubscriber:
 
         messages = []
         message_generator = subscriber.stream_messages()
-        async for message in message_generator:
-            messages.append(message)
+        async for sqs_message in message_generator:
+            messages.append(sqs_message.message)
             if len(messages) >= 2:
                 await message_generator.aclose()
                 break
@@ -712,7 +754,10 @@ class TestEcsObserver:
         message = self._ecs_task_state_change_message()
         mock_sqs_client = self._setup_sqs_client(
             mock_get_session,
-            [{"Messages": [message]}],
+            [
+                {"Messages": [message]},
+                asyncio.CancelledError(),
+            ],
         )
 
         observer = EcsObserver(
@@ -739,10 +784,11 @@ class TestEcsObserver:
         mock_sqs_client.delete_message.assert_not_called()
 
         handler_finished.set()
-        done, _ = await asyncio.wait({task}, timeout=1)
 
-        assert task in done
-        assert task.exception() is not None
+        try:
+            await asyncio.wait_for(task, timeout=1)
+        except asyncio.CancelledError:
+            pass
         mock_sqs_client.delete_message.assert_not_called()
 
     async def test_run_skips_message_without_body(
@@ -2541,4 +2587,8 @@ class TestObserverManagement:
 
 async def async_generator_from_list(items: list) -> AsyncGenerator[Any, None]:
     for item in items:
-        yield item
+        if isinstance(item, SqsMessage):
+            yield item
+        else:
+            ack = AsyncMock(return_value=True)
+            yield SqsMessage(message=item, ack=ack)

--- a/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
+++ b/src/integrations/prefect-aws/tests/observers/test_ecs_observer.py
@@ -875,6 +875,65 @@ class TestEcsObserver:
         assert extend_visibility.await_count == 2
 
     @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
+    async def test_run_stops_processing_when_visibility_backoff_is_exhausted(
+        self, mock_get_session, settings, mock_tags_reader
+    ):
+        message = self._ecs_task_state_change_message()
+        mock_sqs_client = self._setup_sqs_client(
+            mock_get_session,
+            [
+                {"Messages": [message]},
+                asyncio.CancelledError(),
+            ],
+        )
+        mock_sqs_client.change_message_visibility.side_effect = [
+            Exception("Persistent visibility error") for _ in range(18)
+        ]
+
+        observer = EcsObserver(
+            settings=settings,
+            sqs_subscriber=SqsSubscriber("test-queue", "us-east-1"),
+            ecs_tags_reader=mock_tags_reader,
+        )
+
+        handler_started = asyncio.Event()
+        handler_exited = asyncio.Event()
+        handler_finished = asyncio.Event()
+
+        async def handler(event, tags):
+            handler_started.set()
+            try:
+                await handler_finished.wait()
+            finally:
+                handler_exited.set()
+
+        observer.on_event("task", tags={"prefect": "test"})(handler)
+        mock_tags_reader.read_tags.return_value = {"prefect": "test"}
+
+        with (
+            patch("prefect_aws.observers.ecs.SQS_BACKOFF", 0),
+            patch(
+                "prefect_aws.observers.ecs.SQS_VISIBILITY_EXTENSION_INTERVAL_SECONDS",
+                0.01,
+            ),
+            patch(
+                "prefect_aws.observers.ecs.SQS_VISIBILITY_EXTENSION_RETRY_INTERVAL_SECONDS",
+                0,
+            ),
+        ):
+            task = asyncio.create_task(observer.run())
+            await asyncio.wait_for(handler_started.wait(), timeout=1)
+            await asyncio.wait_for(handler_exited.wait(), timeout=1)
+
+        assert mock_sqs_client.change_message_visibility.await_count == 18
+        mock_sqs_client.delete_message.assert_not_called()
+
+        try:
+            await asyncio.wait_for(task, timeout=1)
+        except asyncio.CancelledError:
+            pass
+
+    @patch("prefect_aws.observers.ecs.aiobotocore.session.get_session")
     async def test_run_does_not_delete_message_when_handler_fails(
         self, mock_get_session, settings, mock_tags_reader
     ):


### PR DESCRIPTION
this PR updates the ECS observer so SQS task state change messages are only deleted after matching handlers finish successfully.

<details>
<summary>Details</summary>

The observer previously scheduled matching handlers in the long-running observer task group, then returned control to the SQS subscriber before crash handling completed. That allowed the subscriber to delete messages before handlers had finished.

This change scopes handler execution to each SQS message before acknowledgement, keeps SQS receive/delete backoff handling scoped to SQS operations, and re-raises crash proposal failures so unsuccessful `Crashed` state proposals leave the message available for SQS retry.

Added regression coverage for handler completion timing, handler failure without message deletion, and crash proposal failures.
</details>