### PR TITLE
feat(cli): add `prefect deployment export` command

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -12,6 +12,7 @@ import textwrap
 import warnings
 from asyncio import gather
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Optional, TypedDict
 from uuid import UUID
 
@@ -128,6 +129,74 @@ async def _get_deployment(
         exit_with_error("Only provide a deployed flow's name or id")
 
     return deployment
+
+
+def _schedule_to_yaml(deployment_schedule: DeploymentSchedule) -> dict[str, Any]:
+    """Serialize a deployment schedule into a prefect.yaml-friendly dict.
+
+    `model_dump(mode="json")` handles every schedule type uniformly (interval as
+    seconds, anchor_date as an ISO string, cron/rrule as strings), all of which
+    round-trip cleanly through `prefect.yaml`.
+    """
+    config = {
+        k: v
+        for k, v in deployment_schedule.schedule.model_dump(mode="json").items()
+        if v is not None
+    }
+    config["active"] = deployment_schedule.active
+    return config
+
+
+def _deployment_response_to_yaml(deployment: DeploymentResponse) -> dict[str, Any]:
+    """Convert a server `DeploymentResponse` into a `prefect.yaml` deployment entry.
+
+    The output mirrors the deployment schema accepted by `prefect deploy` so that
+    the result can be pasted into (or written as) a `prefect.yaml` and re-deployed.
+    """
+    entry: dict[str, Any] = {"name": deployment.name}
+
+    if deployment.version is not None:
+        entry["version"] = deployment.version
+    if deployment.tags:
+        entry["tags"] = list(deployment.tags)
+    # `concurrency_limit` on the response is deprecated and always None; the live
+    # value lives on `global_concurrency_limit`. Emit a plain int, or the nested
+    # form when a collision strategy is configured.
+    if deployment.global_concurrency_limit is not None:
+        limit = deployment.global_concurrency_limit.limit
+        if deployment.concurrency_options is not None:
+            entry["concurrency_limit"] = {
+                "limit": limit,
+                "collision_strategy": str(
+                    deployment.concurrency_options.collision_strategy.value
+                ),
+            }
+        else:
+            entry["concurrency_limit"] = limit
+    if deployment.description is not None:
+        entry["description"] = deployment.description
+    entry["entrypoint"] = deployment.entrypoint
+    if deployment.parameters:
+        entry["parameters"] = deployment.parameters
+    if deployment.enforce_parameter_schema is not None:
+        entry["enforce_parameter_schema"] = deployment.enforce_parameter_schema
+    if deployment.paused:
+        entry["paused"] = deployment.paused
+
+    if deployment.work_pool_name is not None:
+        work_pool: dict[str, Any] = {"name": deployment.work_pool_name}
+        if deployment.work_queue_name is not None:
+            work_pool["work_queue_name"] = deployment.work_queue_name
+        if deployment.job_variables:
+            work_pool["job_variables"] = deployment.job_variables
+        entry["work_pool"] = work_pool
+    elif deployment.work_queue_name is not None:
+        entry["work_queue_name"] = deployment.work_queue_name
+
+    if deployment.schedules:
+        entry["schedules"] = [_schedule_to_yaml(s) for s in deployment.schedules]
+
+    return entry
 
 
 # =============================================================================
@@ -272,6 +341,103 @@ async def ls(
             )
 
         _cli.console.print(table)
+
+
+@deployment_app.command()
+@with_cli_exception_handling
+async def export(
+    name: Annotated[
+        Optional[str],
+        cyclopts.Parameter(
+            "--name",
+            alias="-n",
+            help=(
+                "A deployed flow's name to export: "
+                "<FLOW_NAME>/<DEPLOYMENT_NAME>. May be provided multiple times."
+            ),
+        ),
+    ] = None,
+    *,
+    all_deployments: Annotated[
+        bool,
+        cyclopts.Parameter(
+            "--all",
+            help="Export all deployments on the server.",
+        ),
+    ] = False,
+    output: Annotated[
+        Optional[str],
+        cyclopts.Parameter(
+            "--output",
+            alias="-o",
+            help=(
+                "File to write the exported configuration to. Defaults to stdout "
+                "in non-interactive mode, or prompts for a path interactively."
+            ),
+        ),
+    ] = None,
+):
+    """Export deployment configuration from the server as `prefect.yaml`.
+
+    This is the inverse of `prefect deploy`: instead of turning a `prefect.yaml`
+    into deployments, it reads existing deployments from the server and emits
+    YAML that can be saved and re-deployed.
+
+    Examples:
+        Export a single deployment to stdout:
+        $ prefect deployment export --name my-flow/my-deployment
+
+        Export all deployments to a file:
+        $ prefect deployment export --all --output prefect.yaml
+    """
+    from prefect.cli._app import is_interactive
+    from prefect.cli._prompts import confirm, prompt
+
+    if all_deployments and name:
+        exit_with_error("Provide either --name or --all, not both.")
+    if not all_deployments and not name:
+        exit_with_error("Must provide --name or --all.")
+
+    async with get_client() as client:
+        if all_deployments:
+            deployments = await client.read_deployments()
+        else:
+            deployments = []
+            _assert_deployment_name_format(name)
+            try:
+                deployments.append(await client.read_deployment_by_name(name))
+            except ObjectNotFound:
+                exit_with_error(f"Deployment {name!r} not found!")
+
+    if not deployments:
+        exit_with_error("No deployments found to export.")
+
+    config = {"deployments": [_deployment_response_to_yaml(d) for d in deployments]}
+    rendered = yaml.dump(config, sort_keys=False)
+
+    # determine output destination
+    output_path = output
+    if output_path is None and is_interactive():
+        if confirm(
+            f"Found {len(deployments)} deployment(s). Write to a prefect.yaml file?",
+            default=True,
+        ):
+            output_path = prompt("Output file path", default="prefect.yaml")
+
+    if output_path is None:
+        _cli.console.print(rendered, soft_wrap=True)
+        return
+
+    path = Path(output_path)
+    if (
+        path.exists()
+        and is_interactive()
+        and not confirm(f"{output_path!r} already exists. Overwrite?", default=False)
+    ):
+        exit_with_error("Aborted.")
+
+    path.write_text(rendered)
+    exit_with_success(f"Exported {len(deployments)} deployment(s) to {output_path!r}.")
 
 
 @deployment_app.command()

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -1,10 +1,12 @@
 import json
 import sys
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
 import pytest
+import yaml
 
 from prefect import flow
 from prefect.client.orchestration import PrefectClient
@@ -1547,4 +1549,76 @@ class TestDeploymentList:
             ["deployment", "ls", "-o", "xml"],
             expected_code=1,
             expected_output_contains="Only 'json' output format is supported.",
+        )
+
+
+class TestExport:
+    def test_export_single_to_stdout(self, flojo_deployment: DeploymentResponse):
+        result = invoke_and_assert(
+            ["deployment", "export", "--name", "rence-griffith/test-deployment"],
+            expected_code=0,
+            expected_output_contains=[
+                "deployments:",
+                "name: test-deployment",
+                "version: git-commit-hash",
+            ],
+        )
+        parsed = yaml.safe_load(result.stdout)
+        assert len(parsed["deployments"]) == 1
+        entry = parsed["deployments"][0]
+        assert entry["name"] == "test-deployment"
+        assert entry["parameters"] == {"foo": "bar"}
+        assert sorted(entry["tags"]) == ["bar", "foo"]
+        # parameter_openapi_schema is not part of the prefect.yaml schema
+        assert "parameter_openapi_schema" not in entry
+        # schedules round-trip
+        assert entry["schedules"][0]["interval"] == 10.76
+
+    def test_export_all_to_stdout(self, flojo_deployment: DeploymentResponse):
+        result = invoke_and_assert(
+            ["deployment", "export", "--all"],
+            expected_code=0,
+            expected_output_contains=["deployments:", "name: test-deployment"],
+        )
+        parsed = yaml.safe_load(result.stdout)
+        assert any(d["name"] == "test-deployment" for d in parsed["deployments"])
+
+    def test_export_to_file(
+        self, flojo_deployment: DeploymentResponse, tmp_path: "Path"
+    ):
+        out = tmp_path / "prefect.yaml"
+        invoke_and_assert(
+            [
+                "deployment",
+                "export",
+                "--name",
+                "rence-griffith/test-deployment",
+                "--output",
+                str(out),
+            ],
+            expected_code=0,
+            expected_output_contains="Exported 1 deployment(s)",
+        )
+        parsed = yaml.safe_load(out.read_text())
+        assert parsed["deployments"][0]["name"] == "test-deployment"
+
+    def test_export_requires_name_or_all(self):
+        invoke_and_assert(
+            ["deployment", "export"],
+            expected_code=1,
+            expected_output_contains="Must provide --name or --all.",
+        )
+
+    def test_export_rejects_name_and_all(self):
+        invoke_and_assert(
+            ["deployment", "export", "--all", "--name", "foo/bar"],
+            expected_code=1,
+            expected_output_contains="Provide either --name or --all, not both.",
+        )
+
+    def test_export_unknown_deployment(self):
+        invoke_and_assert(
+            ["deployment", "export", "--name", "no/such"],
+            expected_code=1,
+            expected_output_contains="not found",
         )


