### PR TITLE
Fix _cancel_run to kill infrastructure for already-running flow runs

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1779,7 +1779,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         """
         Cancel a flow run by killing its infrastructure and marking it cancelled.
 
-        Only cancels flow runs that were pending (not yet started).
+        Attempts to kill infrastructure for both pending (never started) and running
+        flow runs. Running flow runs whose infrastructure has already exited are
+        handled gracefully via InfrastructureNotFound.
         """
         try:
             flow_run = await self.client.read_flow_run(flow_run_id)
@@ -1790,10 +1792,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             return
 
         run_logger = self.get_flow_run_logger(flow_run)
-
-        # Only cancel if the flow run was pending (never started)
-        if flow_run.start_time is not None:
-            return
 
         # No infrastructure to kill if no pid
         if not flow_run.infrastructure_pid:
@@ -1853,9 +1851,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         await self._mark_flow_run_as_cancelled(
             flow_run,
-            state_updates={"message": "Flow run cancelled by worker while pending."},
+            state_updates={"message": "Flow run cancelled by worker."},
         )
-        run_logger.info(f"Cancelled pending flow run '{flow_run.id}'")
+        run_logger.info(f"Cancelled flow run '{flow_run.id}'")
 
     async def kill_infrastructure(
         self,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -4932,7 +4932,9 @@ class TestWorkerCancellationHandling:
                         worker, "kill_infrastructure", new_callable=AsyncMock
                     ) as mock_kill:
                         with mock.patch.object(
-                            worker, "_mark_flow_run_as_cancelled", new_callable=AsyncMock
+                            worker,
+                            "_mark_flow_run_as_cancelled",
+                            new_callable=AsyncMock,
                         ) as mock_mark:
                             await worker._cancel_run(flow_run.id)
                             # kill_infrastructure must be attempted even for started runs

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -4884,30 +4884,37 @@ class TestWorkerCancellationHandling:
                 # Should have set up cancellation observer
                 assert worker._cancelling_observer is not None
 
-    async def test_cancel_run_skips_non_pending_flow_runs(
+    async def test_cancel_run_kills_infrastructure_for_running_flow_runs(
         self,
         prefect_client: PrefectClient,
         work_pool: WorkPool,
+        deployment: DeploymentResponse,
     ):
-        """Test that _cancel_run skips flow runs that were not pending."""
+        """Test that _cancel_run kills infrastructure for already-running flow runs.
 
-        @flow
-        def test_flow():
-            pass
-
-        flow_run = await prefect_client.create_flow_run(
-            test_flow, work_pool_name=work_pool.name
+        Previously _cancel_run bailed out early when start_time was set, leaving
+        zombie pods/containers alive indefinitely when the flow was hung and could
+        not self-terminate on receiving Cancelling state.
+        """
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment.id,
+        )
+        await prefect_client.update_flow_run(
+            flow_run.id, infrastructure_pid="test-pod-id"
         )
 
         async with WorkerTestImpl(
             work_pool_name=work_pool.name,
             name="test-worker",
         ) as worker:
-            # Create a flow run with start_time set (already started)
-            flow_run_with_start_time = FlowRun(
+            # Simulate a flow run that has already started (start_time is set)
+            flow_run_running = FlowRun(
                 id=flow_run.id,
                 flow_id=flow_run.flow_id,
                 name=flow_run.name,
+                deployment_id=flow_run.deployment_id,
+                infrastructure_pid="test-pod-id",
+                work_pool_name=work_pool.name,
                 state=Running(),
                 start_time=now_fn("UTC"),
             )
@@ -4915,14 +4922,26 @@ class TestWorkerCancellationHandling:
             with mock.patch.object(
                 worker.client, "read_flow_run", new_callable=AsyncMock
             ) as mock_read:
-                mock_read.return_value = flow_run_with_start_time
-                with mock.patch.object(worker, "kill_infrastructure") as mock_kill:
+                mock_read.return_value = flow_run_running
+                with mock.patch(
+                    "prefect.workers.base.BaseJobConfiguration.resolve_for_flow_run",
+                    new_callable=AsyncMock,
+                ) as mock_resolve:
+                    mock_resolve.return_value = BaseJobConfiguration()
                     with mock.patch.object(
-                        worker, "_mark_flow_run_as_cancelled"
-                    ) as mock_mark:
-                        await worker._cancel_run(flow_run.id)
-                        mock_kill.assert_not_called()
-                        mock_mark.assert_not_called()
+                        worker, "kill_infrastructure", new_callable=AsyncMock
+                    ) as mock_kill:
+                        with mock.patch.object(
+                            worker, "_mark_flow_run_as_cancelled", new_callable=AsyncMock
+                        ) as mock_mark:
+                            await worker._cancel_run(flow_run.id)
+                            # kill_infrastructure must be attempted even for started runs
+                            mock_kill.assert_called_once()
+                            assert (
+                                mock_kill.call_args[1]["infrastructure_pid"]
+                                == "test-pod-id"
+                            )
+                            mock_mark.assert_called_once()
 
     async def test_cancellation_observer_filters_by_work_pool(
         self,


### PR DESCRIPTION
## What was broken

When a flow run was in `Running` state and became stuck (hung future, blocked I/O, cloudpickle deserialization error swallowed by `concurrent.futures`), cancelling it from the UI had no effect.

`BaseWorker._cancel_run` returned immediately if `flow_run.start_time is not None`, under the assumption that the flow engine inside the pod would detect `Cancelling` state and self-terminate. If the engine is hung, it never polls for state, so the pod lives forever.

Kubernetes jobs, ECS tasks, Docker containers — workers for all of these implement `kill_infrastructure`, but it was never called for started runs. There is no other actor in the system that will kill the infrastructure: Kopf only fires on `backoffLimit` exceeded (a hung pod looks healthy), and the foreman only checks worker heartbeats.

In parent/subflow setups this cascades: each retry spawns a new hung subflow, accumulating hundreds of zombie pods.

## Repro

1. Deploy a flow that blocks indefinitely (e.g. a future that never resolves due to a deserialization error)
2. Trigger a run — pod starts, enters `Running`
3. Cancel from UI or API
4. Observe: pod continues running; `_cancel_run` returned early because `start_time is not None`

## Fix

Remove the `start_time` guard. Workers already handle `InfrastructureNotFound` gracefully for infrastructure that exited before the cancel request arrived, so this is safe for flows that completed naturally.

The success message is updated from "while pending" to generic "Flow run cancelled by worker." since it now covers both cases.

## Test

Updated `test_cancel_run_skips_non_pending_flow_runs` → `test_cancel_run_kills_infrastructure_for_running_flow_runs`, which asserts that `kill_infrastructure` is called and the run is marked cancelled even when `start_time` is set.

Closes #21616