### PR TITLE
Make scheduler query use the #20699 partial index

### DIFF
--- a/src/prefect/server/services/scheduler.py
+++ b/src/prefect/server/services/scheduler.py
@@ -74,7 +74,12 @@ def _get_select_deployments_to_schedule_query(
             db.FlowRun.deployment_id == db.DeploymentSchedule.deployment_id,
             db.FlowRun.state_type == StateType.SCHEDULED,
             db.FlowRun.next_scheduled_start_time >= right_now,
-            db.FlowRun.auto_scheduled.is_(True),
+            # `== true` (not `.is_(True)`) so the predicate matches the
+            # `auto_scheduled = true` clause of the partial index
+            # `ix_flow_run__schedule_id_scheduler`.  PostgreSQL's predicate
+            # implication prover does not treat `IS true` as implying
+            # `= true`, so `.is_(True)` silently disqualifies the index.
+            db.FlowRun.auto_scheduled == sa.true(),
             schedule_id_match,
         )
         .correlate(db.DeploymentSchedule)
@@ -88,7 +93,7 @@ def _get_select_deployments_to_schedule_query(
             db.FlowRun.deployment_id == db.DeploymentSchedule.deployment_id,
             db.FlowRun.state_type == StateType.SCHEDULED,
             db.FlowRun.next_scheduled_start_time >= right_now,
-            db.FlowRun.auto_scheduled.is_(True),
+            db.FlowRun.auto_scheduled == sa.true(),
             schedule_id_match,
         )
         .correlate(db.DeploymentSchedule)

--- a/tests/server/services/test_scheduler.py
+++ b/tests/server/services/test_scheduler.py
@@ -928,3 +928,37 @@ class TestMultiScheduleDeployments:
                 "After deleting consumed runs, the scheduler should create new runs "
                 "for the frequent schedule."
             )
+
+
+class TestSchedulerQueryUsesPartialIndex:
+    """The per-schedule deployment-selection query relies on the partial index
+    `ix_flow_run__schedule_id_scheduler`, whose predicate is
+    `... AND auto_scheduled = true` (Postgres) / `... AND auto_scheduled = 1`
+    (SQLite).
+
+    The query's `auto_scheduled` filter must compile to the same equality form.
+    `.is_(True)` compiles to `auto_scheduled IS true` / `IS 1`, which neither
+    planner accepts as implying the index's `= true` / `= 1` predicate, so the
+    index is silently disqualified and the query falls back to a full scan.
+    """
+
+    @pytest.mark.parametrize(
+        "dialect, expected, forbidden",
+        [
+            ("postgresql", "auto_scheduled = true", "auto_scheduled IS true"),
+            ("sqlite", "auto_scheduled = 1", "auto_scheduled IS 1"),
+        ],
+    )
+    def test_auto_scheduled_predicate_matches_partial_index(
+        self, db: PrefectDBInterface, dialect: str, expected: str, forbidden: str
+    ):
+        query = _get_select_deployments_to_schedule_query(
+            db,
+            deployment_batch_size=100,
+            min_runs=3,
+            min_scheduled_time=datetime.timedelta(hours=1),
+        )
+        compiled = str(query.compile(dialect=sa.dialects.registry.load(dialect)()))
+
+        assert expected in compiled
+        assert forbidden not in compiled


### PR DESCRIPTION
Follow-up to #20699. The per-schedule deployment-selection query filters on `auto_scheduled.is_(True)`, but the partial index that PR added for it — `ix_flow_run__schedule_id_scheduler` — has predicate `auto_scheduled = true`. `IS true` doesn't match `= true` for either planner's predicate-implication prover, so **the index has never been used**; the query has been silently riding the older 2022 index with a post-filter. Switching to `== sa.true()` emits the equality form and activates the purpose-built index on both databases.

<details>
<summary>Empirical proof (~15× faster, ~10× less I/O)</summary>

Throwaway Postgres 16, both production indexes present, 2.2M flow_runs (355 MB), 100 deployments × 20 active schedules × 100 future runs each (the steady-state case where `EXISTS` must evaluate every schedule). Identical query, only `auto_scheduled IS true` → `auto_scheduled = true`:

| | execution time | buffers touched |
|---|---|---|
| current (`IS true`) | ~1,550 ms | 4,041,082 |
| this PR (`= true`) | ~100 ms | 416,068 |

Stable across 3 runs.

**Current** — subquery falls back to the 2022 index and reads *all* of a deployment's scheduled rows, then discards the other schedules':
```
Bitmap Heap Scan on flow_run  (... ix_flow_run__scheduler_deployment_id_auto_scheduled_next_schedu)
  Filter: ((auto_scheduled IS TRUE) AND ((created_by ->> 'id') = ...))
  Rows Removed by Filter: 1900     ← every loop, 2000 loops
  Heap Blocks: exact=4000000
```
The #20699 index is never mentioned.

**This PR** — both subqueries use the #20699 index with the schedule id promoted into the index condition (zero filter waste):
```
Index Scan using ix_flow_run__schedule_id_scheduler on flow_run
  Index Cond: (deployment_id = ... AND (created_by ->> 'id') = ... AND next_scheduled_start_time >= now())
```

The benefit scales with schedules-per-deployment (the old path re-reads a deployment's full scheduled set once *per schedule* — quadratic in schedules/deployment). Single-schedule deployments see no change; high-frequency / multi-schedule setups (cf. #18861) see the most.

</details>

<details>
<summary>Why `IS true` vs `= true` matters for partial indexes</summary>

For a regular indexed *column*, Postgres normalizes `IS true` to `= true` as an index condition (which is why the older index, where `auto_scheduled` is a column, kept working for ~2 years). But when `auto_scheduled = true` lives in a *partial index predicate*, the planner must prove the query's predicate **implies** the index predicate, and its implication prover does not treat the `BooleanTest` `IS true` as implying the `OpExpr` `= true`. So the partial index is disqualified. Same on SQLite (`IS 1` vs `= 1`).

Regression test asserts the compiled SQL emits `auto_scheduled = true` / `= 1` (and not `IS true` / `IS 1`) on both dialects — deterministic, unlike an EXPLAIN-based assertion which is meaningless on tiny test tables.

</details>