### PR TITLE
feat(prefect-aws): add S3CompatibleCredentials base + BackblazeB2Credentials, tag boto3 User-Agent

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/__init__.py
+++ b/src/integrations/prefect-aws/prefect_aws/__init__.py
@@ -1,5 +1,10 @@
 from . import _version
-from .credentials import AwsCredentials, MinIOCredentials
+from .credentials import (
+    AwsCredentials,
+    BackblazeB2Credentials,
+    MinIOCredentials,
+    S3CompatibleCredentials,
+)
 from .client_parameters import AwsClientParameters
 from .lambda_function import LambdaFunction
 from .s3 import S3Bucket
@@ -9,11 +14,13 @@ from .workers import ECSWorker
 __all__ = [
     "AwsCredentials",
     "AwsClientParameters",
+    "AwsSecret",
+    "BackblazeB2Credentials",
+    "ECSWorker",
     "LambdaFunction",
     "MinIOCredentials",
     "S3Bucket",
-    "AwsSecret",
-    "ECSWorker",
+    "S3CompatibleCredentials",
 ]
 
 __version__ = _version.__version__

--- a/src/integrations/prefect-aws/prefect_aws/client_parameters.py
+++ b/src/integrations/prefect-aws/prefect_aws/client_parameters.py
@@ -39,7 +39,9 @@ class AwsClientParameters(BaseModel):
             then `use_ssl` is ignored.
         config: Advanced configuration for Botocore clients. See
             [botocore docs](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html)
-            for more details.
+            for more details. A `prefect-aws/<version>` token is always
+            appended to `user_agent_extra`; any caller-supplied value is
+            preserved.
     """  # noqa E501
 
     api_version: Optional[str] = Field(
@@ -142,7 +144,7 @@ class AwsClientParameters(BaseModel):
             # to ensure that verify doesn't re-overwrite verify_cert_path
             params.pop("verify")
 
-        params_override = {}
+        params_override: Dict[str, Any] = {}
         for key, value in params.items():
             if value is None:
                 continue
@@ -159,4 +161,29 @@ class AwsClientParameters(BaseModel):
                     params_override[key] = value
             else:
                 params_override[key] = value
+
+        # Tag the boto3 client with prefect-aws/<version> for attribution.
+        params_override["config"] = _apply_prefect_user_agent(
+            params_override.get("config")
+        )
         return params_override
+
+
+def _apply_prefect_user_agent(config: Optional[Config]) -> Config:
+    """Append `prefect-aws/<version>` to `config.user_agent_extra` (idempotent).
+
+    Mutates `config` in place rather than using `Config.merge`, which would
+    reconstruct the Config from `_user_provided_options` and drop attribute-
+    level adjustments such as the `signature_version=UNSIGNED` conversion
+    applied by `get_params_override`.
+    """
+    from prefect_aws import __version__ as _prefect_aws_version
+
+    token = f"prefect-aws/{_prefect_aws_version}"
+    if config is None:
+        return Config(user_agent_extra=token)
+    existing = getattr(config, "user_agent_extra", None) or ""
+    if token in existing:
+        return config
+    config.user_agent_extra = f"{existing} {token}".strip()
+    return config

--- a/src/integrations/prefect-aws/prefect_aws/credentials.py
+++ b/src/integrations/prefect-aws/prefect_aws/credentials.py
@@ -1,5 +1,6 @@
 """Module handling AWS credentials"""
 
+import abc
 import uuid
 from enum import Enum
 from functools import lru_cache
@@ -264,89 +265,63 @@ class AwsCredentials(CredentialsBlock):
         return self.get_client(client_type=ClientType.SECRETS_MANAGER)
 
 
-class MinIOCredentials(CredentialsBlock):
+class S3CompatibleCredentials(CredentialsBlock, abc.ABC):
     """
