### PR TITLE
docs: document flow_run_log_summary automation template variable

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -235,7 +235,8 @@
             "group": "AI",
             "pages": [
               "v3/how-to-guides/ai/index",
-              "v3/how-to-guides/ai/use-prefect-mcp-server"
+              "v3/how-to-guides/ai/use-prefect-mcp-server",
+              "v3/how-to-guides/ai/flow-run-log-summaries"
             ]
           },
           {

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -142,7 +142,7 @@ The `flow_run|ui_url` token returns the URL to view the flow run in the UI.
 
 <Note>The `flow_run_log_summary` variable is only available in Prefect Cloud.</Note>
 
-For automations triggered by a flow run event, the `flow_run_log_summary` token renders an
+For automations triggered by a flow run event, the `flow_run_log_summary` variable renders an
 AI-generated, one-line summary of the run's logs (for example,
 `Failed due to a KeyError in the extract_data task`). This lets on-call recipients see what
 happened inline instead of clicking through to the UI.
@@ -155,19 +155,19 @@ AI summary: {{ flow_run_log_summary }}
 {%- endif %}
 ```
 
-Wrapping the token in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
+Wrapping the variable in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
 the summary is empty (the feature is disabled, the model provider is unavailable, or the event
 has no associated flow run), so recipients do not see a dangling `AI summary:` label.
 
 A few details to keep in mind:
 
-- **Opt in by referencing the token.** The default notification body does not include it. The
+- **Opt in by referencing the variable.** The default notification body does not include it. The
   summary, and the underlying call to generate it, is only produced when your custom message
   references `{{ flow_run_log_summary }}`.
 - **Account setting.** AI log summaries must be enabled for your account. When the feature is
-  disabled, the token renders an empty string and no summary is generated.
+  disabled, the variable renders an empty string and no summary is generated.
 - **Graceful fallback.** If the summary cannot be generated (for example, during a model
-  provider outage), or the triggering event has no associated flow run, the token renders an
+  provider outage), or the triggering event has no associated flow run, the variable renders an
   empty string rather than failing the notification.
 
 Use `{{ value | tojson }}` to serialize any template variable to a JSON string. The filter handles Pydantic model objects such as `flow_run`, `deployment`, and `event` directly — for example, `{{ flow_run | tojson(indent=2) }}` renders the full flow run as formatted JSON. The optional `indent` argument controls pretty-printing.

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -150,8 +150,14 @@ likely cause inline instead of clicking through to the UI.
 ```
 Flow run {{ flow_run.name }} entered state {{ flow_run.state.name }}.
 
+{%- if flow_run_log_summary %}
 Likely cause: {{ flow_run_log_summary }}
+{%- endif %}
 ```
+
+Wrapping the token in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
+the summary is empty (the feature is disabled, the model provider is unavailable, or the event
+has no associated flow run), so recipients do not see a dangling `Likely cause:` label.
 
 A few details to keep in mind:
 

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -222,20 +222,9 @@ AI summary: {{ flow_run_log_summary }}
 {%- endif %}
 ```
 
