### PR TITLE
fix: preserve concurrency lease for in-process flow retries (#20251)

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -865,6 +865,12 @@ class ReleaseFlowConcurrencySlots(FlowRunUniversalTransform):
 
     This rule releases a concurrency slot for a deployment when a flow run
     transitions out of the Running or Cancelling state.
+
+    Exception: in-process retries (``retry_type == "in_process"``) are exempt.
+    The flow engine keeps the same process alive during the retry delay and
+    continuously renews the concurrency lease.  Releasing the slot here would
+    invalidate the lease mid-delay, causing a spurious "Concurrency lease renewal
+    failed" crash instead of a successful retry.
     """
 
     async def after_transition(
@@ -901,6 +907,21 @@ class ReleaseFlowConcurrencySlots(FlowRunUniversalTransform):
         ):
             return
         if not context.session or not context.run.deployment_id:
+            return
+
+        # For in-process retries the flow engine remains alive across the retry delay
+        # and actively renews the concurrency lease.  Releasing the lease here would
+        # cause the renewal task to hit a "lease not found" error at
+        # lease_duration * 0.75 seconds (225 s for the default 300 s lease), which
+        # terminates the execution with a spurious crash instead of completing the
+        # retry.  The slot and lease remain valid — skip the release and let the
+        # engine hold them until the retry run finishes normally.
+        # See: https://github.com/PrefectHQ/prefect/issues/20251
+        if (
+            proposed_state_type == states.StateType.SCHEDULED
+            and context.run.empirical_policy
+            and context.run.empirical_policy.retry_type == "in_process"
+        ):
             return
 
         if (

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -4984,6 +4984,184 @@ class TestFlowConcurrencyLimits:
         actual_ttl_seconds = (lease.expiration - created_at).total_seconds()
         assert abs(actual_ttl_seconds - 720.0) < 5
 
+    async def test_in_process_retry_preserves_concurrency_slot_and_lease(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        """
+        Regression test for https://github.com/PrefectHQ/prefect/issues/20251
+
+        When a flow with a deployment concurrency limit fails and schedules an
+        in-process retry (retry_type == "in_process"), ReleaseFlowConcurrencySlots
+        must NOT revoke the lease or decrement the active slot count.
+
+        The flow engine remains alive across the retry delay and keeps renewing the
+        lease.  If the server releases the lease here, the renewal task hits a
+        "lease not found" error at lease_duration * 0.75 seconds (225 s for the
+        default 300 s lease) and terminates the execution with a spurious crash.
+        """
+        deployment = await self.create_deployment_with_concurrency_limit(
+            session, 1, flow
+        )
+
+        pending_transition = (states.StateType.SCHEDULED, states.StateType.PENDING)
+        running_transition = (states.StateType.PENDING, states.StateType.RUNNING)
+        # Simulates the RUNNING → FAILED → AwaitingRetry path that RetryFailedFlows
+        # produces when a retry is still available.
+        awaiting_retry_transition = (
+            states.StateType.RUNNING,
+            states.StateType.SCHEDULED,
+        )
+
+        # Acquire the concurrency slot (SCHEDULED → PENDING)
+        ctx = await initialize_orchestration(
+            session, "flow", *pending_transition, deployment_id=deployment.id
+        )
+        async with contextlib.AsyncExitStack() as stack:
+            ctx = await stack.enter_async_context(
+                SecureFlowConcurrencySlots(ctx, *pending_transition)
+            )
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+        lease_id = ctx.validated_state.state_details.deployment_concurrency_lease_id
+        assert lease_id is not None
+
+        # Transition to RUNNING, copying the lease forward
+        ctx_running = await initialize_orchestration(
+            session,
+            "flow",
+            *running_transition,
+            deployment_id=deployment.id,
+            run_override=ctx.run,
+            initial_details=ctx.validated_state.state_details,
+        )
+        async with contextlib.AsyncExitStack() as stack:
+            ctx_running = await stack.enter_async_context(
+                ValidateDeploymentConcurrencyAtRunning(ctx_running, *running_transition)
+            )
+            await ctx_running.validate_proposed_state()
+
+        assert (
+            ctx_running.validated_state.state_details.deployment_concurrency_lease_id
+            == lease_id
+        )
+
+        # Set retry_type = "in_process" on the run — this is what RetryFailedFlows
+        # does before ReleaseFlowConcurrencySlots runs in the real policy chain.
+        ctx_running.run.empirical_policy = schemas.core.FlowRunPolicy(
+            retries=3, retry_type="in_process"
+        )
+
+        # Now simulate RUNNING → SCHEDULED (AwaitingRetry) with in-process retry.
+        ctx_retry = await initialize_orchestration(
+            session,
+            "flow",
+            *awaiting_retry_transition,
+            deployment_id=deployment.id,
+            run_override=ctx_running.run,
+            initial_details=ctx_running.validated_state.state_details,
+        )
+        ctx_retry.run.empirical_policy = schemas.core.FlowRunPolicy(
+            retries=3, retry_type="in_process"
+        )
+
+        async with contextlib.AsyncExitStack() as stack:
+            ctx_retry = await stack.enter_async_context(
+                ReleaseFlowConcurrencySlots(ctx_retry, *awaiting_retry_transition)
+            )
+            await ctx_retry.validate_proposed_state()
+
+        assert ctx_retry.response_status == SetStateStatus.ACCEPT
+
+        # The slot must still be held — the engine is alive and renewing the lease.
+        await assert_deployment_concurrency_limit(
+            session, deployment, expected_limit=1, expected_active_slots=1
+        )
+
+        # The lease must still be valid.
+        lease_storage = get_concurrency_lease_storage()
+        lease = await lease_storage.read_lease(lease_id=lease_id)
+        assert lease is not None, "Lease must not be revoked for an in-process retry"
+
+    async def test_exhausted_retries_release_slot_normally(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        """
+        When retries are exhausted (retry_type cleared to None by RetryFailedFlows),
+        ReleaseFlowConcurrencySlots must still release the slot and revoke the lease.
+        """
+        deployment = await self.create_deployment_with_concurrency_limit(
+            session, 1, flow
+        )
+
+        pending_transition = (states.StateType.SCHEDULED, states.StateType.PENDING)
+        running_transition = (states.StateType.PENDING, states.StateType.RUNNING)
+        failed_transition = (states.StateType.RUNNING, states.StateType.FAILED)
+
+        ctx = await initialize_orchestration(
+            session, "flow", *pending_transition, deployment_id=deployment.id
+        )
+        async with contextlib.AsyncExitStack() as stack:
+            ctx = await stack.enter_async_context(
+                SecureFlowConcurrencySlots(ctx, *pending_transition)
+            )
+            await ctx.validate_proposed_state()
+
+        lease_id = ctx.validated_state.state_details.deployment_concurrency_lease_id
+        assert lease_id is not None
+
+        ctx_running = await initialize_orchestration(
+            session,
+            "flow",
+            *running_transition,
+            deployment_id=deployment.id,
+            run_override=ctx.run,
+            initial_details=ctx.validated_state.state_details,
+        )
+        async with contextlib.AsyncExitStack() as stack:
+            ctx_running = await stack.enter_async_context(
+                ValidateDeploymentConcurrencyAtRunning(ctx_running, *running_transition)
+            )
+            await ctx_running.validate_proposed_state()
+
+        # Exhausted retries: retry_type is None (cleared by RetryFailedFlows).
+        ctx_running.run.empirical_policy = schemas.core.FlowRunPolicy(
+            retries=1, retry_type=None
+        )
+
+        ctx_failed = await initialize_orchestration(
+            session,
+            "flow",
+            *failed_transition,
+            deployment_id=deployment.id,
+            run_override=ctx_running.run,
+            initial_details=ctx_running.validated_state.state_details,
+        )
+        ctx_failed.run.empirical_policy = schemas.core.FlowRunPolicy(
+            retries=1, retry_type=None
+        )
+
+        async with contextlib.AsyncExitStack() as stack:
+            ctx_failed = await stack.enter_async_context(
+                ReleaseFlowConcurrencySlots(ctx_failed, *failed_transition)
+            )
+            await ctx_failed.validate_proposed_state()
+
+        # Slot must be released now that retries are exhausted.
+        await assert_deployment_concurrency_limit(
+            session, deployment, expected_limit=1, expected_active_slots=0
+        )
+
+        lease_storage = get_concurrency_lease_storage()
+        lease = await lease_storage.read_lease(lease_id=lease_id)
+        assert lease is None, "Lease must be revoked when retries are exhausted"
+
 
 class TestPreserveDeploymentConcurrencyLeaseId:
     """Tests for PreserveDeploymentConcurrencyLeaseId transform."""


### PR DESCRIPTION
closes #20251

## Summary

When a flow with a deployment concurrency limit fails and is scheduled for an **in-process retry** (`retry_delay_seconds` set), `ReleaseFlowConcurrencySlots` was unconditionally revoking the concurrency lease on the `RUNNING → SCHEDULED (AwaitingRetry)` transition.

The flow engine remains alive across the retry delay and actively renews the lease.  Revoking it here caused the background renewal task to receive a "lease not found" error at `lease_duration × 0.75` seconds into the delay (225 s for the default 300 s TTL).  This triggered:

> `Concurrency lease renewal failed - slots are no longer reserved. Terminating execution to prevent over-allocation.`

…and crashed the flow instead of allowing the retry.  The bug reproduces **consistently** whenever `retry_delay_seconds ≥ 225`.  Shorter delays worked by accident because the renewal task hadn't fired before `run_context` exited and cancelled it.

<details>
<summary>Root-cause trace</summary>

1. `SecureFlowConcurrencySlots` acquires slot + lease `X` at `SCHEDULED → PENDING`.
2. Flow engine enters `maintain_concurrency_lease(X, 300, raise_on_lease_renewal_failure=True)` which fires a renewal every 225 s.
3. Flow fails → engine proposes `FAILED`.
4. `RetryFailedFlows.before_transition` intercepts, sets `empirical_policy.retry_type = "in_process"`, and rejects to `AwaitingRetry`.
5. `ReleaseFlowConcurrencySlots.after_transition` fires on `RUNNING → SCHEDULED` and **revokes lease X** (bug).
6. Engine proposes `Running()` from `AwaitingRetry` → `WaitForScheduledTime` responds WAIT N s → `propose_state_sync` sleeps N s.
7. At 225 s the renewal task wakes, calls `renew_concurrency_lease(X)` → 404 / not found → exception.
8. Failure callback: `cancel_scope.cancel()` → raises `TerminationSignal` → flow crashes.

</details>

## Changes

**`src/prefect/server/orchestration/core_policy.py`**

- `ReleaseFlowConcurrencySlots.after_transition`: skip releasing the slot and lease when `empirical_policy.retry_type == "in_process"` **and** the destination state is `SCHEDULED`.  All other transitions (normal completion, exhausted retries, cancellation, timeout) are unaffected — they use a different destination state type or `retry_type` is not `"in_process"`.

**`tests/server/orchestration/test_core_policy.py`**

- `test_in_process_retry_preserves_concurrency_slot_and_lease`: verifies the slot count stays at 1 and the lease remains valid after the `RUNNING → SCHEDULED (AwaitingRetry)` transition with `retry_type="in_process"`.
- `test_exhausted_retries_release_slot_normally`: verifies that when retries are exhausted (`retry_type=None`) the slot is correctly released and the lease is revoked.

### Checklist

- [x] This pull request references any related issue by including "closes `#20251`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

🤖 Generated with [Claude Code](https://claude.ai/code)