### PR TITLE
fix(types): enforce tz-aware `DateTime` on Python >= 3.13

### DIFF
--- a/src/prefect/types/_datetime.py
+++ b/src/prefect/types/_datetime.py
@@ -13,6 +13,8 @@ from pydantic import AfterValidator
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 13):
+    from pydantic import GetCoreSchemaHandler
+    from pydantic_core import core_schema as _core_schema
     from whenever import DateTimeDelta
     from whenever import ZonedDateTime as _ZDTProbe
 
@@ -21,7 +23,34 @@ if sys.version_info >= (3, 13):
     _WHENEVER_NEW_API: bool = hasattr(_ZDTProbe, "to_stdlib")
     del _ZDTProbe
 
-    DateTime: TypeAlias = datetime.datetime
+    class _DateTime(datetime.datetime):
+        """`datetime.datetime` with a Pydantic schema that coerces naive to UTC.
+
+        On Python <= 3.12 the pendulum-backed `PydanticDateTime` enforces
+        tz-awareness during validation. This class is the 3.13+ equivalent so
+        any field typed as `DateTime` gets the same guarantee instead of
+        deferring to ad-hoc per-field validators (see #21949). Coercion reuses
+        the existing `create_datetime_instance` helper rather than open-coding
+        the naive→UTC check.
+
+        Runtime construction (`DateTime(2020, 1, 1)`) preserves the underlying
+        `datetime.datetime` semantics — naive in, naive out. The coercion
+        applies during Pydantic validation, which is where the silent
+        server-side drop originated.
+        """
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source_type: Any,
+            handler: GetCoreSchemaHandler,
+        ) -> _core_schema.CoreSchema:
+            return _core_schema.no_info_after_validator_function(
+                create_datetime_instance,
+                handler(datetime.datetime),
+            )
+
+    DateTime: TypeAlias = _DateTime
     Date: TypeAlias = datetime.date
     Duration: TypeAlias = datetime.timedelta
     if _WHENEVER_NEW_API:

--- a/tests/events/client/test_events_schema.py
+++ b/tests/events/client/test_events_schema.py
@@ -1,5 +1,5 @@
 import json
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -20,6 +20,48 @@ def test_client_events_generate_an_id_by_default():
 def test_client_events_generate_occurred_by_default(start_of_test: DateTime):
     event = Event(event="hello", resource={"prefect.resource.id": "hello"})
     assert start_of_test <= event.occurred <= now("UTC")
+
+
+def test_client_events_coerce_naive_occurred_to_utc():
+    """Regression for #21949: on Python >= 3.13, `Event.occurred` is aliased to a
+    bare `datetime.datetime` (no pendulum coercion), so a naive datetime would
+    pass validation and later be silently dropped by the server's SQL bind
+    layer (`Timestamps must have a timezone.`). The `DateTime` type alias must
+    coerce naive datetimes to UTC during Pydantic validation so the event
+    reaches the server."""
+    naive = datetime(2026, 5, 14, 12, 0, 0)
+    assert naive.tzinfo is None
+
+    event = Event(
+        event="hello", resource={"prefect.resource.id": "hello"}, occurred=naive
+    )
+
+    assert event.occurred.tzinfo is not None
+    assert event.occurred.utcoffset().total_seconds() == 0
+    # The wall-clock fields are preserved (assumed UTC, not converted from local).
+    assert (event.occurred.year, event.occurred.month, event.occurred.day) == (
+        2026,
+        5,
+        14,
+    )
+    assert (event.occurred.hour, event.occurred.minute, event.occurred.second) == (
+        12,
+        0,
+        0,
+    )
+
+
+def test_client_events_preserve_aware_occurred():
+    """A tz-aware `occurred` value must be preserved as-is (no UTC conversion)."""
+    eastern = timezone(timedelta(hours=-5))
+    aware = datetime(2026, 5, 14, 12, 0, 0, tzinfo=eastern)
+
+    event = Event(
+        event="hello", resource={"prefect.resource.id": "hello"}, occurred=aware
+    )
+
+    assert event.occurred.utcoffset() == aware.utcoffset()
+    assert event.occurred.hour == 12
 
 
 def test_client_events_may_have_empty_related_resources():

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -11,8 +11,15 @@ import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
+from pydantic import BaseModel
 
-from prefect.types._datetime import end_of_period, in_local_tz, now, start_of_day
+from prefect.types._datetime import (
+    DateTime,
+    end_of_period,
+    in_local_tz,
+    now,
+    start_of_day,
+)
 
 # Saturday 2024-06-15 14:30:45 America/New_York (UTC-4, i.e. EDT)
 FIXED = datetime.datetime(2024, 6, 15, 14, 30, 45, tzinfo=ZoneInfo("America/New_York"))
@@ -119,3 +126,59 @@ class TestInLocalTz:
         naive = datetime.datetime(2024, 6, 15, 14, 30, 45)
         result = in_local_tz(naive)
         assert result.tzinfo is not None
