### PR TITLE
Reject COMPLETED→COMPLETED transitions that discard result data

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -260,6 +260,7 @@ class MinimalFlowPolicy(FlowRunOrchestrationPolicy):
         ]
     ]:
         return [
+            PreventResultDataLoss,
             BypassCancellingFlowRunsWithNoInfra,  # cancel scheduled or suspended runs from the UI
             InstrumentFlowRunStateTransitions,
             ReleaseFlowConcurrencySlots,
@@ -1608,6 +1609,25 @@ class HandleFlowTerminalStateTransitions(FlowRunOrchestrationRule):
             await self.reject_transition(None, "Run is already COMPLETED.")
             return
 
+        # Prevent COMPLETED → COMPLETED transitions that would discard result data.
+        # See https://github.com/PrefectHQ/prefect/issues/21955
+        if (
+            initial_state.is_completed()
+            and proposed_state.is_completed()
+            and initial_state.data
+            and initial_state.data.get("type") != "unpersisted"
+            and (
+                not proposed_state.data
+                or proposed_state.data.get("type") == "unpersisted"
+            )
+        ):
+            await self.reject_transition(
+                None,
+                "Cannot overwrite a COMPLETED state that carries persisted result "
+                "data with one that does not.",
+            )
+            return
+
         # Do not allows runs to be rescheduled without a deployment
         if proposed_state.is_scheduled() and not context.run.deployment_id:
             await self.abort_transition(
@@ -1635,6 +1655,46 @@ class HandleFlowTerminalStateTransitions(FlowRunOrchestrationRule):
         context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy],
     ) -> None:
         context.run.empirical_policy = core.FlowRunPolicy(**self.original_flow_policy)
+
+
+class PreventResultDataLoss(FlowRunOrchestrationRule):
+    """Reject terminal-to-terminal transitions that would discard persisted result data.
+
+    This is intentionally lightweight so it can be included in MinimalFlowPolicy
+    (used by force=True transitions) without pulling in the full
+    HandleFlowTerminalStateTransitions rule.
+
+    See https://github.com/PrefectHQ/prefect/issues/21955
+    """
+
+    FROM_STATES: set[states.StateType | None] = TERMINAL_STATES  # pyright: ignore[reportAssignmentType]
+    TO_STATES: set[states.StateType | None] = TERMINAL_STATES  # pyright: ignore[reportAssignmentType]
+
+    async def before_transition(
+        self,
+        initial_state: states.State[Any] | None,
+        proposed_state: states.State[Any] | None,
+        context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy],
+    ) -> None:
+        if initial_state is None or proposed_state is None:
+            return
+
+        if (
+            initial_state.is_completed()
+            and proposed_state.is_completed()
+            and initial_state.data
+            and initial_state.data.get("type") != "unpersisted"
+            and (
+                not proposed_state.data
+                or proposed_state.data.get("type") == "unpersisted"
+            )
+        ):
+            await self.reject_transition(
+                None,
+                "Cannot overwrite a COMPLETED state that carries persisted result "
+                "data with one that does not.",
+            )
+            return
 
 
 class PreventPendingTransitions(GenericOrchestrationRule):

--- a/tests/server/orchestration/api/test_flow_runs.py
+++ b/tests/server/orchestration/api/test_flow_runs.py
@@ -2314,6 +2314,81 @@ class TestSetFlowRunState:
             assert concurrency_limit.json()["active_slots"] == 0
 
 
