### PR TITLE
Use shared git output sanitizer in prefect-gitlab

### DIFF
--- a/src/integrations/prefect-gitlab/prefect_gitlab/repositories.py
+++ b/src/integrations/prefect-gitlab/prefect_gitlab/repositories.py
@@ -53,6 +53,7 @@ from pydantic import Field
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 from prefect._internal.compatibility.async_dispatch import async_dispatch
+from prefect._internal.urls import strip_auth_from_urls_in_text
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.processutils import run_process
 from prefect_gitlab.credentials import GitLabCredentials
@@ -116,6 +117,12 @@ class GitLabRepository(ReadableDeploymentStorage):
 
         return full_url
 
+    def _git_error_extra_secrets(self) -> list[str]:
+        if self.credentials is None:
+            return []
+        token = self.credentials.token.get_secret_value()
+        return [token, f"oauth2:{token}"]
+
     @staticmethod
     def _get_paths(
         dst_dir: Union[str, None], src_dir: str, sub_directory: Optional[str]
@@ -176,7 +183,10 @@ class GitLabRepository(ReadableDeploymentStorage):
             process = await run_process(cmd, stream_output=(out_stream, err_stream))
             if process.returncode != 0:
                 err_stream.seek(0)
-                raise OSError(f"Failed to pull from remote:\n {err_stream.read()}")
+                sanitized_error = strip_auth_from_urls_in_text(
+                    err_stream.read(), extra_secrets=self._git_error_extra_secrets()
+                )
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path
@@ -221,7 +231,10 @@ class GitLabRepository(ReadableDeploymentStorage):
 
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                raise OSError(f"Failed to pull from remote:\n {result.stderr}")
+                sanitized_error = strip_auth_from_urls_in_text(
+                    result.stderr, extra_secrets=self._git_error_extra_secrets()
+                )
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["prefect>=3.6.17", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
+dependencies = ["prefect>=3.7.4", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
 dynamic = ["version"]
 
 [dependency-groups]

--- a/src/integrations/prefect-gitlab/tests/test_repositories.py
+++ b/src/integrations/prefect-gitlab/tests/test_repositories.py
@@ -139,6 +139,34 @@ class TestGitLab:
         ]
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
+    async def test_get_directory_redacts_token_in_clone_error(self, monkeypatch):
+        class p:
+            returncode = 1
+
+        async def mock(cmd, stream_output=None, **kwargs):
+            if stream_output:
+                _, err_stream = stream_output
+                err_stream.write(
+                    "fatal: Authentication failed for "
+                    "'https://oauth2:p@ss:word#1@gitlab.com/PrefectHQ/prefect.git/'"
+                    "\nremote: token p@ss:word#1 rejected"
+                )
+            return p()
+
+        monkeypatch.setattr(prefect_gitlab.repositories, "run_process", mock)
+
+        g = GitLabRepository(
+            repository="https://gitlab.com/PrefectHQ/prefect.git",
+            credentials=GitLabCredentials(token=SecretStr("p@ss:word#1")),
+        )
+
+        with pytest.raises(OSError) as exc_info:
+            await g.get_directory()
+
+        message = str(exc_info.value)
+        assert "p@ss:word#1" not in message
+        assert "https://gitlab.com/PrefectHQ/prefect.git/" in message
+
     async def test_cloning_with_custom_depth(self, monkeypatch):
         """Ensure that we can retrieve the whole history, i.e. support true git clone"""  # noqa: E501
 


### PR DESCRIPTION
Depends on Prefect `>=3.7.4`, which includes `prefect._internal.urls.strip_auth_from_urls_in_text` from #22196.

This is a draft adoption PR for `prefect-gitlab`.

## Changes

- sanitize GitLab repository block async and sync clone stderr with the shared core helper
- pass the configured GitLab token as an extra redaction secret so token echoes outside URL-shaped stderr are also redacted
- add regression coverage for a malformed credential URL such as `https://oauth2:p@ss:word#1@gitlab.com/...`
- bump the package's Prefect lower bound to `prefect>=3.7.4`

## Validation

- `uv run pytest tests/test_repositories.py -q -k redacts_token_in_clone_error` from `src/integrations/prefect-gitlab`
- `uv run ruff check src/integrations/prefect-gitlab/prefect_gitlab/repositories.py src/integrations/prefect-gitlab/tests/test_repositories.py` from repo root
- `uv run ruff format --check src/integrations/prefect-gitlab/prefect_gitlab/repositories.py src/integrations/prefect-gitlab/tests/test_repositories.py` from repo root