-    Block used to manage authentication with MinIO. Refer to the
-    [MinIO docs](https://docs.min.io/docs/minio-server-configuration-guide.html)
-    for more info about the possible credential configurations.
+    Base block for authentication against any S3-compatible object storage
+    service (Backblaze B2, Cloudflare R2, MinIO, Wasabi, etc.).
+
+    Subclasses provide vendor-named credential fields and implement
+    `_access_key_id` / `_secret_access_key`; this base class handles the
+    shared boto3 session and client plumbing.
+
+    For the generic case, use `AwsCredentials` with
+    `aws_client_parameters.endpoint_url` set to the provider's S3 endpoint.
 
     Attributes:
-        minio_root_user: Admin or root user.
-        minio_root_password: Admin or root password.
-        region_name: Location of server, e.g. "us-east-1".
-
-    Example:
-        Load stored MinIO credentials:
-        ```python
-        from prefect_aws import MinIOCredentials
-
-        minio_credentials_block = MinIOCredentials.load("BLOCK_NAME")
-        ```
-    """  # noqa E501
+        region_name: Region or location of the bucket. Must match the region
+            segment in `aws_client_parameters.endpoint_url` when the provider
+            requires it.
+        aws_client_parameters: Extra parameters used to initialize the boto3
+            client; set `endpoint_url` here.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/676cb17bcbdff601f97e0a02ff8bcb480e91ff40-250x250.png"  # noqa
-    _block_type_name = "MinIO Credentials"
-    _description = (
-        "Block used to manage authentication with MinIO. Refer to the MinIO "
-        "docs: https://docs.min.io/docs/minio-server-configuration-guide.html "
-        "for more info about the possible credential configurations."
-    )
-    _documentation_url = "https://docs.prefect.io/integrations/prefect-aws"  # noqa
-
-    minio_root_user: str = Field(default=..., description="Admin or root user.")
-    minio_root_password: SecretStr = Field(
-        default=..., description="Admin or root password."
-    )
     region_name: Optional[str] = Field(
         default=None,
-        description="The AWS Region where you want to create new connections.",
+        description="Region or location of the bucket.",
     )
     aws_client_parameters: AwsClientParameters = Field(
         default_factory=AwsClientParameters,
         description="Extra parameters to initialize the Client.",
     )
 
-    def __hash__(self):
-        return hash(
-            (
-                hash(self.minio_root_user),
-                hash(self.minio_root_password),
-                hash(self.region_name),
-                hash(self.aws_client_parameters),
-            )
-        )
+    # Inheriting from `abc.ABC` opts this class out of Prefect's Block
+    # registry (see `prefect.utilities.dispatch._register_subclass_of_base_type`),
+    # so only concrete vendor subclasses appear in the Blocks UI and in the
+    # block-standards test suite.
+
+    @property
+    @abc.abstractmethod
+    def _access_key_id(self) -> str: ...
+
+    @property
+    @abc.abstractmethod
+    def _secret_access_key(self) -> Optional[SecretStr]: ...
 
     def get_boto3_session(self) -> boto3.Session:
         """
-        Returns an authenticated boto3 session that can be used to create clients
-        and perform object operations on MinIO server.
-
-        Example:
-            Create an S3 client from an authorized boto3 session
-
-            ```python
-            minio_credentials = MinIOCredentials(
-                minio_root_user = "minio_root_user",
-                minio_root_password = "minio_root_password"
-            )
-            s3_client = minio_credentials.get_boto3_session().client(
-                service_name="s3",
-                endpoint_url="http://localhost:9000"
-            )
-            ```
+        Returns an authenticated boto3 session that can be used to create
+        clients and perform object operations on the S3-compatible service.
         """
-
-        minio_root_password = (
-            self.minio_root_password.get_secret_value()
-            if self.minio_root_password
+        secret = (
+            self._secret_access_key.get_secret_value()
+            if self._secret_access_key
             else None
         )
-
         return boto3.Session(
-            aws_access_key_id=self.minio_root_user,
-            aws_secret_access_key=minio_root_password,
+            aws_access_key_id=self._access_key_id,
+            aws_secret_access_key=secret,
             region_name=self.region_name,
         )
 
@@ -376,3 +351,118 @@ class MinIOCredentials(CredentialsBlock):
             An authenticated S3 client.
         """
         return self.get_client(client_type=ClientType.S3)
+
+
+class MinIOCredentials(S3CompatibleCredentials):
+    """
+    Block used to manage authentication with MinIO. Refer to the
+    [MinIO docs](https://docs.min.io/docs/minio-server-configuration-guide.html)
+    for more info about the possible credential configurations.
+
+    Attributes:
+        minio_root_user: Admin or root user.
+        minio_root_password: Admin or root password.
+        region_name: Location of server, e.g. "us-east-1".
+
+    Example:
+        Load stored MinIO credentials:
+        ```python
+        from prefect_aws import MinIOCredentials
+
+        minio_credentials_block = MinIOCredentials.load("BLOCK_NAME")
+        ```
+    """  # noqa E501
+
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/676cb17bcbdff601f97e0a02ff8bcb480e91ff40-250x250.png"  # noqa
+    _block_type_name = "MinIO Credentials"
+    _description = (
+        "Block used to manage authentication with MinIO. Refer to the MinIO "
+        "docs: https://docs.min.io/docs/minio-server-configuration-guide.html "
+        "for more info about the possible credential configurations."
+    )
+    _documentation_url = "https://docs.prefect.io/integrations/prefect-aws"  # noqa
+
+    minio_root_user: str = Field(default=..., description="Admin or root user.")
+    minio_root_password: SecretStr = Field(
+        default=..., description="Admin or root password."
+    )
+
+    @property
+    def _access_key_id(self) -> str:
+        return self.minio_root_user
+
+    @property
+    def _secret_access_key(self) -> Optional[SecretStr]:
+        return self.minio_root_password
+
+    def __hash__(self):
+        return hash(
+            (
+                hash(self.minio_root_user),
+                hash(self.minio_root_password),
+                hash(self.region_name),
+                hash(self.aws_client_parameters),
+            )
+        )
+
+
+class BackblazeB2Credentials(S3CompatibleCredentials):
+    """
+    Block used to manage authentication with Backblaze B2 via its
+    [S3-compatible API](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api).
+    Create a bucket-scoped [Application Key](https://www.backblaze.com/docs/cloud-storage-application-keys)
+    in the B2 console; the `keyID` becomes `application_key_id` and the
+    `applicationKey` becomes `application_key`.
+
+    Attributes:
+        application_key_id: B2 application key ID (the "keyID" in the B2
+            console).
+        application_key: B2 application key (the "applicationKey" in the B2
+            console).
+        region_name: B2 region, e.g. "us-west-004". Must match the region
+            segment in `aws_client_parameters.endpoint_url`.
+
+    Example:
+        Load stored Backblaze B2 credentials:
+        ```python
+        from prefect_aws import BackblazeB2Credentials
+
+        b2_credentials_block = BackblazeB2Credentials.load("BLOCK_NAME")
+        ```
+    """  # noqa E501
+
+    _logo_url = "https://cdn.prod.website-files.com/63d32de856f6323a43a277f2/64b1ab4daf31e414a481b056_Webclip.png"  # noqa
+    _block_type_name = "Backblaze B2 Credentials"
+    _description = (
+        "Block used to manage authentication with Backblaze B2 via its "
+        "S3-compatible API. See "
+        "https://www.backblaze.com/docs/cloud-storage-s3-compatible-api"
+    )
+    _documentation_url = "https://docs.prefect.io/integrations/prefect-aws"  # noqa
+
+    application_key_id: str = Field(
+        default=...,
+        description='B2 application key ID (the "keyID" in the B2 console).',
+    )
+    application_key: SecretStr = Field(
+        default=...,
+        description='B2 application key (the "applicationKey" in the B2 console).',
+    )
+
+    @property
+    def _access_key_id(self) -> str:
+        return self.application_key_id
+
+    @property
+    def _secret_access_key(self) -> Optional[SecretStr]:
+        return self.application_key
+
+    def __hash__(self):
+        return hash(
+            (
+                hash(self.application_key_id),
+                hash(self.application_key),
+                hash(self.region_name),
+                hash(self.aws_client_parameters),
+            )
+        )

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -19,7 +19,7 @@ from prefect.logging import get_run_logger
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.filesystem import filter_files
 from prefect.utilities.pydantic import lookup_type
-from prefect_aws import AwsCredentials, MinIOCredentials
+from prefect_aws import AwsCredentials, BackblazeB2Credentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
 
 
@@ -809,11 +809,13 @@ s3_list_objects = list_objects  # backward compatibility
 
 class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock):
     """
-    Block used to store data using AWS S3 or S3-compatible object storage like MinIO.
+    Block used to store data using AWS S3 or S3-compatible object storage
+    such as Backblaze B2, Cloudflare R2, or MinIO.
 
     Attributes:
         bucket_name: Name of your bucket.
-        credentials: A block containing your credentials to AWS or MinIO.
+        credentials: A block containing your credentials to AWS or to an
+            S3-compatible service.
         bucket_folder: A default path to a folder within the S3 bucket to use
             for reading and writing objects.
     """
