### PR TITLE
fix(_config): prevent ValueError on multi-slash deploy names

### DIFF
--- a/src/prefect/cli/deploy/_config.py
+++ b/src/prefect/cli/deploy/_config.py
@@ -355,7 +355,7 @@ def _filter_matching_deploy_config(
 ) -> list[dict[str, Any]]:
     matching_deployments: list[dict[str, Any]] = []
     if "/" in name:
-        flow_name, deployment_name = name.split("/")
+        flow_name, deployment_name = name.split("/", 1)
         flow_name = flow_name.replace("-", "_")
         matching_deployments = [
             deploy_config

--- a/tests/cli/deploy/test_config.py
+++ b/tests/cli/deploy/test_config.py
@@ -1,0 +1,12 @@
+"""Tests for helper functions in prefect.cli.deploy._config."""
+
+import pytest
+
+from prefect.cli.deploy._config import _filter_matching_deploy_config
+
+
+def test_filter_matching_deploy_config_multiple_slashes_no_valueerror():
+    """Name with multiple slashes must not raise ValueError on unpack."""
+    deploy_configs = [{"name": "deployment", "entrypoint": "path.py:flow"}]
+    result = _filter_matching_deploy_config("flow/extra/deployment", deploy_configs)
+    assert isinstance(result, list)


### PR DESCRIPTION
## What's broken

`_filter_matching_deploy_config` at line 358 of `src/prefect/cli/deploy/_config.py` does `flow_name, deployment_name = name.split("/")`. When a user runs `prefect deploy -n flow/extra/deployment`, the split returns 3 parts and Python raises `ValueError: too many values to unpack (expected 2)`. The guard on line 357 checks only that a slash is present, not that there is exactly one.

## Why it happens

The `str.split` call has no `maxsplit` argument, so inputs with multiple slashes produce more values than the 2-variable unpack can accept.

## Fix

Changed `name.split("/")` to `name.split("/", 1)` so at most 2 parts are produced. The first part becomes `flow_name` and everything after the first slash becomes `deployment_name`.

## Test

Added `test_filter_matching_deploy_config_multiple_slashes_no_valueerror` in `tests/cli/deploy/test_config.py` which passes a three-segment name and asserts no exception is raised.

Fixes #22171