### PR TITLE
fix(orchestration): guard ZeroDivisionError in RetryFailedTasks when retry_jitter_factor set without retry_delay

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1159,8 +1159,9 @@ class RetryFailedTasks(TaskRunOrchestrationRule):
         else:
             base_delay = delay or 0
 
-        # guard against negative relative jitter inputs
-        if run_settings.retry_jitter_factor:
+        # guard against negative relative jitter inputs; also guard against
+        # base_delay == 0: clamped_poisson_interval(0, ...) divides by zero.
+        if run_settings.retry_jitter_factor and base_delay > 0:
             delay = clamped_poisson_interval(
                 base_delay, clamping_factor=run_settings.retry_jitter_factor
             )

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -1161,6 +1161,47 @@ class TestTaskRetryingRule:
             rel_tol=0.1,
         )
 
+    async def test_jitter_with_zero_delay_does_not_raise(
+        self, session, initialize_orchestration
+    ):
+        """Regression test: setting retry_jitter_factor without retry_delay must not
+        raise ZeroDivisionError.
+
+        clamped_poisson_interval(0, ...) divides by zero when computing the exponential
+        CDF with average_interval=0.  The policy must skip jitter and fall back to
+        base_delay (0) when retry_delay is None or 0.
+        """
+        retry_policy = [RetryFailedTasks]
+        initial_state_type = states.StateType.RUNNING
+        proposed_state_type = states.StateType.FAILED
+        intended_transition = (initial_state_type, proposed_state_type)
+        ctx = await initialize_orchestration(
+            session,
+            "task",
+            *intended_transition,
+        )
+
+        orm_run = ctx.run
+        run_settings = ctx.run_settings
+        orm_run.run_count = 1
+        run_settings.retries = 2
+        # retry_delay intentionally left unset (None → base_delay=0)
+        run_settings.retry_delay = None
+        run_settings.retry_jitter_factor = 0.5
+
+        # Should not raise ZeroDivisionError
+        async with contextlib.AsyncExitStack() as stack:
+            orchestration_start = now("UTC")
+            for rule in retry_policy:
+                ctx = await stack.enter_async_context(rule(ctx, *intended_transition))
+            await ctx.validate_proposed_state()
+
+        scheduled_time = ctx.validated_state.state_details.scheduled_time
+        assert ctx.response_status == SetStateStatus.REJECT
+        assert ctx.validated_state_type == states.StateType.SCHEDULED
+        # With base_delay=0, the scheduled time should be approximately now (no delay).
+        assert abs((scheduled_time - orchestration_start).total_seconds()) < 5
+
     async def test_stops_retrying_eventually(
         self,
         session,


### PR DESCRIPTION
## Summary

`RetryFailedTasks.after_transition` passes `base_delay` directly to `clamped_poisson_interval` when `retry_jitter_factor` is configured, but `clamped_poisson_interval(0, …)` raises `ZeroDivisionError` inside its exponential-CDF computation because it divides by `average_interval`.

This crashes the orchestration server whenever a task is decorated with `retry_jitter_factor` but **no** `retry_delay_seconds`:

```python
@task(retries=3, retry_jitter_factor=0.5)   # no retry_delay_seconds!
def my_task():
    raise ValueError("boom")
```

Execution path:

1. Task fails → `RetryFailedTasks.after_transition` is called.
2. `run_settings.retry_delay` is `None` (not set by the user).
3. `base_delay = None or 0` → **`base_delay = 0`**.
4. `if run_settings.retry_jitter_factor:` → `0.5` is truthy → enters the branch.
5. `clamped_poisson_interval(0, clamping_factor=0.5)` calls `exponential_cdf(0, 0)` → `ld = 1/0` → **`ZeroDivisionError`**.

## Fix

Skip jitter when `base_delay == 0` — applying jitter to a zero-length delay is meaningless, and avoids the division by zero:

```python
# before
if run_settings.retry_jitter_factor:

# after
if run_settings.retry_jitter_factor and base_delay > 0:
```

## Tests

New regression test `test_jitter_with_zero_delay_does_not_raise` in `TestRetryFailedTasks` verifies that:
- The orchestration handler does **not** raise when `retry_delay=None` and `retry_jitter_factor=0.5`.
- The retry is still scheduled (state is `SCHEDULED`).
- The scheduled time is approximately "now" (no delay added).