### PR TITLE
fix(runner): use tz-aware now("UTC") for last_adhoc_pull timestamp

### DIFF
--- a/src/prefect/runner/_scheduled_run_poller.py
+++ b/src/prefect/runner/_scheduled_run_poller.py
@@ -182,11 +182,9 @@ class ScheduledRunPoller:
             pull_interval = getattr(storage, "pull_interval", None)
             if storage and isinstance(pull_interval, (int, float)) and pull_interval:
                 last_adhoc_pull = getattr(storage, "last_adhoc_pull", None)
-                if (
-                    last_adhoc_pull is None
-                    or last_adhoc_pull
-                    < now("UTC") - datetime.timedelta(seconds=storage.pull_interval)
-                ):
+                if last_adhoc_pull is None or last_adhoc_pull < now(
+                    "UTC"
+                ) - datetime.timedelta(seconds=storage.pull_interval):
                     self._logger.debug(
                         "Performing adhoc pull of code for flow run %s",
                         flow_run.id,

--- a/src/prefect/runner/_scheduled_run_poller.py
+++ b/src/prefect/runner/_scheduled_run_poller.py
@@ -185,7 +185,7 @@ class ScheduledRunPoller:
                 if (
                     last_adhoc_pull is None
                     or last_adhoc_pull
-                    < datetime.datetime.now()
+                    < now("UTC")
                     - datetime.timedelta(seconds=storage.pull_interval)
                 ):
                     self._logger.debug(
@@ -193,7 +193,7 @@ class ScheduledRunPoller:
                         flow_run.id,
                     )
                     await storage.pull_code()
-                    storage.last_adhoc_pull = datetime.datetime.now()
+                    storage.last_adhoc_pull = now("UTC")
 
             executor = FlowRunExecutor(
                 flow_run=flow_run,

--- a/src/prefect/runner/_scheduled_run_poller.py
+++ b/src/prefect/runner/_scheduled_run_poller.py
@@ -185,8 +185,7 @@ class ScheduledRunPoller:
                 if (
                     last_adhoc_pull is None
                     or last_adhoc_pull
-                    < now("UTC")
-                    - datetime.timedelta(seconds=storage.pull_interval)
+                    < now("UTC") - datetime.timedelta(seconds=storage.pull_interval)
                 ):
                     self._logger.debug(
                         "Performing adhoc pull of code for flow run %s",

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1052,11 +1052,9 @@ class Runner:
             # adhoc pull hasn't been performed in the last pull_interval
             # TODO: Explore integrating this behavior with global concurrency.
             last_adhoc_pull = getattr(storage, "last_adhoc_pull", None)
-            if (
-                last_adhoc_pull is None
-                or last_adhoc_pull
-                < now("UTC") - datetime.timedelta(seconds=storage.pull_interval)
-            ):
+            if last_adhoc_pull is None or last_adhoc_pull < now(
+                "UTC"
+            ) - datetime.timedelta(seconds=storage.pull_interval):
                 self._logger.debug(
                     "Performing adhoc pull of code for flow run %s with storage %r",
                     flow_run.id,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -129,6 +129,7 @@ from prefect.settings import (
 from prefect.states import (
     AwaitingRetry,
 )
+from prefect.types._datetime import now
 from prefect.types.entrypoint import EntrypointType
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import (
@@ -1054,7 +1055,7 @@ class Runner:
             if (
                 last_adhoc_pull is None
                 or last_adhoc_pull
-                < datetime.datetime.now()
+                < now("UTC")
                 - datetime.timedelta(seconds=storage.pull_interval)
             ):
                 self._logger.debug(
@@ -1063,7 +1064,7 @@ class Runner:
                     storage,
                 )
                 await storage.pull_code()
-                setattr(storage, "last_adhoc_pull", datetime.datetime.now())
+                setattr(storage, "last_adhoc_pull", now("UTC"))
 
         handed_off = False
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1055,8 +1055,7 @@ class Runner:
             if (
                 last_adhoc_pull is None
                 or last_adhoc_pull
-                < now("UTC")
-                - datetime.timedelta(seconds=storage.pull_interval)
+                < now("UTC") - datetime.timedelta(seconds=storage.pull_interval)
             ):
                 self._logger.debug(
                     "Performing adhoc pull of code for flow run %s with storage %r",


### PR DESCRIPTION
closes #21960


This PR replaces naive `datetime.datetime.now()` calls with tz-aware `now("UTC")` from `prefect.types._datetime` in the runner's adhoc pull interval logic.
<details>
<summary>Details</summary>
In both `_scheduled_run_poller.py` and `runner.py`, `last_adhoc_pull` was being set and compared using `datetime.datetime.now()` — a naive (timezone-unaware) datetime. Every other datetime in these files already uses `now("UTC")` from `prefect.types._datetime` (e.g. `self.last_polled = now("UTC")`). Mixing naive and tz-aware datetimes causes `TypeError: can't compare offset-naive and offset-aware datetimes`, which becomes increasingly likely on Python >= 3.13.
`_scheduled_run_poller.py` already imported `now` at the top of the file but wasn't using it for this code path. `runner.py` has been updated to add the import.
</details>

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
