### PR TITLE
Use shared git output sanitizer in prefect-github

### DIFF
--- a/src/integrations/prefect-github/prefect_github/repository.py
+++ b/src/integrations/prefect-github/prefect_github/repository.py
@@ -8,7 +8,6 @@ GitHub query_repository* tasks and the GitHub storage block.
 # is outdated, rerun scripts/generate.py.
 
 import io
-import re
 import shutil
 import subprocess
 from datetime import datetime
@@ -22,7 +21,7 @@ from sgqlc.operation import Operation
 
 from prefect import task
 from prefect._internal.compatibility.async_dispatch import async_dispatch
-from prefect._internal.urls import strip_auth_from_url
+from prefect._internal.urls import strip_auth_from_urls_in_text
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.processutils import run_process
 from prefect_github import GitHubCredentials
@@ -32,15 +31,6 @@ from prefect_github.utils import initialize_return_fields_defaults, strip_kwargs
 
 config_path = Path(__file__).parent.resolve() / "configs" / "query" / "repository.json"
 return_fields_defaults = initialize_return_fields_defaults(config_path)
-
-_URL_PATTERN = re.compile(r"https?://[^\s'\"<>]+")
-
-
-def _sanitize_git_error(message: str) -> str:
-    def _replace(match: re.Match[str]) -> str:
-        return strip_auth_from_url(match.group(0))
-
-    return _URL_PATTERN.sub(_replace, message)
 
 
 class GitHubRepository(ReadableDeploymentStorage):
@@ -86,6 +76,11 @@ class GitHubRepository(ReadableDeploymentStorage):
             full_url = self.repository_url
 
         return full_url
+
+    def _git_error_extra_secrets(self) -> list[str]:
+        if self.credentials is None:
+            return []
+        return [self.credentials.token.get_secret_value()]
 
     @staticmethod
     def _get_paths(
@@ -138,7 +133,9 @@ class GitHubRepository(ReadableDeploymentStorage):
             process = await run_process(cmd, stream_output=(out_stream, err_stream))
             if process.returncode != 0:
                 err_stream.seek(0)
-                sanitized_error = _sanitize_git_error(err_stream.read())
+                sanitized_error = strip_auth_from_urls_in_text(
+                    err_stream.read(), extra_secrets=self._git_error_extra_secrets()
+                )
                 raise RuntimeError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
@@ -178,7 +175,9 @@ class GitHubRepository(ReadableDeploymentStorage):
 
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                sanitized_error = _sanitize_git_error(result.stderr)
+                sanitized_error = strip_auth_from_urls_in_text(
+                    result.stderr, extra_secrets=self._git_error_extra_secrets()
+                )
                 raise RuntimeError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-github"
-dependencies = ["sgqlc>=15.0", "prefect>=3.6.17"]
+dependencies = ["sgqlc>=15.0", "prefect>=3.7.4"]
 dynamic = ["version"]
 description = "Prefect integrations interacting with GitHub"
 readme = "README.md"

--- a/src/integrations/prefect-github/tests/test_repository.py
+++ b/src/integrations/prefect-github/tests/test_repository.py
@@ -84,6 +84,7 @@ class TestGitHubRepository:
                 err_stream.write(
                     "fatal: Authentication failed for "
                     "'https://XYZ@github.com/PrefectHQ/prefect.git/'"
+                    "\nremote: token XYZ rejected"
                 )
             return p()
 


### PR DESCRIPTION
Depends on Prefect `>=3.7.4`, which includes `prefect._internal.urls.strip_auth_from_urls_in_text` from #22196.

This is a draft adoption PR for `prefect-github`.

## Changes

- remove the local GitHub repository clone-error sanitizer
- use the shared core URL-auth sanitizer for async and sync clone stderr
- pass the configured GitHub token as an extra redaction secret so token echoes outside URL-shaped stderr are also redacted
- bump the package's Prefect lower bound to `prefect>=3.7.4`

## Validation

- `uv run pytest tests/test_repository.py -q -k redacts_token_in_error` from `src/integrations/prefect-github`
- `uv run ruff check src/integrations/prefect-github/prefect_github/repository.py src/integrations/prefect-github/tests/test_repository.py` from repo root
- `uv run ruff format --check src/integrations/prefect-github/prefect_github/repository.py src/integrations/prefect-github/tests/test_repository.py` from repo root