### PR TITLE
fix: ecs-worker-recover-stale-pending-runs

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/settings.py
+++ b/src/integrations/prefect-aws/prefect_aws/settings.py
@@ -127,6 +127,32 @@ class EcsWorkerSettings(PrefectBaseSettings):
         ge=0,
     )
 
+    recover_stale_pending_flow_runs: bool = Field(
+        default=True,
+        description=(
+            "Whether the ECS worker should recover stale flow runs that are stuck in "
+            "Pending/Submitting before infrastructure is created."
+        ),
+    )
+
+    stale_pending_flow_run_age_seconds: int = Field(
+        default=60,
+        description=(
+            "Minimum age in seconds for Pending/Submitting flow runs to be "
+            "considered stale and eligible for recovery."
+        ),
+        ge=1,
+    )
+
+    stale_pending_flow_run_query_limit: int = Field(
+        default=200,
+        description=(
+            "Maximum number of Pending/Submitting flow runs to scan for recovery "
+            "per polling cycle."
+        ),
+        ge=1,
+    )
+
 
 class EcsSettings(PrefectBaseSettings):
     model_config = build_settings_config(("integrations", "aws", "ecs"))

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -48,6 +48,7 @@ ignored.
 from __future__ import annotations
 
 import copy
+import datetime
 import json
 import logging
 from copy import deepcopy
@@ -77,8 +78,22 @@ from tenacity import (
 )
 from typing_extensions import Literal, Self
 
-from prefect.client.schemas.objects import FlowRun
+from prefect.client.schemas.filters import (
+    FlowRunFilter,
+    FlowRunFilterStartTime,
+    FlowRunFilterState,
+    FlowRunFilterStateName,
+    FlowRunFilterStateType,
+    WorkPoolFilter,
+    WorkPoolFilterName,
+    WorkQueueFilter,
+    WorkQueueFilterName,
+)
+from prefect.client.schemas.objects import FlowRun, StateType
+from prefect.client.schemas.responses import WorkerFlowRunResponse
+from prefect.client.schemas.sorting import FlowRunSort
 from prefect.exceptions import InfrastructureNotFound
+from prefect.types._datetime import now
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
 from prefect.utilities.processutils import command_from_string
