### PR TITLE
fix(events): coerce naive datetime in Event.occurred to UTC

### DIFF
--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -1,5 +1,4 @@
 import copy
-import datetime
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,

--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -123,12 +123,12 @@ class Event(PrefectBaseModel):
         description="When the event happened from the sender's perspective",
     )
 
-    @field_validator("occurred", mode="before")
+    @field_validator("occurred", mode="after")
     @classmethod
-    def ensure_occurred_is_tz_aware(cls, v: object) -> object:
-        if isinstance(v, datetime.datetime):
-            return prefect.types._datetime.create_datetime_instance(v)
-        return v
+    def ensure_occurred_is_tz_aware(
+        cls, v: prefect.types._datetime.DateTime
+    ) -> prefect.types._datetime.DateTime:
+        return prefect.types._datetime.create_datetime_instance(v)
 
     event: str = Field(description="The name of the event that happened")
     resource: Resource = Field(

--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -1,4 +1,5 @@
 import copy
+import datetime
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -20,6 +21,7 @@ from pydantic import (
     ConfigDict,
     Field,
     RootModel,
+    field_validator,
     model_validator,
 )
 from typing_extensions import Annotated, Self
@@ -120,6 +122,14 @@ class Event(PrefectBaseModel):
         default_factory=lambda: prefect.types._datetime.now("UTC"),
         description="When the event happened from the sender's perspective",
     )
+
+    @field_validator("occurred", mode="before")
+    @classmethod
+    def ensure_occurred_is_tz_aware(cls, v: object) -> object:
+        if isinstance(v, datetime.datetime):
+            return prefect.types._datetime.create_datetime_instance(v)
+        return v
+
     event: str = Field(description="The name of the event that happened")
     resource: Resource = Field(
         description="The primary Resource this event concerns",

--- a/tests/events/client/test_events_schema.py
+++ b/tests/events/client/test_events_schema.py
@@ -262,6 +262,24 @@ def test_non_utc_aware_occurred_is_unchanged():
     assert event.occurred.utcoffset().total_seconds() == -4 * 3600  # type: ignore[union-attr]
 
 
+def test_naive_iso_string_occurred_is_coerced_to_utc():
+    """A naive ISO-8601 string passed to Event.occurred must also be coerced to UTC.
+
+    On Python >= 3.13 Pydantic parses the string into a bare datetime.datetime
+    before validators run, so a mode='before' isinstance check would miss it.
+    The mode='after' validator catches it regardless of the input type.
+    """
+    event = Event(
+        occurred="2024-06-01T12:00:00",
+        event="test.naive.string",
+        resource={"prefect.resource.id": "test"},
+    )
+    assert event.occurred.tzinfo is not None, (
+        "occurred must be tz-aware when constructed from a naive ISO string"
+    )
+    assert event.occurred.utcoffset().total_seconds() == 0  # type: ignore[union-attr]
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 13),
     reason="Naive datetime was only silently accepted on Python >= 3.13",

--- a/tests/events/client/test_events_schema.py
+++ b/tests/events/client/test_events_schema.py
@@ -232,7 +232,6 @@ def test_naive_occurred_is_coerced_to_utc():
     assert event.occurred.tzinfo is not None, "occurred must be tz-aware after coercion"
     assert event.occurred.replace(tzinfo=None) == naive
     # Naive datetimes are assumed to be UTC
-    utc = ZoneInfo("UTC")
     assert event.occurred.utcoffset().total_seconds() == 0  # type: ignore[union-attr]
 
 

--- a/tests/events/client/test_events_schema.py
+++ b/tests/events/client/test_events_schema.py
@@ -1,6 +1,8 @@
 import json
-from datetime import timezone
+import sys
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -210,3 +212,69 @@ def test_finding_resources_in_role(example_event: Event):
     ]
     assert [r.id for r in example_event.resources_in_role["role-2"]] == ["related-3"]
     assert example_event.resources_in_role["role-3"] == []
+
+
+# Tests for naive datetime coercion (issue #21949)
+
+
+def test_naive_occurred_is_coerced_to_utc():
+    """A naive datetime passed to Event.occurred must be treated as UTC, not silently
+    dropped by the server's SQL bind layer."""
+    naive = datetime(2024, 6, 1, 12, 0, 0)
+    assert naive.tzinfo is None
+
+    event = Event(
+        occurred=naive,
+        event="test.naive",
+        resource={"prefect.resource.id": "test"},
+    )
+
+    assert event.occurred.tzinfo is not None, "occurred must be tz-aware after coercion"
+    assert event.occurred.replace(tzinfo=None) == naive
+    # Naive datetimes are assumed to be UTC
+    utc = ZoneInfo("UTC")
+    assert event.occurred.utcoffset().total_seconds() == 0  # type: ignore[union-attr]
+
+
+def test_tz_aware_occurred_is_unchanged():
+    """A tz-aware datetime must pass through the validator without modification."""
+    aware = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    event = Event(
+        occurred=aware,
+        event="test.aware",
+        resource={"prefect.resource.id": "test"},
+    )
+    assert event.occurred == aware
+    assert event.occurred.tzinfo is not None
+
+
+def test_non_utc_aware_occurred_is_unchanged():
+    """A tz-aware datetime in a non-UTC zone must not be altered."""
+    eastern = ZoneInfo("America/New_York")
+    aware = datetime(2024, 6, 1, 12, 0, 0, tzinfo=eastern)
+    event = Event(
+        occurred=aware,
+        event="test.aware.eastern",
+        resource={"prefect.resource.id": "test"},
+    )
+    assert event.occurred.tzinfo is not None
+    # Offset for America/New_York in summer (EDT) is -4h
+    assert event.occurred.utcoffset().total_seconds() == -4 * 3600  # type: ignore[union-attr]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason="Naive datetime was only silently accepted on Python >= 3.13",
+)
+def test_naive_occurred_has_tz_on_py313_plus():
+    """Regression test: on Python >= 3.13 DateTime is a bare datetime.datetime, which
+    previously allowed naive values to bypass validation entirely (issue #21949)."""
+    naive = datetime(2026, 1, 1, 0, 0, 0)
+    event = Event(
+        occurred=naive,
+        event="prefect.regression.21949",
+        resource={"prefect.resource.id": "test"},
+    )
+    assert event.occurred.tzinfo is not None, (
+        "Event.occurred must be tz-aware on Python 3.13+ (regression: issue #21949)"
+    )


### PR DESCRIPTION
closes #21949

This PR adds a `field_validator` on `Event.occurred` to coerce naive datetimes to UTC at validation time, preventing events from being silently dropped by the server.

<details>
<summary>Details</summary>

On Python >= 3.13, `DateTime` is a bare `datetime.datetime` with no tz-awareness enforcement. A naive datetime passed to `Event.occurred` would propagate to the server's SQL bind layer, which raises `ValueError("Timestamps must have a timezone.")`, causing the event to be silently dropped after 5 retries with no error surfaced to the caller.

The fix adds a `mode="before"` `field_validator` that calls the existing `create_datetime_instance()` helper from `types/_datetime.py`, which coerces naive datetimes to UTC on Python 3.13+ and delegates to `DateTime.instance()` on earlier versions. This matches the pattern already used in `_internal/schemas/validators.py` and is consistent with how `parse_datetime()` treats naive datetime strings (assumes UTC).

</details>

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
