### PR TITLE
Surface sanitized git clone stderr

### DIFF
--- a/src/prefect/_internal/urls.py
+++ b/src/prefect/_internal/urls.py
@@ -1,4 +1,10 @@
+import re
+from collections.abc import Iterable
 from urllib.parse import urlparse, urlunparse
+
+_URL_AUTH_PATTERN = re.compile(
+    r"(?P<scheme>https?://)[^/\s'\"<>]*@", flags=re.IGNORECASE
+)
 
 
 def strip_auth_from_url(url: str) -> str:
@@ -8,22 +14,44 @@ def strip_auth_from_url(url: str) -> str:
     Useful for sanitizing URLs before including them in error messages
     or logs to avoid leaking secrets.
     """
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
 
-    if not parsed.hostname:
-        return url
+        if not parsed.hostname:
+            return url
 
-    netloc = parsed.hostname
-    if parsed.port:
-        netloc = f"{netloc}:{parsed.port}"
+        netloc = parsed.hostname
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
 
-    return urlunparse(
-        (
-            parsed.scheme,
-            netloc,
-            parsed.path,
-            parsed.params,
-            parsed.query,
-            parsed.fragment,
+        return urlunparse(
+            (
+                parsed.scheme,
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
         )
-    )
+    except ValueError:
+        return strip_auth_from_urls_in_text(url)
+
+
+def strip_auth_from_urls_in_text(
+    text: str, extra_secrets: Iterable[str] | None = None
+) -> str:
+    """
+    Remove authentication credentials from HTTP(S) URLs embedded in text.
+
+    Useful for sanitizing command output before including it in error messages
+    or logs. Any caller-supplied secrets are replaced with a redaction marker.
+    """
+    if not text:
+        return text
+
+    sanitized = _URL_AUTH_PATTERN.sub(r"\g<scheme>", text)
+    for secret in extra_secrets or ():
+        if secret:
+            sanitized = sanitized.replace(secret, "***")
+    return sanitized

--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -22,7 +22,7 @@ from anyio import run_process
 from pydantic import SecretStr
 
 from prefect._internal.concurrency.api import create_call, from_async
-from prefect._internal.urls import strip_auth_from_url
+from prefect._internal.urls import strip_auth_from_url, strip_auth_from_urls_in_text
 from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
@@ -499,6 +499,21 @@ class GitRepository:
                 else exc
             )
             safe_url = strip_auth_from_url(self._url)
+            sanitized_stderr = strip_auth_from_urls_in_text(
+                _decode_stderr(exc),
+                extra_secrets=[parsed_url.password] if parsed_url.password else None,
+            )
+            # Surface the raw git error at DEBUG so users can opt in via log
+            # level when the hint patterns don't match. The exception chain is
+            # suppressed above when credentials are present, so DEBUG is the
+            # only way to see the actual git output in that case.
+            if sanitized_stderr:
+                self._logger.debug(
+                    "git clone failed (exit %d) for %r: %s",
+                    exc.returncode,
+                    safe_url,
+                    sanitized_stderr.strip(),
+                )
             error_message = (
                 f"Failed to clone repository {safe_url!r} with exit code"
                 f" {exc.returncode}."
@@ -506,6 +521,14 @@ class GitRepository:
             hint = _get_git_clone_error_hint(exc)
             if hint:
                 error_message += f" {hint}"
+            elif sanitized_stderr:
+                # No pattern matched -- surface the actual git error so the
+                # user doesn't have to enable DEBUG to know what went wrong.
+                snippet = sanitized_stderr.strip().splitlines()
+                # Keep the last few lines; git's final 'fatal:' line is usually
+                # the actionable one.
+                tail = " | ".join(snippet[-3:])
+                error_message += f" git stderr: {tail}"
             raise RuntimeError(error_message) from exc_chain
 
         if self._commit_sha:
@@ -985,15 +1008,18 @@ _GIT_CLONE_ERROR_HINTS: list[tuple[str, str]] = [
 ]
 
 
+def _decode_stderr(exc: subprocess.CalledProcessError) -> str:
+    """Decode a CalledProcessError's stderr to text, tolerating bytes/None."""
+    if not exc.stderr:
+        return ""
+    if isinstance(exc.stderr, bytes):
+        return exc.stderr.decode("utf-8", errors="replace")
+    return str(exc.stderr)
+
+
 def _get_git_clone_error_hint(exc: subprocess.CalledProcessError) -> str | None:
     """Extract a resolution hint from a git clone CalledProcessError's stderr."""
-    stderr = ""
-    if exc.stderr:
-        stderr = (
-            exc.stderr.decode("utf-8", errors="replace")
-            if isinstance(exc.stderr, bytes)
-            else str(exc.stderr)
-        )
+    stderr = _decode_stderr(exc)
     for pattern, hint in _GIT_CLONE_ERROR_HINTS:
         if pattern.lower() in stderr.lower():
             return hint

