### PR TITLE
Fix Azure blob result storage to overwrite on rewrite (#19411)

### DIFF
--- a/src/integrations/prefect-azure/prefect_azure/blob_storage.py
+++ b/src/integrations/prefect-azure/prefect_azure/blob_storage.py
@@ -712,7 +712,10 @@ class AzureBlobStorageContainer(
             path: The path where the content will be written.
             content: The content to be written.
         """
-        await self.upload_from_file_object(BytesIO(content), path)
+        # `write_path` backs results storage, where re-writing an existing key
+        # (e.g. when a task runs with `refresh_cache=True`) must replace the
+        # existing blob rather than raise `ResourceExistsError`.
+        await self.upload_from_file_object(BytesIO(content), path, overwrite=True)
 
     @sync_compatible
     async def list_blobs(self) -> List[str]:

--- a/src/integrations/prefect-azure/tests/test_blob_storage.py
+++ b/src/integrations/prefect-azure/tests/test_blob_storage.py
@@ -312,6 +312,23 @@ class TestAzureBlobStorageContainer:
 
         assert result == b"write_path_works"
 
+    async def test_blob_storage_write_path_overwrites_existing(
+        self, mock_blob_storage_credentials
+    ):
+        # Regression test for #19411: writing to an existing key (e.g. when a
+        # task runs with `refresh_cache=True`) must overwrite the blob instead
+        # of raising `ResourceExistsError`.
+        container = AzureBlobStorageContainer(
+            container_name="prefect",
+            credentials=mock_blob_storage_credentials,
+        )
+        await container.write_path("prefect-write-path.txt", b"original")
+        await container.write_path("prefect-write-path.txt", b"overwritten")
+
+        result = await container.read_path("prefect-write-path.txt")
+
+        assert result == b"overwritten"
+
     async def test_list_blobs(self, mock_blob_storage_credentials):
         blob_container = AzureBlobStorageContainer(
             container_name="container",


### PR DESCRIPTION
Closes #19411

### Problem
When a task runs with `PREFECT_TASKS_REFRESH_CACHE=true` (`refresh_cache=True`), the result transaction commits with `overwrite=True` and re-writes the result record under the same key. With Azure Blob result storage this raised `azure.core.exceptions.ResourceExistsError: The specified blob already exists`, because `AzureBlobStorageContainer.write_path` called `upload_from_file_object` without `overwrite=True`, and the underlying `upload_blob` defaults to `overwrite=False`.

### Fix
`write_path` backs Prefect results storage, where result keys are content/cache addressed and rewriting a key must replace the existing blob. Pass `overwrite=True` from `write_path` (consistent with how local filesystem result storage already overwrites).

### Tests
- Added `test_blob_storage_write_path_overwrites_existing` — fails before the fix (`ResourceExistsError`), passes after.
- Full `tests/test_blob_storage.py` suite passes (20 passed).