### PR TITLE
fix(tests): preserve cyclopts modules in reset_sys_modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -585,12 +585,23 @@ def reset_sys_modules():
     # subsequent monkeypatch / import resolution doesn't find a stale module
     # object via getattr on the parent while sys.modules has no entry.
     #
-    # Preserve prefect.cli.* modules: cyclopts lazy loading caches resolved
-    # command Apps internally.  Removing the module from sys.modules creates
-    # a stale-reference split where cyclopts holds the old module's objects
-    # but monkeypatch patches a freshly re-imported copy.
+    # Preserve prefect.cli.* and cyclopts modules: cyclopts lazy loading caches
+    # resolved command Apps and type converters internally.  Removing a module
+    # from sys.modules creates a stale-reference split where cyclopts holds the
+    # old module's objects but monkeypatch / re-import resolution finds a freshly
+    # re-imported copy.  For cyclopts specifically, deleting its lazily-imported
+    # submodules (e.g. cyclopts._convert) breaks type-converter identity on the
+    # next in-process invocation, surfacing as spurious "unable to convert ...
+    # into str" CoercionErrors on every command after the first.
+    def _should_preserve(module: str) -> bool:
+        return (
+            module.startswith("prefect.cli.")
+            or module == "cyclopts"
+            or module.startswith("cyclopts.")
+        )
+
     for module in set(sys.modules.keys()):
-        if module not in original_modules and not module.startswith("prefect.cli."):
+        if module not in original_modules and not _should_preserve(module):
             parts = module.rsplit(".", 1)
             if len(parts) == 2:
                 parent = sys.modules.get(parts[0])


### PR DESCRIPTION
the `reset_sys_modules` autouse fixture corrupts cyclopts' internal type-converter cache across in-process CLI invocations, causing every CLI command after the first in a process to fail with a spurious `unable to convert ... into str` CoercionError.

<details>
<summary>root cause & repro</summary>

`reset_sys_modules` deletes modules imported during a test so they don't leak into the cache. cyclopts lazily imports submodules (e.g. `cyclopts._convert`) on the **first** command invocation. Deleting them afterward leaves cyclopts' preserved top-level module holding references to the now-deleted submodule objects, while the next invocation re-imports fresh copies — a type-identity split that breaks converter lookups (`str(...)` coercion path).

This is the same class of stale-reference bug the fixture already documents and works around for `prefect.cli.*`; it just didn't cover cyclopts' own lazily-imported submodules.

Minimal repro (any two in-process invocations in a file under `tests/`):
```python
def test_a():
    invoke_and_assert(["deployment", "export"], expected_code=1, ...)  # passes
def test_b():
    invoke_and_assert(["deployment", "export"], expected_code=1, ...)  # fails: "unable to convert deployment into str"
```

Before: `tests/cli/deployment/test_deployment_cli.py` → 44 failed locally (serial and xdist). After: 69 passed (both serial single-process and `--numprocesses auto --dist worksteal`). Broader `tests/cli/` slice: 155 passed.
</details>

the fix extends the existing `prefect.cli.*` preservation in `reset_sys_modules` to also preserve `cyclopts` modules.