@@ -824,9 +826,18 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
 
     bucket_name: str = Field(default=..., description="Name of your bucket.")
 
-    credentials: Union[MinIOCredentials, AwsCredentials] = Field(
-        default_factory=AwsCredentials,
-        description="A block containing your credentials to AWS or MinIO.",
+    # `AwsCredentials` is listed last: its fields are all optional, so
+    # pydantic would otherwise greedily pick it for any dict in the Union.
+    # The vendor-specific blocks have required fields that discriminate
+    # cleanly (`minio_root_user` for MinIO, `application_key_id` for B2).
+    credentials: Union[BackblazeB2Credentials, MinIOCredentials, AwsCredentials] = (
+        Field(
+            default_factory=AwsCredentials,
+            description=(
+                "A block containing your credentials to AWS or to an "
+                "S3-compatible service (Backblaze B2, Cloudflare R2, MinIO, etc.)."
+            ),
+        )
     )
 
     bucket_folder: str = Field(

--- a/src/integrations/prefect-aws/tests/test_client_parameters.py
+++ b/src/integrations/prefect-aws/tests/test_client_parameters.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 import pytest
 from botocore import UNSIGNED
 from botocore.client import Config
+from prefect_aws import __version__ as PREFECT_AWS_VERSION
 from prefect_aws.client_parameters import AwsClientParameters
 
 
@@ -34,7 +35,10 @@ class TestAwsClientParameters:
     def test_get_params_override_expected_output(
         self, params: AwsClientParameters, result: Dict[str, Any], tmp_path
     ):
-        assert result == params.get_params_override()
+        override = params.get_params_override()
+        # A default prefect-aws User-Agent Config is always injected.
+        assert isinstance(override.pop("config"), Config)
+        assert override == result
 
     @pytest.mark.parametrize(
         "params,result",
@@ -133,6 +137,42 @@ class TestAwsClientParameters:
         override_params = params.get_params_override()
         assert "verify" not in override_params, (
             "verify should not be in params_override when not explicitly set"
+        )
+
+    def test_default_user_agent_extra_includes_prefect_aws(self):
+        # Every constructed boto3 client should advertise prefect-aws so
+        # operators can attribute traffic back to Prefect workloads.
+        override = AwsClientParameters().get_params_override()
+        assert (
+            f"prefect-aws/{PREFECT_AWS_VERSION}" in override["config"].user_agent_extra
+        )
+
+    def test_caller_user_agent_extra_is_preserved(self):
+        # If a caller already set user_agent_extra, the prefect-aws token is
+        # appended without dropping the caller's value.
+        params = AwsClientParameters(config=Config(user_agent_extra="my-app/1.0"))
+        override = params.get_params_override()
+        ua_extra = override["config"].user_agent_extra
+        assert "my-app/1.0" in ua_extra
+        assert f"prefect-aws/{PREFECT_AWS_VERSION}" in ua_extra
+
+    def test_user_agent_extra_is_idempotent(self):
+        # Calling get_params_override repeatedly must not duplicate the token.
+        params = AwsClientParameters()
+        first = params.get_params_override()["config"].user_agent_extra
+        second = params.get_params_override()["config"].user_agent_extra
+        assert first == second
+        assert first.count(f"prefect-aws/{PREFECT_AWS_VERSION}") == 1
+
+    def test_unsigned_signature_version_preserved_with_user_agent(self):
+        # Regression: the UA-tagging step must not undo the manual
+        # signature_version=UNSIGNED conversion that get_params_override
+        # performs after constructing the Config.
+        params = AwsClientParameters(config=Config(signature_version="unsigned"))
+        override = params.get_params_override()
+        assert override["config"].signature_version is UNSIGNED
+        assert (
+            f"prefect-aws/{PREFECT_AWS_VERSION}" in override["config"].user_agent_extra
         )
 
     def test_get_params_override_with_explicit_verify(self):

--- a/src/integrations/prefect-aws/tests/test_credentials.py
+++ b/src/integrations/prefect-aws/tests/test_credentials.py
@@ -6,8 +6,10 @@ from botocore.client import BaseClient
 from moto import mock_aws
 from prefect_aws.credentials import (
     AwsCredentials,
+    BackblazeB2Credentials,
     ClientType,
     MinIOCredentials,
+    S3CompatibleCredentials,
     _get_client_cached,
 )
 
@@ -37,12 +39,38 @@ def test_minio_credentials_get_boto3_session():
     assert isinstance(boto3_session, Session)
 
 
+def test_backblaze_b2_credentials_get_boto3_session():
+    """
+    Asserts that instantiated BackblazeB2Credentials block creates
+    an authenticated boto3 session.
+    """
+
+    b2_credentials_block = BackblazeB2Credentials(
+        application_key_id="key_id", application_key="application_key"
+    )
+    boto3_session = b2_credentials_block.get_boto3_session()
+    assert isinstance(boto3_session, Session)
+
+
+def test_s3_compatible_credentials_base_is_abstract():
+    """
+    The base S3CompatibleCredentials class is abstract (via abc.ABC) and
+    cannot be instantiated directly. This also opts it out of Prefect's
+    Block registry so it does not surface in the Blocks UI.
+    """
+    with pytest.raises(TypeError, match="abstract"):
+        S3CompatibleCredentials()
+
+
 @pytest.mark.parametrize(
     "credentials",
     [
         AwsCredentials(),
         MinIOCredentials(
             minio_root_user="root_user", minio_root_password="root_password"
+        ),
+        BackblazeB2Credentials(
+            application_key_id="key_id", application_key="application_key"
         ),
     ],
 )
@@ -60,6 +88,11 @@ def test_credentials_get_client(credentials, client_type):
             minio_root_user="root_user",
             minio_root_password="root_password",
             region_name="us-east-1",
+        ),
+        BackblazeB2Credentials(
+            application_key_id="key_id",
+            application_key="application_key",
+            region_name="us-west-004",
         ),
     ],
 )
