### PR TITLE
security: enable SSRF webhook protections by default

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -113,8 +113,8 @@ class AppriseNotificationBlock(AbstractAppriseNotificationBlock, ABC):
         examples=["https://hooks.example.com/XXX"],
     )
     allow_private_urls: bool = Field(
-        default=True,
-        description="Whether to allow notifications to private URLs. Defaults to True.",
+        default=False,
+        description="Whether to allow notifications to private URLs. Defaults to False.",
     )
 
     async def anotify(
@@ -942,8 +942,8 @@ class CustomWebhookNotificationBlock(NotificationBlock):
     )
 
     allow_private_urls: bool = Field(
-        default=True,
-        description="Whether to allow notifications to private URLs. Defaults to True.",
+        default=False,
+        description="Whether to allow notifications to private URLs. Defaults to False.",
     )
 
     secrets: SecretDict = Field(

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -53,8 +53,8 @@ class Webhook(Block):
         description="A dictionary of headers to send with the webhook request.",
     )
     allow_private_urls: bool = Field(
-        default=True,
-        description="Whether to allow notifications to private URLs. Defaults to True.",
+        default=False,
+        description="Whether to allow notifications to private URLs. Defaults to False.",
     )
     verify: bool = Field(
         default=True,

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -1200,7 +1200,7 @@ class TestMicrosoftTeamsWebhook:
             apprise_instance_mock = AppriseMock.return_value
             apprise_instance_mock.async_notify = AsyncMock()
 
-            block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL)
+            block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL, allow_private_urls=True)
             await block.notify("test")
 
             AppriseMock.assert_called_once()
@@ -1218,7 +1218,7 @@ class TestMicrosoftTeamsWebhook:
             apprise_instance_mock = AppriseMock.return_value
             apprise_instance_mock.notify = MagicMock(return_value=True)
 
-            block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL)
+            block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL, allow_private_urls=True)
 
             @flow
             def test_flow():

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -1016,13 +1016,23 @@ class TestCustomWebhookRestrictedUrls:
         with pytest.raises(ValueError, match=f"is not a valid URL.*{reason}"):
             await block.notify(subject="test", body="test")
 
-    async def test_allows_private_urls_by_default(self):
+    async def test_rejects_private_urls_by_default(self):
+        block = CustomWebhookNotificationBlock(
+            name="test",
+            url="https://127.0.0.1/webhook",
+            json_data={"msg": "{{body}}"},
+        )
+        with pytest.raises(ValueError, match="is not a valid URL.*private address"):
+            await block.notify(subject="test", body="test")
+
+    async def test_allows_private_urls_when_enabled(self):
         with respx.mock(using="httpx") as xmock:
             xmock.post("https://127.0.0.1/webhook")
             block = CustomWebhookNotificationBlock(
                 name="test",
                 url="https://127.0.0.1/webhook",
                 json_data={"msg": "{{body}}"},
+                allow_private_urls=True,
             )
             await block.notify(subject="test", body="test")
             assert xmock.calls.call_count == 1

--- a/tests/blocks/test_webhook.py
+++ b/tests/blocks/test_webhook.py
@@ -92,9 +92,9 @@ class TestWebhook:
         send_mock = AsyncMock()
         monkeypatch.setattr("httpx.AsyncClient.request", send_mock)
 
-        await Webhook(
-            url="https://169.254.169.254", allow_private_urls=True
-        ).call(payload="some payload")
+        await Webhook(url="https://169.254.169.254", allow_private_urls=True).call(
+            payload="some payload"
+        )
 
         send_mock.assert_called_once()
 

--- a/tests/blocks/test_webhook.py
+++ b/tests/blocks/test_webhook.py
@@ -82,6 +82,22 @@ class TestWebhook:
         with pytest.raises(ValueError, match=f"is not a valid URL.*{reason}"):
             await insecure_webhook.call(payload="some payload")
 
+    async def test_webhook_rejects_restricted_urls_by_default(self):
+        webhook = Webhook(url="https://169.254.169.254")
+
+        with pytest.raises(ValueError, match="is not a valid URL.*private address"):
+            await webhook.call(payload="some payload")
+
+    async def test_webhook_can_opt_in_to_private_urls(self, monkeypatch):
+        send_mock = AsyncMock()
+        monkeypatch.setattr("httpx.AsyncClient.request", send_mock)
+
+        await Webhook(
+            url="https://169.254.169.254", allow_private_urls=True
+        ).call(payload="some payload")
+
+        send_mock.assert_called_once()
+
     async def test_webhook_sends(self, monkeypatch):
         send_mock = AsyncMock()
         monkeypatch.setattr("httpx.AsyncClient.request", send_mock)


### PR DESCRIPTION
<!-- Include an overview of the proposed changes here -->
This changes the default for `Webhook` and `CustomWebhookNotificationBlock` so private/internal URL destinations are blocked unless the operator explicitly sets `allow_private_urls=True`.

Prefect already has restricted-URL validation and DNS-rebinding protected HTTP transports; this PR keeps those protections active by default for generic webhook blocks. That avoids accidental SSRF exposure to loopback, RFC1918, and link-local metadata endpoints from saved webhook configuration.

Validation:

```text
PYTHONPATH=src python -m pytest tests/blocks/test_notifications.py::TestCustomWebhookRestrictedUrls::test_rejects_private_urls_by_default tests/blocks/test_notifications.py::TestCustomWebhookRestrictedUrls::test_allows_private_urls_when_enabled tests/blocks/test_webhook.py::TestWebhook::test_webhook_rejects_restricted_urls_by_default tests/blocks/test_webhook.py::TestWebhook::test_webhook_can_opt_in_to_private_urls -q
4 passed

python -m py_compile src\prefect\blocks\notifications.py tests\blocks\test_notifications.py tests\blocks\test_webhook.py
git diff --check
```

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - Security hardening change; no public issue opened to avoid unnecessary disclosure.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
  - Not applicable; no docs files removed.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
  - Not applicable; no functions/classes added.
