### PR TITLE
fix: route events through trigger evaluation in EventsPipeline (#21932)

### DIFF
--- a/src/prefect/server/events/pipeline.py
+++ b/src/prefect/server/events/pipeline.py
@@ -1,3 +1,5 @@
+from prefect.server.events import triggers
+from prefect.server.events.ordering import EventArrivedEarly
 from prefect.server.events.schemas.events import Event, ReceivedEvent
 from prefect.server.events.services import event_persister
 from prefect.server.services import task_run_recorder
@@ -18,6 +20,7 @@ class EventsPipeline:
         return messages
 
     async def process_events(self, events: list[Event]) -> None:
+        await triggers.reconcile_automations()
         messages = self.events_to_messages(events)
         await self.process_messages(messages)
 
@@ -28,7 +31,6 @@ class EventsPipeline:
     async def process_message(self, message: MemoryMessage) -> None:
         """Process a single event message"""
 
-        # TODO: Investigate if we want to include triggers/actions etc.
         async with task_run_recorder.consumer(
             write_batch_size=1, flush_every=1
         ) as handler:
@@ -36,3 +38,12 @@ class EventsPipeline:
 
         async with event_persister.create_handler(batch_size=1) as handler:
             await handler(message)
+
+        if message.attributes.get("event") == "prefect.log.write":
+            return
+
+        event = ReceivedEvent.model_validate_json(message.data)
+        try:
+            await triggers.reactive_evaluation(event)
+        except EventArrivedEarly:
+            pass

--- a/tests/events/server/triggers/test_regressions.py
+++ b/tests/events/server/triggers/test_regressions.py
@@ -1,7 +1,8 @@
 import asyncio
 import random
+from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Callable, List, Union
+from typing import AsyncGenerator, Callable, List, Union
 from unittest import mock
 from uuid import UUID, uuid4
 
@@ -10,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.events import actions, triggers
 from prefect.server.events.models import automations
+from prefect.server.events.pipeline import EventsPipeline
 from prefect.server.events.schemas.automations import (
     Automation,
     EventTrigger,
@@ -978,3 +980,84 @@ async def test_same_event_in_expect_and_after_proactively_fires_with_for_each_th
                     id=uuid4(),
                 ).receive()
             )
+
+
+async def test_zombie_flow_detection_does_not_fire_when_flow_completes(
+    act: mock.AsyncMock,
+    frozen_time: DateTime,
+    zombie_flow_detection_automation: Automation,
+):
+    assert isinstance(zombie_flow_detection_automation.trigger, EventTrigger)
+    flow_run_id = uuid4()
+    heartbeat = Event(
+        occurred=frozen_time,
+        event="prefect.flow-run.heartbeat",
+        resource={"prefect.resource.id": f"prefect.flow-run.{flow_run_id}"},
+        id=uuid4(),
+    ).receive()
+    completed = Event(
+        occurred=frozen_time + timedelta(seconds=30),
+        event="prefect.flow-run.Completed",
+        resource={"prefect.resource.id": f"prefect.flow-run.{flow_run_id}"},
+        id=uuid4(),
+    ).receive()
+
+    await triggers.reactive_evaluation(heartbeat)
+    await triggers.reactive_evaluation(completed)
+    act.assert_not_awaited()
+
+    await triggers.proactive_evaluation(
+        zombie_flow_detection_automation.trigger,
+        frozen_time + timedelta(seconds=121),
+    )
+
+    act.assert_not_awaited()
+
+
+async def test_events_pipeline_routes_events_to_trigger_evaluation(
+    act: mock.AsyncMock,
+    frozen_time: DateTime,
+    zombie_flow_detection_automation: Automation,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    assert isinstance(zombie_flow_detection_automation.trigger, EventTrigger)
+
+    @asynccontextmanager
+    async def noop_consumer(**kwargs) -> AsyncGenerator:
+        async def handler(message):
+            pass
+
+        yield handler
+
+    @asynccontextmanager
+    async def noop_handler(**kwargs) -> AsyncGenerator:
+        async def handler(message):
+            pass
+
+        yield handler
+
+    monkeypatch.setattr(
+        "prefect.server.services.task_run_recorder.consumer", noop_consumer
+    )
+    monkeypatch.setattr(
+        "prefect.server.events.services.event_persister.create_handler", noop_handler
+    )
+
+    flow_run_id = uuid4()
+    heartbeat = Event(
+        occurred=frozen_time,
+        event="prefect.flow-run.heartbeat",
+        resource={"prefect.resource.id": f"prefect.flow-run.{flow_run_id}"},
+        id=uuid4(),
+    )
+
+    pipeline = EventsPipeline()
+    await pipeline.process_events([heartbeat])
+    act.assert_not_awaited()
+
+    await triggers.proactive_evaluation(
+        zombie_flow_detection_automation.trigger,
+        frozen_time + timedelta(seconds=121),
+    )
+
+    act.assert_awaited_once()


### PR DESCRIPTION
In ephemeral server mode (the default for local development when no `PREFECT_API_URL` is set), all events sent to the `/api/events` endpoint are processed through `EventsPipeline`. However, `EventsPipeline.process_message()` only routed events to `task_run_recorder` and `event_persister` — there was an explicit `# TODO: Investigate if we want to include triggers/actions etc.` comment acknowledging this gap.

This means that in ephemeral mode, **no automation trigger evaluation ever happened** for any event. Proactive automations like the zombie-detection pattern would always fire their timeouts because events like `prefect.flow-run.Completed` were persisted to the event log but never seen by `reactive_evaluation`.

## Changes

- `src/prefect/server/events/pipeline.py`: 
  - Add `triggers.reconcile_automations()` in `process_events` to load automation state from the DB once per batch (uses internal snapshot caching, cheap if nothing changed)
  - Add `triggers.reactive_evaluation(event)` routing in `process_message`, skipping `prefect.log.write` events and catching `EventArrivedEarly` (matching the behaviour of `triggers.consumer()`)
  - Remove the TODO comment

- `tests/events/server/triggers/test_regressions.py`:
  - `test_zombie_flow_detection_does_not_fire_when_flow_completes`: verifies the automation stays quiet when a `prefect.flow-run.Completed` event arrives within the window
  - `test_events_pipeline_routes_events_to_trigger_evaluation`: verifies `EventsPipeline` now drives trigger evaluation end-to-end

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - Closes #21932
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes