### PR TITLE
fix(pydantic): parse_obj_as() crashes with StopIteration on empty dict

### DIFF
--- a/src/prefect/utilities/pydantic.py
+++ b/src/prefect/utilities/pydantic.py
@@ -333,7 +333,8 @@ def parse_obj_as(
     origin: Optional[Any] = get_origin(type_)
     if origin is list and isinstance(data, dict):
         values_dict: dict[Any, Any] = data
-        data = next(iter(values_dict.values()))
+        if values_dict:
+            data = next(iter(values_dict.values()))
 
     parser: Callable[[Any], T] = getattr(adapter, f"validate_{mode}")
 

--- a/tests/utilities/test_pydantic.py
+++ b/tests/utilities/test_pydantic.py
@@ -3,13 +3,14 @@ from pathlib import Path
 
 import cloudpickle
 import pytest
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from prefect.utilities.dispatch import register_type
 from prefect.utilities.pydantic import (
     PartialModel,
     add_cloudpickle_reduction,
     get_class_fields_only,
+    parse_obj_as,
 )
 
 with warnings.catch_warnings():
@@ -203,3 +204,9 @@ class TestJsonPatch:
                 "additionalProperties": {"type": "string"},
             },
         }
+
+
+def test_parse_obj_as_list_with_empty_dict_raises_validation_error():
+    """parse_obj_as should raise ValidationError, not StopIteration, for empty dict."""
+    with pytest.raises(ValidationError):
+        parse_obj_as(list[str], {})


### PR DESCRIPTION
## What's broken

Calling `parse_obj_as(list[str], {})` raises `StopIteration` instead of a proper validation error. The function has a branch that handles `list` types with dict input by extracting the first dict value using `next(iter(values_dict.values()))`. When the dict is empty, `next()` raises `StopIteration` with no message, which bypasses callers that only catch `ValueError` or `TypeError`.

```
  File "src/prefect/utilities/pydantic.py", line 336, in parse_obj_as
    data = next(iter(values_dict.values()))
StopIteration
```

## Why it happens

`next()` on an empty iterator raises `StopIteration` unconditionally, and there was no empty-dict guard before the call.

## Fix

Added `if values_dict:` before the `next()` call so an empty dict falls through to the `TypeAdapter` validator, which raises a proper `ValidationError`.

## Test

Added `test_parse_obj_as_list_with_empty_dict_raises_validation_error` which confirms that passing an empty dict raises `ValidationError` rather than `StopIteration`.

Fixes #22187