### PR TITLE
Cache block document template resolution

### DIFF
--- a/src/prefect/utilities/templating/__init__.py
+++ b/src/prefect/utilities/templating/__init__.py
@@ -1,6 +1,7 @@
 import enum
 import os
 import re
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -338,7 +339,51 @@ async def resolve_block_document_references(
         # the function signature must mark it as optional to callers.
         assert client is not None
 
-    async def _resolve_single_placeholder(placeholder: Placeholder) -> Any:
+    block_document_by_id_cache: dict[Any, Any] = {}
+    block_document_by_name_cache: dict[tuple[str, str], Any] = {}
+
+    async def _read_block_document_by_name(
+        block_type_slug: str, block_document_name: str
+    ) -> Any:
+        cache_key = (block_type_slug, block_document_name)
+        if cache_key not in block_document_by_name_cache:
+            try:
+                block_document = await client.read_block_document_by_name(
+                    name=block_document_name, block_type_slug=block_type_slug
+                )
+            except prefect.exceptions.ObjectNotFound as exc:
+                raise prefect.exceptions.ObjectNotFound(
+                    http_exc=exc.http_exc,
+                    help_message=(
+                        f"Block not found: '{block_document_name}' of type '{block_type_slug}'. "
+                        f"This block was referenced in your deployment or work pool configuration but no longer exists. "
+                        f"It may have been deleted. Please check your configuration or create a new block."
+                    ),
+                ) from exc
+            block_document_by_name_cache[cache_key] = block_document
+
+        return block_document_by_name_cache[cache_key]
+
+    async def _read_block_document_by_id(block_document_id: Any) -> Any:
+        if block_document_id not in block_document_by_id_cache:
+            try:
+                block_document = await client.read_block_document(block_document_id)
+            except prefect.exceptions.ObjectNotFound as exc:
+                raise prefect.exceptions.ObjectNotFound(
+                    http_exc=exc.http_exc,
+                    help_message=(
+                        f"Block not found: ID '{block_document_id}'. "
+                        f"This block was referenced in your deployment or work pool configuration but no longer exists. "
+                        f"It may have been deleted. Please check your configuration or create a new block."
+                    ),
+                ) from exc
+            block_document_by_id_cache[block_document_id] = block_document
+
+        return block_document_by_id_cache[block_document_id]
+
+    async def _resolve_single_placeholder(
+        placeholder: Placeholder, tmpl: T
+    ) -> Any:
         parts = placeholder.name.replace(BLOCK_DOCUMENT_PLACEHOLDER_PREFIX, "").split(
             ".", 2
         )
@@ -349,19 +394,9 @@ async def resolve_block_document_references(
             )
         block_type_slug, block_document_name, *value_keypath = parts
 
-        try:
-            block_document = await client.read_block_document_by_name(
-                name=block_document_name, block_type_slug=block_type_slug
-            )
-        except prefect.exceptions.ObjectNotFound as exc:
-            raise prefect.exceptions.ObjectNotFound(
-                http_exc=exc.http_exc,
-                help_message=(
-                    f"Block not found: '{block_document_name}' of type '{block_type_slug}'. "
-                    f"This block was referenced in your deployment or work pool configuration but no longer exists. "
-                    f"It may have been deleted. Please check your configuration or create a new block."
-                ),
-            ) from exc
+        block_document = await _read_block_document_by_name(
+            block_type_slug, block_document_name
+        )
 
         data = block_document.data
         value: Any = data
@@ -375,80 +410,67 @@ async def resolve_block_document_references(
             from_dict: Any = get_from_dict(data, value_keypath[0], default=NotSet)
             if from_dict is NotSet:
                 raise ValueError(
-                    f"Invalid template: {template!r}. Could not resolve the"
+                    f"Invalid template: {tmpl!r}. Could not resolve the"
                     " keypath in the block document data."
                 )
             value = from_dict
+
+        value = deepcopy(value)
 
         if value_transformer:
             value = value_transformer(placeholder.full_match, value)
 
         return value
 
-    if isinstance(template, dict):
-        block_document_id = template.get("$ref", {}).get("block_document_id")
-        if block_document_id:
-            try:
-                block_document = await client.read_block_document(block_document_id)
-            except prefect.exceptions.ObjectNotFound as exc:
-                raise prefect.exceptions.ObjectNotFound(
-                    http_exc=exc.http_exc,
-                    help_message=(
-                        f"Block not found: ID '{block_document_id}'. "
-                        f"This block was referenced in your deployment or work pool configuration but no longer exists. "
-                        f"It may have been deleted. Please check your configuration or create a new block."
-                    ),
-                ) from exc
-            return block_document.data
-        updated_template: dict[str, Any] = {}
-        for key, value in template.items():
-            updated_value = await resolve_block_document_references(
-                value, value_transformer=value_transformer, client=client
+    async def _resolve(tmpl: T) -> Union[T, dict[str, Any]]:
+        if isinstance(tmpl, dict):
+            block_document_id = tmpl.get("$ref", {}).get("block_document_id")
+            if block_document_id:
+                block_document = await _read_block_document_by_id(block_document_id)
+                return deepcopy(block_document.data)
+            updated_template: dict[str, Any] = {}
+            for key, value in tmpl.items():
+                updated_template[key] = await _resolve(value)
+            return updated_template
+        elif isinstance(tmpl, list):
+            return [await _resolve(item) for item in tmpl]
+        elif isinstance(tmpl, str):
+            placeholders = find_placeholders(tmpl)
+            has_block_document_placeholder = any(
+                placeholder.type is PlaceholderType.BLOCK_DOCUMENT
+                for placeholder in placeholders
             )
-            updated_template[key] = updated_value
-        return updated_template
-    elif isinstance(template, list):
-        return [
-            await resolve_block_document_references(
-                item, value_transformer=value_transformer, client=client
-            )
-            for item in template
-        ]
-    elif isinstance(template, str):
-        placeholders = find_placeholders(template)
-        has_block_document_placeholder = any(
-            placeholder.type is PlaceholderType.BLOCK_DOCUMENT
-            for placeholder in placeholders
-        )
-        if not (placeholders and has_block_document_placeholder):
-            return template
-        elif (
-            len(placeholders) == 1
-            and list(placeholders)[0].full_match == template
-            and list(placeholders)[0].type is PlaceholderType.BLOCK_DOCUMENT
-        ):
-            [placeholder] = placeholders
-            return await _resolve_single_placeholder(placeholder)
-        else:
-            # Inline substitution: replace each block placeholder with its resolved value.
-            # Any non-block placeholders are left intact for later resolution.
-            result = template
-            for placeholder in placeholders:
-                if placeholder.type is not PlaceholderType.BLOCK_DOCUMENT:
-                    continue
-                value = await _resolve_single_placeholder(placeholder)
-                if isinstance(value, (dict, list)):
-                    raise ValueError(
-                        f"Invalid template: {template!r}. Block placeholder"
-                        f" {placeholder.full_match!r} resolved to a {type(value).__name__},"
-                        " which cannot be used for inline string substitution."
-                        " Resolve a scalar attribute instead (e.g., '.value' or '.url')."
-                    )
-                result = result.replace(placeholder.full_match, str(value))
+            if not (placeholders and has_block_document_placeholder):
+                return tmpl
+            elif (
+                len(placeholders) == 1
+                and list(placeholders)[0].full_match == tmpl
+                and list(placeholders)[0].type is PlaceholderType.BLOCK_DOCUMENT
+            ):
+                [placeholder] = placeholders
+                return await _resolve_single_placeholder(placeholder, tmpl)
+            else:
+                # Inline substitution: replace each block placeholder with its resolved value.
+                # Any non-block placeholders are left intact for later resolution.
+                result = tmpl
+                for placeholder in placeholders:
+                    if placeholder.type is not PlaceholderType.BLOCK_DOCUMENT:
+                        continue
+                    value = await _resolve_single_placeholder(placeholder, tmpl)
+                    if isinstance(value, (dict, list)):
+                        raise ValueError(
+                            f"Invalid template: {tmpl!r}. Block placeholder"
+                            f" {placeholder.full_match!r} resolved to a {type(value).__name__},"
+                            " which cannot be used for inline string substitution."
+                            " Resolve a scalar attribute instead (e.g., '.value' or '.url')."
+                        )
+                    result = result.replace(placeholder.full_match, str(value))
 
-            return cast(T, result)
+                return cast(T, result)
 
-    return template
+        return tmpl
+
+    return await _resolve(template)
 
 
 @inject_client

--- a/src/prefect/utilities/templating/__init__.py
+++ b/src/prefect/utilities/templating/__init__.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     import logging
 
     from prefect.client.orchestration import PrefectClient
+    from prefect.client.schemas.objects import BlockDocument
 
 
 T = TypeVar("T", str, int, float, bool, dict[Any, Any], list[Any], None)
@@ -339,14 +340,14 @@ async def resolve_block_document_references(
         # the function signature must mark it as optional to callers.
         assert client is not None
 
-    block_document_by_id_cache: dict[Any, Any] = {}
-    block_document_by_name_cache: dict[tuple[str, str], Any] = {}
+    block_documents_by_id: dict[Any, "BlockDocument"] = {}
+    block_documents_by_name: dict[tuple[str, str], "BlockDocument"] = {}
 
     async def _read_block_document_by_name(
         block_type_slug: str, block_document_name: str
-    ) -> Any:
+    ) -> "BlockDocument":
         cache_key = (block_type_slug, block_document_name)
-        if cache_key not in block_document_by_name_cache:
+        if cache_key not in block_documents_by_name:
             try:
                 block_document = await client.read_block_document_by_name(
                     name=block_document_name, block_type_slug=block_type_slug
@@ -360,12 +361,12 @@ async def resolve_block_document_references(
                         f"It may have been deleted. Please check your configuration or create a new block."
                     ),
                 ) from exc
-            block_document_by_name_cache[cache_key] = block_document
+            block_documents_by_name[cache_key] = block_document
 
-        return block_document_by_name_cache[cache_key]
+        return block_documents_by_name[cache_key]
 
-    async def _read_block_document_by_id(block_document_id: Any) -> Any:
-        if block_document_id not in block_document_by_id_cache:
+    async def _read_block_document_by_id(block_document_id: Any) -> "BlockDocument":
+        if block_document_id not in block_documents_by_id:
             try:
                 block_document = await client.read_block_document(block_document_id)
             except prefect.exceptions.ObjectNotFound as exc:
@@ -377,13 +378,11 @@ async def resolve_block_document_references(
                         f"It may have been deleted. Please check your configuration or create a new block."
                     ),
                 ) from exc
-            block_document_by_id_cache[block_document_id] = block_document
+            block_documents_by_id[block_document_id] = block_document
 
-        return block_document_by_id_cache[block_document_id]
+        return block_documents_by_id[block_document_id]
 
-    async def _resolve_single_placeholder(
-        placeholder: Placeholder, tmpl: T
-    ) -> Any:
+    async def _resolve_single_placeholder(placeholder: Placeholder, tmpl: T) -> Any:
         parts = placeholder.name.replace(BLOCK_DOCUMENT_PLACEHOLDER_PREFIX, "").split(
             ".", 2
         )

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -433,6 +433,34 @@ class TestResolveBlockDocumentReferences:
 
         assert result == [block_document.data]
 
+    async def test_resolve_block_document_references_caches_block_document_refs_by_id(
+        self,
+    ):
+        """Repeated block document ID references only trigger one API read."""
+        from types import SimpleNamespace
+
+        block_document_id = uuid.uuid4()
+        calls: list[uuid.UUID] = []
+
+        class FakeClient:
+            async def read_block_document(self, block_document_id):
+                calls.append(block_document_id)
+                return SimpleNamespace(data={"nested": {"value": "hello"}})
+
+        template = {
+            "first": {"$ref": {"block_document_id": block_document_id}},
+            "second": {"$ref": {"block_document_id": block_document_id}},
+        }
+
+        result = await resolve_block_document_references(template, client=FakeClient())
+
+        assert result == {
+            "first": {"nested": {"value": "hello"}},
+            "second": {"nested": {"value": "hello"}},
+        }
+        assert calls == [block_document_id]
+        assert result["first"] is not result["second"]
+
     async def test_resolve_block_document_references_with_dot_delimited_syntax(
         self, prefect_client, block_document_id
     ):
@@ -449,6 +477,39 @@ class TestResolveBlockDocumentReferences:
         )
 
         assert result == {"key": block_document.data}
+
+    async def test_resolve_block_document_references_caches_block_document_refs_by_name(
+        self,
+    ):
+        """Repeated named block placeholders only trigger one API read."""
+        from types import SimpleNamespace
+
+        calls: list[tuple[str, str]] = []
+
+        class FakeClient:
+            async def read_block_document_by_name(self, name, block_type_slug):
+                calls.append((block_type_slug, name))
+                return SimpleNamespace(data={"a": 1, "b": "hello"})
+
+        template = {
+            "full": "{{ prefect.blocks.arbitraryblock.my-block }}",
+            "inline": "prefix-{{ prefect.blocks.arbitraryblock.my-block.b }}-suffix",
+            "nested": {
+                "repeat": "{{ prefect.blocks.arbitraryblock.my-block }}",
+            },
+        }
+
+        result = await resolve_block_document_references(template, client=FakeClient())
+
+        assert result == {
+            "full": {"a": 1, "b": "hello"},
+            "inline": "prefix-hello-suffix",
+            "nested": {
+                "repeat": {"a": 1, "b": "hello"},
+            },
+        }
+        assert calls == [("arbitraryblock", "my-block")]
+        assert result["full"] is not result["nested"]["repeat"]
 
     async def test_resolve_block_document_references_allows_inline_substitution(
         self, prefect_client, block_document_id

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -1,4 +1,5 @@
 import uuid
+from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
@@ -437,13 +438,13 @@ class TestResolveBlockDocumentReferences:
         self,
     ):
         """Repeated block document ID references only trigger one API read."""
-        from types import SimpleNamespace
-
         block_document_id = uuid.uuid4()
         calls: list[uuid.UUID] = []
 
         class FakeClient:
-            async def read_block_document(self, block_document_id):
+            async def read_block_document(
+                self, block_document_id: uuid.UUID
+            ) -> SimpleNamespace:
                 calls.append(block_document_id)
                 return SimpleNamespace(data={"nested": {"value": "hello"}})
 
@@ -482,12 +483,12 @@ class TestResolveBlockDocumentReferences:
         self,
     ):
         """Repeated named block placeholders only trigger one API read."""
