### PR TITLE
clean up stale redis ephemeral groups

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -694,12 +694,17 @@ async def _trim_stream_to_lowest_delivered_id(stream_name: str) -> None:
 
 async def _cleanup_empty_consumer_groups(stream_name: str) -> None:
     """
-    Removes consumer groups that have no active consumers and have consumed at least
-    one message.
+    Removes ephemeral consumer groups that have no active consumers, or whose
+    consumers have all been idle beyond the configured trim idle threshold, and have
+    consumed at least one message.
 
     Consumer groups with no consumers that have previously consumed messages are
     considered abandoned and can safely be deleted to prevent them from blocking
     stream trimming operations.
+
+    Ephemeral groups with only stale consumers can be left behind by ungraceful
+    process termination before the ephemeral subscription cleanup runs. These are
+    also safe to remove once all consumers are idle beyond the trim idle threshold.
 
     Groups with last-delivered-id of "0-0" are skipped because they haven't consumed
     any messages yet - they may be newly created and waiting for consumers to be added.
@@ -709,6 +714,8 @@ async def _cleanup_empty_consumer_groups(stream_name: str) -> None:
         stream_name: The name of the Redis stream to clean up groups for
     """
     redis_client: Redis = get_async_redis_client()
+    settings = RedisMessagingConsumerSettings()
+    idle_threshold_ms = int(settings.trim_idle_threshold.total_seconds() * 1000)
 
     try:
         groups = await redis_client.xinfo_groups(stream_name)
@@ -724,9 +731,11 @@ async def _cleanup_empty_consumer_groups(stream_name: str) -> None:
                 continue
 
             consumers = await redis_client.xinfo_consumers(stream_name, group["name"])
-            if not consumers and group["name"].startswith("ephemeral"):
-                # No consumers in this group and it has consumed messages - it's abandoned
-                logger.debug(f"Deleting empty consumer group '{group['name']}'")
+            if group["name"].startswith("ephemeral") and (
+                not consumers
+                or all(consumer["idle"] > idle_threshold_ms for consumer in consumers)
+            ):
+                logger.debug(f"Deleting abandoned consumer group '{group['name']}'")
                 await redis_client.xgroup_destroy(stream_name, group["name"])
         except Exception as e:
             # If we can't check or delete, just continue

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -644,6 +644,53 @@ async def test_cleanup_empty_consumer_groups(redis: Redis):
     assert groups_after[0]["name"] == "ephemeral-active-group"
 
 
+async def test_cleanup_stale_ephemeral_consumer_groups(
+    redis: Redis, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that idle ephemeral groups with consumers are cleaned up."""
+
+    stream_name = "test-cleanup-stale-ephemeral-stream"
+
+    await redis.xadd(stream_name, {"data": "test"})
+
+    await redis.xgroup_create(stream_name, "ephemeral-stale-group", id="0")
+    await redis.xgroup_create(stream_name, "ephemeral-active-group", id="0")
+    await redis.xgroup_create(stream_name, "permanent-stale-group", id="0")
+
+    for group_name in [
+        "ephemeral-stale-group",
+        "ephemeral-active-group",
+        "permanent-stale-group",
+    ]:
+        await redis.xreadgroup(
+            groupname=group_name,
+            consumername=f"{group_name}-consumer",
+            streams={stream_name: ">"},
+            count=1,
+        )
+
+    await asyncio.sleep(1.5)
+    monkeypatch.setenv("PREFECT_REDIS_MESSAGING_CONSUMER_TRIM_IDLE_THRESHOLD", "1")
+
+    await redis.xadd(stream_name, {"data": "test2"})
+    await redis.xreadgroup(
+        groupname="ephemeral-active-group",
+        consumername="fresh-consumer",
+        streams={stream_name: ">"},
+        count=1,
+    )
+
+    await _cleanup_empty_consumer_groups(stream_name)
+
+    groups_after = await redis.xinfo_groups(stream_name)
+    group_names_after = {g["name"] for g in groups_after}
+
+    assert group_names_after == {
+        "ephemeral-active-group",
+        "permanent-stale-group",
+    }
+
+
 async def test_cleanup_preserves_newly_created_empty_groups(redis: Redis):
     """Test that newly created empty consumer groups are NOT deleted.
 


### PR DESCRIPTION
closes #22136

this PR cleans up stale Redis `ephemeral-*` consumer groups that can be left behind when a process dies before `ephemeral_subscription()` runs its `finally` block.

<details>
<summary>Details</summary>

Redis stream cleanup already removes empty ephemeral groups that have consumed messages, but an ungracefully killed consumer leaves the group with one Redis consumer attached. That group keeps a stale `last-delivered-id`, remains eligible for trimming calculations until it crosses the idle skip threshold, and is not removed by `_cleanup_empty_consumer_groups` because it is not empty.

This changes `_cleanup_empty_consumer_groups` to also destroy ephemeral groups whose consumers have all been idle longer than `PREFECT_REDIS_MESSAGING_CONSUMER_TRIM_IDLE_THRESHOLD`, while still preserving newly-created groups with `last-delivered-id == "0-0"` and non-ephemeral groups.

I reproduced the issue in an HA Helm deployment with 3 API pods, 2 background-service pods, Postgres, Redis-backed messaging/cache/ordering/leases, and Redis-backed Docket. After killing a subscriber container with `SIGKILL`, Redis retained an `ephemeral-*` group with `consumers=1`, `entries-read=75`, and then `lag=50` after live groups advanced to `entries-read=125`. Running Prefect's trim and cleanup functions left the stream pinned until this fix.

</details>

Validation:

- `uv run --project src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_messaging.py -k test_cleanup_stale_ephemeral_consumer_groups -q`
- `uv run --project src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_messaging.py -k 'trimming or cleanup' -q`
- `uv run --project src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_messaging.py -q`
- `uv run ruff check src/integrations/prefect-redis/prefect_redis/messaging.py src/integrations/prefect-redis/tests/test_messaging.py`