+
+
+class TestDateTimeTypeAlias:
+    """`DateTime` is the type alias used for Pydantic-validated datetime fields.
+
+    On Python <= 3.12 it is pendulum-backed (`PydanticDateTime`); on Python
+    >= 3.13 it is a `datetime.datetime` subclass with a Pydantic schema that
+    enforces tz-awareness. These tests guard parity across versions — a naive
+    input must come out tz-aware regardless of which backend is active. See
+    #21949.
+    """
+
+    def test_naive_value_is_coerced_to_utc(self):
+        class Model(BaseModel):
+            when: DateTime
+
+        naive = datetime.datetime(2024, 6, 15, 14, 30, 45)
+        result = Model(when=naive).when
+
+        assert result.tzinfo is not None
+        assert result.utcoffset() == datetime.timedelta(0)
+        # Wall-clock components are preserved (treated as UTC, not converted).
+        assert (result.year, result.month, result.day) == (2024, 6, 15)
+        assert (result.hour, result.minute, result.second) == (14, 30, 45)
+
+    def test_aware_value_is_preserved(self):
+        class Model(BaseModel):
+            when: DateTime
+
+        aware = datetime.datetime(2024, 6, 15, 14, 30, 45, tzinfo=ZoneInfo("UTC"))
+        result = Model(when=aware).when
+
+        assert result.utcoffset() == datetime.timedelta(0)
+        assert result.hour == 14
+
+    def test_non_utc_aware_value_is_preserved(self):
+        class Model(BaseModel):
+            when: DateTime
+
+        eastern = datetime.timezone(datetime.timedelta(hours=-5))
+        aware = datetime.datetime(2024, 6, 15, 14, 30, 45, tzinfo=eastern)
+        result = Model(when=aware).when
+
+        assert result.utcoffset() == aware.utcoffset()
+        assert result.hour == 14
+
+    def test_naive_iso_string_is_coerced_to_utc(self):
+        """Pydantic parses ISO strings without offsets into naive datetimes;
+        the type alias must still produce a tz-aware result."""
+
+        class Model(BaseModel):
+            when: DateTime
+
+        result = Model(when="2024-06-15T14:30:45").when
+        assert result.tzinfo is not None
+        assert result.utcoffset() == datetime.timedelta(0)


### PR DESCRIPTION
closes #21949

`prefect.types._datetime.DateTime` was supposed to be a Pydantic-validated, tz-aware datetime regardless of Python version. The 3.13+ branch broke that contract: it aliased to bare `datetime.datetime`, which Pydantic does not enforce tz-awareness on. A naive value passed to any `DateTime`-typed field (e.g. `Event.occurred` via `emit_event(..., occurred=datetime.now())`) was accepted client-side, rejected by the server's SQL bind layer (`Timestamps must have a timezone.`), retried 5x by the in-memory bus, and silently dropped — the emitter saw no error.

On Python <= 3.12 the pendulum-backed `PydanticDateTime` already coerces naive datetimes to UTC during validation, so the bug was 3.13+ only.

### approach

Fix at the type alias rather than per-field. On 3.13+, `DateTime` is now a `datetime.datetime` subclass whose Pydantic core schema runs `no_info_after_validator_function(create_datetime_instance, ...)`. `create_datetime_instance` is the existing helper already in `_datetime.py` that does the naive→UTC coercion on 3.13+ (and passes through to `DateTime.instance` on 3.12) — reusing it avoids introducing a redundant validator. Every field typed as `DateTime` (or `Annotated[DateTime, ...]`) inherits the guarantee.

Runtime construction (`DateTime(2020, 1, 1)`) preserves bare `datetime.datetime` semantics — naive in, naive out — so existing call sites that use `DateTime` as a constructor are unaffected. The coercion is a validation-time concern only. The 3.12 branch (pendulum) is unchanged; it already coerces naive→UTC.

Same shape of fix as #21640, one layer up.

### testing

- `tests/test_datetime.py` — new `TestDateTimeTypeAlias` covers the type alias directly against a `BaseModel` field on both Python versions:
  - naive datetime → tz-aware UTC, wall-clock preserved
  - tz-aware datetime → preserved as-is
  - non-UTC tz-aware → preserved (no conversion to UTC)
  - naive ISO string → tz-aware UTC
- `tests/events/client/test_events_schema.py` — regression tests for `Event.occurred` specifically (the user-visible bug site).
- Existing event schema / emit / worker / client suites pass on Python 3.12 and 3.13.
- `tests/cli/deployment/test_deployment_run.py` and `tests/utilities/test_callables.py` (the largest users of `DateTime(...)` as a constructor) pass unchanged — confirming the subclass approach doesn't break runtime construction.

<details>
<summary>Reproduction (run on Python >= 3.13)</summary>

```python
from datetime import datetime
from prefect.events.schemas.events import Event

# Before this PR (on Python >= 3.13):
#   Event accepts a naive datetime; server silently drops the event.
# After this PR:
#   tzinfo is coerced to UTC during Pydantic validation.
e = Event(event="test", resource={"prefect.resource.id": "r1"}, occurred=datetime.now())
print(e.occurred.tzinfo)  # zoneinfo.ZoneInfo(key='UTC')
```

</details>

### checklist

- [x] tests added (type-level + field-level regression)
- [x] pre-commit clean
- [x] passes on Python 3.12 and 3.13