### PR TITLE
fix: hard-delete-cloud-assets

### DIFF
--- a/src/prefect/cli/cloud/asset.py
+++ b/src/prefect/cli/cloud/asset.py
@@ -121,29 +121,41 @@ async def asset_delete(
         ),
     ] = False,
 ):
-    """Delete an asset by its key.
+    """Permanently delete an asset by its key.
 
-    The key should be the full asset URI (e.g., 's3://bucket/data.csv').
+    The key should be the full asset URI (e.g., 's3://bucket/data.csv'). This
+    deletes every stored version for the key so deleted assets do not reappear.
     """
     from prefect.cli._prompts import confirm
-    from prefect.client.cloud import get_cloud_client
+    from prefect.client.orchestration import get_client
+    from prefect.client.schemas.filters import ArtifactFilter, ArtifactFilterKey
     from prefect.exceptions import ObjectNotFound
-    from prefect.settings import get_current_settings
 
     confirm_logged_in(console=_cli.console)
 
-    if _cli.is_interactive() and not force:
-        if not confirm(
-            f"Are you sure you want to delete asset {key!r}?",
-            default=False,
-            console=_cli.console,
-        ):
-            exit_with_error("Deletion aborted.")
+    async with get_client() as client:
+        artifacts = await client.read_artifacts(
+            artifact_filter=ArtifactFilter(key=ArtifactFilterKey(any_=[key]))
+        )
 
-    async with get_cloud_client(host=get_current_settings().api.url) as client:
-        try:
-            await client.request("DELETE", "/assets/key", params={"key": key})
-        except ObjectNotFound:
+        if not artifacts:
             exit_with_error(f"Asset {key!r} not found.")
+
+        if _cli.is_interactive() and not force:
+            if not confirm(
+                (
+                    f"Are you sure you want to permanently delete asset {key!r} and"
+                    f" all {len(artifacts)} version(s)?"
+                ),
+                default=False,
+                console=_cli.console,
+            ):
+                exit_with_error("Deletion aborted.")
+
+        for artifact in artifacts:
+            try:
+                await client.delete_artifact(artifact.id)
+            except ObjectNotFound:
+                exit_with_error(f"Asset {key!r} not found.")
 
     exit_with_success(f"Deleted asset {key!r}.")

--- a/tests/cli/cloud/test_asset.py
+++ b/tests/cli/cloud/test_asset.py
@@ -225,9 +225,23 @@ class TestAssetDelete:
 
         monkeypatch.setattr(_cli, "is_interactive", lambda: True)
 
-        respx_mock.delete(f"{workspace.api_url()}/assets/key").mock(
-            return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
+        artifacts = [
+            {
+                "id": str(uuid.uuid4()),
+                "key": "s3://my-bucket/data.csv",
+            },
+            {
+                "id": str(uuid.uuid4()),
+                "key": "s3://my-bucket/data.csv",
+            },
+        ]
+        respx_mock.post(f"{workspace.api_url()}/artifacts/filter").mock(
+            return_value=httpx.Response(status.HTTP_200_OK, json=artifacts)
         )
+        for artifact in artifacts:
+            respx_mock.delete(f"{workspace.api_url()}/artifacts/{artifact['id']}").mock(
+                return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
+            )
 
         with use_profile(profile_name):
             invoke_and_assert(
@@ -241,7 +255,14 @@ class TestAssetDelete:
         self, respx_mock: respx.MockRouter, cloud_workspace: tuple[Workspace, str]
     ) -> None:
         workspace, profile_name = cloud_workspace
-        respx_mock.delete(f"{workspace.api_url()}/assets/key").mock(
+        artifact = {
+            "id": str(uuid.uuid4()),
+            "key": "s3://my-bucket/data.csv",
+        }
+        respx_mock.post(f"{workspace.api_url()}/artifacts/filter").mock(
+            return_value=httpx.Response(status.HTTP_200_OK, json=[artifact])
+        )
+        respx_mock.delete(f"{workspace.api_url()}/artifacts/{artifact['id']}").mock(
             return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
         )
 
@@ -256,10 +277,8 @@ class TestAssetDelete:
         self, respx_mock: respx.MockRouter, cloud_workspace: tuple[Workspace, str]
     ) -> None:
         workspace, profile_name = cloud_workspace
-        respx_mock.delete(f"{workspace.api_url()}/assets/key").mock(
-            return_value=httpx.Response(
-                status.HTTP_404_NOT_FOUND, json={"detail": "Asset not found"}
-            )
+        respx_mock.post(f"{workspace.api_url()}/artifacts/filter").mock(
+            return_value=httpx.Response(status.HTTP_200_OK, json=[])
         )
 
         with use_profile(profile_name):


### PR DESCRIPTION
closes: #21835

Fixes `prefect cloud asset delete` behaving like a soft-delete, where deleted assets could later reappear without new materialization events.

This change updates `prefect cloud asset delete` to:

- query all artifacts matching the asset key.
- delete every matching artifact individually.
- ensure stale assets cannot be reconstructed from persisted artifacts.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
