### PR TITLE
Use shared git output sanitizer in prefect-bitbucket

### DIFF
--- a/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
+++ b/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
@@ -47,6 +47,7 @@ from pydantic import Field, model_validator
 from typing_extensions import Self
 
 from prefect._internal.compatibility.async_dispatch import async_dispatch
+from prefect._internal.urls import strip_auth_from_urls_in_text
 from prefect.exceptions import InvalidRepositoryURLError
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.processutils import run_process
@@ -136,6 +137,22 @@ class BitBucketRepository(ReadableDeploymentStorage):
 
         return full_url
 
+    def _git_error_extra_secrets(self) -> list[str]:
+        if self.bitbucket_credentials is None or not self.bitbucket_credentials.token:
+            return []
+
+        token = self.bitbucket_credentials.token.get_secret_value()
+        username = self.bitbucket_credentials.username or "x-token-auth"
+        quoted_token = _quote_credential(token)
+        quoted_username = _quote_credential(username)
+
+        return [
+            token,
+            quoted_token,
+            f"{username}:{token}",
+            f"{quoted_username}:{quoted_token}",
+        ]
+
     @staticmethod
     def _get_paths(
         dst_dir: Union[str, None], src_dir: str, sub_directory: Optional[str]
@@ -188,7 +205,10 @@ class BitBucketRepository(ReadableDeploymentStorage):
             process = await run_process(cmd, stream_output=(out_stream, err_stream))
             if process.returncode != 0:
                 err_stream.seek(0)
-                raise OSError(f"Failed to pull from remote:\n {err_stream.read()}")
+                sanitized_error = strip_auth_from_urls_in_text(
+                    err_stream.read(), extra_secrets=self._git_error_extra_secrets()
+                )
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path
@@ -221,7 +241,10 @@ class BitBucketRepository(ReadableDeploymentStorage):
 
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                raise OSError(f"Failed to pull from remote:\n {result.stderr}")
+                sanitized_error = strip_auth_from_urls_in_text(
+                    result.stderr, extra_secrets=self._git_error_extra_secrets()
+                )
+                raise OSError(f"Failed to pull from remote:\n {sanitized_error}")
 
             content_source, content_destination = self._get_paths(
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.6.17",
+  "prefect>=3.7.4",
   "pydantic>=2.4",
   "atlassian-python-api>=3.32.1,!=3.41.5,!=3.41.6,!=3.41.7,!=3.41.8",
 ]

--- a/src/integrations/prefect-bitbucket/tests/test_repository.py
+++ b/src/integrations/prefect-bitbucket/tests/test_repository.py
@@ -180,6 +180,36 @@ class TestBitBucketRepository:
         ]
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
+    async def test_get_directory_redacts_token_in_clone_error(self, monkeypatch):
+        class p:
+            returncode = 1
+
+        async def mock(cmd, stream_output=None, **kwargs):
+            if stream_output:
+                _, err_stream = stream_output
+                err_stream.write(
+                    "fatal: Authentication failed for "
+                    "'https://dev:p@ss:word#1@bitbucket.org/PrefectHQ/prefect.git/'"
+                    "\nremote: token p@ss:word#1 rejected"
+                )
+            return p()
+
+        monkeypatch.setattr(prefect_bitbucket.repository, "run_process", mock)
+
+        b = BitBucketRepository(
+            repository="https://bitbucket.org/PrefectHQ/prefect.git",
+            bitbucket_credentials=BitBucketCredentials(
+                token="p@ss:word#1", username="dev"
+            ),
+        )
+
+        with pytest.raises(OSError) as exc_info:
+            await b.get_directory()
+
+        message = str(exc_info.value)
+        assert "dev:p@ss:word#1" not in message
+        assert "https://bitbucket.org/PrefectHQ/prefect.git/" in message
+
     async def test_ssh_fails_with_credential(self, monkeypatch):
         """Ensure that credentials cannot be passed in if the URL is not in the HTTPS
         format.


### PR DESCRIPTION
Depends on Prefect `>=3.7.4`, which includes `prefect._internal.urls.strip_auth_from_urls_in_text` from #22196.

This is a draft adoption PR for `prefect-bitbucket`.

## Changes

- sanitize Bitbucket repository block async and sync clone stderr with the shared core helper
- pass configured Bitbucket token material as extra redaction secrets so token echoes outside URL-shaped stderr are also redacted
- add regression coverage for a malformed credential URL such as `https://dev:p@ss:word#1@bitbucket.org/...`
- bump the package's Prefect lower bound to `prefect>=3.7.4`

## Validation

- `uv run pytest tests/test_repository.py -q -k redacts_token_in_clone_error` from `src/integrations/prefect-bitbucket`
- `uv run ruff check src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py src/integrations/prefect-bitbucket/tests/test_repository.py` from repo root
- `uv run ruff format --check src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py src/integrations/prefect-bitbucket/tests/test_repository.py` from repo root