### PR TITLE
Fix worker channel reconnect backoff overflow

### DIFF
--- a/src/prefect/workers/_worker_channel/_transport.py
+++ b/src/prefect/workers/_worker_channel/_transport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import Awaitable, Callable
 from logging import Logger
 from urllib.parse import quote
@@ -238,8 +239,15 @@ class WorkerChannelTransport:
     def reconnect_delay(self, attempt: int) -> float:
         if self._reconnect_base_seconds <= 0:
             return 0
+        try:
+            delay = math.ldexp(
+                self._reconnect_base_seconds,
+                max(attempt - 1, 0),
+            )
+        except OverflowError:
+            return self._reconnect_max_seconds
         return min(
-            self._reconnect_base_seconds * 2 ** max(attempt - 1, 0),
+            delay,
             self._reconnect_max_seconds,
         )
 

--- a/tests/workers/test_worker_channel_transport.py
+++ b/tests/workers/test_worker_channel_transport.py
@@ -1,0 +1,17 @@
+import logging
+
+from prefect.workers._worker_channel._transport import WorkerChannelTransport
+
+
+def test_reconnect_delay_caps_before_float_overflow():
+    transport = WorkerChannelTransport(
+        api_url="http://localhost:4200/api",
+        work_pool_name="test-work-pool",
+        logger=logging.getLogger("test-worker-channel"),
+        reconnect_base_seconds=1.0,
+        reconnect_max_seconds=30.0,
+    )
+
+    assert transport.reconnect_delay(1) == 1.0
+    assert transport.reconnect_delay(6) == 30.0
+    assert transport.reconnect_delay(1025) == 30.0


### PR DESCRIPTION
closes #22082

this PR prevents worker channel reconnect backoff from crashing when sustained reconnect failures push the attempt counter past the float range.

<details>
<summary>Details</summary>

- uses `math.ldexp` for the exponential delay calculation instead of multiplying by a huge integer
- returns `reconnect_max_seconds` if the delay calculation overflows
- adds regression coverage for attempt 1025 with the default float backoff values

Tests:
- `python -m pytest tests/workers/test_worker_channel_transport.py -q`
- `python -m ruff check src/prefect/workers/_worker_channel/_transport.py tests/workers/test_worker_channel_transport.py`
- `python -m ruff format --check src/prefect/workers/_worker_channel/_transport.py tests/workers/test_worker_channel_transport.py`
</details>