-Wrapping the variable in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
-the summary is empty (the feature is disabled, the model provider is unavailable, or the event
-has no associated flow run), so recipients do not see a dangling `AI summary:` label.
-
-A few details to keep in mind:
-
-- **Opt in by referencing the variable.** The default notification body does not include it. The
-  summary, and the underlying call to generate it, is only produced when your custom message
-  references `{{ flow_run_log_summary }}`.
-- **Account setting.** AI log summaries must be enabled for your account. When the feature is
-  disabled, the variable renders an empty string and no summary is generated.
-- **Graceful fallback.** If the summary cannot be generated (for example, during a model
-  provider outage), or the triggering event has no associated flow run, the variable renders an
-  empty string rather than failing the notification.
+The variable is opt-in and renders an empty string when the feature is disabled or a summary
+cannot be generated. For setup and behavior details, see the [AI log summaries
+guide](/v3/how-to-guides/ai/flow-run-log-summaries).
 
 ## Further reading
 

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -138,38 +138,6 @@ In addition to its native properties, each object includes an `id` along with `c
 
 The `flow_run|ui_url` token returns the URL to view the flow run in the UI.
 
-### AI log summary
-
-<Note>The `flow_run_log_summary` variable is only available in Prefect Cloud.</Note>
-
-For automations triggered by a flow run event, the `flow_run_log_summary` variable renders an
-AI-generated, one-line summary of the run's logs (for example,
-`Failed due to a KeyError in the extract_data task`). This lets on-call recipients see what
-happened inline instead of clicking through to the UI.
-
-```
-Flow run {{ flow_run.name }} entered state {{ flow_run.state.name }}.
-
-{%- if flow_run_log_summary %}
-AI summary: {{ flow_run_log_summary }}
-{%- endif %}
-```
-
-Wrapping the variable in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
-the summary is empty (the feature is disabled, the model provider is unavailable, or the event
-has no associated flow run), so recipients do not see a dangling `AI summary:` label.
-
-A few details to keep in mind:
-
-- **Opt in by referencing the variable.** The default notification body does not include it. The
-  summary, and the underlying call to generate it, is only produced when your custom message
-  references `{{ flow_run_log_summary }}`.
-- **Account setting.** AI log summaries must be enabled for your account. When the feature is
-  disabled, the variable renders an empty string and no summary is generated.
-- **Graceful fallback.** If the summary cannot be generated (for example, during a model
-  provider outage), or the triggering event has no associated flow run, the variable renders an
-  empty string rather than failing the notification.
-
 Use `{{ value | tojson }}` to serialize any template variable to a JSON string. The filter handles Pydantic model objects such as `flow_run`, `deployment`, and `event` directly — for example, `{{ flow_run | tojson(indent=2) }}` renders the full flow run as formatted JSON. The optional `indent` argument controls pretty-printing.
 
 Here's an example relevant to a flow run state-based notification:
@@ -234,6 +202,38 @@ Related Resources:
 Note that this example also illustrates the ability to use Jinja features such as iterator and for loop
 [control structures](https://jinja.palletsprojects.com/en/3.1.x/templates/#list-of-control-structures) when
 templating notifications.
+
+### AI log summary
+
+<Note>The `flow_run_log_summary` variable is only available in Prefect Cloud.</Note>
+
+For automations triggered by a flow run event, the `flow_run_log_summary` variable renders an
+AI-generated, one-line summary of the run's logs (for example,
+`Failed due to a KeyError in the extract_data task`). This lets on-call recipients see what
+happened inline instead of clicking through to the UI.
+
+```
+Flow run {{ flow_run.name }} entered state {{ flow_run.state.name }}.
+
+{%- if flow_run_log_summary %}
+AI summary: {{ flow_run_log_summary }}
+{%- endif %}
+```
+
+Wrapping the variable in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
+the summary is empty (the feature is disabled, the model provider is unavailable, or the event
+has no associated flow run), so recipients do not see a dangling `AI summary:` label.
+
+A few details to keep in mind:
+
+- **Opt in by referencing the variable.** The default notification body does not include it. The
+  summary, and the underlying call to generate it, is only produced when your custom message
+  references `{{ flow_run_log_summary }}`.
+- **Account setting.** AI log summaries must be enabled for your account. When the feature is
+  disabled, the variable renders an empty string and no summary is generated.
+- **Graceful fallback.** If the summary cannot be generated (for example, during a model
+  provider outage), or the triggering event has no associated flow run, the variable renders an
+  empty string rather than failing the notification.
 
 For more on the common use case of passing an upstream flow run's parameters to the flow run invoked by the automation, see the [Passing parameters to a flow run](/v3/how-to-guides/automations/access-parameters-in-templates/) guide.
 

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -143,21 +143,21 @@ The `flow_run|ui_url` token returns the URL to view the flow run in the UI.
 <Note>The `flow_run_log_summary` variable is only available in Prefect Cloud.</Note>
 
 For automations triggered by a flow run event, the `flow_run_log_summary` token renders an
-AI-generated, one-line explanation of why the run reached its current state (for example,
-`Failed due to a KeyError in the extract_data task`). This lets on-call recipients see the
-likely cause inline instead of clicking through to the UI.
+AI-generated, one-line summary of the run's logs (for example,
+`Failed due to a KeyError in the extract_data task`). This lets on-call recipients see what
+happened inline instead of clicking through to the UI.
 
 ```
 Flow run {{ flow_run.name }} entered state {{ flow_run.state.name }}.
 
 {%- if flow_run_log_summary %}
