### PR TITLE
docs: add Tuning Engines flow example

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -328,7 +328,8 @@
               "v3/examples/ai-data-analyst-with-pydantic-ai",
               "v3/examples/ai-database-cleanup-with-approval",
               "v3/examples/per-worker-task-concurrency",
-              "v3/examples/resume-flow-run-on-pr-merge"
+              "v3/examples/resume-flow-run-on-pr-merge",
+              "v3/examples/tuning-engines-governed-ai"
             ]
           }
         ],

--- a/docs/v3/examples/index.mdx
+++ b/docs/v3/examples/index.mdx
@@ -56,4 +56,9 @@ Have an example to share? Check out our [contributing guide](/contribute/docs-co
             Automatically resume failed flow runs when a hotfix PR is merged in GitHub.
         </Card>
 
+
+        <Card title="Governed AI with Tuning Engines" icon="robot" href="/v3/examples/tuning-engines-governed-ai">
+            Route model calls through Tuning Engines while Prefect owns retries, schedules, and flow observability.
+        </Card>
+
 </CardGroup>

--- a/docs/v3/examples/tuning-engines-governed-ai.mdx
+++ b/docs/v3/examples/tuning-engines-governed-ai.mdx
@@ -1,0 +1,84 @@
+---
+title: Governed AI with Tuning Engines
+description: Route model calls through Tuning Engines while Prefect owns retries, schedules, and flow observability.
+icon: robot
+keywords: ["ai", "llm", "governance", "orchestration"]
+---
+
+{/*
+This page is automatically generated via the `generate_example_pages.py` script. Any changes to this page will be overwritten.
+*/}
+
+<a href="https://github.com/PrefectHQ/prefect/blob/main/examples/tuning_engines_governed_ai.py" target="_blank">View on GitHub</a>
+
+This example shows how to call Tuning Engines from a Prefect task. Prefect
+owns the flow run, retries, schedules, and deployment lifecycle. Tuning
+Engines owns model routing, policy checks, approval decisions, usage
+attribution, and gateway traces.
+
+## Setup
+
+```bash
+uv add prefect httpx
+export TE_INFERENCE_KEY=sk-te-your-inference-key
+export TE_MODEL=auto
+```
+
+```python
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import httpx
+
+from prefect import flow, task
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+@task(retries=2, retry_delay_seconds=5)
+def governed_model_call(prompt: str, run_id: str) -> dict[str, Any]:
+    """Call Tuning Engines from a durable Prefect task."""
+    request_id = new_id("req")
+    api_key = os.environ["TE_INFERENCE_KEY"]
+    response = httpx.post(
+        "https://api.tuningengines.com/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-TE-Run-ID": run_id,
+            "X-TE-Request-ID": request_id,
+        },
+        timeout=60,
+        json={
+            "model": os.getenv("TE_MODEL", "auto"),
+            "messages": [{"role": "user", "content": prompt}],
+            "metadata": {
+                "run_id": run_id,
+                "request_id": request_id,
+                "runtime": "prefect",
+                "event_type": "model.call",
+            },
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@flow(name="tuning-engines-governed-ai", log_prints=True)
+def governed_ai_flow(
+    prompt: str = "Summarize why durable AI workflows matter.",
+) -> dict[str, Any]:
+    run_id = new_id("prefect")
+    result = governed_model_call(prompt, run_id)
+    print(f"Correlate this Prefect flow with Tuning Engines run_id={run_id}")
+    return result
+
+
+if __name__ == "__main__":
+    governed_ai_flow()
+```

--- a/examples/tuning_engines_governed_ai.py
+++ b/examples/tuning_engines_governed_ai.py
@@ -1,0 +1,79 @@
+# ---
+# title: Governed AI with Tuning Engines
+# description: Route model calls through Tuning Engines while Prefect owns retries, schedules, and flow observability.
+# icon: robot
+# dependencies: ["prefect", "httpx"]
+# keywords: ["ai", "llm", "governance", "orchestration"]
+# draft: false
+# order: 10
+# ---
+#
+# This example shows how to call Tuning Engines from a Prefect task. Prefect
+# owns the flow run, retries, schedules, and deployment lifecycle. Tuning
+# Engines owns model routing, policy checks, approval decisions, usage
+# attribution, and gateway traces.
+#
+# ## Setup
+#
+# ```bash
+# uv add prefect httpx
+# export TE_INFERENCE_KEY=sk-te-your-inference-key
+# export TE_MODEL=auto
+# ```
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import httpx
+
+from prefect import flow, task
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+@task(retries=2, retry_delay_seconds=5)
+def governed_model_call(prompt: str, run_id: str) -> dict[str, Any]:
+    """Call Tuning Engines from a durable Prefect task."""
+    request_id = new_id("req")
+    api_key = os.environ["TE_INFERENCE_KEY"]
+    response = httpx.post(
+        "https://api.tuningengines.com/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-TE-Run-ID": run_id,
+            "X-TE-Request-ID": request_id,
+        },
+        timeout=60,
+        json={
+            "model": os.getenv("TE_MODEL", "auto"),
+            "messages": [{"role": "user", "content": prompt}],
+            "metadata": {
+                "run_id": run_id,
+                "request_id": request_id,
+                "runtime": "prefect",
+                "event_type": "model.call",
+            },
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@flow(name="tuning-engines-governed-ai", log_prints=True)
+def governed_ai_flow(
+    prompt: str = "Summarize why durable AI workflows matter.",
+) -> dict[str, Any]:
+    run_id = new_id("prefect")
+    result = governed_model_call(prompt, run_id)
+    print(f"Correlate this Prefect flow with Tuning Engines run_id={run_id}")
+    return result
+
+
+if __name__ == "__main__":
+    governed_ai_flow()


### PR DESCRIPTION
Adds a Prefect example flow that routes a model call through Tuning Engines while Prefect owns retries, scheduling, and flow observability.\n\nThe example uses placeholder environment variables only and includes the generated docs page/index entry.\n\nValidation run locally:\n- python3 -m py_compile examples/tuning_engines_governed_ai.py\n- git diff --check