### PR TITLE
fix(prefect-kubernetes): allow TLS overrides for the observer

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -13,6 +13,7 @@ from typing import Any
 import anyio
 import kopf
 from cachetools import TTLCache
+from kopf import ConnectionInfo, login_via_async_client
 from kubernetes_asyncio import config
 from kubernetes_asyncio.client import ApiClient, BatchV1Api, CoreV1Api, V1Job
 
@@ -56,6 +57,49 @@ settings = KubernetesSettings()
 events_client: EventsClient | None = None
 orchestration_client: PrefectClient | None = None
 _startup_event_semaphore: asyncio.Semaphore | None = None
+
+
+def _apply_tls_overrides(
+    info: ConnectionInfo,
+    *,
+    ca_cert_path: str | None,
+    insecure_skip_tls_verify: bool,
+) -> ConnectionInfo:
+    """Return a ConnectionInfo with user-configured TLS overrides applied.
+
+    Bumps the priority so the override beats kopf's auto-registered
+    `login_via_async_client` (priority 15) in the credential vault. See #22048.
+    """
+    overrides: dict[str, Any] = {}
+    if ca_cert_path is not None:
+        overrides["ca_path"] = ca_cert_path
+        overrides["ca_data"] = None
+    if insecure_skip_tls_verify:
+        overrides["insecure"] = True
+    if not overrides:
+        return info
+    return dataclasses.replace(info, **overrides, priority=info.priority + 100)
+
+
+if (
+    settings.observer.ca_cert_path is not None
+    or settings.observer.insecure_skip_tls_verify
+):
+
+    @kopf.on.login()
+    async def _observer_login(**kwargs: Any) -> ConnectionInfo | None:  # pyright: ignore[reportUnusedFunction]
+        info = await login_via_async_client(**kwargs)
+        if info is None:
+            return None
+        return _apply_tls_overrides(
+            info,
+            ca_cert_path=(
+                str(settings.observer.ca_cert_path)
+                if settings.observer.ca_cert_path
+                else None
+            ),
+            insecure_skip_tls_verify=settings.observer.insecure_skip_tls_verify,
+        )
 
 
 @kopf.on.startup()

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from pathlib import Path
 from typing import Annotated, Optional, Union
 
 from pydantic import AliasChoices, AliasPath, BeforeValidator, Field
@@ -75,6 +76,22 @@ class KubernetesObserverSettings(PrefectBaseSettings):
         ge=1,
         description="Number of tail lines to fetch from crashed pod containers "
         "when forwarding logs.",
+    )
+
+    ca_cert_path: Optional[Path] = Field(
+        default=None,
+        description="Path to a CA certificate bundle used by the observer when "
+        "connecting to the Kubernetes API. Override only when the cluster CA "
+        "shipped via the service-account token volume is not accepted by "
+        "OpenSSL (e.g. missing `CA:TRUE` basic-constraint). When set, takes "
+        "precedence over the in-cluster CA.",
+    )
+
+    insecure_skip_tls_verify: bool = Field(
+        default=False,
+        description="If `True`, the observer skips TLS verification when "
+        "connecting to the Kubernetes API. Use only as a last resort when the "
+        "cluster CA bundle cannot be made valid; prefer `ca_cert_path`.",
     )
 
 

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -2162,3 +2162,93 @@ class TestLoggingConfiguration:
         finally:
             stop_observer()
             monkeypatch.delenv("PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER")