-Likely cause: {{ flow_run_log_summary }}
+AI summary: {{ flow_run_log_summary }}
 {%- endif %}
 ```
 
 Wrapping the token in an `{%- if flow_run_log_summary %}` block keeps the notification tidy when
 the summary is empty (the feature is disabled, the model provider is unavailable, or the event
-has no associated flow run), so recipients do not see a dangling `Likely cause:` label.
+has no associated flow run), so recipients do not see a dangling `AI summary:` label.
 
 A few details to keep in mind:
 

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -203,6 +203,8 @@ Note that this example also illustrates the ability to use Jinja features such a
 [control structures](https://jinja.palletsprojects.com/en/3.1.x/templates/#list-of-control-structures) when
 templating notifications.
 
+For more on the common use case of passing an upstream flow run's parameters to the flow run invoked by the automation, see the [Passing parameters to a flow run](/v3/how-to-guides/automations/access-parameters-in-templates/) guide.
+
 ### AI log summary
 
 <Note>The `flow_run_log_summary` variable is only available in Prefect Cloud.</Note>
@@ -234,8 +236,6 @@ A few details to keep in mind:
 - **Graceful fallback.** If the summary cannot be generated (for example, during a model
   provider outage), or the triggering event has no associated flow run, the variable renders an
   empty string rather than failing the notification.
-
-For more on the common use case of passing an upstream flow run's parameters to the flow run invoked by the automation, see the [Passing parameters to a flow run](/v3/how-to-guides/automations/access-parameters-in-templates/) guide.
 
 ## Further reading
 

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -138,6 +138,32 @@ In addition to its native properties, each object includes an `id` along with `c
 
 The `flow_run|ui_url` token returns the URL to view the flow run in the UI.
 
+### AI log summary
+
+<Note>The `flow_run_log_summary` variable is only available in Prefect Cloud.</Note>
+
+For automations triggered by a flow run event, the `flow_run_log_summary` token renders an
+AI-generated, one-line explanation of why the run reached its current state (for example,
+`Failed due to a KeyError in the extract_data task`). This lets on-call recipients see the
+likely cause inline instead of clicking through to the UI.
+
+```
+Flow run {{ flow_run.name }} entered state {{ flow_run.state.name }}.
+
+Likely cause: {{ flow_run_log_summary }}
+```
+
+A few details to keep in mind:
+
+- **Opt in by referencing the token.** The default notification body does not include it. The
+  summary, and the underlying call to generate it, is only produced when your custom message
+  references `{{ flow_run_log_summary }}`.
+- **Account setting.** AI log summaries must be enabled for your account. When the feature is
+  disabled, the token renders an empty string and no summary is generated.
+- **Graceful fallback.** If the summary cannot be generated (for example, during a model
+  provider outage), or the triggering event has no associated flow run, the token renders an
+  empty string rather than failing the notification.
+
 Use `{{ value | tojson }}` to serialize any template variable to a JSON string. The filter handles Pydantic model objects such as `flow_run`, `deployment`, and `event` directly — for example, `{{ flow_run | tojson(indent=2) }}` renders the full flow run as formatted JSON. The optional `indent` argument controls pretty-printing.
 
 Here's an example relevant to a flow run state-based notification:

--- a/docs/v3/how-to-guides/ai/flow-run-log-summaries.mdx
+++ b/docs/v3/how-to-guides/ai/flow-run-log-summaries.mdx
@@ -16,9 +16,17 @@ returns the cached result rather than calling the model a second time.
 
 ## Enable AI log summaries
 
-AI log summaries are controlled by an account-level setting that an account administrator must
-enable before summaries are generated. While the setting is disabled, no summaries are produced
-and the model is never called.
+AI log summaries depend on AI features being enabled for your account. An account administrator
+enables them under **Settings > Account Settings > Controls** by turning on the **Marvin AI**
+toggle in the **Data processing** section. This setting is account-wide and applies to all
+workspaces.
+
+While AI features are disabled, no summaries are produced and the model is never called.
+
+<Note>
+AI-enabled features may use third-party models. See the **Marvin AI** setting for links to
+Prefect's data processing addendum and subprocessor documentation.
+</Note>
 
 ## View a summary in the UI
 

