### PR TITLE
fix: skip-saturated-deployment-runs

### DIFF
--- a/src/prefect/server/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/server/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
@@ -83,8 +83,8 @@ FROM
                 ORDER BY
                     fr.next_scheduled_start_time ASC
                 LIMIT LEAST (:queue_limit, queue_slots.available_slots)
-                -- lock runs
-                FOR UPDATE SKIP LOCKED
+                -- lock runs without locking the joined deployment tables
+                FOR UPDATE OF fr SKIP LOCKED
                 ) fr_inner
         
         WHERE

--- a/src/prefect/server/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/server/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
@@ -62,10 +62,18 @@ FROM
                     fr.*
                 FROM
                     flow_run fr
+                    LEFT JOIN deployment d ON fr.deployment_id = d.id
+                    LEFT JOIN concurrency_limit_v2 dcl ON d.concurrency_limit_id = dcl.id
                 WHERE
                     fr.work_queue_id = wq.id
                     AND fr.state_type = 'SCHEDULED'
                     AND (fr.empirical_policy->>'retry_type' IS NULL OR fr.empirical_policy->>'retry_type' != 'in_process')
+                    AND (
+                        fr.deployment_id IS NULL
+                        OR d.concurrency_limit_id IS NULL
+                        OR dcl.active IS FALSE
+                        OR dcl.active_slots < dcl."limit"
+                    )
                     {% if scheduled_after %}
                     AND fr.next_scheduled_start_time >= :scheduled_after
                     {% endif %}

--- a/src/prefect/server/database/sql/sqlite/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/server/database/sql/sqlite/get-runs-from-worker-queues.sql.jinja
@@ -50,10 +50,18 @@ scheduled_flow_runs AS (
         JOIN (
             SELECT 
                 fr.*,
-                ROW_NUMBER() OVER (PARTITION BY work_queue_id ORDER BY next_scheduled_start_time) AS work_queue_rank
+                ROW_NUMBER() OVER (PARTITION BY fr.work_queue_id ORDER BY fr.next_scheduled_start_time) AS work_queue_rank
             FROM flow_run fr
+            LEFT JOIN deployment d ON fr.deployment_id = d.id
+            LEFT JOIN concurrency_limit_v2 dcl ON d.concurrency_limit_id = dcl.id
             WHERE fr.state_type = 'SCHEDULED'
             AND (json_extract(fr.empirical_policy, '$.retry_type') IS NULL OR json_extract(fr.empirical_policy, '$.retry_type') != 'in_process')
+            AND (
+                fr.deployment_id IS NULL
+                OR d.concurrency_limit_id IS NULL
+                OR dcl.active IS FALSE
+                OR dcl.active_slots < dcl."limit"
+            )
             {% if scheduled_after %}
             AND fr.next_scheduled_start_time >= :scheduled_after
             {% endif %}

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -467,6 +467,7 @@ def asserting_and_emitting_events_worker(
     finally:
         run_coro_as_sync(_drain_events_worker(worker))
 
+
 async def _drain_events_worker(worker: EventsWorker) -> None:
     drain_result = worker.drain()
     if inspect.isawaitable(drain_result):

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import os
 import signal
@@ -451,7 +452,7 @@ def asserting_events_worker(
     try:
         yield worker
     finally:
-        worker.drain()
+        run_coro_as_sync(_drain_events_worker(worker))
 
 
 @pytest.fixture
@@ -464,7 +465,12 @@ def asserting_and_emitting_events_worker(
     try:
         yield worker
     finally:
-        worker.drain()
+        run_coro_as_sync(_drain_events_worker(worker))
+
+async def _drain_events_worker(worker: EventsWorker) -> None:
+    drain_result = worker.drain()
+    if inspect.isawaitable(drain_result):
+        await drain_result
 
 
 @pytest.fixture

--- a/tests/server/models/test_workers.py
+++ b/tests/server/models/test_workers.py
@@ -872,6 +872,80 @@ class TestGetScheduledRuns:
         )
         assert len(runs) == 0
 
+    async def test_saturated_deployment_concurrency_limits_are_skipped(
+        self, session, flow
+    ):
+        work_pool = await models.workers.create_work_pool(
+            session=session,
+            work_pool=schemas.actions.WorkPoolCreate(name=f"pool-{uuid4()}"),
+        )
+        work_queue = await models.workers.create_work_queue(
+            session=session,
+            work_pool_id=work_pool.id,
+            work_queue=schemas.actions.WorkQueueCreate(name=f"q-{uuid4()}"),
+        )
+
+        limited_deployment = await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name=f"limited-{uuid4()}",
+                flow_id=flow.id,
+                work_queue_name=work_queue.name,
+                concurrency_limit=1,
+            ),
+        )
+        unconstrained_deployment = await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name=f"unconstrained-{uuid4()}",
+                flow_id=flow.id,
+                work_queue_name=work_queue.name,
+            ),
+        )
+
+        limited_run = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id,
+                deployment_id=limited_deployment.id,
+                work_queue_id=work_queue.id,
+                state=schemas.states.Scheduled(
+                    scheduled_time=now("UTC") - datetime.timedelta(minutes=5)
+                ),
+            ),
+        )
+        unconstrained_run = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id,
+                deployment_id=unconstrained_deployment.id,
+                work_queue_id=work_queue.id,
+                state=schemas.states.Scheduled(
+                    scheduled_time=now("UTC") - datetime.timedelta(minutes=4)
+                ),
+            ),
+        )
+
+        acquired = await models.concurrency_limits_v2.bulk_increment_active_slots(
+            session=session,
+            concurrency_limit_ids=[limited_deployment.concurrency_limit_id],
+            slots=1,
+        )
+        assert acquired is True
+
+        await session.commit()
+
+        runs = await models.workers.get_scheduled_flow_runs(
+            session=session,
+            work_pool_ids=[work_pool.id],
+            limit=1,
+            respect_queue_priorities=False,
+        )
+
+        assert len(runs) == 1
+        assert runs[0].flow_run.id == unconstrained_run.id
+        assert runs[0].flow_run.id != limited_run.id
+
 
 class TestDeleteWorker:
     async def test_delete_worker(self, session, work_pool):


### PR DESCRIPTION
closes: #19403

- Fixes worker queue starvation caused by deployment concurrency-limited flow runs.
 
- Previously, saturated deployment concurrency runs were still included in worker polling batches, allowing them to monopolize the queue window and prevent runnable flow runs from being discovered.
 
- This change filters out deployment runs whose concurrency limits are already saturated when fetching scheduled flow runs for workers.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