+class TestPreventResultDataLossAPI:
+    """API-level regression test: force=True routes through MinimalFlowPolicy
+    and PreventResultDataLoss rejects COMPLETED→COMPLETED when result data
+    would be discarded.
+
+    See https://github.com/PrefectHQ/prefect/issues/21955
+    """
+
+    async def test_force_set_state_rejects_completed_overwrite_without_data(
+        self, flow_run, client
+    ):
+        from prefect._internal.result_records import ResultRecordMetadata
+
+        result_data = ResultRecordMetadata.model_construct().model_dump(mode="json")
+
+        # Transition to COMPLETED with persisted result data
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(
+                state=dict(type="COMPLETED", name="Completed", data=result_data),
+                force=True,
+            ),
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["status"] == "ACCEPT"
+
+        # Try to overwrite with a bare COMPLETED (no data) using force=True
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(
+                state=dict(type="COMPLETED", name="Completed"),
+                force=True,
+            ),
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "REJECT"
+
+        # Verify the original state is still intact via the API
+        response = await client.get(f"/flow_runs/{flow_run.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"]["type"] == "COMPLETED"
+        assert response.json()["state"]["data"] is not None
+
+    async def test_force_set_state_allows_completed_to_completed_with_data(
+        self, flow_run, client
+    ):
+        from prefect._internal.result_records import ResultRecordMetadata
+
+        result_data = ResultRecordMetadata.model_construct().model_dump(mode="json")
+
+        # Transition to COMPLETED with persisted result data
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(
+                state=dict(type="COMPLETED", name="Completed", data=result_data),
+                force=True,
+            ),
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Overwrite with another COMPLETED that also carries result data
+        new_result_data = ResultRecordMetadata.model_construct(
+            storage_key="new-key"
+        ).model_dump(mode="json")
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(
+                state=dict(type="COMPLETED", name="Completed", data=new_result_data),
+                force=True,
+            ),
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["status"] == "ACCEPT"
+
+
 class TestManuallyRetryingFlowRuns:
     async def test_manual_flow_run_retries(
         self, failed_flow_run_with_deployment, client, session

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -38,6 +38,7 @@ from prefect.server.orchestration.core_policy import (
     PreserveDeploymentConcurrencyLeaseId,
     PreventDuplicateTransitions,
     PreventPendingTransitions,
+    PreventResultDataLoss,
     PreventRunningTasksFromStoppedFlows,
     ReleaseFlowConcurrencySlots,
     ReleaseTaskConcurrencySlots,
@@ -1516,6 +1517,95 @@ class TestTransitionsFromTerminalStatesRule:
             await ctx.validate_proposed_state()
 
         assert ctx.response_status == SetStateStatus.ACCEPT
+
+
+@pytest.mark.parametrize("run_type", ["flow"])
+class TestPreventResultDataLoss:
+    """Prevent COMPLETED → COMPLETED transitions that would discard result data.
+
+    See https://github.com/PrefectHQ/prefect/issues/21955
+    """
+
+    async def test_rejects_completed_to_completed_when_result_data_is_lost(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        intended_transition = (StateType.COMPLETED, StateType.COMPLETED)
+        ctx = await initialize_orchestration(
+            session,
+            run_type,
+            *intended_transition,
+            initial_state_data=ResultRecordMetadata.model_construct().model_dump(),
+        )
+
+        rule = PreventResultDataLoss(ctx, *intended_transition)
+        async with rule as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.REJECT
+
+    async def test_allows_completed_to_completed_without_result_data(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        intended_transition = (StateType.COMPLETED, StateType.COMPLETED)
+        ctx = await initialize_orchestration(
+            session,
+            run_type,
+            *intended_transition,
+            initial_state_data=None,
+        )
+
+        rule = PreventResultDataLoss(ctx, *intended_transition)
+        async with rule as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+
+    async def test_allows_completed_to_completed_with_unpersisted_initial(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        intended_transition = (StateType.COMPLETED, StateType.COMPLETED)
+        ctx = await initialize_orchestration(
+            session,
+            run_type,
+            *intended_transition,
+            initial_state_data={"type": "unpersisted"},
+        )
+
+        rule = PreventResultDataLoss(ctx, *intended_transition)
+        async with rule as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+
+    async def test_handle_flow_terminal_also_rejects_data_loss(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        """HandleFlowTerminalStateTransitions also guards against data loss."""
+        intended_transition = (StateType.COMPLETED, StateType.COMPLETED)
+        ctx = await initialize_orchestration(
+            session,
+            run_type,
+            *intended_transition,
+            initial_state_data=ResultRecordMetadata.model_construct().model_dump(),
+        )
+
+        rule = HandleFlowTerminalStateTransitions(ctx, *intended_transition)
+        async with rule as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.REJECT
 
 
 @pytest.mark.parametrize("run_type", ["flow"])


### PR DESCRIPTION
## Summary

- Add guard in `HandleFlowTerminalStateTransitions` (`CoreFlowPolicy`) to reject COMPLETED → COMPLETED transitions when the initial state has persisted result data and the proposed state does not
- Add new `PreventResultDataLoss` rule to `MinimalFlowPolicy` so the guard also applies to `force=True` transitions
- Add 4 tests covering the new behavior

Fixes #21955

## Background

When a cleanup function calls `set_flow_run_state(state=State(type=COMPLETED), force=True)` on a subflow that already completed with result data, the result data is silently discarded. Downstream callers that call `await state.aresult()` then get `MissingResult` instead of the actual return value.

## Test plan

- [x] `TestPreventResultDataLoss::test_rejects_completed_to_completed_when_result_data_is_lost` — verifies rejection
- [x] `TestPreventResultDataLoss::test_allows_completed_to_completed_without_result_data` — no false positives when initial has no data
- [x] `TestPreventResultDataLoss::test_allows_completed_to_completed_with_unpersisted_initial` — no false positives for unpersisted results
- [x] `TestPreventResultDataLoss::test_handle_flow_terminal_also_rejects_data_loss` — verifies the `CoreFlowPolicy` rule also guards
- [x] All 139 existing terminal state tests pass (plus 1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)