### PR TITLE
Preserve persisted result metadata

### DIFF
--- a/src/prefect/_internal/result_records.py
+++ b/src/prefect/_internal/result_records.py
@@ -16,6 +16,7 @@ from uuid import UUID
 from pydantic import (
     BaseModel,
     Field,
+    PrivateAttr,
     ValidationError,
     field_validator,
     model_validator,
@@ -105,6 +106,14 @@ class ResultRecord(BaseModel, Generic[R]):
 
     metadata: ResultRecordMetadata
     result: R
+    _persisted: bool = PrivateAttr(default=False)
+
+    @property
+    def is_persisted(self) -> bool:
+        return self._persisted
+
+    def mark_persisted(self) -> None:
+        self._persisted = True
 
     @property
     def expiration(self) -> DateTime | None:

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -867,6 +867,7 @@ class ResultStore(BaseModel):
 
         if self.cache_result_in_memory:
             self.cache[resolved_key_path] = result_record
+        result_record.mark_persisted()
         return result_record
 
     def _read(self, key: str, holder: str) -> "ResultRecord[Any]":
@@ -936,6 +937,7 @@ class ResultStore(BaseModel):
 
         if self.cache_result_in_memory:
             self.cache[resolved_key_path] = result_record
+        result_record.mark_persisted()
         return result_record
 
     def read(
@@ -1122,6 +1124,7 @@ class ResultStore(BaseModel):
                 (result_record.metadata.storage_key,),
                 {"content": result_record.serialize()},
             )
+        result_record.mark_persisted()
         if self.cache_result_in_memory:
             self.cache[key] = result_record
 
@@ -1185,6 +1188,7 @@ class ResultStore(BaseModel):
                 (result_record.metadata.storage_key,),
                 {"content": result_record.serialize()},
             )
+        result_record.mark_persisted()
         if self.cache_result_in_memory:
             self.cache[key] = result_record
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -57,7 +57,11 @@ def to_state_create(state: State) -> "StateCreate":
         should_persist_result,
     )
 
-    if isinstance(state.data, ResultRecord) and should_persist_result():
+    # Preserve metadata for records already written to storage, even if this
+    # serialization happens after run context teardown.
+    if isinstance(state.data, ResultRecord) and (
+        state.data.is_persisted or should_persist_result()
+    ):
         data = state.data.metadata  # pyright: ignore[reportUnknownMemberType] unable to narrow ResultRecord type
     else:
         data = None

--- a/src/prefect/utilities/engine/__init__.py
+++ b/src/prefect/utilities/engine/__init__.py
@@ -850,7 +850,9 @@ def emit_task_run_state_change_event(
 ) -> Optional[Event]:
     state_message_truncation_length = 100_000
 
-    if _is_result_record(validated_state.data) and should_persist_result():
+    if _is_result_record(validated_state.data) and (
+        validated_state.data.is_persisted or should_persist_result()
+    ):
         data = validated_state.data.metadata.model_dump(mode="json")
     else:
         data = None

--- a/src/prefect/utilities/engine/__init__.py
+++ b/src/prefect/utilities/engine/__init__.py
@@ -850,9 +850,7 @@ def emit_task_run_state_change_event(
 ) -> Optional[Event]:
     state_message_truncation_length = 100_000
 
-    if _is_result_record(validated_state.data) and (
-        validated_state.data.is_persisted or should_persist_result()
-    ):
+    if _is_result_record(validated_state.data) and should_persist_result():
         data = validated_state.data.metadata.model_dump(mode="json")
     else:
         data = None

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -3,6 +3,7 @@ Generic tests for `State.result`
 """
 
 import time
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -16,7 +17,7 @@ from prefect.results import (
     ResultStore,
 )
 from prefect.serializers import JSONSerializer
-from prefect.states import State, StateType
+from prefect.states import State, StateType, to_state_create
 
 
 @pytest.mark.parametrize(
@@ -79,6 +80,52 @@ async def a_real_result(store: ResultStore) -> ResultRecord[str]:
 @pytest.fixture
 def completed_state(a_real_result: ResultRecord[str]) -> State[str]:
     return State(type=StateType.COMPLETED, data=a_real_result.metadata)
+
+
+def test_to_state_create_drops_unpersisted_result_record_without_run_context(
+    tmp_path: Path,
+) -> None:
+    store = ResultStore(
+        result_storage=LocalFileSystem(basepath=tmp_path),
+        serializer=JSONSerializer(),
+    )
+    record = store.create_result_record({"answer": 42}, key="flow-result")
+    state = State(type=StateType.COMPLETED, data=record)
+
+    assert record.is_persisted is False
+    assert to_state_create(state).data is None
+
+
+def test_to_state_create_preserves_persisted_result_record_without_run_context(
+    tmp_path: Path,
+) -> None:
+    store = ResultStore(
+        result_storage=LocalFileSystem(basepath=tmp_path),
+        serializer=JSONSerializer(),
+    )
+    record = store.create_result_record({"answer": 42}, key="flow-result")
+
+    store.persist_result_record(record)
+
+    state = State(type=StateType.COMPLETED, data=record)
+    assert record.is_persisted is True
+    assert to_state_create(state).data == record.metadata
+
+
+async def test_to_state_create_preserves_async_persisted_result_record_without_run_context(
+    tmp_path: Path,
+) -> None:
+    store = ResultStore(
+        result_storage=LocalFileSystem(basepath=tmp_path),
+        serializer=JSONSerializer(),
+    )
+    record = store.create_result_record({"answer": 42}, key="flow-result")
+
+    await store.apersist_result_record(record)
+
+    state = State(type=StateType.COMPLETED, data=record)
+    assert record.is_persisted is True
+    assert to_state_create(state).data == record.metadata
 
 
 async def test_graceful_retries_are_finite_while_retrieving_missing_results(


### PR DESCRIPTION
closes #22101

this PR preserves flow result metadata for `ResultRecord`s that have already been written to result storage, even when terminal state serialization happens outside an active run context.

<details>
<summary>Details</summary>

The regression came from `to_state_create()` deciding whether to include `state.data.metadata` solely from `should_persist_result()`. At worker lifecycle boundaries, that can run after `FlowRunContext` or `TaskRunContext` is gone, causing persisted results to be sent to the API as `data=None`.

This adds an internal persisted marker to `ResultRecord`, sets it after successful result store writes and reads, and uses that marker when serializing state-create payloads. Unwritten records still serialize as `data=None`, so the server does not create artifacts pointing at missing storage.

Checks run:
- `uv run ruff check src/prefect/_internal/result_records.py src/prefect/results.py src/prefect/states.py src/prefect/utilities/engine/__init__.py tests/results/test_state_result.py`
- `uv run pytest tests/events/client/instrumentation/test_task_run_state_change_events.py::test_task_state_change_task_failure`
- `uv run pytest tests/client/test_state_serialization.py tests/results/test_state_result.py tests/results/test_result_store.py tests/results/test_result_record.py`
- `uv run pytest tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/ --ignore=tests/test_settings.py --ignore=tests/input/ --ignore-glob='tests/test_*.py' -m 'not windows' --numprocesses auto --maxprocesses 6 --dist worksteal --disable-docker-image-builds --exclude-service kubernetes --exclude-service docker --durations 26`

</details>
