### PR TITLE
Use Kubernetes timestamps for pod events

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -51,6 +51,51 @@ _last_diagnosis_cache: TTLCache[str, InfrastructureDiagnosis] = TTLCache(
     maxsize=1000, ttl=60 * 5
 )
 
+
+def _parse_k8s_datetime(value: Any) -> DateTime | None:
+    if not isinstance(value, str):
+        return None
+
+    try:
+        return DateTime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _container_state_times(
+    status: kopf.Status, state: str, timestamp_key: str
+) -> list[DateTime]:
+    timestamps: list[DateTime] = []
+    for status_key in ("initContainerStatuses", "containerStatuses"):
+        for container_status in status.get(status_key, []) or []:
+            container_state = container_status.get("state") or {}
+            state_details = container_state.get(state) or {}
+            timestamp = _parse_k8s_datetime(state_details.get(timestamp_key))
+            if timestamp:
+                timestamps.append(timestamp)
+    return timestamps
+
+
+def _pod_phase_occurred(
+    phase: str, status: kopf.Status, k8s_created_time: DateTime | None
+) -> DateTime | None:
+    if phase == "Pending":
+        return k8s_created_time
+
+    if phase == "Running":
+        running_times = _container_state_times(status, "running", "startedAt")
+        if running_times:
+            return min(running_times)
+        return _parse_k8s_datetime(status.get("startTime"))
+
+    if phase in {"Succeeded", "Failed", "evicted"}:
+        terminated_times = _container_state_times(status, "terminated", "finishedAt")
+        if terminated_times:
+            return max(terminated_times)
+
+    return None
+
+
 settings = KubernetesSettings()
 
 events_client: EventsClient | None = None
@@ -250,12 +295,16 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
                 resource["kubernetes.reason"] = reason
                 break
 
-    # Create the Prefect event, using the K8s event timestamp as the occurred time if available
+    k8s_occurred = _pod_phase_occurred(phase, status, k8s_created_time)
+
+    # Prefer Kubernetes lifecycle timestamps so replicated events preserve
+    # when the pod phase changed instead of when the observer processed it.
     prefect_event = Event(
         event=f"prefect.kubernetes.pod.{phase.lower()}",
         resource=Resource.model_validate(resource),
         id=event_id,
         related=_related_resources_from_labels(labels),
+        **({"occurred": k8s_occurred} if k8s_occurred else {}),
     )
 
     if (prev_event := _last_event_cache.get(uid)) is not None:

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -63,10 +63,13 @@ def _parse_k8s_datetime(value: Any) -> DateTime | None:
 
 
 def _container_state_times(
-    status: kopf.Status, state: str, timestamp_key: str
+    status: kopf.Status,
+    state: str,
+    timestamp_key: str,
+    status_keys: tuple[str, ...] = ("containerStatuses",),
 ) -> list[DateTime]:
     timestamps: list[DateTime] = []
-    for status_key in ("initContainerStatuses", "containerStatuses"):
+    for status_key in status_keys:
         for container_status in status.get(status_key, []) or []:
             container_state = container_status.get("state") or {}
             state_details = container_state.get(state) or {}
@@ -85,11 +88,16 @@ def _pod_phase_occurred(
     if phase == "Running":
         running_times = _container_state_times(status, "running", "startedAt")
         if running_times:
-            return min(running_times)
+            return max(running_times)
         return _parse_k8s_datetime(status.get("startTime"))
 
     if phase in {"Succeeded", "Failed", "evicted"}:
-        terminated_times = _container_state_times(status, "terminated", "finishedAt")
+        terminated_times = _container_state_times(
+            status,
+            "terminated",
+            "finishedAt",
+            status_keys=("initContainerStatuses", "containerStatuses"),
+        )
         if terminated_times:
             return max(terminated_times)
 

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -20,6 +20,7 @@ from prefect_kubernetes.observer import (
 
 from prefect.client.schemas.objects import FlowRun, State
 from prefect.events.schemas.events import RelatedResource, Resource
+from prefect.types import DateTime
 
 
 @pytest.fixture
@@ -105,6 +106,114 @@ class TestReplicatePodEvent:
                 }
             )
         ]
