### PR TITLE
Surface sanitized git clone stderr

### DIFF
--- a/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
+++ b/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
@@ -47,6 +47,7 @@ from pydantic import Field, model_validator
 from typing_extensions import Self
 
 from prefect._internal.compatibility.async_dispatch import async_dispatch
+from prefect._internal.urls import strip_auth_from_urls_in_text
 from prefect.exceptions import InvalidRepositoryURLError
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.processutils import run_process
@@ -188,7 +189,8 @@ class BitBucketRepository(ReadableDeploymentStorage):
             process = await run_process(cmd, stream_output=(out_stream, err_stream))
             if process.returncode != 0:
                 err_stream.seek(0)
-                raise OSError(f"Failed to pull from remote:\n {err_stream.read()}")
+                sanitized_error = strip_auth_from_urls_in_text(err_stream.read())
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path
@@ -221,7 +223,8 @@ class BitBucketRepository(ReadableDeploymentStorage):
 
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                raise OSError(f"Failed to pull from remote:\n {result.stderr}")
+                sanitized_error = strip_auth_from_urls_in_text(result.stderr)
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.7.3",
+  "prefect>=3.7.4",
   "pydantic>=2.4",
   "atlassian-python-api>=3.32.1,!=3.41.5,!=3.41.6,!=3.41.7,!=3.41.8",
 ]

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.6.17",
+  "prefect>=3.7.3",
   "pydantic>=2.4",
   "atlassian-python-api>=3.32.1,!=3.41.5,!=3.41.6,!=3.41.7,!=3.41.8",
 ]

