### PR TITLE
docs(events): note metric-trigger Cloud gating and event prefix difference

### DIFF
--- a/src/prefect/events/AGENTS.md
+++ b/src/prefect/events/AGENTS.md
@@ -7,6 +7,8 @@ Client-side event system for emitting, subscribing to, and defining automations 
 - **Both client and server define their own event schemas.** The client-side schemas live in `schemas/` here; the server has its own parallel definitions in `server/events/schemas/`. They are structurally similar but independently maintained — the server does not import schemas from this module.
 - Events follow the CloudEvents-inspired schema: `Event` with `Resource` and `RelatedResource`.
 - Automations combine triggers (event, metric, compound, sequence) with actions.
+- **Metric triggers are Cloud-only.** OSS's `ServerTriggerTypes` excludes `MetricTrigger`, so `POST /automations` returns 422. For "alert if a flow takes too long" on OSS, use a proactive `EventTrigger` (`after={prefect.flow-run.Running}`, terminal states in `expect`, SLO in `within`).
+- **Event name prefixes differ by backend.** OSS emits `prefect.*`; Cloud emits `prefect-cloud.*` for automation/action lifecycle events (e.g., `prefect-cloud.automation.triggered`). Cross-backend tooling that filters events must match both.
 - `DeploymentTriggerTypes` are the subset of triggers usable in `prefect.yaml` deployment definitions.
 
 ## clients.py — Checkpointing Invariant


### PR DESCRIPTION
two small additions to \`src/prefect/events/AGENTS.md\` capturing facts that aren't obvious from reading the client schemas alone — both came out of an internal support thread where an agent (and I) walked in circles answering a question about long-running-flow alerting.

## what's added

- **metric triggers are Cloud-only at the server level** — they're in the client schemas but the server-side \`ServerTriggerTypes\` union excludes them, so OSS returns 422 at create. pointing to a proactive \`EventTrigger\` as the OSS-compatible alternative for "alert if a flow takes too long."
- **event name prefixes differ by backend** — \`prefect.*\` on OSS, \`prefect-cloud.*\` for automation/action lifecycle events on Cloud. tooling that filters events via \`read_events\` and runs against both backends has to match both prefixes.

## why

both of these tripped me up while exploring this surface area. the existing AGENTS.md says "automations combine triggers (event, metric, compound, sequence) with actions" without flagging that metric is meaningfully different from the others in OSS. and the prefix difference was something I only discovered by debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)