### PR TITLE
bump prefect-github extra floor to >=0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dask = ["prefect-dask>=0.3.0"]
 ray = ["prefect-ray>=0.4.0"]
 # Version control extras
 bitbucket = ["prefect-bitbucket>=0.3.0"]
-github = ["prefect-github>=0.3.0"]
+github = ["prefect-github>=0.4.2"]
 gitlab = ["prefect-gitlab>=0.3.0"]
 # Database extras
 databricks = ["prefect-databricks>=0.3.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -4245,7 +4245,7 @@ requires-dist = [
     { name = "prefect-docker", marker = "extra == 'docker'", specifier = ">=0.6.0" },
     { name = "prefect-email", marker = "extra == 'email'", specifier = ">=0.4.0" },
     { name = "prefect-gcp", marker = "extra == 'gcp'", specifier = ">=0.6.0" },
-    { name = "prefect-github", marker = "extra == 'github'", specifier = ">=0.3.0" },
+    { name = "prefect-github", marker = "extra == 'github'", specifier = ">=0.4.2" },
     { name = "prefect-gitlab", marker = "extra == 'gitlab'", specifier = ">=0.3.0" },
     { name = "prefect-kubernetes", marker = "extra == 'kubernetes'", specifier = ">=0.4.0" },
     { name = "prefect-ray", marker = "extra == 'ray'", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Summary

bump the `[github]` extra floor in core `prefect`'s `pyproject.toml` from `prefect-github>=0.3.0` → `prefect-github>=0.4.2` so fresh installs of `prefect[github]` can't resolve to the broken `0.4.1`.

## Why

`prefect-github==0.4.1` imports `prefect._internal.urls.strip_auth_from_url` (added in #20331 / `prefect==3.6.13`) but declared only `prefect>=3.0.0` as its floor. The floor was tightened to `prefect>=3.6.17` in `0.4.2` via #20659.

The integration-side fix already shipped, but the `[github]` extra still allows `>=0.3.0`. When a user runs `pip install prefect[github]` against an older `prefect` already in their env, the resolver backtracks past `0.4.2` (which conflicts) and lands on `0.4.1` — which then fails to import at flow load:

```
ModuleNotFoundError: No module named 'prefect._internal.urls'
```

Surfaced in #21939.

<details>
<summary>repro</summary>

```python
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "prefect==3.6.12",
#     "prefect-github==0.4.1",
# ]
# ///
from prefect_github import GitHubCredentials  # noqa
```

```
$ uv run repro.py
...
  File ".../prefect_github/repository.py", line 26, in <module>
    from prefect._internal.urls import strip_auth_from_url
ModuleNotFoundError: No module named 'prefect._internal.urls'
```

</details>

## Test plan
- [ ] CI green