@@ -145,6 +178,34 @@ def test_minio_credentials_change_causes_cache_miss(client_type):
     assert _get_client_cached.cache_info().misses == 2, "Cache should miss twice"
 
 
+@pytest.mark.parametrize("client_type", [member.value for member in ClientType])
+def test_backblaze_b2_credentials_change_causes_cache_miss(client_type):
+    """
+    Changing configuration on a BackblazeB2Credentials instance after
+    fetching a client should cause a cache miss.
+    """
+
+    _get_client_cached.cache_clear()
+
+    credentials = BackblazeB2Credentials(
+        application_key_id="key_id",
+        application_key="application_key",
+        region_name="us-west-004",
+    )
+
+    initial_client = credentials.get_client(client_type)
+
+    credentials.region_name = "us-east-005"
+
+    new_client = credentials.get_client(client_type)
+
+    assert initial_client is not new_client, (
+        "Client should be different after configuration change"
+    )
+
+    assert _get_client_cached.cache_info().misses == 2, "Cache should miss twice"
+
+
 @pytest.mark.parametrize(
     "credentials_type, initial_field, new_field",
     [
@@ -164,6 +225,19 @@ def test_minio_credentials_change_causes_cache_miss(client_type):
                 "region_name": "us-east-2",
                 "minio_root_user": "root_user",
                 "minio_root_password": "root_password",
+            },
+        ),
+        (
+            BackblazeB2Credentials,
+            {
+                "region_name": "us-west-004",
+                "application_key_id": "key_id",
+                "application_key": "application_key",
+            },
+            {
+                "region_name": "us-east-005",
+                "application_key_id": "key_id",
+                "application_key": "application_key",
             },
         ),
     ],