+
+
+class TestObserverTlsOverrides:
+    """Regression coverage for PrefectHQ/prefect#22048.
+
+    Some K8s distributions ship cluster CA bundles that fail OpenSSL's
+    strict CA validation (X509_V_ERR_INVALID_CA). The observer must
+    expose a way to swap the CA bundle or skip verification entirely;
+    otherwise the kopf-based observer cannot start on those clusters.
+    """
+
+    def _sample_info(self):
+        from kopf import ConnectionInfo
+
+        return ConnectionInfo(
+            server="https://10.96.0.1:443",
+            ca_path="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+            token="sa-token",
+            priority=15,
+        )
+
+    def test_no_overrides_returns_info_unchanged(self):
+        from prefect_kubernetes.observer import _apply_tls_overrides
+
+        info = self._sample_info()
+        result = _apply_tls_overrides(
+            info, ca_cert_path=None, insecure_skip_tls_verify=False
+        )
+        assert result is info
+
+    def test_insecure_skip_tls_verify_sets_insecure_and_bumps_priority(self):
+        from prefect_kubernetes.observer import _apply_tls_overrides
+
+        info = self._sample_info()
+        result = _apply_tls_overrides(
+            info, ca_cert_path=None, insecure_skip_tls_verify=True
+        )
+        assert result.insecure is True
+        # Priority must exceed the default piggybacking priority (15) so the
+        # override beats kopf's auto-registered login handler in the vault.
+        assert result.priority > info.priority
+        assert result.server == info.server
+        assert result.token == info.token
+
+    def test_ca_cert_path_overrides_ca_path_and_clears_ca_data(self):
+        from prefect_kubernetes.observer import _apply_tls_overrides
+
+        info = self._sample_info()
+        result = _apply_tls_overrides(
+            info,
+            ca_cert_path="/etc/ssl/my-corrected-ca.pem",
+            insecure_skip_tls_verify=False,
+        )
+        assert result.ca_path == "/etc/ssl/my-corrected-ca.pem"
+        assert result.ca_data is None
+        assert result.priority > info.priority
+
+    def test_both_overrides_combine(self):
+        from prefect_kubernetes.observer import _apply_tls_overrides
+
+        info = self._sample_info()
+        result = _apply_tls_overrides(
+            info,
+            ca_cert_path="/etc/ssl/my-ca.pem",
+            insecure_skip_tls_verify=True,
+        )
+        assert result.insecure is True
+        assert result.ca_path == "/etc/ssl/my-ca.pem"
+
+    def test_settings_expose_tls_overrides(self):
+        from prefect_kubernetes.settings import KubernetesObserverSettings
+
+        fields = KubernetesObserverSettings.model_fields
+        assert "ca_cert_path" in fields
+        assert "insecure_skip_tls_verify" in fields
+
+    def test_settings_read_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        from prefect_kubernetes.settings import KubernetesObserverSettings
+
+        monkeypatch.setenv(
+            "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_INSECURE_SKIP_TLS_VERIFY",
+            "true",
+        )
+        monkeypatch.setenv(
+            "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_CA_CERT_PATH",
+            "/etc/ssl/my-ca.pem",
+        )
+        s = KubernetesObserverSettings()
+        assert s.insecure_skip_tls_verify is True
+        assert str(s.ca_cert_path) == "/etc/ssl/my-ca.pem"


### PR DESCRIPTION
closes #22048

The kopf-based observer in `prefect-kubernetes` crashes on K8s clusters whose service-account CA bundle is missing the `CA:TRUE` basic-constraint (some managed distros, e.g. Vultr). OpenSSL rejects it as `X509_V_ERR_INVALID_CA` and there was no way to point the observer at a corrected CA or skip verification.

This PR adds two `KubernetesObserverSettings` fields — `ca_cert_path` and `insecure_skip_tls_verify` — and registers a `@kopf.on.login()` handler when either is set. The handler wraps kopf's public `login_via_async_client`, applies the overrides via `dataclasses.replace`, and bumps `priority` so it wins in the credential vault. Default behavior is unchanged.

## Status — still draft

Fix is logically correct and unit-tested but I want a few more things before flipping out of draft:

- [ ] **Wiring test.** `_apply_tls_overrides` is covered, but the conditional `@kopf.on.login()` registration at module import isn't. A refactor could silently delete the decorator block and tests would still pass. Want a test that re-imports `observer` with env vars set and asserts the handler ends up in `kopf.get_default_registry()._activities`.
- [ ] **End-to-end verification.** I reproduced the SSL error in isolation and tested the helper, but haven't driven an actual `kopf.operator(...)` against a TLS server with the bad cert to confirm the override priority + vault selection actually works in the live login flow.
- [ ] **Discoverability.** When users hit this in the wild they see `invalid CA certificate (_ssl.c:1032)` with nothing pointing at the new settings. Short troubleshooting note in `docs/v3/how-to-guides/deployment_infra/kubernetes.mdx`.
- [ ] **Release-notes entry** in `docs/v3/release-notes/integrations/prefect-kubernetes.mdx`.
- [ ] **Import-time registration caveat.** Settings are baked in when `prefect_kubernetes.observer` is first imported — probably fine in practice (the worker imports it once) but worth a comment.

Env vars (already work via the existing `PrefectBaseSettings` machinery):

```
PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_CA_CERT_PATH=/etc/ssl/my-ca.pem
PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_INSECURE_SKIP_TLS_VERIFY=true
```