--- a/src/integrations/prefect-bitbucket/tests/test_repository.py
+++ b/src/integrations/prefect-bitbucket/tests/test_repository.py
@@ -180,6 +180,35 @@ class TestBitBucketRepository:
         ]
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
+    async def test_get_directory_redacts_token_in_clone_error(self, monkeypatch):
+        class p:
+            returncode = 1
+
+        async def mock(cmd, stream_output=None, **kwargs):
+            if stream_output:
+                _, err_stream = stream_output
+                err_stream.write(
+                    "fatal: Authentication failed for "
+                    "'https://dev:p@ss:word#1@bitbucket.org/PrefectHQ/prefect.git/'"
+                )
+            return p()
+
+        monkeypatch.setattr(prefect_bitbucket.repository, "run_process", mock)
+
+        b = BitBucketRepository(
+            repository="https://bitbucket.org/PrefectHQ/prefect.git",
+            bitbucket_credentials=BitBucketCredentials(
+                token="p@ss:word#1", username="dev"
+            ),
+        )
+
+        with pytest.raises(OSError) as exc_info:
+            await b.get_directory()
+
+        message = str(exc_info.value)
+        assert "dev:p@ss:word#1" not in message
+        assert "https://bitbucket.org/PrefectHQ/prefect.git/" in message
+
     async def test_ssh_fails_with_credential(self, monkeypatch):
         """Ensure that credentials cannot be passed in if the URL is not in the HTTPS
         format.

--- a/src/integrations/prefect-github/prefect_github/repository.py
+++ b/src/integrations/prefect-github/prefect_github/repository.py
@@ -8,7 +8,6 @@ GitHub query_repository* tasks and the GitHub storage block.
 # is outdated, rerun scripts/generate.py.
 
 import io
-import re
 import shutil
 import subprocess
 from datetime import datetime
@@ -22,7 +21,7 @@ from sgqlc.operation import Operation
 
 from prefect import task
 from prefect._internal.compatibility.async_dispatch import async_dispatch
-from prefect._internal.urls import strip_auth_from_url
+from prefect._internal.urls import strip_auth_from_urls_in_text
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.processutils import run_process
 from prefect_github import GitHubCredentials
@@ -32,15 +31,6 @@ from prefect_github.utils import initialize_return_fields_defaults, strip_kwargs
 
 config_path = Path(__file__).parent.resolve() / "configs" / "query" / "repository.json"
 return_fields_defaults = initialize_return_fields_defaults(config_path)
-
-_URL_PATTERN = re.compile(r"https?://[^\s'\"<>]+")
-
-
-def _sanitize_git_error(message: str) -> str:
-    def _replace(match: re.Match[str]) -> str:
-        return strip_auth_from_url(match.group(0))
-
-    return _URL_PATTERN.sub(_replace, message)
 
 
 class GitHubRepository(ReadableDeploymentStorage):
@@ -138,7 +128,7 @@ class GitHubRepository(ReadableDeploymentStorage):
             process = await run_process(cmd, stream_output=(out_stream, err_stream))
             if process.returncode != 0:
                 err_stream.seek(0)
-                sanitized_error = _sanitize_git_error(err_stream.read())
+                sanitized_error = strip_auth_from_urls_in_text(err_stream.read())
                 raise RuntimeError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
@@ -178,7 +168,7 @@ class GitHubRepository(ReadableDeploymentStorage):
 
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                sanitized_error = _sanitize_git_error(result.stderr)
+                sanitized_error = strip_auth_from_urls_in_text(result.stderr)
                 raise RuntimeError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-github"
-dependencies = ["sgqlc>=15.0", "prefect>=3.7.3"]
+dependencies = ["sgqlc>=15.0", "prefect>=3.7.4"]
 dynamic = ["version"]
 description = "Prefect integrations interacting with GitHub"
 readme = "README.md"

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-github"
-dependencies = ["sgqlc>=15.0", "prefect>=3.6.17"]
+dependencies = ["sgqlc>=15.0", "prefect>=3.7.3"]
 dynamic = ["version"]
 description = "Prefect integrations interacting with GitHub"
 readme = "README.md"

--- a/src/integrations/prefect-gitlab/prefect_gitlab/repositories.py
+++ b/src/integrations/prefect-gitlab/prefect_gitlab/repositories.py
@@ -53,6 +53,7 @@ from pydantic import Field
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 from prefect._internal.compatibility.async_dispatch import async_dispatch
+from prefect._internal.urls import strip_auth_from_urls_in_text
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.processutils import run_process
 from prefect_gitlab.credentials import GitLabCredentials
@@ -176,7 +177,8 @@ class GitLabRepository(ReadableDeploymentStorage):
             process = await run_process(cmd, stream_output=(out_stream, err_stream))
             if process.returncode != 0:
                 err_stream.seek(0)
-                raise OSError(f"Failed to pull from remote:\n {err_stream.read()}")
+                sanitized_error = strip_auth_from_urls_in_text(err_stream.read())
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path
@@ -221,7 +223,8 @@ class GitLabRepository(ReadableDeploymentStorage):
 
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                raise OSError(f"Failed to pull from remote:\n {result.stderr}")
+                sanitized_error = strip_auth_from_urls_in_text(result.stderr)
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["prefect>=3.7.3", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
+dependencies = ["prefect>=3.7.4", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
 dynamic = ["version"]
 
 [dependency-groups]

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["prefect>=3.6.17", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
+dependencies = ["prefect>=3.7.3", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
 dynamic = ["version"]
 
 [dependency-groups]

--- a/src/integrations/prefect-gitlab/tests/test_repositories.py
+++ b/src/integrations/prefect-gitlab/tests/test_repositories.py
@@ -139,6 +139,33 @@ class TestGitLab:
         ]
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
+    async def test_get_directory_redacts_token_in_clone_error(self, monkeypatch):
+        class p:
+            returncode = 1
+
+        async def mock(cmd, stream_output=None, **kwargs):
+            if stream_output:
+                _, err_stream = stream_output
+                err_stream.write(
+                    "fatal: Authentication failed for "
+                    "'https://oauth2:p@ss:word#1@gitlab.com/PrefectHQ/prefect.git/'"
+                )
+            return p()
+
+        monkeypatch.setattr(prefect_gitlab.repositories, "run_process", mock)
+
+        g = GitLabRepository(
+            repository="https://gitlab.com/PrefectHQ/prefect.git",
+            credentials=GitLabCredentials(token=SecretStr("p@ss:word#1")),
+        )
+
+        with pytest.raises(OSError) as exc_info:
+            await g.get_directory()
+
+        message = str(exc_info.value)
+        assert "p@ss:word#1" not in message
+        assert "https://gitlab.com/PrefectHQ/prefect.git/" in message
+
     async def test_cloning_with_custom_depth(self, monkeypatch):
         """Ensure that we can retrieve the whole history, i.e. support true git clone"""  # noqa: E501
 

--- a/src/prefect/_internal/urls.py
+++ b/src/prefect/_internal/urls.py
@@ -1,4 +1,10 @@
+import re
+from collections.abc import Iterable
 from urllib.parse import urlparse, urlunparse
+
+_URL_AUTH_PATTERN = re.compile(
+    r"(?P<scheme>https?://)[^/\s'\"<>]*@", flags=re.IGNORECASE
+)
 
 
 def strip_auth_from_url(url: str) -> str:
@@ -8,22 +14,44 @@ def strip_auth_from_url(url: str) -> str:
     Useful for sanitizing URLs before including them in error messages
     or logs to avoid leaking secrets.
     """
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
 
