### PR TITLE
Don't copy file-derived labels from linked issues

### DIFF
--- a/.github/workflows/copy-linked-issue-labels.yml
+++ b/.github/workflows/copy-linked-issue-labels.yml
@@ -16,7 +16,19 @@ jobs:
             references
             reference
             to
+          # Exclude labels that describe the *referenced* issue rather than this
+          # PR, plus labels that labeler.yml derives from the PR's own files or
+          # base branch. Copying the latter from a linked issue is always wrong:
+          # whether a PR is a migration/docs/etc. change is determined by its own
+          # diff, not by what it references (e.g. "follow-up to #20699" should not
+          # inherit #20699's `migration` label).
           labels-to-exclude: |
             great writeup
             good first issue
+            migration
+            docs
+            plan
+            upstream dependency
+            ui-replatform
+            2.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The copy-issue-labels workflow keeps applying `migration` to PRs that aren't migrations (e.g. #22111). This excludes the labels that shouldn't be inheritable from a referenced issue.

**Root cause:** the workflow's `custom-keywords` includes `in` / `to` / `reference(s)` (added in #15288 for "related to #X" phrasing). Those are common English words, so any `#NNNN` in a PR body triggers a label copy — including ordinary prose. #22111's body says "Follow-up **to** #20699", and #20699 carries `migration` (it added a migration), so the bot copied `migration` onto #22111 on `opened`, `ready_for_review`, and `review_requested` (three separate adds; maintainers removed it twice).

**Fix:** `migration` — like `docs`, `plan`, `upstream dependency`, `ui-replatform`, and `2.x` — is derived by `labeler.yml` from a PR's *own* files or base branch. Whether a PR is a migration change is a property of its diff, never of what it references, so copying these from a linked issue is always wrong. Added them to `labels-to-exclude` alongside the existing `great writeup` / `good first issue` entries.

I left the `in`/`to` keywords in place: narrowing them would revert the intentional "related to #X" behavior from #15288, and it's correct for content labels like `bug` to transfer. The problem was specifically the file/branch-derived labels, which this scopes out.

<details>
<summary>Verification</summary>

- #22111 changed only `scheduler.py` + `test_scheduler.py`; the `migration` glob (`src/**/_migrations/**/*.py`) does not match either (confirmed against minimatch v3 and v10, the versions labeler uses).
- #22111 timeline: `migration` added 3× by `github-actions[bot]`, removed by zzstoatzz and desertaxle — matches the `opened` / `ready_for_review` / `review_requested` triggers.
- `gh pr view 20699 --json labels` → `migration`.

</details>