--- a/src/prefect/settings/_types.py
+++ b/src/prefect/settings/_types.py
@@ -57,6 +57,7 @@ SettingAccessor: TypeAlias = Literal[
     "results.default_storage_block",
     "results.local_storage_path",
     "results.persist_by_default",
+    "runner.auto_install_dependencies",
     "runner.crash_on_cancellation_failure",
     "runner.poll_frequency",
     "runner.process_limit",


### PR DESCRIPTION
Hello team, thanks for this awesome project.

This PR does two related things to the `prefect-aws` integration:

1. Adds an `S3CompatibleCredentials` abstract base class and a concrete `BackblazeB2Credentials` subclass, generalizing the existing `MinIOCredentials` pattern so any S3-compatible object storage provider can be added in ~25 lines of subclass code.
2. Tags every boto3 client constructed via `AwsClientParameters.get_params_override()` with a `prefect-aws/<version>` `User-Agent` suffix so server-side operators can attribute traffic to Prefect.

Both changes are generic and follow patterns already present in the codebase. AWS-only callers see no functional change — only a new `prefect-aws/<version>` suffix on the boto3 `User-Agent` header.

## Changes

### Credentials hierarchy

- `src/integrations/prefect-aws/prefect_aws/credentials.py`
  - Added `S3CompatibleCredentials(CredentialsBlock, abc.ABC)` holding the shared `region_name`, `aws_client_parameters`, and the `get_boto3_session` / `get_client` / `get_s3_client` plumbing. Subclasses provide only the `_access_key_id` / `_secret_access_key` `@abc.abstractmethod` properties and vendor-specific UI metadata.
  - Inheriting from `abc.ABC` opts the base class out of Prefect's block registry via `prefect.utilities.dispatch._register_subclass_of_base_type` (which skips registration for any class with `abc.ABC` in its direct bases). The base class therefore does not surface in the Blocks UI and is correctly excluded from `test_block_standards.py`.
  - Refactored `MinIOCredentials` to inherit from `S3CompatibleCredentials`. Public field names (`minio_root_user`, `minio_root_password`) are unchanged; existing saved MinIO blocks deserialize identically. The previous inline `get_boto3_session` / `get_client` / `get_s3_client` bodies are removed in favor of inheritance.
  - Added `BackblazeB2Credentials(S3CompatibleCredentials)` with `application_key_id` / `application_key` fields matching the B2 console naming (`keyID` / `applicationKey`).

- `src/integrations/prefect-aws/prefect_aws/__init__.py`
  - Exported `S3CompatibleCredentials` and `BackblazeB2Credentials`. Alphabetized `__all__`.

- `src/integrations/prefect-aws/prefect_aws/s3.py`
  - Extended `S3Bucket.credentials` to `Union[BackblazeB2Credentials, MinIOCredentials, AwsCredentials]`. `AwsCredentials` is intentionally listed last; its fields are all optional, so pydantic would otherwise greedily pick it for any dict in the Union. The vendor-specific blocks have required fields that discriminate cleanly (`minio_root_user` for MinIO, `application_key_id` for B2).
  - Updated the `S3Bucket` class docstring and `credentials` field description to mention Backblaze B2 and Cloudflare R2 alongside MinIO under the existing "S3-compatible object storage" framing.

### User-Agent attribution

- `src/integrations/prefect-aws/prefect_aws/client_parameters.py`
  - `AwsClientParameters.get_params_override()` always injects a `botocore.client.Config(user_agent_extra=f"prefect-aws/{__version__}")` into the override dict.
  - When the caller already supplied a `Config` with their own `user_agent_extra`, the prefect-aws token is appended via in-place mutation of `user_agent_extra` (the caller's value is preserved). The operation is idempotent.
  - In-place mutation is used instead of `Config.merge` so the attribute-level `signature_version = UNSIGNED` conversion performed by `get_params_override` is preserved (a `merge` would reconstruct the `Config` from `_user_provided_options` and drop it).
  - Class docstring updated; the auto-generated API reference picks up the new behavior on the next `yarn build-api-docs`.

### Generated settings types

- `src/prefect/settings/_types.py`
  - Single-line regeneration (`"runner.auto_install_dependencies"`) picked up by the `generate-settings-types` pre-commit hook from a setting added on `main` in a separate PR. Unrelated to the credentials / User-Agent work; included so CI passes.

## Compatibility

- Existing saved `MinIOCredentials` blocks deserialize identically. The refactor moves method bodies up to the base class but does not change public field names, method signatures, return types, or on-disk schema.
- AWS-only callers see no functional change. The only observable difference is a `prefect-aws/<version>` suffix on the boto3 `User-Agent` header.
- Callers who pass their own `botocore.client.Config` keep their `user_agent_extra` (we concatenate, not override) and keep all other Config fields, including `signature_version = UNSIGNED`.

## Testing

- `pytest src/integrations/prefect-aws/tests/test_credentials.py`: passes. The existing MinIO test suite is unchanged and serves as the backwards-compatibility regression for the refactor. Added mirrored coverage for `BackblazeB2Credentials` (`get_boto3_session`, `get_client`, cache-miss-on-region-change, hash-changes-on-region-change) and `test_s3_compatible_credentials_base_is_abstract` to lock in that the base class raises `TypeError` on direct instantiation.
- `pytest src/integrations/prefect-aws/tests/test_client_parameters.py`: passes, including new tests for the default `prefect-aws/<version>` token, caller `user_agent_extra` preservation, idempotency on repeated calls, and the `signature_version = UNSIGNED` regression after applying the UA.
- `pytest src/integrations/prefect-aws/tests/test_block_standards.py`: passes — `S3CompatibleCredentials` is correctly hidden from `find_module_blocks()` and the standards suite runs only against `AwsCredentials`, `AwsSecret`, `BackblazeB2Credentials`, `LambdaFunction`, `MinIOCredentials`, and `S3Bucket`.
- `pytest src/integrations/prefect-aws/tests/test_s3.py`: 166 passed, 2 xfailed — no regressions on the `S3Bucket.credentials` Union extension, including the `minio_credentials` parametrize cases that exercise the `endpoint_url` override path.
- `pre-commit run --all-files`: all hooks green (ruff check, ruff format, codespell, mypy, uv-lock, no-double-backticks, generate-settings-types, check-ui-v2).

## Notes

- `BackblazeB2Credentials._logo_url` uses the Backblaze corporate Webflow CDN. If maintainers prefer the logo to be uploaded to Prefect's Sanity CMS to match the `MinIOCredentials` / `AwsCredentials` convention (`cdn.sanity.io/images/3ugk85nk/...`), happy to swap the URL in a follow-up once it's hosted.
- Cloudflare R2, Wasabi, Linode Object Storage, etc. can be added as additional `S3CompatibleCredentials` subclasses in ~25 lines each. Not in scope for this PR; opening only the two most-requested providers (MinIO already existed, B2 is the first new one).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - No standalone issue; small enhancement to an existing integration.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
  - N/A, no docs files removed.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.