+
+    @pytest.mark.parametrize(
+        "event,status,expected_event,expected_occurred",
+        [
+            (
+                {
+                    "type": "ADDED",
+                    "object": {
+                        "metadata": {"creationTimestamp": "2026-05-11T09:30:00Z"}
+                    },
+                },
+                {"phase": "Pending"},
+                "prefect.kubernetes.pod.pending",
+                "2026-05-11T09:30:00+00:00",
+            ),
+            (
+                {
+                    "type": "MODIFIED",
+                    "object": {
+                        "metadata": {"creationTimestamp": "2026-05-11T09:29:55Z"}
+                    },
+                },
+                {
+                    "phase": "Running",
+                    "startTime": "2026-05-11T09:30:01Z",
+                    "containerStatuses": [
+                        {
+                            "name": "main",
+                            "state": {"running": {"startedAt": "2026-05-11T09:30:07Z"}},
+                        }
+                    ],
+                },
+                "prefect.kubernetes.pod.running",
+                "2026-05-11T09:30:07+00:00",
+            ),
+            (
+                {"type": "MODIFIED"},
+                {"phase": "Running", "startTime": "2026-05-11T09:30:01Z"},
+                "prefect.kubernetes.pod.running",
+                "2026-05-11T09:30:01+00:00",
+            ),
+            (
+                {"type": "MODIFIED"},
+                {
+                    "phase": "Succeeded",
+                    "containerStatuses": [
+                        {
+                            "name": "main",
+                            "state": {
+                                "terminated": {"finishedAt": "2026-05-11T10:00:00Z"}
+                            },
+                        },
+                        {
+                            "name": "sidecar",
+                            "state": {
+                                "terminated": {"finishedAt": "2026-05-11T10:00:05Z"}
+                            },
+                        },
+                    ],
+                },
+                "prefect.kubernetes.pod.succeeded",
+                "2026-05-11T10:00:05+00:00",
+            ),
+            (
+                {"type": "MODIFIED"},
+                {
+                    "phase": "Failed",
+                    "containerStatuses": [
+                        {
+                            "name": "main",
+                            "state": {
+                                "terminated": {
+                                    "reason": "Evicted",
+                                    "finishedAt": "2026-05-11T11:05:49Z",
+                                }
+                            },
+                        }
+                    ],
+                },
+                "prefect.kubernetes.pod.evicted",
+                "2026-05-11T11:05:49+00:00",
+            ),
+        ],
+    )
+    async def test_uses_kubernetes_timestamp_for_occurred(
+        self,
+        mock_events_client: AsyncMock,
+        event: dict[str, object],
+        status: dict[str, object],
+        expected_event: str,
+        expected_occurred: str,
+    ):
+        await _replicate_pod_event(
+            event=event,
+            uid=str(uuid.uuid4()),
+            name="test",
+            namespace="test",
+            labels={
+                "prefect.io/flow-run-id": str(uuid.uuid4()),
+                "prefect.io/flow-run-name": "test-run",
+            },
+            status=status,
+            logger=MagicMock(),
+        )
+
+        emitted_event = mock_events_client.emit.call_args[1]["event"]
+        assert emitted_event.event == expected_event
+        assert emitted_event.occurred == DateTime.fromisoformat(expected_occurred)
 
     async def test_deterministic_event_id(self, mock_events_client: AsyncMock):
         """Test that the event ID is deterministic"""

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -143,6 +143,31 @@ class TestReplicatePodEvent:
             ),
             (
                 {"type": "MODIFIED"},
+                {
+                    "phase": "Running",
+                    "startTime": "2026-05-11T09:30:01Z",
+                    "initContainerStatuses": [
+                        {
+                            "name": "native-sidecar",
+                            "state": {"running": {"startedAt": "2026-05-11T09:29:59Z"}},
+                        }
+                    ],
+                    "containerStatuses": [
+                        {
+                            "name": "main",
+                            "state": {"running": {"startedAt": "2026-05-11T09:30:07Z"}},
+                        },
+                        {
+                            "name": "worker",
+                            "state": {"running": {"startedAt": "2026-05-11T10:00:00Z"}},
+                        },
+                    ],
+                },
+                "prefect.kubernetes.pod.running",
+                "2026-05-11T10:00:00+00:00",
+            ),
+            (
+                {"type": "MODIFIED"},
                 {"phase": "Running", "startTime": "2026-05-11T09:30:01Z"},
                 "prefect.kubernetes.pod.running",
                 "2026-05-11T09:30:01+00:00",


### PR DESCRIPTION
this PR updates replicated Kubernetes pod events to prefer Kubernetes lifecycle timestamps for `occurred` instead of defaulting to observer emission time.

<details>
<summary>Details</summary>

- Adds Kubernetes timestamp selection for replicated pod phase events.
- Uses pod `creationTimestamp` for Pending events, container `running.startedAt` or pod `startTime` for Running events, and the latest container `terminated.finishedAt` for terminal or evicted events.
- Preserves the existing observed-time fallback when Kubernetes does not provide a usable timestamp.
- Adds observer tests covering Pending, Running, Succeeded, and Evicted event timestamps.

Checked with:
- `uv run ruff check src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py src/integrations/prefect-kubernetes/tests/test_observer.py`
- `uv run --project . pytest tests/test_observer.py`

</details>