### PR TITLE
fix(workers): cancel running flow runs by killing their infrastructure (fixes #21616)

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1779,7 +1779,12 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         """
         Cancel a flow run by killing its infrastructure and marking it cancelled.
 
-        Only cancels flow runs that were pending (not yet started).
+        Handles both pending (not yet started) and running flow runs.  Skipping
+        running runs was the previous behaviour and caused zombie infrastructure
+        (Kubernetes Jobs, ECS tasks, Docker containers) whenever the flow engine
+        inside the pod could not self-terminate — e.g. a hung future, blocked
+        I/O, or a swallowed exception.  See
+        https://github.com/PrefectHQ/prefect/issues/21616
         """
         try:
             flow_run = await self.client.read_flow_run(flow_run_id)
@@ -1790,10 +1795,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             return
 
         run_logger = self.get_flow_run_logger(flow_run)
-
-        # Only cancel if the flow run was pending (never started)
-        if flow_run.start_time is not None:
-            return
 
         # No infrastructure to kill if no pid
         if not flow_run.infrastructure_pid:
@@ -1851,11 +1852,16 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             run_logger.exception("Error killing infrastructure")
             return
 
+        state_msg = (
+            "Flow run cancelled by worker while running."
+            if flow_run.start_time is not None
+            else "Flow run cancelled by worker while pending."
+        )
         await self._mark_flow_run_as_cancelled(
             flow_run,
-            state_updates={"message": "Flow run cancelled by worker while pending."},
+            state_updates={"message": state_msg},
         )
-        run_logger.info(f"Cancelled pending flow run '{flow_run.id}'")
+        run_logger.info(f"Cancelled flow run '{flow_run.id}'")
 
     async def kill_infrastructure(
         self,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2353,6 +2353,45 @@ def worker_channel_test_client(
     return client
 
 
+class TestReconnectDelay:
+    def test_exponential_backoff(self):
+        transport = WorkerChannelTransport(
+            api_url="http://localhost:4200/api",
+            work_pool_name="test",
+            logger=logging.getLogger("test"),
+            reconnect_base_seconds=1.0,
+            reconnect_max_seconds=30.0,
+        )
+        assert transport.reconnect_delay(1) == 1.0
+        assert transport.reconnect_delay(2) == 2.0
+        assert transport.reconnect_delay(3) == 4.0
+        assert transport.reconnect_delay(6) == 30.0  # clamped to max
+
+    def test_zero_base_returns_zero(self):
+        transport = WorkerChannelTransport(
+            api_url="http://localhost:4200/api",
+            work_pool_name="test",
+            logger=logging.getLogger("test"),
+            reconnect_base_seconds=0,
+            reconnect_max_seconds=30.0,
+        )
+        assert transport.reconnect_delay(1) == 0
+        assert transport.reconnect_delay(9999) == 0
+
+    def test_large_attempt_does_not_overflow(self):
+        transport = WorkerChannelTransport(
+            api_url="http://localhost:4200/api",
+            work_pool_name="test",
+            logger=logging.getLogger("test"),
+            reconnect_base_seconds=1.0,
+            reconnect_max_seconds=30.0,
+        )
+        # These previously raised OverflowError
+        assert transport.reconnect_delay(1024) == 30.0
+        assert transport.reconnect_delay(2000) == 30.0
+        assert transport.reconnect_delay(100_000) == 30.0
+
+
 class TestWorkerChannelClient:
     async def test_worker_uses_real_server_channel_for_setup_and_heartbeat(
         self,
@@ -4884,45 +4923,61 @@ class TestWorkerCancellationHandling:
                 # Should have set up cancellation observer
                 assert worker._cancelling_observer is not None
 
-    async def test_cancel_run_skips_non_pending_flow_runs(
+    async def test_cancel_run_kills_infrastructure_for_running_flow_runs(
         self,
         prefect_client: PrefectClient,
         work_pool: WorkPool,
+        deployment: DeploymentResponse,
     ):
-        """Test that _cancel_run skips flow runs that were not pending."""
+        """Regression test for https://github.com/PrefectHQ/prefect/issues/21616.
 
-        @flow
-        def test_flow():
-            pass
-
-        flow_run = await prefect_client.create_flow_run(
-            test_flow, work_pool_name=work_pool.name
+        _cancel_run must kill infrastructure and mark the run cancelled even when
+        the flow has already started (start_time is not None).  The old guard
+        ``if flow_run.start_time is not None: return`` silently skipped running
+        flows, leaving zombie pods/containers that could never be cleaned up.
+        """
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment.id,
+        )
+        await prefect_client.update_flow_run(
+            flow_run.id, infrastructure_pid="test-pid"
         )
 
         async with WorkerTestImpl(
             work_pool_name=work_pool.name,
             name="test-worker",
         ) as worker:
-            # Create a flow run with start_time set (already started)
-            flow_run_with_start_time = FlowRun(
+            # Simulate a flow run that has already started
+            flow_run_running = FlowRun(
                 id=flow_run.id,
                 flow_id=flow_run.flow_id,
                 name=flow_run.name,
                 state=Running(),
                 start_time=now_fn("UTC"),
+                infrastructure_pid="test-pid",
+                deployment_id=deployment.id,
             )
 
             with mock.patch.object(
                 worker.client, "read_flow_run", new_callable=AsyncMock
             ) as mock_read:
-                mock_read.return_value = flow_run_with_start_time
-                with mock.patch.object(worker, "kill_infrastructure") as mock_kill:
+                mock_read.return_value = flow_run_running
+                with mock.patch.object(
+                    worker, "kill_infrastructure", new_callable=AsyncMock
+                ) as mock_kill:
                     with mock.patch.object(
-                        worker, "_mark_flow_run_as_cancelled"
+                        worker,
+                        "_mark_flow_run_as_cancelled",
+                        new_callable=AsyncMock,
                     ) as mock_mark:
                         await worker._cancel_run(flow_run.id)
-                        mock_kill.assert_not_called()
-                        mock_mark.assert_not_called()
+                        # Infrastructure must be killed even for running flows
+                        mock_kill.assert_called_once()
+                        assert (
+                            mock_kill.call_args[1]["infrastructure_pid"] == "test-pid"
+                        )
+                        # Run must be marked cancelled
+                        mock_mark.assert_called_once()
 
     async def test_cancellation_observer_filters_by_work_pool(
         self,


### PR DESCRIPTION
## Summary

Fixes #21616 — zombie infrastructure when cancelling a running flow run.

**Before:** `_cancel_run` contained an early-return guard:
```python
# Only cancel if the flow run was pending (never started)
if flow_run.start_time is not None:
    return
```
When a `Cancelling` event fired for a flow that had already started (any legitimately *running* flow), the worker silently did nothing. If the flow engine inside the pod couldn't self-terminate — hung future, blocked I/O, swallowed exception, pickle deserialization error — the infrastructure (Kubernetes Job, ECS task, Docker container) kept running forever with no actor in the system to clean it up. In parent/subflow scenarios each retry spawned another zombie, compounding cluster resource consumption indefinitely.

**After:** The guard is removed. `_cancel_run` handles both pending and running flow runs. The existing downstream path (`kill_infrastructure` → `_mark_flow_run_as_cancelled`) already handles every edge case:
- No `infrastructure_pid` → mark cancelled immediately
- `ObjectNotFound` / `NotImplementedError` / `InfrastructureNotFound` / `InfrastructureNotAvailable` → each has a logged warning + early return (infrastructure may still be running, same as before for unsupported workers)

## Changes

**`src/prefect/workers/base.py`**
- Removed the `if flow_run.start_time is not None: return` guard (lines 1794–1796)
- Updated the docstring to reflect that both pending and running flows are handled
- Updated the success state message to distinguish pending vs. running cancellations in the run log

**`tests/workers/test_base_worker.py`**
- Renamed `test_cancel_run_skips_non_pending_flow_runs` → `test_cancel_run_kills_infrastructure_for_running_flow_runs`
- Updated the test to verify the new correct behavior: `kill_infrastructure` **is** called and the run **is** marked cancelled when `start_time` is set and an `infrastructure_pid` is present

## Test plan
- [x] All 4 `_cancel_run`-related tests pass: `uv run python -m pytest tests/workers/test_base_worker.py -k cancel_run -v` → `4 passed`
- [x] No regressions in existing worker tests