### PR TITLE
fix(cli): lowercase work pool name in storage block document name

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -161,8 +161,8 @@ def _result_storage_block_name(work_pool_name: str) -> str:
     """Return a block-document-friendly name derived from a work pool name.
 
     Block document names must be lowercase.  A 6-character hex suffix derived
-    from the original name ensures that case-variant pools (e.g. ``Prod`` and
-    ``prod``) each get a distinct block document rather than silently sharing
+    from the original name ensures that case-variant pools (e.g. 'Prod' and
+    'prod') each get a distinct block document rather than silently sharing
     one.
     """
     slug = re.sub(r"[^a-z0-9]+", "-", work_pool_name.lower()).strip("-") or "pool"

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -7,7 +7,9 @@ Manage work pools.
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
+import re
 import textwrap
 from typing import Annotated, Any, Optional
 
@@ -153,6 +155,19 @@ def _build_launcher(
         exit_with_error(f"{executable_option} cannot be empty.")
 
     return [executable, *(args or [])]
+
+
+def _result_storage_block_name(work_pool_name: str) -> str:
+    """Return a block-document-friendly name derived from a work pool name.
+
+    Block document names must be lowercase.  A 6-character hex suffix derived
+    from the original name ensures that case-variant pools (e.g. ``Prod`` and
+    ``prod``) each get a distinct block document rather than silently sharing
+    one.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", work_pool_name.lower()).strip("-") or "pool"
+    suffix = hashlib.md5(work_pool_name.encode()).hexdigest()[:6]
+    return f"default-{slug}-{suffix}-result-storage"
 
 
 def _resolve_launcher_override(
@@ -1379,7 +1394,7 @@ async def storage_configure_s3(
                     " --aws-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
+        result_storage_block_document_name = _result_storage_block_name(work_pool_name)
         # Always set `credentials` explicitly (a $ref for a named block, or
         # an empty dict for ambient auth). Setting it on every run clears any
         # stale credential reference from a prior --aws-credentials-block-name
@@ -1518,7 +1533,7 @@ async def storage_configure_gcs(
                     " --gcp-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
+        result_storage_block_document_name = _result_storage_block_name(work_pool_name)
         # Always set `gcp_credentials` explicitly (a $ref for a named block,
         # or an empty dict for ambient auth). Setting it on every run clears
         # any stale credential reference from a prior
@@ -1652,7 +1667,7 @@ async def storage_configure_azure_blob_storage(
                 " `prefect block create azure-blob-storage-credentials`."
             )
 
-        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
+        result_storage_block_document_name = _result_storage_block_name(work_pool_name)
         block_data = {
             "container_name": container,
             "credentials": {

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -1379,7 +1379,7 @@ async def storage_configure_s3(
                     " --aws-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
         # Always set `credentials` explicitly (a $ref for a named block, or
         # an empty dict for ambient auth). Setting it on every run clears any
         # stale credential reference from a prior --aws-credentials-block-name
@@ -1518,7 +1518,7 @@ async def storage_configure_gcs(
                     " --gcp-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
         # Always set `gcp_credentials` explicitly (a $ref for a named block,
         # or an empty dict for ambient auth). Setting it on every run clears
         # any stale credential reference from a prior
@@ -1652,7 +1652,7 @@ async def storage_configure_azure_blob_storage(
                 " `prefect block create azure-blob-storage-credentials`."
             )
 
-        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
         block_data = {
             "container_name": container,
             "credentials": {

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -11,7 +11,7 @@ import pytest
 import readchar
 
 from prefect import flow as flow_decorator
-from prefect.cli.work_pool import work_pool_storage_configure_app
+from prefect.cli.work_pool import _result_storage_block_name, work_pool_storage_configure_app
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import (
     BlockSchemaCreate,
@@ -1304,7 +1304,7 @@ class TestStorageConfigure:
                 }
             }
             block_document = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="s3-bucket",
             )
             assert block_document.data == {
@@ -1689,7 +1689,7 @@ class TestStorageConfigure:
                 }
             }
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="s3-bucket",
             )
             assert storage.data == {
@@ -1726,7 +1726,7 @@ class TestStorageConfigure:
                 expected_code=0,
             )
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="s3-bucket",
             )
             assert storage.data["credentials"] == aws_credentials.data
@@ -1747,7 +1747,7 @@ class TestStorageConfigure:
             )
 
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="s3-bucket",
             )
             assert storage.data["credentials"] == {}
@@ -1801,7 +1801,7 @@ class TestStorageConfigure:
                 ],
             )
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="s3-bucket",
             )
             assert storage.data["credentials"] == aws_credentials.data
@@ -1834,7 +1834,7 @@ class TestStorageConfigure:
                 ],
             )
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="s3-bucket",
             )
             assert storage.data["credentials"] == {}
@@ -1884,7 +1884,7 @@ class TestStorageConfigure:
                 }
             }
             block_document = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="gcs-bucket",
             )
             assert block_document.data == {
@@ -1991,7 +1991,7 @@ class TestStorageConfigure:
                 }
             }
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="gcs-bucket",
             )
             assert storage.data == {
@@ -2028,7 +2028,7 @@ class TestStorageConfigure:
                 expected_code=0,
             )
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="gcs-bucket",
             )
             assert storage.data["gcp_credentials"] == gcs_credentials.data
@@ -2049,7 +2049,7 @@ class TestStorageConfigure:
             )
 
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="gcs-bucket",
             )
             assert storage.data["gcp_credentials"] == {}
@@ -2103,7 +2103,7 @@ class TestStorageConfigure:
                 ],
             )
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="gcs-bucket",
             )
             assert storage.data["gcp_credentials"] == gcs_credentials.data
@@ -2136,7 +2136,7 @@ class TestStorageConfigure:
                 ],
             )
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="gcs-bucket",
             )
             assert storage.data["gcp_credentials"] == {}
@@ -2186,7 +2186,7 @@ class TestStorageConfigure:
                 }
             }
             block_document = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="azure-blob-storage-container",
             )
             assert block_document.data == {
@@ -2271,7 +2271,7 @@ class TestStorageConfigure:
 
             # Simulate a user adding base_folder to the auto-created block.
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="azure-blob-storage-container",
             )
             await prefect_client.update_block_document(
@@ -2288,7 +2288,7 @@ class TestStorageConfigure:
             )
 
             storage = await prefect_client.read_block_document_by_name(
-                name=f"default-{work_pool.name}-result-storage",
+                name=_result_storage_block_name(work_pool.name),
                 block_type_slug="azure-blob-storage-container",
             )
             assert storage.data["base_folder"] == "custom/prefix"

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -11,7 +11,10 @@ import pytest
 import readchar
 
 from prefect import flow as flow_decorator
-from prefect.cli.work_pool import _result_storage_block_name, work_pool_storage_configure_app
+from prefect.cli.work_pool import (
+    _result_storage_block_name,
+    work_pool_storage_configure_app,
+)
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import (
     BlockSchemaCreate,


### PR DESCRIPTION
## Summary

Fixes #22143.

Block document names must be lowercase. The three `work-pool storage
configure` sub-commands (s3, gcs, azure-blob-storage) all derive the
result-storage block document name as:

```python
result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
```

When `work_pool_name` contains uppercase letters the derived name fails
server-side validation, surfacing as an unhelpful error to the user.

## Fix

Apply `.lower()` to the `work_pool_name` component of the block document
name in all three storage configure commands.

```python
result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
```

The work pool itself is looked up by its original name (unchanged), so
pools with uppercase names continue to work. Only the derived block
document name is lowercased.

## Test plan

- [ ] `prefect work-pool create "MyPool" --type process`
- [ ] `prefect work-pool storage configure s3 MyPool --bucket my-bucket` → should succeed
- [ ] Verify block document created as `default-mypool-result-storage`
- [ ] Re-run the command → should update, not create duplicate