### PR TITLE
fix(databricks): add partner user agent attribution

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/credentials.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/credentials.py
@@ -4,10 +4,12 @@ import base64
 import time
 from typing import Any, Dict, Optional
 
-from httpx import AsyncClient, Client
+from httpx import AsyncClient, Client, Headers
 from pydantic import Field, PrivateAttr, SecretStr, model_validator
 
 from prefect.blocks.core import Block
+
+_DATABRICKS_PARTNER_USER_AGENT = "prefect+prefect-databricks"
 
 
 class DatabricksCredentials(Block):
@@ -258,7 +260,14 @@ class DatabricksCredentials(Block):
         else:
             auth_token = self.token.get_secret_value()
 
-        client_kwargs = self.client_kwargs or {}
-        client_kwargs["headers"] = {"Authorization": f"Bearer {auth_token}"}
+        client_kwargs = dict(self.client_kwargs or {})
+        headers = Headers(client_kwargs.pop("headers", {}) or {})
+        user_agent = headers.get("User-Agent")
+        if not user_agent:
+            headers["User-Agent"] = _DATABRICKS_PARTNER_USER_AGENT
+        elif _DATABRICKS_PARTNER_USER_AGENT not in user_agent.split():
+            headers["User-Agent"] = f"{user_agent} {_DATABRICKS_PARTNER_USER_AGENT}"
+        headers["Authorization"] = f"Bearer {auth_token}"
+        client_kwargs["headers"] = headers
         client = AsyncClient(base_url=base_url, **client_kwargs)
         return client

--- a/src/integrations/prefect-databricks/tests/test_credentials.py
+++ b/src/integrations/prefect-databricks/tests/test_credentials.py
@@ -15,6 +15,7 @@ class TestDatabricksCredentialsPATAuth:
         ).get_client()
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer token_value"
+        assert client.headers["user-agent"] == "prefect+prefect-databricks"
 
     def test_backward_compatibility_with_token(self):
         """Test backward compatibility - existing PAT-based credentials work unchanged."""
@@ -37,6 +38,21 @@ class TestDatabricksCredentialsPATAuth:
         client = credentials.get_client()
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer token_value"
+
+    def test_get_client_appends_to_user_agent_from_client_kwargs(self):
+        """Test that user-agent headers include Prefect attribution."""
+        credentials = DatabricksCredentials(
+            databricks_instance="databricks_instance",
+            token="token_value",
+            client_kwargs={"headers": {"User-Agent": "custom-client/1.0"}},
+        )
+        client = credentials.get_client()
+        assert isinstance(client, AsyncClient)
+        assert client.headers["authorization"] == "Bearer token_value"
+        assert (
+            client.headers["user-agent"]
+            == "custom-client/1.0 prefect+prefect-databricks"
+        )
 
 
 class TestDatabricksCredentialsServicePrincipalAuth:


### PR DESCRIPTION
this PR adds Databricks partner attribution to `prefect-databricks` REST clients.

<details>
<summary>Details</summary>

- Adds centralized `User-Agent` composition in `DatabricksCredentials.get_client`.
- Sends `prefect+prefect-databricks` by default.
- Appends Prefect attribution to a user-supplied user-agent instead of overwriting it.
- Preserves the existing bearer `Authorization` header behavior.

</details>

## Test Plan

- [x] `uv run pytest tests/test_credentials.py -q`
- [x] `uv run pytest -q`
- [x] `uv run ruff check prefect_databricks/credentials.py tests/test_credentials.py`
- [x] `uv run ruff format --check prefect_databricks/credentials.py tests/test_credentials.py`
- [x] `git diff --check`