--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -14,7 +14,7 @@ from typing import (
     Union,
     runtime_checkable,
 )
-from urllib.parse import quote, urlparse, urlsplit, urlunparse
+from urllib.parse import quote, unquote, urlparse, urlsplit, urlunparse
 from uuid import uuid4
 
 import fsspec  # pyright: ignore[reportMissingTypeStubs]
@@ -501,7 +501,7 @@ class GitRepository:
             safe_url = strip_auth_from_url(self._url)
             sanitized_stderr = strip_auth_from_urls_in_text(
                 _decode_stderr(exc),
-                extra_secrets=[parsed_url.password] if parsed_url.password else None,
+                extra_secrets=_url_auth_secrets(self._url, repository_url),
             )
             # Surface the raw git error at DEBUG so users can opt in via log
             # level when the hint patterns don't match. The exception chain is
@@ -1015,6 +1015,22 @@ def _decode_stderr(exc: subprocess.CalledProcessError) -> str:
     if isinstance(exc.stderr, bytes):
         return exc.stderr.decode("utf-8", errors="replace")
     return str(exc.stderr)
+
+
+def _url_auth_secrets(*urls: str) -> list[str]:
+    """Extract userinfo values from URLs so echoed auth can be redacted."""
+    secrets: list[str] = []
+    seen: set[str] = set()
+    for url in urls:
+        parsed = urlparse(url)
+        for value in (parsed.username, parsed.password):
+            if not value:
+                continue
+            for secret in (value, unquote(value)):
+                if secret and secret not in seen:
+                    secrets.append(secret)
+                    seen.add(secret)
+    return secrets
 
 
 def _get_git_clone_error_hint(exc: subprocess.CalledProcessError) -> str | None:

--- a/tests/_internal/test_urls.py
+++ b/tests/_internal/test_urls.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefect._internal.urls import strip_auth_from_url
+from prefect._internal.urls import strip_auth_from_url, strip_auth_from_urls_in_text
 
 
 @pytest.mark.parametrize(
@@ -48,3 +48,49 @@ from prefect._internal.urls import strip_auth_from_url
 )
 def test_strip_auth_from_url(url: str, expected: str):
     assert strip_auth_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (
+            "fatal: could not read Username for 'https://github.com'",
+            "fatal: could not read Username for 'https://github.com'",
+        ),
+        (
+            "fatal: unable to access 'https://ghp_abc123@github.com/org/repo.git/'",
+            "fatal: unable to access 'https://github.com/org/repo.git/'",
+        ),
+        (
+            "error for https://user:secret@gitlab.com/path and https://tok@example.com/x",
+            "error for https://gitlab.com/path and https://example.com/x",
+        ),
+        (
+            "fatal: Authentication failed for "
+            "'https://oauth2:p@ss:word#1@gitlab.com/PrefectHQ/prefect.git/'",
+            "fatal: Authentication failed for "
+            "'https://gitlab.com/PrefectHQ/prefect.git/'",
+        ),
+        ("", ""),
+        ("no urls here", "no urls here"),
+    ],
+)
+def test_strip_auth_from_urls_in_text(raw: str, expected: str):
+    assert strip_auth_from_urls_in_text(raw) == expected
+
+
+def test_strip_auth_from_urls_in_text_redacts_extra_secrets():
+    text = "remote: token=ghp_abc123 hit rate limit"
+    assert (
+        strip_auth_from_urls_in_text(text, extra_secrets=["ghp_abc123"])
+        == "remote: token=*** hit rate limit"
+    )
+
+
+def test_strip_auth_from_url_handles_malformed_credential_url():
+    assert (
+        strip_auth_from_url(
+            "https://oauth2:p@ss:word#1@gitlab.com/PrefectHQ/prefect.git/"
+        )
+        == "https://gitlab.com/PrefectHQ/prefect.git/"
+    )

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -1342,6 +1342,75 @@ class TestGitCloneErrorHints:
         with pytest.raises(RuntimeError, match="credentials or access token"):
             await repo.pull_code()
 
