### PR TITLE
fix(cli): prompt to save new deployments into an existing prefect.yaml

### DIFF
--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -19,7 +19,10 @@ from prefect.cli._prompts import (
 )
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.filters import WorkerFilter
-from prefect.deployments.base import _save_deployment_to_prefect_file
+from prefect.deployments.base import (
+    _deployment_already_saved_to_prefect_file,
+    _save_deployment_to_prefect_file,
+)
 from prefect.deployments.runner import RunnerDeployment
 from prefect.deployments.steps.core import run_steps
 from prefect.exceptions import ObjectNotFound
@@ -420,7 +423,9 @@ async def _run_single_deploy(
         )
         console.print(message, soft_wrap=True)
 
-    if is_interactive() and not prefect_file.exists():
+    if is_interactive() and not _deployment_already_saved_to_prefect_file(
+        deploy_config_before_templating, prefect_file
+    ):
         if confirm(
             (
                 "Would you like to save configuration for this deployment for faster"

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -278,6 +278,33 @@ def _interval_schedule_to_dict(schedule: IntervalSchedule) -> dict[str, Any]:
     return schedule_config
 
 
+def _deployment_already_saved_to_prefect_file(
+    deployment: dict[str, Any],
+    prefect_file: Path = Path("prefect.yaml"),
+) -> bool:
+    """
+    Return True if `prefect.yaml` already contains a deployment entry matching the
+    given deployment's name and entrypoint.
+
+    Used to decide whether the interactive `prefect deploy` flow should offer to
+    persist a newly-created deployment: a deployment that is already declared in
+    the file does not need to be saved again, but a brand-new one (even when the
+    file otherwise exists) should still be offered up for saving.
+    """
+    if not prefect_file.exists():
+        return False
+
+    with prefect_file.open(mode="r") as f:
+        contents = yaml.safe_load(f) or {}
+
+    for existing in contents.get("deployments") or []:
+        if existing.get("name") == deployment.get("name") and existing.get(
+            "entrypoint"
+        ) == deployment.get("entrypoint"):
+            return True
+    return False
+
+
 def _save_deployment_to_prefect_file(
     deployment: dict[str, Any],
     build_steps: list[dict[str, Any]] | None = None,

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1170,7 +1170,11 @@ class TestProjectDeploy:
                 expected_code=0,
                 user_input=(
                     # Decline pulling from remote storage
-                    "n" + readchar.key.ENTER
+                    "n"
+                    + readchar.key.ENTER
+                    # decline saving to the (existing) prefect.yaml
+                    + "n"
+                    + readchar.key.ENTER
                 ),
                 expected_output_contains=[
                     "prefect deployment run 'An important name/test-name'"
@@ -5118,8 +5122,21 @@ class TestSaveUserInputs:
         assert config["deployments"][0]["work_pool"]["name"] == "inflatable"
 
     def test_save_user_inputs_existing_prefect_file(self):
+        """
+        Regression test: an existing `prefect.yaml` that does not already declare
+        the deployment being created should still prompt to save it.
+
+        Previously `prefect deploy` only offered to save when no `prefect.yaml`
+        existed at all (#17519), which meant users with an `init`-scaffolded file
+        could never persist a new deployment via the interactive wizard.
+        """
         prefect_file = Path("prefect.yaml")
         assert prefect_file.exists()
+
+        # the init-scaffolded file has a single placeholder deployment with a
+        # null name/entrypoint, which never matches a real deployment
+        with prefect_file.open(mode="r") as f:
+            assert len(yaml.safe_load(f)["deployments"]) == 1
 
         invoke_and_assert(
             command="deploy flows/hello.py:my_flow",
@@ -5139,14 +5156,70 @@ class TestSaveUserInputs:
                 # decline schedule
                 + "n"
                 + readchar.key.ENTER
+                # accept saving the new deployment to the existing file
+                + "y"
+                + readchar.key.ENTER
             ),
             expected_code=0,
-            expected_output_contains="View Deployment in UI",
+            expected_output_contains=[
+                (
+                    "Would you like to save configuration for this deployment for"
+                    " faster deployments in the future?"
+                ),
+                "Deployment configuration saved to prefect.yaml",
+            ],
         )
 
         with prefect_file.open(mode="r") as f:
             config = yaml.safe_load(f)
 
+        # the new deployment is appended alongside the placeholder entry
+        assert len(config["deployments"]) == 2
+        new_deployment = config["deployments"][-1]
+        assert new_deployment["name"] == "default"
+        assert new_deployment["entrypoint"] == "flows/hello.py:my_flow"
+        assert new_deployment["work_pool"]["name"] == "inflatable"
+
+    def test_does_not_prompt_save_when_deployment_already_in_prefect_file(self):
+        """A deployment already declared in `prefect.yaml` should not re-prompt."""
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
+            contents = yaml.safe_load(f)
+
+        # declare the deployment we're about to deploy so it matches
+        contents["deployments"] = [
+            {"name": "default", "entrypoint": "flows/hello.py:my_flow"}
+        ]
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump(contents, f)
+
+        invoke_and_assert(
+            command="deploy flows/hello.py:my_flow -n default",
+            user_input=(
+                # accept create work pool
+                readchar.key.ENTER
+                +
+                # choose process work pool
+                readchar.key.ENTER
+                +
+                # enter work pool name
+                "inflatable"
+                + readchar.key.ENTER
+                # decline schedule
+                + "n"
+                + readchar.key.ENTER
+            ),
+            expected_code=0,
+            expected_output_contains="View Deployment in UI",
+            expected_output_does_not_contain=(
+                "Would you like to save configuration for this deployment"
+            ),
+        )
+
+        with prefect_file.open(mode="r") as f:
+            config = yaml.safe_load(f)
+
+        # no new entry was appended
         assert len(config["deployments"]) == 1
 
 
@@ -5915,7 +5988,11 @@ class TestDeployDockerBuildSteps:
             ),
             user_input=(
                 # Reject build custom docker image
-                "n" + readchar.key.ENTER
+                "n"
+                + readchar.key.ENTER
+                # decline saving to the (existing) prefect.yaml
+                + "n"
+                + readchar.key.ENTER
             ),
             expected_output_contains=[
                 "Would you like to build a custom Docker image",
@@ -5935,7 +6012,11 @@ class TestDeployDockerBuildSteps:
             ),
             user_input=(
                 # Reject build custom docker image
-                "n" + readchar.key.ENTER
+                "n"
+                + readchar.key.ENTER
+                # decline saving to the (existing) prefect.yaml
+                + "n"
+                + readchar.key.ENTER
             ),
             expected_output_contains=["Would you like to build a custom Docker image"],
         )
@@ -5990,6 +6071,9 @@ class TestDeployDockerBuildSteps:
                 +
                 # Reject push to registry
                 "n"
+                + readchar.key.ENTER
+                # decline saving to the (existing) prefect.yaml
+                + "n"
                 + readchar.key.ENTER
             ),
             expected_output_contains=[
@@ -6215,6 +6299,9 @@ class TestDeployDockerBuildSteps:
                 # Decline remote storage
                 + "n"
                 + readchar.key.ENTER
+                # decline saving to the (existing) prefect.yaml
+                + "n"
+                + readchar.key.ENTER
             ),
             expected_output_contains=[
                 "Would you like to build a custom Docker image",
@@ -6418,6 +6505,9 @@ class TestDeployDockerPushSteps:
                 # Reject push to registry
                 + "n"
                 + readchar.key.ENTER
+                # decline saving to the (existing) prefect.yaml
+                + "n"
+                + readchar.key.ENTER
             ),
             expected_output_contains=[
                 "Would you like to build a custom Docker image",
@@ -6464,6 +6554,9 @@ class TestDeployDockerPushSteps:
                 + "https://hub.docker.com"
                 + readchar.key.ENTER
                 # Reject private registry
+                + "n"
+                + readchar.key.ENTER
+                # decline saving to the (existing) prefect.yaml
                 + "n"
                 + readchar.key.ENTER
             ),

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -5180,35 +5180,32 @@ class TestSaveUserInputs:
         assert new_deployment["entrypoint"] == "flows/hello.py:my_flow"
         assert new_deployment["work_pool"]["name"] == "inflatable"
 
