### PR TITLE
runner: remove redundant `submitted_ids` set in ScheduledRunPoller

### DIFF
--- a/src/prefect/runner/_scheduled_run_poller.py
+++ b/src/prefect/runner/_scheduled_run_poller.py
@@ -126,7 +126,6 @@ class ScheduledRunPoller:
             ),
         )
 
-        submitted_ids: set[UUID] = set()
         for flow_run in submittable_flow_runs:
             if flow_run.id in self._submitting_flow_run_ids:
                 continue
@@ -135,13 +134,12 @@ class ScheduledRunPoller:
             except anyio.WouldBlock:
                 break  # sorted: no earlier run fits
             self._submitting_flow_run_ids.add(flow_run.id)
-            submitted_ids.add(flow_run.id)
             task_group.start_soon(self._submit_run, flow_run, task_group, slot_token)
 
         skipped_count = sum(
             1
             for r in submittable_flow_runs
-            if r.id not in self._submitting_flow_run_ids and r.id not in submitted_ids
+            if r.id not in self._submitting_flow_run_ids
         )
         if skipped_count > 0:
             self._logger.info("%d scheduled runs skipped (at capacity)", skipped_count)


### PR DESCRIPTION
closes #21981

Every ID added to `submitted_ids` was also added to `self._submitting_flow_run_ids` on the immediately preceding line, making `submitted_ids` a strict subset at all times. The second clause in the skipped-count predicate was therefore dead code that could never fire. Remove the set and simplify the predicate.

No behaviour change.

This PR removes the redundant `submitted_ids` local set from
`ScheduledRunPoller._submit_scheduled_flow_runs`.
Every ID added to `submitted_ids` was also added to
`self._submitting_flow_run_ids` on the immediately preceding line,
making `submitted_ids` a strict subset at all times. The second
clause in the skipped-count predicate was therefore dead code that
could never fire:
```python
# before
if r.id not in self._submitting_flow_run_ids and r.id not in submitted_ids
# after
if r.id not in self._submitting_flow_run_ids
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
