### PR TITLE
Add PREFECT_RUNNER_UV_RUN_ENABLED setting to disable automatic uv project environment setup

### DIFF
--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1041,17 +1041,17 @@ Whether to crash flow runs and shut down the runner when cancellation observing 
 **Supported environment variables**:
 `PREFECT_RUNNER_CRASH_ON_CANCELLATION_FAILURE`
 
-### `uv_auto_sync`
+### `uv_run_enabled`
 Whether to automatically use `uv run --project` to execute flow runs when a `pyproject.toml` declaring prefect as a dependency is found in the workspace. Disable this to use the Python executable from the current environment instead.
 
 **Type**: `boolean`
 
 **Default**: `True`
 
-**TOML dotted key path**: `runner.uv_auto_sync`
+**TOML dotted key path**: `runner.uv_run_enabled`
 
 **Supported environment variables**:
-`PREFECT_RUNNER_UV_AUTO_SYNC`
+`PREFECT_RUNNER_UV_RUN_ENABLED`
 
 ### `server`
 

--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1041,6 +1041,18 @@ Whether to crash flow runs and shut down the runner when cancellation observing 
 **Supported environment variables**:
 `PREFECT_RUNNER_CRASH_ON_CANCELLATION_FAILURE`
 
+### `uv_auto_sync`
+Whether to automatically use `uv run --project` to execute flow runs when a `pyproject.toml` declaring prefect as a dependency is found in the workspace. Disable this to use the Python executable from the current environment instead.
+
+**Type**: `boolean`
+
+**Default**: `True`
+
+**TOML dotted key path**: `runner.uv_auto_sync`
+
+**Supported environment variables**:
+`PREFECT_RUNNER_UV_AUTO_SYNC`
+
 ### `server`
 
 **Type**: [RunnerServerSettings](#runnerserversettings)

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -167,7 +167,7 @@ def _pyproject_declares_prefect_dependency(pyproject: Path) -> bool:
 
 
 def _uv_run_command(workspace: PreparedWorkspace) -> str | None:
-    if not get_current_settings().runner.uv_auto_sync:
+    if not get_current_settings().runner.uv_run_enabled:
         return None
 
     project_root = workspace.project_root

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -167,6 +167,9 @@ def _pyproject_declares_prefect_dependency(pyproject: Path) -> bool:
 
 
 def _uv_run_command(workspace: PreparedWorkspace) -> str | None:
+    if not get_current_settings().runner.uv_auto_sync:
+        return None
+
     project_root = workspace.project_root
     if project_root is None:
         return None

--- a/src/prefect/settings/models/runner.py
+++ b/src/prefect/settings/models/runner.py
@@ -71,6 +71,16 @@ class RunnerSettings(PrefectBaseSettings):
         ),
     )
 
+    uv_auto_sync: bool = Field(
+        default=True,
+        description=(
+            "Whether to automatically use `uv run --project` to execute flow runs "
+            "when a `pyproject.toml` declaring prefect as a dependency is found in "
+            "the workspace. Disable this to use the Python executable from the "
+            "current environment instead."
+        ),
+    )
+
     server: RunnerServerSettings = Field(
         default_factory=RunnerServerSettings,
         description="Settings for controlling runner server behavior",

--- a/src/prefect/settings/models/runner.py
+++ b/src/prefect/settings/models/runner.py
@@ -71,7 +71,7 @@ class RunnerSettings(PrefectBaseSettings):
         ),
     )
 
-    uv_auto_sync: bool = Field(
+    uv_run_enabled: bool = Field(
         default=True,
         description=(
             "Whether to automatically use `uv run --project` to execute flow runs "

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -327,6 +327,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_RESULTS_LOCAL_STORAGE_PATH": {"test_value": Path("/path/to/storage")},
     "PREFECT_RESULTS_PERSIST_BY_DEFAULT": {"test_value": True},
     "PREFECT_RUNNER_CRASH_ON_CANCELLATION_FAILURE": {"test_value": True},
+    "PREFECT_RUNNER_UV_AUTO_SYNC": {"test_value": False},
     "PREFECT_FLOWS_HEARTBEAT_FREQUENCY": {"test_value": 30},
     "PREFECT_RUNNER_HEARTBEAT_FREQUENCY": {"test_value": 30, "legacy": True},
     "PREFECT_RUNNER_POLL_FREQUENCY": {"test_value": 10},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -327,7 +327,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_RESULTS_LOCAL_STORAGE_PATH": {"test_value": Path("/path/to/storage")},
     "PREFECT_RESULTS_PERSIST_BY_DEFAULT": {"test_value": True},
     "PREFECT_RUNNER_CRASH_ON_CANCELLATION_FAILURE": {"test_value": True},
-    "PREFECT_RUNNER_UV_AUTO_SYNC": {"test_value": False},
+    "PREFECT_RUNNER_UV_RUN_ENABLED": {"test_value": False},
     "PREFECT_FLOWS_HEARTBEAT_FREQUENCY": {"test_value": 30},
     "PREFECT_RUNNER_HEARTBEAT_FREQUENCY": {"test_value": 30, "legacy": True},
     "PREFECT_RUNNER_POLL_FREQUENCY": {"test_value": 10},


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

Closes #22016 

When a workspace contains a pyproject.toml declaring prefect as a dependency and uv is available, the workspace resolver automatically uses uv run --project to execute flow runs. This installs all project dependencies into the workspace on every run, which is unnecessary and wasteful when the execution environment already has a fully prepared environment (e.g. a container image built with uv sync). 
Setting PREFECT_RUNNER_UV_RUN_ENABLED=false disables this auto-detection and uses the Python executable from the current environment instead. 