### PR TITLE
fix(cli): lowercase work pool name in result storage block document name

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -1379,7 +1379,9 @@ async def storage_configure_s3(
                     " --aws-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
+        result_storage_block_document_name = (
+            f"default-{work_pool_name.lower()}-result-storage"
+        )
         # Always set `credentials` explicitly (a $ref for a named block, or
         # an empty dict for ambient auth). Setting it on every run clears any
         # stale credential reference from a prior --aws-credentials-block-name
@@ -1518,7 +1520,9 @@ async def storage_configure_gcs(
                     " --gcp-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
+        result_storage_block_document_name = (
+            f"default-{work_pool_name.lower()}-result-storage"
+        )
         # Always set `gcp_credentials` explicitly (a $ref for a named block,
         # or an empty dict for ambient auth). Setting it on every run clears
         # any stale credential reference from a prior
@@ -1652,7 +1656,9 @@ async def storage_configure_azure_blob_storage(
                 " `prefect block create azure-blob-storage-credentials`."
             )
 
-        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
+        result_storage_block_document_name = (
+            f"default-{work_pool_name.lower()}-result-storage"
+        )
         block_data = {
             "container_name": container,
             "credentials": {

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -1379,7 +1379,7 @@ async def storage_configure_s3(
                     " --aws-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
         # Always set `credentials` explicitly (a $ref for a named block, or
         # an empty dict for ambient auth). Setting it on every run clears any
         # stale credential reference from a prior --aws-credentials-block-name
@@ -1518,7 +1518,7 @@ async def storage_configure_gcs(
                     " --gcp-credentials-block-name to use default credentials."
                 )
 
-        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
         # Always set `gcp_credentials` explicitly (a $ref for a named block,
         # or an empty dict for ambient auth). Setting it on every run clears
         # any stale credential reference from a prior
@@ -1652,7 +1652,7 @@ async def storage_configure_azure_blob_storage(
                 " `prefect block create azure-blob-storage-credentials`."
             )
 
-        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        result_storage_block_document_name = f"default-{work_pool_name.lower()}-result-storage"
         block_data = {
             "container_name": container,
             "credentials": {


### PR DESCRIPTION
## Changes

Block document names must only contain lowercase letters, numbers, and dashes. When a work pool name contains uppercase characters (e.g. \ECS-Push-OIDC\), the constructed block document name would fail validation with a pydantic error.

Fix by lowercasing the work pool name in all three storage backends (S3, GCS, Azure) when constructing the \esult_storage_block_document_name\.

### Affected code paths
- \storage_configure_s3\ — \src/prefect/cli/work_pool.py:1382\
- \storage_configure_gcs\ — \src/prefect/cli/work_pool.py:1521\
- \storage_configure_azure_blob_storage\ — \src/prefect/cli/work_pool.py:1655\

Closes #22143