--- a/docs/v3/how-to-guides/ai/flow-run-log-summaries.mdx
+++ b/docs/v3/how-to-guides/ai/flow-run-log-summaries.mdx
@@ -1,0 +1,62 @@
+---
+title: AI log summaries
+sidebarTitle: AI log summaries
+description: Use AI-generated summaries of flow run logs to understand failures faster.
+keywords: ["AI", "log summary", "flow run logs", "failure", "notification", "automation"]
+---
+
+<Note>AI log summaries are only available in Prefect Cloud.</Note>
+
+An AI log summary is a short, AI-generated description of a flow run's logs, such as
+`Failed due to a KeyError in the extract_data task`. Instead of scrolling through raw logs to
+work out what happened, you get the gist in one line.
+
+Summaries are generated on demand and cached, so requesting the same flow run's summary again
+returns the cached result rather than calling the model a second time.
+
+## Enable AI log summaries
+
+AI log summaries are controlled by an account-level setting that an account administrator must
+enable before summaries are generated. While the setting is disabled, no summaries are produced
+and the model is never called.
+
+## View a summary in the UI
+
+Open a flow run in the Prefect Cloud UI to request an AI summary of its logs. This is useful for
+investigating a single run after the fact.
+
+## Include a summary in automation notifications
+
+You can also surface the summary automatically in notifications sent by an automation, so an
+on-call recipient sees the likely explanation inline without opening the UI.
+
+Reference the `flow_run_log_summary` variable in a [custom notification
+template](/v3/concepts/automations#templating-with-jinja) on an automation triggered by a flow
+run event:
+
+```
+Flow run {{ flow_run.name }} entered state {{ flow_run.state.name }}.
+
+{%- if flow_run_log_summary %}
+AI summary: {{ flow_run_log_summary }}
+{%- endif %}
+```
+
+A few details to keep in mind:
+
+- **Opt in by referencing the variable.** The summary, and the underlying call to generate it,
+  is only produced when your custom message references `{{ flow_run_log_summary }}`. The default
+  notification body does not include it.
+- **Account setting applies.** If AI log summaries are disabled for your account, the variable
+  renders an empty string and no summary is generated.
+- **Graceful fallback.** If the summary cannot be generated (for example, during a model provider
+  outage), or the triggering event has no associated flow run, the variable renders an empty
+  string rather than failing the notification.
+
+Wrapping the variable in an `{%- if flow_run_log_summary %}` block keeps the notification tidy
+when the summary is empty, so recipients do not see a dangling `AI summary:` label.
+
+## Further reading
+
+- [Templating notifications with Jinja](/v3/concepts/automations#templating-with-jinja)
+- [Sending notifications with automations](/v3/concepts/automations#sending-notifications-with-automations)

--- a/docs/v3/how-to-guides/ai/flow-run-log-summaries.mdx
+++ b/docs/v3/how-to-guides/ai/flow-run-log-summaries.mdx
@@ -22,8 +22,10 @@ and the model is never called.
 
 ## View a summary in the UI
 
-Open a flow run in the Prefect Cloud UI to request an AI summary of its logs. This is useful for
-investigating a single run after the fact.
+Open a flow run in the Prefect Cloud UI and select the **Logs** tab. Click the AI summary icon in
+the top-right corner of the log panel, next to the log search, to generate a summary of the run's
+logs. The summary appears inline above the logs. This is useful for investigating a single run
+after the fact.
 
 ## Include a summary in automation notifications
 

--- a/docs/v3/how-to-guides/ai/index.mdx
+++ b/docs/v3/how-to-guides/ai/index.mdx
@@ -16,3 +16,9 @@ With one setup, assistants can:
 <Card title="Use the Prefect MCP server" icon="chart-network" href="/v3/how-to-guides/ai/use-prefect-mcp-server">
   Installation, client configuration, credential setup, and security guidance.
 </Card>
+
+Prefect Cloud also offers AI features built into the platform:
+
+<Card title="AI log summaries" icon="wand-magic-sparkles" href="/v3/how-to-guides/ai/flow-run-log-summaries">
+  Surface AI-generated summaries of flow run logs in the UI and automation notifications.
+</Card>


### PR DESCRIPTION
## Context

The implementation for surfacing the AI log summary in Slack/email automations shipped in the Cloud repos; the only remaining item on CLOUD-3856 was public docs. Until now the feature wasn't documented anywhere, so this adds a dedicated guide and wires it into the automations templating docs.

What's here:

- A new `v3/how-to-guides/ai/flow-run-log-summaries` guide covering what AI log summaries are, enabling the account setting, viewing a summary in the UI, and surfacing one in automation notifications via the `flow_run_log_summary` variable.
- A short subsection in the automations "Templating with Jinja" docs that introduces the `{{ flow_run_log_summary }}` variable and links to the guide for setup and behavior details.
- A card on the AI guides overview for discoverability.

The wording deliberately stays light on UI specifics (no invented button names or settings paths) since those weren't part of the verified feature details. The example wraps the variable in an `{%- if flow_run_log_summary %}` block so the notification stays tidy when the summary is empty, and labels the field "AI summary:" rather than "Likely cause:" since the summary describes the run logs rather than claiming a root cause.

Related to CLOUD-3856

### Testing

- https://prefect-bd373955-cloud-3856-docs-ai-log-summary.mintlify.app/v3/concepts/automations#ai-log-summary
- https://prefect-bd373955-cloud-3856-docs-ai-log-summary.mintlify.app/v3/how-to-guides/ai
- https://prefect-bd373955-cloud-3856-docs-ai-log-summary.mintlify.app/v3/how-to-guides/ai/flow-run-log-summaries

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

<details>
<summary>Session context</summary>

Worked via `/start` on CLOUD-3856, scoped to the docs requirement. Iterated on placement and wording in the automations section, then expanded scope to a dedicated AI log summaries guide since no existing page documented the feature.
</details>
