### PR TITLE
Speed up client test CI shards

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -117,11 +117,6 @@ jobs:
               tests/test_datetime.py
               tests/test_exceptions.py
               tests/test_filesystems.py
-              tests/test_flow_engine.py
-              tests/test_flow_runs.py
-              tests/test_flows.py
-              tests/test_flows_compat.py
-              tests/test_futures.py
               tests/test_highlighters.py
               tests/test_infrastructure_bound_flow.py
               tests/test_locking.py
@@ -131,6 +126,17 @@ jobs:
               tests/test_plugins.py
               tests/test_schedules.py
               tests/test_serializers.py
+              tests/test_types.py
+              tests/test_ui_build_validation.py
+              tests/test_variables.py
+              tests/test_versioning.py
+          - name: "Client Tests: Execution"
+            modules: >-
+              tests/test_flow_engine.py
+              tests/test_flow_runs.py
+              tests/test_flows.py
+              tests/test_flows_compat.py
+              tests/test_futures.py
               tests/test_states.py
               tests/test_subprocess_logging.py
               tests/test_task_engine.py
@@ -138,10 +144,6 @@ jobs:
               tests/test_task_worker.py
               tests/test_tasks.py
               tests/test_transactions.py
-              tests/test_types.py
-              tests/test_ui_build_validation.py
-              tests/test_variables.py
-              tests/test_versioning.py
               tests/test_waiters.py
           - name: Runner, Worker, Settings, Input, and CLI Tests
             modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
@@ -180,13 +182,9 @@ jobs:
                 tests/test_background_tasks.py
                 tests/test_cache_policies.py
                 tests/test_context.py
+                tests/test_datetime.py
                 tests/test_exceptions.py
                 tests/test_filesystems.py
-                tests/test_flow_engine.py
-                tests/test_flow_runs.py
-                tests/test_flows.py
-                tests/test_flows_compat.py
-                tests/test_futures.py
                 tests/test_highlighters.py
                 tests/test_infrastructure_bound_flow.py
                 tests/test_locking.py
@@ -196,16 +194,26 @@ jobs:
                 tests/test_plugins.py
                 tests/test_schedules.py
                 tests/test_serializers.py
+                tests/test_types.py
+                tests/test_ui_build_validation.py
+                tests/test_variables.py
+                tests/test_versioning.py
+          - database: "sqlite"
+            test-type:
+              name: "Client Tests: Execution"
+              modules: >-
+                tests/test_flow_engine.py
+                tests/test_flow_runs.py
+                tests/test_flows.py
+                tests/test_flows_compat.py
+                tests/test_futures.py
                 tests/test_states.py
+                tests/test_subprocess_logging.py
                 tests/test_task_engine.py
                 tests/test_task_runs.py
                 tests/test_task_worker.py
                 tests/test_tasks.py
                 tests/test_transactions.py
-                tests/test_types.py
-                tests/test_ui_build_validation.py
-                tests/test_variables.py
-                tests/test_versioning.py
                 tests/test_waiters.py
           - database: "sqlite"
             test-type:

--- a/scripts/verify_test_selection.py
+++ b/scripts/verify_test_selection.py
@@ -85,13 +85,48 @@ def file_covered_by(
     return True
 
 
+def validate_excluded_test_types(
+    test_types: list[dict[str, str]], excludes: list[dict[str, object]]
+) -> list[str]:
+    """Return errors for excludes whose test-type entry no longer matches."""
+    known_test_types = {
+        (entry.get("name"), entry.get("modules")) for entry in test_types
+    }
+
+    errors: list[str] = []
+    for index, exclude in enumerate(excludes, start=1):
+        test_type = exclude.get("test-type")
+        if not isinstance(test_type, dict):
+            continue
+
+        key = (test_type.get("name"), test_type.get("modules"))
+        if key not in known_test_types:
+            name = test_type.get("name", "<unnamed>")
+            errors.append(
+                f"matrix exclude #{index} references test-type {name!r}, "
+                "but its definition does not match any matrix test-type entry"
+            )
+
+    return errors
+
+
 def main() -> None:
     with open(WORKFLOW_PATH) as f:
         workflow = yaml.safe_load(f)
 
-    test_types: list[dict[str, str]] = workflow["jobs"]["run-tests"]["strategy"][
-        "matrix"
-    ]["test-type"]
+    matrix = workflow["jobs"]["run-tests"]["strategy"]["matrix"]
+    test_types: list[dict[str, str]] = matrix["test-type"]
+
+    exclude_errors = validate_excluded_test_types(test_types, matrix.get("exclude", []))
+    if exclude_errors:
+        print("ERROR: Some run-tests matrix excludes are stale:")
+        for error in exclude_errors:
+            print(f"  {error}")
+        print(
+            "\nPlease update the exclude entry in "
+            f"{WORKFLOW_PATH} to match the corresponding test-type matrix entry."
+        )
+        sys.exit(1)
 
     all_test_files = discover_test_files("tests")
 


### PR DESCRIPTION
this PR reduces client test CI timeout risk by fixing stale sqlite excludes and splitting execution-heavy top-level tests into a separate client shard.

<details>
<summary>Details</summary>

- Restores sqlite exclusion for client top-level tests by syncing the exclude list with the matrix entry and adding the equivalent exclude for the new execution shard.
- Moves flow/task execution-heavy top-level files into `Client Tests: Execution`, leaving lighter top-level files in the existing client shard.
- Extends `scripts/verify_test_selection.py` to fail when a matrix exclude's copied `test-type` no longer matches any matrix entry, which is what allowed sqlite client jobs to run unintentionally.
- Checked with `uv run --with pyyaml --no-project -s scripts/verify_test_selection.py`, a matrix sanity check confirming `client sqlite remaining []`, `uv run --with ruff --no-project ruff check --config pyproject.toml scripts/verify_test_selection.py`, `uv run --with ruff --no-project ruff format --check --config pyproject.toml scripts/verify_test_selection.py`, and `git diff --check`.

</details>