-    if not parsed.hostname:
-        return url
+        if not parsed.hostname:
+            return url
 
-    netloc = parsed.hostname
-    if parsed.port:
-        netloc = f"{netloc}:{parsed.port}"
+        netloc = parsed.hostname
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
 
-    return urlunparse(
-        (
-            parsed.scheme,
-            netloc,
-            parsed.path,
-            parsed.params,
-            parsed.query,
-            parsed.fragment,
+        return urlunparse(
+            (
+                parsed.scheme,
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
         )
-    )
+    except ValueError:
+        return strip_auth_from_urls_in_text(url)
+
+
+def strip_auth_from_urls_in_text(
+    text: str, extra_secrets: Iterable[str] | None = None
+) -> str:
+    """
+    Remove authentication credentials from HTTP(S) URLs embedded in text.
+
+    Useful for sanitizing command output before including it in error messages
+    or logs. Any caller-supplied secrets are replaced with a redaction marker.
+    """
+    if not text:
+        return text
+
+    sanitized = _URL_AUTH_PATTERN.sub(r"\g<scheme>", text)
+    for secret in extra_secrets or ():
+        if secret:
+            sanitized = sanitized.replace(secret, "***")
+    return sanitized

--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -499,6 +499,21 @@ class GitRepository:
                 else exc
             )
             safe_url = strip_auth_from_url(self._url)
+            sanitized_stderr = _sanitize_git_output(
+                _decode_stderr(exc),
+                extra_secrets=[parsed_url.password] if parsed_url.password else None,
+            )
+            # Surface the raw git error at DEBUG so users can opt in via log
+            # level when the hint patterns don't match. The exception chain is
+            # suppressed above when credentials are present, so DEBUG is the
+            # only way to see the actual git output in that case.
+            if sanitized_stderr:
+                self._logger.debug(
+                    "git clone failed (exit %d) for %r: %s",
+                    exc.returncode,
+                    safe_url,
+                    sanitized_stderr.strip(),
+                )
             error_message = (
                 f"Failed to clone repository {safe_url!r} with exit code"
                 f" {exc.returncode}."
@@ -506,6 +521,14 @@ class GitRepository:
             hint = _get_git_clone_error_hint(exc)
             if hint:
                 error_message += f" {hint}"
+            elif sanitized_stderr:
+                # No pattern matched -- surface the actual git error so the
+                # user doesn't have to enable DEBUG to know what went wrong.
+                snippet = sanitized_stderr.strip().splitlines()
+                # Keep the last few lines; git's final 'fatal:' line is usually
+                # the actionable one.
+                tail = " | ".join(snippet[-3:])
+                error_message += f" git stderr: {tail}"
             raise RuntimeError(error_message) from exc_chain
 
         if self._commit_sha:
@@ -985,15 +1008,41 @@ _GIT_CLONE_ERROR_HINTS: list[tuple[str, str]] = [
 ]
 
 
+def _decode_stderr(exc: subprocess.CalledProcessError) -> str:
+    """Decode a CalledProcessError's stderr to text, tolerating bytes/None."""
+    if not exc.stderr:
+        return ""
+    if isinstance(exc.stderr, bytes):
+        return exc.stderr.decode("utf-8", errors="replace")
+    return str(exc.stderr)
+
+
+# Match inline basic-auth creds in URLs (e.g. https://user:token@host/...).
+# The replacement preserves the scheme and host so sanitized output is still
+# readable, but scrubs anything between `://` and the last `@` before the host.
+_URL_AUTH_PATTERN = re.compile(r"(?P<scheme>https?://)[^/\s@]+@", flags=re.IGNORECASE)
+
+
+def _sanitize_git_output(text: str, extra_secrets: Optional[list[str]] = None) -> str:
+    """Strip embedded credentials and caller-supplied secrets from git output.
+
+    Git writes the clone URL back to stderr in many failure modes (e.g. "fatal:
+    could not read Username for 'https://token@github.com'"), so we sanitize
+    before logging or surfacing in error messages. Returns `text` unchanged if
+    nothing needs scrubbing.
+    """
+    if not text:
+        return text
+    sanitized = _URL_AUTH_PATTERN.sub(r"\g<scheme>", text)
+    for secret in extra_secrets or ():
+        if secret:
+            sanitized = sanitized.replace(secret, "***")
+    return sanitized
+
+
 def _get_git_clone_error_hint(exc: subprocess.CalledProcessError) -> str | None:
     """Extract a resolution hint from a git clone CalledProcessError's stderr."""
-    stderr = ""
-    if exc.stderr:
-        stderr = (
-            exc.stderr.decode("utf-8", errors="replace")
-            if isinstance(exc.stderr, bytes)
-            else str(exc.stderr)
-        )
+    stderr = _decode_stderr(exc)
     for pattern, hint in _GIT_CLONE_ERROR_HINTS:
         if pattern.lower() in stderr.lower():
             return hint

--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -22,7 +22,7 @@ from anyio import run_process
 from pydantic import SecretStr
 
 from prefect._internal.concurrency.api import create_call, from_async
-from prefect._internal.urls import strip_auth_from_url
+from prefect._internal.urls import strip_auth_from_url, strip_auth_from_urls_in_text
 from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
@@ -499,7 +499,7 @@ class GitRepository:
                 else exc
             )
             safe_url = strip_auth_from_url(self._url)
-            sanitized_stderr = _sanitize_git_output(
+            sanitized_stderr = strip_auth_from_urls_in_text(
                 _decode_stderr(exc),
                 extra_secrets=[parsed_url.password] if parsed_url.password else None,
             )
@@ -1015,29 +1015,6 @@ def _decode_stderr(exc: subprocess.CalledProcessError) -> str:
     if isinstance(exc.stderr, bytes):
         return exc.stderr.decode("utf-8", errors="replace")
     return str(exc.stderr)
-
-
-# Match inline basic-auth creds in URLs (e.g. https://user:token@host/...).
-# The replacement preserves the scheme and host so sanitized output is still
-# readable, but scrubs anything between `://` and the last `@` before the host.
-_URL_AUTH_PATTERN = re.compile(r"(?P<scheme>https?://)[^/\s@]+@", flags=re.IGNORECASE)
-
-
-def _sanitize_git_output(text: str, extra_secrets: Optional[list[str]] = None) -> str:
-    """Strip embedded credentials and caller-supplied secrets from git output.
-
-    Git writes the clone URL back to stderr in many failure modes (e.g. "fatal:
-    could not read Username for 'https://token@github.com'"), so we sanitize
-    before logging or surfacing in error messages. Returns `text` unchanged if
-    nothing needs scrubbing.
-    """
-    if not text:
-        return text
-    sanitized = _URL_AUTH_PATTERN.sub(r"\g<scheme>", text)
-    for secret in extra_secrets or ():
-        if secret:
-            sanitized = sanitized.replace(secret, "***")
-    return sanitized
 
 
 def _get_git_clone_error_hint(exc: subprocess.CalledProcessError) -> str | None:

--- a/tests/_internal/test_urls.py
+++ b/tests/_internal/test_urls.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefect._internal.urls import strip_auth_from_url
+from prefect._internal.urls import strip_auth_from_url, strip_auth_from_urls_in_text
 
 
 @pytest.mark.parametrize(
@@ -48,3 +48,49 @@ from prefect._internal.urls import strip_auth_from_url
 )
 def test_strip_auth_from_url(url: str, expected: str):
     assert strip_auth_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (
+            "fatal: could not read Username for 'https://github.com'",
+            "fatal: could not read Username for 'https://github.com'",
+        ),
+        (
+            "fatal: unable to access 'https://ghp_abc123@github.com/org/repo.git/'",
+            "fatal: unable to access 'https://github.com/org/repo.git/'",
+        ),
+        (
+            "error for https://user:secret@gitlab.com/path and https://tok@example.com/x",
+            "error for https://gitlab.com/path and https://example.com/x",
+        ),
+        (
+            "fatal: Authentication failed for "
+            "'https://oauth2:p@ss:word#1@gitlab.com/PrefectHQ/prefect.git/'",
+            "fatal: Authentication failed for "
+            "'https://gitlab.com/PrefectHQ/prefect.git/'",
+        ),
+        ("", ""),
+        ("no urls here", "no urls here"),
+    ],
+)
+def test_strip_auth_from_urls_in_text(raw: str, expected: str):
+    assert strip_auth_from_urls_in_text(raw) == expected
+
+
+def test_strip_auth_from_urls_in_text_redacts_extra_secrets():
+    text = "remote: token=ghp_abc123 hit rate limit"
+    assert (
+        strip_auth_from_urls_in_text(text, extra_secrets=["ghp_abc123"])
+        == "remote: token=*** hit rate limit"
+    )
+
+
+def test_strip_auth_from_url_handles_malformed_credential_url():
+    assert (
+        strip_auth_from_url(
+            "https://oauth2:p@ss:word#1@gitlab.com/PrefectHQ/prefect.git/"
+        )
+        == "https://gitlab.com/PrefectHQ/prefect.git/"
+    )

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -24,7 +24,6 @@ from prefect.runner.storage import (
     RunnerStorage,
     _get_git_clone_error_hint,
     _get_remote_storage_error_hint,
-    _sanitize_git_output,
     create_storage_from_source,
 )
 from prefect.utilities.filesystem import tmpchdir