-        from types import SimpleNamespace
-
         calls: list[tuple[str, str]] = []
 
         class FakeClient:
-            async def read_block_document_by_name(self, name, block_type_slug):
+            async def read_block_document_by_name(
+                self, name: str, block_type_slug: str
+            ) -> SimpleNamespace:
                 calls.append((block_type_slug, name))
                 return SimpleNamespace(data={"a": 1, "b": "hello"})
 


### PR DESCRIPTION
this PR caches block document reads within a single `resolve_block_document_references()` call. Repeated `$ref` block document IDs and repeated `{{ prefect.blocks... }}` placeholders now reuse the first fetched block document while preserving per-call scope and independent mutable resolved values.

This follows the same safety shape as #22060 for variable placeholders: no global cache, no cross-call reuse, and missing-block errors remain unchanged.

<details>
<summary>Details</summary>

- Adds per-call caches for block document reads by ID and by `(block_type_slug, block_document_name)`.
- Keeps value transformers invoked per placeholder.
- Deep-copies resolved block data before returning it so repeated mutable values do not share object identity in the rendered config.
- Adds tests covering duplicate `$ref` IDs and duplicate named block placeholders.

</details>

Validation:
- `uv run pytest tests/utilities/test_templating.py -q`
- `uv run pre-commit run --files src/prefect/utilities/templating/__init__.py tests/utilities/test_templating.py`
- `NVM_DIR=/tmp/fake-nvm uv run pre-commit run --all-files`

Note: the plain `uv run pre-commit run --all-files` failed locally only because `check-ui-v2` tried to source `/nvm.sh`; rerunning with the fake `NVM_DIR` setup used by CI passed all hooks.