+    async def test_clone_repo_surfaces_stderr_when_no_hint_matches(self, monkeypatch):
+        """When git's stderr doesn't match any known pattern, the raw (sanitized)
+        stderr should appear in the RuntimeError so users don't have to
+        monkey-patch Prefect to find out what actually went wrong.
+
+        Regression for private-repo clone failures in GCP Cloud Run Jobs where
+        users saw only `exit code 1.` with no further signal.
+        """
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+
+        stderr = (
+            b"remote: Counting objects: 100% (1/1), done.\n"
+            b"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly\n"
+            b"fatal: early EOF\n"
+        )
+
+        async def mock_run_process_transient(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, ["git", "clone"], stderr=stderr)
+
+        monkeypatch.setattr(
+            "prefect.runner.storage.run_process", mock_run_process_transient
+        )
+
+        repo = GitRepository(url="https://github.com/org/repo.git")
+        with pytest.raises(RuntimeError) as exc_info:
+            await repo.pull_code()
+
+        message = str(exc_info.value)
+        assert "exit code 1" in message
+        assert "git stderr:" in message
+        # The actionable final line should be visible to the user.
+        assert "early EOF" in message
+
+    async def test_clone_repo_logs_sanitized_stderr_at_debug(self, monkeypatch, caplog):
+        """Sanitized stderr should be emitted on the GitRepository debug logger
+        even when credentials are present (so the exception chain is suppressed)."""
+        import logging
+
+        monkeypatch.setattr("pathlib.Path.exists", lambda x: False)
+
+        stderr = (
+            b"fatal: unable to access "
+            b"'https://ghp_SECRETTOKEN@github.com/org/repo.git/': HTTP/2 stream closed\n"
+        )
+
+        async def mock_run_process(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, ["git", "clone"], stderr=stderr)
+
+        monkeypatch.setattr("prefect.runner.storage.run_process", mock_run_process)
+
+        # Embed credentials directly in the URL so exc_chain is suppressed.
+        repo = GitRepository(url="https://ghp_SECRETTOKEN@github.com/org/repo.git")
+        with caplog.at_level(
+            logging.DEBUG, logger="prefect.runner.storage.git-repository.repo"
+        ):
+            with pytest.raises(RuntimeError):
+                await repo.pull_code()
+
+        debug_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+            and "git clone failed" in record.getMessage()
+        ]
+        assert debug_messages, "expected a DEBUG log with sanitized git stderr"
+        joined = "\n".join(debug_messages)
+        assert "ghp_SECRETTOKEN" not in joined, "token must be sanitized"
+        assert "github.com" in joined
+
 
 class TestGitRepositoryConcurrency:
     """Tests for file-based locking in GitRepository.pull_code()."""

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -1385,6 +1385,7 @@ class TestGitCloneErrorHints:
         stderr = (
             b"fatal: unable to access "
             b"'https://ghp_SECRETTOKEN@github.com/org/repo.git/': HTTP/2 stream closed\n"
+            b"remote: token ghp_SECRETTOKEN was rejected\n"
         )
 
         async def mock_run_process(*args, **kwargs):
@@ -1397,9 +1398,10 @@ class TestGitCloneErrorHints:
         with caplog.at_level(
             logging.DEBUG, logger="prefect.runner.storage.git-repository.repo"
         ):
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError) as exc_info:
                 await repo.pull_code()
 
+        assert "ghp_SECRETTOKEN" not in str(exc_info.value)
         debug_messages = [
             record.getMessage()
             for record in caplog.records


### PR DESCRIPTION
Supersedes the core portion of #21689 and replaces the mixed draft #22185.

this PR is intentionally limited to Prefect core. It adds centralized URL-auth redaction for command output and uses it in `GitRepository._clone_repo` so users get useful, sanitized git stderr when no existing clone-error hint matches.

## Why

`GitRepository._clone_repo` currently suppresses the exception chain when credentials are present, which is correct for preventing token leaks. The tradeoff is that unusual git failures can collapse to only:

```text
RuntimeError: Failed to clone repository 'https://github.com/org/repo.git' with exit code 1.
```

When the stderr does not match one of the known hint patterns, users lose the actionable git error entirely. This change keeps the credential protection, but surfaces sanitized stderr in the exception message and debug log.

## Changes

- add `strip_auth_from_urls_in_text` to `prefect._internal.urls`
- make `strip_auth_from_url` tolerate malformed credential URLs by falling back to the text sanitizer
- use the shared sanitizer in `GitRepository._clone_repo` before logging or surfacing git stderr
- append a sanitized stderr tail when no known hint matches
- add regression coverage for URL auth redaction, caller-supplied secrets, malformed credential URLs, and the runner error/log paths

## What follows

Provider integrations such as `prefect-github`, `prefect-gitlab`, and `prefect-bitbucket` still have repository storage-block paths that can adopt this utility. Those adoption PRs should be separate draft PRs and must remain dependent on a released Prefect version that contains this core utility. Until that Prefect release exists, those packages should not import this helper or pin to a nonexistent Prefect version.

## Validation

- `uv run pytest tests/_internal/test_urls.py tests/runner/test_storage.py -q -k 'urls or git_clone_error_hint or clone_repo_surfaces_stderr_when_no_hint_matches or clone_repo_logs_sanitized_stderr_at_debug'`
- `uv run ruff check src/prefect/_internal/urls.py src/prefect/runner/storage.py tests/_internal/test_urls.py tests/runner/test_storage.py`
- `uv run ruff format --check src/prefect/_internal/urls.py src/prefect/runner/storage.py tests/_internal/test_urls.py tests/runner/test_storage.py`