@@ -1342,35 +1341,6 @@ class TestGitCloneErrorHints:
         repo = GitRepository(url="https://github.com/org/repo.git")
         with pytest.raises(RuntimeError, match="credentials or access token"):
             await repo.pull_code()
-
-    @pytest.mark.parametrize(
-        "raw, expected",
-        [
-            (
-                "fatal: could not read Username for 'https://github.com'",
-                "fatal: could not read Username for 'https://github.com'",
-            ),
-            (
-                "fatal: unable to access 'https://ghp_abc123@github.com/org/repo.git/'",
-                "fatal: unable to access 'https://github.com/org/repo.git/'",
-            ),
-            (
-                "error for https://user:secret@gitlab.com/path and https://tok@example.com/x",
-                "error for https://gitlab.com/path and https://example.com/x",
-            ),
-            ("", ""),
-            ("no urls here", "no urls here"),
-        ],
-    )
-    def test_sanitize_git_output_strips_url_auth(self, raw, expected):
-        assert _sanitize_git_output(raw) == expected
-
-    def test_sanitize_git_output_redacts_extra_secrets(self):
-        text = "remote: token=ghp_abc123 hit rate limit"
-        assert (
-            _sanitize_git_output(text, extra_secrets=["ghp_abc123"])
-            == "remote: token=*** hit rate limit"
-        )
 
     async def test_clone_repo_surfaces_stderr_when_no_hint_matches(self, monkeypatch):
         """When git's stderr doesn't match any known pattern, the raw (sanitized)

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -24,6 +24,7 @@ from prefect.runner.storage import (
     RunnerStorage,
     _get_git_clone_error_hint,
     _get_remote_storage_error_hint,
+    _sanitize_git_output,
     create_storage_from_source,
 )
 from prefect.utilities.filesystem import tmpchdir
@@ -1341,6 +1342,104 @@ class TestGitCloneErrorHints:
         repo = GitRepository(url="https://github.com/org/repo.git")
         with pytest.raises(RuntimeError, match="credentials or access token"):
             await repo.pull_code()
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (
+                "fatal: could not read Username for 'https://github.com'",
+                "fatal: could not read Username for 'https://github.com'",
+            ),
+            (
+                "fatal: unable to access 'https://ghp_abc123@github.com/org/repo.git/'",
+                "fatal: unable to access 'https://github.com/org/repo.git/'",
+            ),
+            (
+                "error for https://user:secret@gitlab.com/path and https://tok@example.com/x",
+                "error for https://gitlab.com/path and https://example.com/x",
+            ),
+            ("", ""),
+            ("no urls here", "no urls here"),
+        ],
+    )
+    def test_sanitize_git_output_strips_url_auth(self, raw, expected):
+        assert _sanitize_git_output(raw) == expected
+
+    def test_sanitize_git_output_redacts_extra_secrets(self):
+        text = "remote: token=ghp_abc123 hit rate limit"
+        assert (
+            _sanitize_git_output(text, extra_secrets=["ghp_abc123"])
+            == "remote: token=*** hit rate limit"
+        )
+
+    async def test_clone_repo_surfaces_stderr_when_no_hint_matches(self, monkeypatch):
+        """When git's stderr doesn't match any known pattern, the raw (sanitized)
+        stderr should appear in the RuntimeError so users don't have to
+        monkey-patch Prefect to find out what actually went wrong.
+
+        Regression for private-repo clone failures in GCP Cloud Run Jobs where
+        users saw only `exit code 1.` with no further signal.
+        """
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+
+        stderr = (
+            b"remote: Counting objects: 100% (1/1), done.\n"
+            b"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly\n"
+            b"fatal: early EOF\n"
+        )
+
+        async def mock_run_process_transient(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, ["git", "clone"], stderr=stderr)
+
+        monkeypatch.setattr(
+            "prefect.runner.storage.run_process", mock_run_process_transient
+        )
+
+        repo = GitRepository(url="https://github.com/org/repo.git")
+        with pytest.raises(RuntimeError) as exc_info:
+            await repo.pull_code()
+
+        message = str(exc_info.value)
+        assert "exit code 1" in message
+        assert "git stderr:" in message
+        # The actionable final line should be visible to the user.
+        assert "early EOF" in message
+
+    async def test_clone_repo_logs_sanitized_stderr_at_debug(self, monkeypatch, caplog):
+        """Sanitized stderr should be emitted on the GitRepository debug logger
+        even when credentials are present (so the exception chain is suppressed)."""
+        import logging
+
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+
+        stderr = (
+            b"fatal: unable to access "
+            b"'https://ghp_SECRETTOKEN@github.com/org/repo.git/': HTTP/2 stream closed\n"
+        )
+
+        async def mock_run_process(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, ["git", "clone"], stderr=stderr)
+
+        monkeypatch.setattr("prefect.runner.storage.run_process", mock_run_process)
+
+        # Embed credentials directly in the URL so exc_chain is suppressed.
+        repo = GitRepository(url="https://ghp_SECRETTOKEN@github.com/org/repo.git")
+        with caplog.at_level(
+            logging.DEBUG, logger="prefect.runner.storage.git-repository.repo"
+        ):
+            with pytest.raises(RuntimeError):
+                await repo.pull_code()
+
+        debug_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+            and "git clone failed" in record.getMessage()
+        ]
+        assert debug_messages, "expected a DEBUG log with sanitized git stderr"
+        joined = "\n".join(debug_messages)
+        assert "ghp_SECRETTOKEN" not in joined, "token must be sanitized"
+        assert "github.com" in joined
 
 
 class TestGitRepositoryConcurrency:


### PR DESCRIPTION
Supersedes #21689 and covers the credential-redaction provider-block gap surfaced by #22174.

this PR revives the stale draft work to surface sanitized git clone stderr when no known hint pattern matches, then cleans it up so URL auth redaction is centralized instead of provider-local.

<details>
<summary>Changes</summary>

- add shared `strip_auth_from_urls_in_text` handling in `prefect._internal.urls`
- use the shared sanitizer in `GitRepository._clone_repo` before logging or surfacing git stderr
- keep showing a sanitized stderr tail when no known hint matches
- replace GitHub's local clone-error sanitizer with the shared helper
- apply the same shared sanitizer to GitHub, GitLab, and Bitbucket repository block clone errors
- bump `prefect-github`, `prefect-gitlab`, and `prefect-bitbucket` lower bounds to `prefect>=3.7.4` because `3.7.3` is already tagged and does not contain the new centralized utility
- add regression coverage for malformed credential URLs like `https://oauth2:p@ss:word#1@gitlab.com/...`

</details>

## Validation

- `uv run pytest tests/_internal/test_urls.py tests/runner/test_storage.py -q -k 'urls or git_clone_error_hint or clone_repo_surfaces_stderr_when_no_hint_matches or clone_repo_logs_sanitized_stderr_at_debug'`
- `uv run pytest tests/test_repositories.py -q -k redacts_token_in_clone_error` from `src/integrations/prefect-gitlab`
- `uv run pytest tests/test_repository.py -q -k redacts_token_in_clone_error` from `src/integrations/prefect-bitbucket`
- `uv run pytest tests/test_repository.py -q -k redacts_token_in_error` from `src/integrations/prefect-github`
- `uv run ruff check ...` on touched files
- `uv run ruff format --check ...` on touched files
- `uv run ruff format --check src/integrations/prefect-bitbucket/pyproject.toml src/integrations/prefect-github/pyproject.toml src/integrations/prefect-gitlab/pyproject.toml && uv run ruff check src/integrations/prefect-bitbucket/pyproject.toml src/integrations/prefect-github/pyproject.toml src/integrations/prefect-gitlab/pyproject.toml`