-    def test_does_not_prompt_save_when_deployment_already_in_prefect_file(self):
-        """A deployment already declared in `prefect.yaml` should not re-prompt."""
+    def test_does_not_prompt_save_when_deployment_already_in_prefect_file(
+        self, work_pool: WorkPool
+    ):
+        """
+        Faithful reproduction of #17409 (the report that motivated #17519): a
+        deployment already fully declared in `prefect.yaml` must not prompt to
+        save again when re-deployed by name.
+        """
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             contents = yaml.safe_load(f)
 
-        # declare the deployment we're about to deploy so it matches
+        # fully declare the deployment so `deploy -n` needs no interactive input
         contents["deployments"] = [
-            {"name": "default", "entrypoint": "flows/hello.py:my_flow"}
+            {
+                "name": "already-saved",
+                "entrypoint": "flows/hello.py:my_flow",
+                "schedules": [],
+                "work_pool": {"name": work_pool.name},
+            }
         ]
         with prefect_file.open(mode="w") as f:
             yaml.safe_dump(contents, f)
 
         invoke_and_assert(
-            command="deploy flows/hello.py:my_flow -n default",
-            user_input=(
-                # accept create work pool
-                readchar.key.ENTER
-                +
-                # choose process work pool
-                readchar.key.ENTER
-                +
-                # enter work pool name
-                "inflatable"
-                + readchar.key.ENTER
-                # decline schedule
-                + "n"
-                + readchar.key.ENTER
-            ),
+            command="deploy -n already-saved",
             expected_code=0,
             expected_output_contains="View Deployment in UI",
             expected_output_does_not_contain=(
@@ -5219,8 +5216,9 @@ class TestSaveUserInputs:
         with prefect_file.open(mode="r") as f:
             config = yaml.safe_load(f)
 
-        # no new entry was appended
+        # no new entry was appended; the existing one is untouched
         assert len(config["deployments"]) == 1
+        assert config["deployments"][0]["name"] == "already-saved"
 
 
 @pytest.mark.usefixtures("project_dir", "interactive_console", "work_pool")

--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -6,6 +6,7 @@ import yaml
 
 import prefect
 from prefect.deployments.base import (
+    _deployment_already_saved_to_prefect_file,
     configure_project_by_recipe,
     initialize_project,
 )
@@ -140,4 +141,57 @@ class TestInitProject:
         assert (
             contents["deployments"][0]["work_pool"]["job_variables"]["image"]
             == "{{ build_image.image }}"
+        )
+
+
+class TestDeploymentAlreadySavedToPrefectFile:
+    """
+    Unit coverage for the matching check that gates the interactive save prompt
+    in `prefect deploy`.  Restores coverage removed in #17519 and underpins the
+    fix for #17409 (don't re-prompt already-declared deployments) and the Slack
+    report (do prompt for new deployments in an existing file).
+    """
+
+    def _write(self, deployments) -> Path:
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump({"deployments": deployments}, f)
+        return prefect_file
+
+    def test_returns_false_when_file_missing(self):
+        assert not _deployment_already_saved_to_prefect_file(
+            {"name": "x", "entrypoint": "flows/hello.py:my_flow"},
+            prefect_file=Path("does-not-exist.yaml"),
+        )
+
+    def test_returns_true_on_name_and_entrypoint_match(self):
+        prefect_file = self._write(
+            [{"name": "x", "entrypoint": "flows/hello.py:my_flow"}]
+        )
+        assert _deployment_already_saved_to_prefect_file(
+            {"name": "x", "entrypoint": "flows/hello.py:my_flow"},
+            prefect_file=prefect_file,
+        )
+
+    def test_returns_false_when_name_matches_but_entrypoint_differs(self):
+        prefect_file = self._write(
+            [{"name": "x", "entrypoint": "flows/hello.py:my_flow"}]
+        )
+        assert not _deployment_already_saved_to_prefect_file(
+            {"name": "x", "entrypoint": "flows/other.py:my_flow"},
+            prefect_file=prefect_file,
+        )
+
+    def test_returns_false_for_new_deployment_in_scaffolded_file(self):
+        # an `init`-scaffolded file has a single null-field placeholder entry;
+        # a real deployment must not match it (the Slack-reported case)
+        initialize_project()
+        assert not _deployment_already_saved_to_prefect_file(
+            {"name": "default", "entrypoint": "flows/hello.py:my_flow"},
+        )
+
+    def test_returns_false_when_no_deployments_declared(self):
+        self._write(None)
+        assert not _deployment_already_saved_to_prefect_file(
+            {"name": "x", "entrypoint": "flows/hello.py:my_flow"},
         )


### PR DESCRIPTION
`prefect deploy`'s interactive wizard today does not offer to save a new deployment when a `prefect.yaml` already exists — so those who scaffold with `prefect init` (which writes a `prefect.yaml`) can create a deployment via the wizard but never persist it to the file

## when this changed and why

- **#17519 ("Only prompt to save if file does not exist"), shipped in `3.3.4` (2025-04-09)** replaced `should_prompt_for_save = is_interactive()` with `is_interactive() and not prefect_file.exists()`.
- The cyclopts migration (#20783) carried that condition forward **verbatim** (it only renamed `root.is_interactive()` → `is_interactive()`), so the behavior has been the same since 3.3.4.

#17519 closed **#17437**, whose root cause was that **`is_interactive()` itself was unreliable** — Rich's `console.is_interactive` returned `True` even in non-interactive `prefect deploy` runs — and **#17409**, where a user with a deployment **already declared** in `prefect.yaml` was prompted to "save" it again. The chosen fix (`not prefect_file.exists()`) is a blunt proxy: *file exists → assume it's already managed → don't prompt.* That silences #17409 (there the deployment **was** in the file) but also silences the legitimate case below.

## the edge case

`not prefect_file.exists()` can't distinguish "this deployment is already declared" from "a file merely exists." The Slack report is the latter: a fresh `prefect init` scaffold (whose only entry is a null-field placeholder) + a brand-new deployment → no prompt, nothing written.

This PR swaps the file-existence check for: *is this deployment (name + entrypoint) already declared in the file?* (`_deployment_already_saved_to_prefect_file`):

- #17409 (deployment already declared) → still suppressed ✅
- Slack report (new deployment, existing file) → prompts and saves ✅

the original motivation around unreliable `is_interactive()` no longer applies: `is_interactive()` now lives in `prefect.cli._app` and reflects real interactivity, so the narrower name+entrypoint check is safe to restore. #17519 also deleted the entire suite that tested this matching behavior; this PR restores faithful equivalents.

## test coverage

Covers both motivating cases:

| case | test |
|------|------|
| #17409 — already-declared deployment, re-deployed by name → **no** save prompt | `TestSaveUserInputs::test_does_not_prompt_save_when_deployment_already_in_prefect_file` (faithful repro) |
| Slack — new deployment in an existing scaffold file → **prompts + saves** | `TestSaveUserInputs::test_save_user_inputs_existing_prefect_file` (rewritten; previously asserted the buggy no-prompt behavior) |
| matching-helper unit coverage (restored from #17519) | `tests/deployment/test_base.py::TestDeploymentAlreadySavedToPrefectFile` (match / entrypoint mismatch / scaffolded placeholder / missing file / no deployments) |

Also updated 7 docker build/push wizard tests that deploy a new deployment into the scaffold to answer the (now-present, correct) save prompt. Full `tests/cli/test_deploy.py` passes (188).

> [!NOTE]
> Running the full `tests/cli/test_deploy.py` in a single process locally needs the companion fix (cyclopts/`reset_sys_modules` isolation); verified here with that fix applied locally.