### PR TITLE
Deprecate `@sync_compatible` in favor of `@async_dispatch`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,7 @@ filterwarnings = [
     "ignore:Runner\\.execute_flow_run has been deprecated:prefect._internal.compatibility.deprecated.PrefectDeprecationWarning",
     "ignore:Runner\\.execute_bundle has been deprecated:prefect._internal.compatibility.deprecated.PrefectDeprecationWarning",
     "ignore:Runner\\.reschedule_current_flow_runs has been deprecated:prefect._internal.compatibility.deprecated.PrefectDeprecationWarning",
+    "ignore:`sync_compatible` has been deprecated:prefect._internal.compatibility.deprecated.PrefectDeprecationWarning",
     "ignore::sqlalchemy.exc.SAWarning",
     "ignore::ResourceWarning",
     "ignore::pytest.PytestUnraisableExceptionWarning",

--- a/src/prefect/settings/_types.py
+++ b/src/prefect/settings/_types.py
@@ -57,6 +57,7 @@ SettingAccessor: TypeAlias = Literal[
     "results.default_storage_block",
     "results.local_storage_path",
     "results.persist_by_default",
+    "runner.auto_install_dependencies",
     "runner.crash_on_cancellation_failure",
     "runner.poll_frequency",
     "runner.process_limit",

--- a/src/prefect/utilities/asyncutils/__init__.py
+++ b/src/prefect/utilities/asyncutils/__init__.py
@@ -300,7 +300,30 @@ def sync_compatible(
     ```
     python result: Coroutine = sync_compatible(my_async_function)(arg1, arg2) # type: ignore
     ```
+
+    Deprecated: define an explicit async function and dispatch to a sync
+    implementation with `@async_dispatch` instead. See
+    https://github.com/PrefectHQ/prefect/issues/15008.
     """
+    # Imported lazily to keep this low-level module free of heavier imports.
+    from prefect._internal.compatibility.deprecated import (
+        PrefectDeprecationWarning,
+        generate_deprecation_message,
+    )
+
+    warnings.warn(
+        generate_deprecation_message(
+            name="`sync_compatible`",
+            start_date="May 2026",
+            help=(
+                "Define an explicit async function and wrap a sync implementation "
+                "with `@async_dispatch(<async_fn>)` instead. See "
+                "https://github.com/PrefectHQ/prefect/issues/15008 for details."
+            ),
+        ),
+        PrefectDeprecationWarning,
+        stacklevel=2,
+    )
 
     @wraps(async_fn)
     def coroutine_wrapper(

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -284,6 +284,18 @@ async def test_sync_compatible_allows_forced_behavior_sync_and_async():
     assert await sync_compatible(foo)() == 42
 
 
+def test_sync_compatible_emits_deprecation_warning():
+    from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
+
+    async def foo():
+        return 42
+
+    with pytest.warns(
+        PrefectDeprecationWarning, match="`sync_compatible` has been deprecated"
+    ):
+        sync_compatible(foo)
+
+
 def test_sync_compatible_requires_async_function():
     with pytest.raises(TypeError, match="must be async"):
 


### PR DESCRIPTION
Final step of #15008. Emits a `PrefectDeprecationWarning` whenever `sync_compatible` is applied, directing authors to the explicit async + `@async_dispatch` pattern.

> [!IMPORTANT]
> Depends on #22140 (prefect-azure) and #22141 (prefect-dbt) merging first — those remove the last source usages of `@sync_compatible`. Holding this as draft until they land.

<details>
<summary>details</summary>

- The warning fires at **decoration time** (once per `@sync_compatible async def foo`), so it targets the code author rather than end users who merely call a decorated function.
- Uses the existing `generate_deprecation_message` helper with `start_date="May 2026"` ⇒ "removal after Nov 2026". Imported lazily inside `sync_compatible` to keep `asyncutils` free of heavier imports.
- After the two migration PRs, core has **zero** source usages — the only place that still applies the decorator is its own test file, `tests/utilities/test_asyncutils.py`. A scoped `filterwarnings` ignore (matching the existing `Runner.*` deprecation entries) keeps those behavior tests green under the suite's `filterwarnings = ["error"]`, and a new `test_sync_compatible_emits_deprecation_warning` asserts the warning actually fires.
- No integration test suites import `sync_compatible` (their remaining references are docstring mentions only), so none are affected.

</details>