@@ -701,6 +716,90 @@ class ECSWorker(BaseWorker[ECSJobConfiguration, ECSVariables, ECSWorkerResult]):
     _display_name = "AWS Elastic Container Service"
     _documentation_url = "https://docs.prefect.io/integrations/prefect-aws/"
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/d74b16fe84ce626345adf235a47008fea2869a60-225x225.png"  # noqa
+
+    async def get_and_submit_flow_runs(self) -> list[FlowRun]:
+        runs_response = await self._get_scheduled_flow_runs()
+        self._last_polled_time = now("UTC")
+
+        recovered_runs = await self._get_stale_pending_flow_run_responses()
+
+        if recovered_runs:
+            seen_run_ids = {entry.flow_run.id for entry in runs_response}
+            new_recovered_runs = [
+                entry
+                for entry in recovered_runs
+                if entry.flow_run.id not in seen_run_ids
+            ]
+            if new_recovered_runs:
+                self._logger.info(
+                    "Recovered %s stale flow run(s) in Pending/Submitting state.",
+                    len(new_recovered_runs),
+                )
+                runs_response.extend(new_recovered_runs)
+
+        return await self._submit_scheduled_flow_runs(flow_run_response=runs_response)
+
+    async def _get_stale_pending_flow_run_responses(
+        self,
+    ) -> list[WorkerFlowRunResponse]:
+        settings = EcsWorkerSettings()
+        if not settings.recover_stale_pending_flow_runs:
+            return []
+
+        stale_before = now("UTC") - datetime.timedelta(
+            seconds=settings.stale_pending_flow_run_age_seconds
+        )
+
+        flow_run_filter = FlowRunFilter(
+            state=FlowRunFilterState(
+                type=FlowRunFilterStateType(any_=[StateType.PENDING]),
+                name=FlowRunFilterStateName(any_=["Pending", "Submitting"]),
+            ),
+            start_time=FlowRunFilterStartTime(is_null_=True),
+        )
+        work_pool_filter = WorkPoolFilter(
+            name=WorkPoolFilterName(any_=[self._work_pool_name])
+        )
+        work_queue_filter = None
+        if self._work_queues:
+            work_queue_filter = WorkQueueFilter(
+                name=WorkQueueFilterName(any_=sorted(self._work_queues))
+            )
+
+        try:
+            candidate_runs = await self.client.read_flow_runs(
+                flow_run_filter=flow_run_filter,
+                work_pool_filter=work_pool_filter,
+                work_queue_filter=work_queue_filter,
+                sort=FlowRunSort.EXPECTED_START_TIME_ASC,
+                limit=settings.stale_pending_flow_run_query_limit,
+            )
+        except Exception:
+            self._logger.exception(
+                "Failed to query Pending/Submitting flow runs for stale-run recovery"
+            )
+            return []
+
+        stale_run_responses: list[WorkerFlowRunResponse] = []
+        for flow_run in candidate_runs:
+            if flow_run.infrastructure_pid:
+                continue
+
+            if flow_run.work_pool_id is None or flow_run.work_queue_id is None:
+                continue
+
+            if flow_run.state is None or flow_run.state.timestamp > stale_before:
+                continue
+
+            stale_run_responses.append(
+                WorkerFlowRunResponse(
+                    work_pool_id=flow_run.work_pool_id,
+                    work_queue_id=flow_run.work_queue_id,
+                    flow_run=flow_run,
+                )
+            )
+
+        return stale_run_responses
 
     async def _initiate_run(
         self,

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import os
+from datetime import timedelta
 from functools import partial
 from itertools import product
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -31,10 +33,12 @@ from prefect_aws.workers.ecs_worker import (
 )
 from pydantic import ValidationError
 
-from prefect.client.schemas.objects import FlowRun
+from prefect.client.schemas.objects import FlowRun, State, StateType
+from prefect.client.schemas.responses import WorkerFlowRunResponse
 from prefect.exceptions import InfrastructureNotFound
 from prefect.settings import PREFECT_API_AUTH_STRING, PREFECT_API_KEY
 from prefect.settings.context import temporary_settings
+from prefect.types._datetime import now as now_fn
 from prefect.utilities.slugify import slugify
 from prefect.utilities.templating import find_placeholders
 
@@ -2589,6 +2593,140 @@ async def test_retry_on_failed_task_definition_registration_with_custom_settings
     finally:
         ecs_client.register_task_definition = original_register
 
+
+async def test_get_stale_pending_flow_run_responses_filters_recoverable_runs():
+    stale_pending = FlowRun(
+        flow_id=uuid4(),
+        deployment_id=uuid4(),
+        work_pool_id=uuid4(),
+        work_queue_id=uuid4(),
+        state=State(
+            type=StateType.PENDING,
+            name="Pending",
+            timestamp=now_fn("UTC") - timedelta(seconds=120),
+        ),
+    )
+    stale_submitting = FlowRun(
+        flow_id=uuid4(),
+        deployment_id=uuid4(),
+        work_pool_id=uuid4(),
+        work_queue_id=uuid4(),
+        state=State(
+            type=StateType.PENDING,
+            name="Submitting",
+            timestamp=now_fn("UTC") - timedelta(seconds=120),
+        ),
+    )
+    fresh_pending = FlowRun(
+        flow_id=uuid4(),
+        deployment_id=uuid4(),
+        work_pool_id=uuid4(),
+        work_queue_id=uuid4(),
+        state=State(
+            type=StateType.PENDING,
+            name="Pending",
+            timestamp=now_fn("UTC") - timedelta(seconds=5),
+        ),
+    )
+    stale_with_pid = FlowRun(
+        flow_id=uuid4(),
+        deployment_id=uuid4(),
+        work_pool_id=uuid4(),
+        work_queue_id=uuid4(),
+        infrastructure_pid="cluster::task",
+        state=State(
+            type=StateType.PENDING,
+            name="Pending",
+            timestamp=now_fn("UTC") - timedelta(seconds=120),
+        ),
+    )
+
+    worker = ECSWorker(work_pool_name="test-pool")
+    worker._client = AsyncMock()
+    worker._client.read_flow_runs = AsyncMock(
+        return_value=[stale_pending, stale_submitting, fresh_pending, stale_with_pid]
+    )
+
+    recovered = await worker._get_stale_pending_flow_run_responses()
+
+    assert {entry.flow_run.id for entry in recovered} == {
+        stale_pending.id,
+        stale_submitting.id,
+    }
+
+
+async def test_get_stale_pending_flow_run_responses_can_be_disabled():
+    worker = ECSWorker(work_pool_name="test-pool")
+    worker._client = AsyncMock()
+    worker._client.read_flow_runs = AsyncMock(return_value=[])
+
+    with mock_patch.dict(
+        os.environ,
+        {
+            "PREFECT_INTEGRATIONS_AWS_ECS_WORKER_RECOVER_STALE_PENDING_FLOW_RUNS": (
+                "false"
+            )
+        },
+    ):
+        recovered = await worker._get_stale_pending_flow_run_responses()
+
+    assert recovered == []
+    worker._client.read_flow_runs.assert_not_called()
+
+
+async def test_get_and_submit_flow_runs_merges_recovered_without_duplicates():
+    existing_run = FlowRun(
+        flow_id=uuid4(),
+        deployment_id=uuid4(),
+        work_pool_id=uuid4(),
+        work_queue_id=uuid4(),
+    )
+    recovered_run = FlowRun(
+        flow_id=uuid4(),
+        deployment_id=uuid4(),
+        work_pool_id=uuid4(),
+        work_queue_id=uuid4(),
+    )
+
+    worker = ECSWorker(work_pool_name="test-pool")
+    worker._get_scheduled_flow_runs = AsyncMock(
+        return_value=[
+            WorkerFlowRunResponse(
+                work_pool_id=existing_run.work_pool_id,
+                work_queue_id=existing_run.work_queue_id,
+                flow_run=existing_run,
+            )
+        ]
+    )
+    worker._get_stale_pending_flow_run_responses = AsyncMock(
+        return_value=[
+            WorkerFlowRunResponse(
+                work_pool_id=existing_run.work_pool_id,
+                work_queue_id=existing_run.work_queue_id,
+                flow_run=existing_run,
+            ),
+            WorkerFlowRunResponse(
+                work_pool_id=recovered_run.work_pool_id,
+                work_queue_id=recovered_run.work_queue_id,
+                flow_run=recovered_run,
+            ),
+        ]
+    )
+    worker._submit_scheduled_flow_runs = AsyncMock(
+        return_value=[existing_run, recovered_run]
+    )
+
+    submitted = await worker.get_and_submit_flow_runs()
+
+    assert submitted == [existing_run, recovered_run]
+    assert worker._submit_scheduled_flow_runs.await_count == 1
+    merged_payload = worker._submit_scheduled_flow_runs.await_args.kwargs[
+        "flow_run_response"
+    ]
+    assert [entry.flow_run.id for entry in merged_payload] == [
+        existing_run.id,
+        recovered_run.id,
+    ]
 
 async def test_mask_sensitive_env_values():
     task_run_request = {


### PR DESCRIPTION
closes: #20485

- Adds stale pending flow run recovery for the ECS worker to prevent flow runs from remaining indefinitely stuck in `Pending/Submitting` when a worker crashes between state transition and ECS task submission.

- This improves resilience against worker crashes, restarts, and connectivity interruptions during ECS task submission.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