### PR DESCRIPTION
closes #19742

this PR adds `prefect deployment export` — the inverse of `prefect deploy`. instead of turning a `prefect.yaml` into deployments, it reads existing deployments from the server and emits YAML you can save and re-deploy. handy for reconstructing a `prefect.yaml` after UI edits, bootstrapping one from programmatically-created deployments, or backing up deployment config.

```bash
# single deployment to stdout
prefect deployment export --name my-flow/my-deployment

# all deployments to a file
prefect deployment export --all --output prefect.yaml

# interactive: prompts whether to write a file, defaulting to prefect.yaml
prefect deployment export --all
```

<details>
<summary>behavior & implementation notes</summary>

- one of `--name` (repeatable) or `--all` is required; providing both errors
- `--output/-o` writes to a file (with an overwrite confirm in interactive mode); otherwise prints to stdout
- in an interactive terminal with no `--output`, prompts whether to write a `prefect.yaml`
- `_deployment_response_to_yaml` maps a `DeploymentResponse` onto the deployment schema accepted by `prefect deploy` (nested `work_pool`, `schedules`, `parameters`, `tags`, `concurrency_limit`, etc.)
- reads the live concurrency limit from `global_concurrency_limit` (the response's `concurrency_limit` field is deprecated and always `None`)
- schedules are serialized via `model_dump(mode="json")`, which round-trips interval/cron/rrule cleanly
- `parameter_openapi_schema` is intentionally omitted (not part of the `prefect.yaml` schema)

basic unit coverage in `tests/cli/deployment/test_deployment_cli.py::TestExport` (single/all/to-file/arg-validation/not-found), exercised against a live test-harness server.
</details>