### PR TITLE
fix: route lease renewal failure log through run logger

### DIFF
--- a/src/prefect/concurrency/_leases.py
+++ b/src/prefect/concurrency/_leases.py
@@ -143,9 +143,14 @@ def _start_lease_renewal_thread(
     stop_event = threading.Event()
     renewal_ctx = contextvars.copy_context()
 
-    def renewal_loop() -> None:
+    def _run_with_failure_handler() -> None:
+        # Runs inside renewal_ctx so the failure handler also sees the
+        # copied flow/task run contextvars; otherwise get_run_logger() in
+        # _handle_lease_renewal_failure can't find the run context and the
+        # message falls back to the plain "prefect.concurrency" logger,
+        # never reaching the run logs API.
         try:
-            renewal_ctx.run(_lease_renewal_loop, lease_id, lease_duration, stop_event)
+            _lease_renewal_loop(lease_id, lease_duration, stop_event)
         except Exception as exc:
             if not stop_event.is_set():
                 _handle_lease_renewal_failure(
@@ -155,6 +160,9 @@ def _start_lease_renewal_thread(
                     suppress_warnings,
                     cancel_scope,
                 )
+
+    def renewal_loop() -> None:
+        renewal_ctx.run(_run_with_failure_handler)
 
     thread = threading.Thread(
         target=renewal_loop,

--- a/tests/concurrency/test_leases.py
+++ b/tests/concurrency/test_leases.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from prefect import flow
 from prefect._internal.concurrency.cancellation import CancelledError
 from prefect.concurrency._leases import (
     amaintain_concurrency_lease,
@@ -154,3 +155,46 @@ async def test_lease_renewal_fires_when_event_loop_blocked():
                 pass
 
     assert mock_client.renew_concurrency_lease.call_count >= 2
+
+
+@mock.patch(
+    "prefect.concurrency._leases.exponential_backoff_with_jitter", _zero_backoff
+)
+def test_lease_renewal_failure_logs_via_run_logger_in_flow_context(
+    caplog: pytest.LogCaptureFixture,
+):
+    """The failure message should reach the run logger (and thus the run logs API)
+    when the lease is maintained from within a flow context, not fall back to the
+    plain "prefect.concurrency" logger.
+
+    Regression test for the contextvar copy in _start_lease_renewal_thread: the
+    failure handler must run inside renewal_ctx so get_run_logger() resolves to
+    the parent flow's FlowRunContext.
+    """
+    mock_client = mock.MagicMock()
+    mock_client.renew_concurrency_lease.side_effect = RuntimeError("server down")
+    failure_message = "Concurrency lease renewal failed - slots are no longer reserved."
+
+    @flow
+    def host_flow() -> None:
+        with _patch_renewal_client(mock_client):
+            with maintain_concurrency_lease(
+                lease_id=uuid4(),
+                lease_duration=60,
+                raise_on_lease_renewal_failure=False,
+            ):
+                assert _wait_for(lambda: caplog.text.count(failure_message) == 1)
+
+    with caplog.at_level(logging.WARNING):
+        host_flow()
+
+    failure_records = [
+        record for record in caplog.records if failure_message in record.getMessage()
+    ]
+    assert failure_records, "expected a lease renewal failure log record"
+    # If the handler runs outside the copied context, get_run_logger() raises
+    # MissingContextError and the fallback emits via "prefect.concurrency".
+    assert any(record.name == "prefect.flow_runs" for record in failure_records), (
+        f"failure log did not reach the run logger; got loggers="
+        f"{[r.name for r in failure_records]}"
+    )


### PR DESCRIPTION
## Summary

The thread-backed renewal that landed in #21925 copies the parent flow/task run's contextvars into `renewal_ctx`, then runs `_lease_renewal_loop` inside that context. But the exception handler that calls `_handle_lease_renewal_failure` runs *outside* the copied context, so `get_run_logger()` raises `MissingContextError` and the message falls back to the plain `prefect.concurrency` logger — which logs to stderr but never reaches the run logs API.

Concretely, before this fix:

\`\`\`python
def renewal_loop() -> None:
    try:
        renewal_ctx.run(_lease_renewal_loop, ...)   # runs IN the copied context
    except Exception as exc:
        if not stop_event.is_set():
            _handle_lease_renewal_failure(...)       # runs OUTSIDE the context ⚠️
\`\`\`

User-visible effect: a flow run that crashes from lease renewal failure is indistinguishable from any other generic cancellation when looking at the flow run state + logs via the API. `state.message` stays as `"Execution was cancelled by the runtime environment."`, the logs show `"Beginning flow run..."` and `"Crash detected!..."`, and the helpful `"Concurrency lease renewal failed - slots are no longer reserved"` message only exists in stderr / process output — invisible to anything reading from the API.

This regresses behavior visible in the original report (#19068) where the failure message came through on `prefect.flow_runs`.

## Fix

Wrap both the loop and the failure handler in a single function and run *that* inside `renewal_ctx.run(...)`, so the handler also sees the same `FlowRunContext` / `TaskRunContext` the loop did. `get_run_logger()` then resolves to the parent run logger and the message lands on `prefect.flow_runs`, queryable via the flow run logs API.

## Test plan

- [x] New regression test `test_lease_renewal_failure_logs_via_run_logger_in_flow_context` asserts the failure log record's logger name is `prefect.flow_runs`. Verified locally:
  - **fails** on main (records come from `prefect.concurrency`)
  - **passes** with this fix
- [x] Existing `tests/concurrency/test_leases.py` (7 tests including the new one) all green locally

## How I found this

While writing an eval for the prefect-mcp-server that asks an agent to diagnose a real lease-renewal crash. The agent has full access to flow run state and logs via the API but couldn't reach the diagnosis — turned out the renewal failure message wasn't in any of the API surfaces. Tracing through `_leases.py` led to the contextvar-copy gap above.

Marked draft because I'd like a sanity check on the wrapping shape — happy to refactor if there's a preferred idiom in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)