### PR TITLE
Preserve task run recorder upsert order

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -37,13 +37,13 @@ from prefect.settings.models.server.services import ServicesBaseSetting
 if TYPE_CHECKING:
     import logging
 
+    TaskRunUpsertKey = tuple[str, UUID] | tuple[str, UUID, str, str]
+    TaskRunBatchKey = tuple[frozenset[str], str]
+    TaskRunBatchByKey = tuple[TaskRunBatchKey, list[dict[str, Any]]]
+
 logger: "logging.Logger" = get_logger(__name__)
 
 DEFAULT_PERSIST_MAX_RETRIES = 5
-
-TaskRunUpsertKey = tuple[str, UUID] | tuple[str, UUID, str, str]
-TaskRunBatchKey = tuple[frozenset[str], str]
-TaskRunBatchByKey = tuple[TaskRunBatchKey, list[dict[str, Any]]]
 
 
 def _task_run_upsert_key(task_run: TaskRun) -> TaskRunUpsertKey:

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -42,6 +42,8 @@ logger: "logging.Logger" = get_logger(__name__)
 DEFAULT_PERSIST_MAX_RETRIES = 5
 
 TaskRunUpsertKey = tuple[str, UUID] | tuple[str, UUID, str, str]
+TaskRunBatchKey = tuple[frozenset[str], str]
+TaskRunBatchByKey = tuple[TaskRunBatchKey, list[dict[str, Any]]]
 
 
 def _task_run_upsert_key(task_run: TaskRun) -> TaskRunUpsertKey:
@@ -334,9 +336,7 @@ async def _record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
         # Batch contiguous rows by keys to avoid column mismatches during bulk insert.
         # Keeping only contiguous runs preserves the global conflict-key sort order
         # established above for deterministic lock acquisition.
-        batches_by_keys: list[
-            tuple[tuple[frozenset[str], str], list[dict[str, Any]]]
-        ] = []
+        batches_by_keys: list[TaskRunBatchByKey] = []
         for tr in unique_task_runs:
             key_signature = (
                 frozenset(tr["task_run_dict"].keys()),

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -331,16 +331,21 @@ async def _record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
                 return "natural-key"
             return "id"
 
-        # Batch by keys to avoid column mismatches during bulk insert.
-        # Each batch preserves the conflict-key sort order established above for
-        # deterministic lock acquisition, preventing deadlocks under concurrency.
-        batches_by_keys: dict[tuple[frozenset[str], str], list] = {}
+        # Batch contiguous rows by keys to avoid column mismatches during bulk insert.
+        # Keeping only contiguous runs preserves the global conflict-key sort order
+        # established above for deterministic lock acquisition.
+        batches_by_keys: list[
+            tuple[tuple[frozenset[str], str], list[dict[str, Any]]]
+        ] = []
         for tr in unique_task_runs:
             key_signature = (
                 frozenset(tr["task_run_dict"].keys()),
                 conflict_target(tr),
             )
-            batches_by_keys.setdefault(key_signature, []).append(tr)
+            if batches_by_keys and batches_by_keys[-1][0] == key_signature:
+                batches_by_keys[-1][1].append(tr)
+            else:
+                batches_by_keys.append((key_signature, [tr]))
 
         logger.debug(
             f"Partitioned task runs into {len(batches_by_keys)} groups by update columns"
@@ -348,7 +353,7 @@ async def _record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
 
         canonical_task_run_ids: dict[TaskRunUpsertKey, UUID] = {}
 
-        for (column_keys, conflict_target_name), batch in batches_by_keys.items():
+        for (column_keys, conflict_target_name), batch in batches_by_keys:
             update_cols = set(column_keys) - {"id", "created"}
 
             logger.debug(f"Preparing to bulk insert {len(batch)} task runs")

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1625,6 +1625,12 @@ async def test_bulk_upserts_preserve_global_conflict_key_order_across_column_gro
     session: AsyncSession,
     flow_run: FlowRun,
 ):
+    """Rows with different insert column signatures still execute in global order.
+
+    Bulk inserts must split rows by column signature, but collecting all matching
+    signatures together can reorder already-sorted conflict keys and reintroduce
+    lock-order inversions across concurrent recorders.
+    """
     captured_keys: list[tuple[UUID, str, str]] = []
     original_values = Insert.values
 

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1621,6 +1621,46 @@ async def test_bulk_upserts_are_sorted_by_conflict_key(
         assert keys == sorted(keys)
 
 
+async def test_bulk_upserts_preserve_global_conflict_key_order_across_column_groups(
+    session: AsyncSession,
+    flow_run: FlowRun,
+):
+    captured_keys: list[tuple[UUID, str, str]] = []
+    original_values = Insert.values
+
+    def spy_values(self, *args, **kwargs):
+        if args and isinstance(args[0], list) and args[0]:
+            if isinstance(args[0][0], dict) and "task_key" in args[0][0]:
+                captured_keys.extend(
+                    (row["flow_run_id"], row["task_key"], row["dynamic_key"])
+                    for row in args[0]
+                )
+        return original_values(self, *args, **kwargs)
+
+    base_time = datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+    flow_run_id = str(flow_run.id)
+    events: list[ReceivedEvent] = []
+
+    for i in reversed(range(6)):
+        event = make_event_with_flow_run(
+            task_run_id=str(uuid4()),
+            flow_run_id=flow_run_id,
+            task_key=f"task-{i:02d}",
+            dynamic_key=f"dyn-{i:02d}",
+            state_ts=base_time,
+            state_type=StateType.RUNNING,
+        )
+        if i % 2 == 0:
+            event.payload["task_run"]["run_count"] = i + 1
+        events.append(event)
+
+    with patch.object(Insert, "values", spy_values):
+        await task_run_recorder.record_bulk_task_run_events(events)
+
+    assert [key[1] for key in captured_keys] == [f"task-{i:02d}" for i in range(6)]
+    assert captured_keys == sorted(captured_keys)
+
+
 async def test_bulk_upsert_retries_once_on_integrity_error(
     session: AsyncSession,
     flow_run: FlowRun,


### PR DESCRIPTION
Related to #21587

this PR preserves task run recorder conflict-key ordering across bulk upsert statement groups.

<details>
<summary>Details</summary>

The task run recorder already sorts bulk rows by the id/natural conflict key before upserting, but the subsequent grouping by column signature could regroup non-contiguous rows. That meant a sorted input like `A, B, A` could execute as `A, A, B`, weakening the lock-ordering guarantee for concurrent recorder instances.

This change batches only contiguous rows that share the same column signature and conflict target. That keeps the global conflict-key order intact while still avoiding mixed-column bulk insert statements.

The regression test builds alternating task-run column signatures and asserts the executed `INSERT ... VALUES` rows remain globally sorted by conflict key.

Checked locally with:

- `uv run ruff check src/prefect/server/services/task_run_recorder.py tests/server/services/test_task_run_recorder.py`
- `uv run pytest tests/server/services/test_task_run_recorder.py -k 'bulk_upserts_are_sorted_by_conflict_key or preserve_global_conflict_key_order'`
- `uv run pytest tests/server/services/test_task_run_recorder.py`

</details>