<details>
<summary>Why OpenSSL rejects the cert (and kubectl doesn't)</summary>

`invalid CA certificate (_ssl.c:1032)` is OpenSSL's `X509_V_ERR_INVALID_CA` (code 24): the cert that signed the API server's leaf cert lacks `basicConstraints: CA:TRUE`, so OpenSSL refuses to treat it as a CA. Some managed K8s distributions ship cluster CA bundles shaped this way. `kubectl` works because Go's `crypto/tls` is more permissive here, so the cluster appears healthy until kopf (Python `ssl` → aiohttp) tries to connect.

</details>

<details>
<summary>Reproduction (drop-in script)</summary>

```python
# /// script
# requires-python = ">=3.10,<3.14"
# dependencies = ["cryptography", "aiohttp", "importlib-metadata"]
# ///
"""Synthesizes a Vultr-style cluster CA (BasicConstraints CA=False) +
leaf cert, stands up a TLS server with that chain, reproduces the exact
aiohttp error chain the observer hits."""

import asyncio, datetime, http.server, ipaddress, ssl, tempfile, threading
from pathlib import Path
import aiohttp
from cryptography import x509
from cryptography.hazmat.primitives import hashes, serialization
from cryptography.hazmat.primitives.asymmetric import rsa
from cryptography.x509.oid import NameOID


def build_vultr_style_chain():
    now = datetime.datetime.now(datetime.timezone.utc)
    ca_key = rsa.generate_private_key(65537, 2048)
    ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "fake-vultr-cluster-ca")])
    ca_cert = (
        x509.CertificateBuilder()
        .subject_name(ca_subject).issuer_name(ca_subject)
        .public_key(ca_key.public_key()).serial_number(x509.random_serial_number())
        .not_valid_before(now).not_valid_after(now + datetime.timedelta(days=1))
        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
        .add_extension(x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()), critical=False)
        .sign(ca_key, hashes.SHA256())
    )
    srv_key = rsa.generate_private_key(65537, 2048)
    srv_cert = (
        x509.CertificateBuilder()
        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "127.0.0.1")]))
        .issuer_name(ca_subject).public_key(srv_key.public_key())
        .serial_number(x509.random_serial_number())
        .not_valid_before(now).not_valid_after(now + datetime.timedelta(days=1))
        .add_extension(x509.SubjectAlternativeName([x509.IPAddress(ipaddress.IPv4Address("127.0.0.1"))]), critical=False)
        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()), critical=False)
        .sign(ca_key, hashes.SHA256())
    )
    ca_path = Path(tempfile.NamedTemporaryFile(suffix=".crt", delete=False).name)
    ca_path.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
    srv_path = Path(tempfile.NamedTemporaryFile(suffix=".pem", delete=False).name)
    srv_path.write_bytes(
        srv_cert.public_bytes(serialization.Encoding.PEM)
        + srv_key.private_bytes(
            serialization.Encoding.PEM,
            serialization.PrivateFormat.TraditionalOpenSSL,
            serialization.NoEncryption(),
        )
    )
    return ca_path, srv_path


class H(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        self.send_response(200); self.end_headers(); self.wfile.write(b"{}")
    def log_message(self, *_a, **_kw): pass


async def main():
    ca_path, srv_pem = build_vultr_style_chain()
    srv = http.server.HTTPServer(("127.0.0.1", 0), H)
    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); ctx.load_cert_chain(str(srv_pem))
    srv.socket = ctx.wrap_socket(srv.socket, server_side=True)
    threading.Thread(target=srv.serve_forever, daemon=True).start()

    client_ctx = ssl.create_default_context(cafile=str(ca_path))
    client_ctx.check_hostname = False
    async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=client_ctx)) as s:
        try:
            async with s.get(f"https://127.0.0.1:{srv.server_address[1]}/api") as r:
                print("unexpected success:", r.status)
        except Exception as e:
            print(type(e).__name__, repr(e))


asyncio.run(main())
```

Output matches the issue traceback:

```
ClientConnectorCertificateError(..., SSLCertVerificationError(1,
  '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
   invalid CA certificate (_ssl.c:1032)'))
```

</details>

<details>
<summary>Tests added</summary>

`TestObserverTlsOverrides` in `tests/test_observer.py`:
- no-op when neither override is set (returns the original `ConnectionInfo` instance)
- `insecure_skip_tls_verify` flips `insecure` and bumps priority above the default piggybacking priority (15)
- `ca_cert_path` sets `ca_path`, clears `ca_data`, bumps priority
- combined overrides
- both new fields are exposed on the settings model
- both new fields are readable from `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_*` env vars

Full `prefect-kubernetes` test suite (254 tests) passes locally.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)