### PR TITLE
Use XREAD for Redis ephemeral subscriptions

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -376,6 +376,7 @@ class Consumer(_Consumer):
             )
 
             if not stream_entries:
+                await self._trim_stream_if_necessary(last_id)
                 continue
 
             for _, messages in stream_entries:
@@ -394,6 +395,7 @@ class Consumer(_Consumer):
                             _noop_ack,
                         )
                     except StopConsumer:
+                        await self._trim_stream_if_necessary(last_id)
                         return
                     except Exception:
                         logger.exception(
@@ -401,6 +403,8 @@ class Consumer(_Consumer):
                             message_id,
                             self.name,
                         )
+
+            await self._trim_stream_if_necessary(last_id)
 
     async def process_pending_messages(
         self,
@@ -630,13 +634,17 @@ class Consumer(_Consumer):
         # Add to a Redis set for easy retrieval
         await redis_client.sadd(self.subscription.dlq_key, message_id)
 
-    async def _trim_stream_if_necessary(self) -> None:
+    async def _trim_stream_if_necessary(
+        self, latest_delivered_id: Optional[str] = None
+    ) -> None:
         now = time.monotonic()
         if self._last_trimmed is None:
             self._last_trimmed = now
 
         if now - self._last_trimmed > self.trim_every.total_seconds():
-            await _trim_stream_to_lowest_delivered_id(self.stream)
+            await _trim_stream_to_lowest_delivered_id(
+                self.stream, latest_delivered_id=latest_delivered_id
+            )
             await _cleanup_empty_consumer_groups(self.stream)
             self._last_trimmed = now
 
@@ -685,14 +693,16 @@ async def break_topic():
         yield
 
 
-async def _trim_stream_to_lowest_delivered_id(stream_name: str) -> None:
+async def _trim_stream_to_lowest_delivered_id(
+    stream_name: str, latest_delivered_id: Optional[str] = None
+) -> None:
     """
-    Trims a Redis stream by removing all messages that have been delivered to and
-    acknowledged by all consumer groups.
+    Trims a Redis stream by removing messages that have been delivered to all
+    active consumers.
 
     This function finds the lowest last-delivered-id across all consumer groups and
-    trims the stream up to that point, as we know all consumers have processed those
-    messages.
+    any non-consumer-group reader, then trims the stream up to that point, as we
+    know all consumers have processed those messages.
 
     Consumer groups with all consumers idle beyond the configured threshold are
     excluded from the trimming calculation to prevent inactive groups from blocking
@@ -700,19 +710,25 @@ async def _trim_stream_to_lowest_delivered_id(stream_name: str) -> None:
 
     Args:
         stream_name: The name of the Redis stream to trim
+        latest_delivered_id: The latest ID delivered to a non-consumer-group reader.
     """
     redis_client: Redis = get_async_redis_client()
     settings = RedisMessagingConsumerSettings()
     idle_threshold_ms = int(settings.trim_idle_threshold.total_seconds() * 1000)
 
+    delivered_ids = []
+    if latest_delivered_id and latest_delivered_id != "0-0":
+        delivered_ids.append(latest_delivered_id)
+
     # Get information about all consumer groups for this stream
     groups = await redis_client.xinfo_groups(stream_name)
     if not groups:
         logger.debug(f"No consumer groups found for stream {stream_name}")
-        return
+        if not delivered_ids:
+            return
 
     # Find the lowest last-delivered-id across all active groups
-    group_ids = []
+    group_ids = delivered_ids
     for group in groups:
         if group["last-delivered-id"] == "0-0":
             # Skip groups that haven't consumed anything

--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -314,6 +314,7 @@ class Consumer(_Consumer):
         max_retries: Optional[int] = None,
         trim_every: Optional[timedelta] = None,
         read_batch_size: Optional[int] = 1,
+        use_consumer_group: bool = True,
     ):
         settings = RedisMessagingConsumerSettings()
 
@@ -348,6 +349,7 @@ class Consumer(_Consumer):
 
         self._last_trimmed: Optional[float] = None
         self._read_batch_size: Optional[int] = read_batch_size
+        self.use_consumer_group = use_consumer_group
 
     async def _ensure_stream_and_group(self, redis_client: Redis) -> None:
         """Ensure the stream and consumer group exist."""
@@ -360,6 +362,45 @@ class Consumer(_Consumer):
             if "BUSYGROUP Consumer Group name already exists" not in str(e):
                 raise
             logger.debug("Consumer group already exists: %s", e)
+
+    async def _run_without_consumer_group(
+        self, handler: MessageHandler, redis_client: Redis
+    ) -> None:
+        last_id = self.starting_message_id
+
+        while True:
+            stream_entries = await redis_client.xread(
+                streams={self.stream: last_id},
+                count=self._read_batch_size,
+                block=int(self.block.total_seconds() * 1000),
+            )
+
+            if not stream_entries:
+                continue
+
+            for _, messages in stream_entries:
+                for message_id, message in messages:
+                    last_id = (
+                        message_id.decode()
+                        if isinstance(message_id, bytes)
+                        else message_id
+                    )
+                    self.starting_message_id = last_id
+                    try:
+                        await self._handle_message(
+                            message_id,
+                            message,
+                            handler,
+                            _noop_ack,
+                        )
+                    except StopConsumer:
+                        return
+                    except Exception:
+                        logger.exception(
+                            "Error handling message %s in consumer %s, continuing",
+                            message_id,
+                            self.name,
+                        )
 
     async def process_pending_messages(
         self,
@@ -426,6 +467,10 @@ class Consumer(_Consumer):
         while True:  # Outer loop for connection resilience
             try:
                 redis_client: Redis = get_async_redis_client()
+
+                if not self.use_consumer_group:
+                    await self._run_without_consumer_group(handler, redis_client)
+                    return
 
                 # Ensure stream and group exist before processing messages
                 await self._ensure_stream_and_group(redis_client)
@@ -601,16 +646,30 @@ async def ephemeral_subscription(
     topic: str, source: Optional[str] = None, group: Optional[str] = None
 ) -> AsyncGenerator[dict[str, Any], None]:
     source = source or topic
-    group_name = group or f"ephemeral-{socket.gethostname()}-{uuid.uuid4().hex}"
+    name = group or f"ephemeral-{socket.gethostname()}-{uuid.uuid4().hex}"
     redis_client: Redis = get_async_redis_client()
 
-    await redis_client.xgroup_create(source, group_name, id="0", mkstream=True)
-
     try:
-        # Return only the arguments that the Consumer expects.
-        yield {"topic": topic, "name": topic, "group": group_name}
-    finally:
-        await redis_client.xgroup_destroy(source, group_name)
+        stream_info = await redis_client.xinfo_stream(source)
+        starting_message_id = stream_info["last-generated-id"]
+    except ResponseError as exc:
+        if "no such key" not in str(exc).lower():
+            raise
+        starting_message_id = "0-0"
+
+    # Ephemeral subscribers only need live messages from this point forward; they do
+    # not need durable consumer-group state. Using XREAD avoids leaking Redis
+    # consumer groups when a process is killed before context manager cleanup runs.
+    yield {
+        "topic": source,
+        "name": name,
+        "starting_message_id": starting_message_id,
+        "use_consumer_group": False,
+    }
+
+
+async def _noop_ack(*args: Any, **kwargs: Any) -> int:
+    return 0
 
 
 @asynccontextmanager

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -407,6 +407,42 @@ async def test_ephemeral_subscription_does_not_skip_messages_received_during_han
     assert [message.data for message in captured_messages] == ["first", "second"]
 
 
+async def test_ephemeral_subscription_trims_stream_without_consumer_groups(
+    redis: Redis, broker: str, publisher: Publisher
+):
+    """Ephemeral XREAD consumers should still periodically trim their stream."""
+    captured_messages: list[Message] = []
+
+    async with publisher as p:
+        for i in range(5):
+            await p.publish_data(b"old", {"message": f"old-{i}"})
+
+    assert await redis.xlen("message-tests") == 5
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        if len(captured_messages) == 2:
+            raise StopConsumer(ack=True)
+
+    async with ephemeral_subscription("message-tests") as consumer_kwargs:
+        consumer = create_consumer(**consumer_kwargs, trim_every=timedelta(seconds=0))
+        consumer_task = asyncio.create_task(consumer.run(handler))
+
+        try:
+            async with publisher as p:
+                await p.publish_data(b"new", {"message": "new-1"})
+                await p.publish_data(b"new", {"message": "new-2"})
+        finally:
+            await consumer_task
+
+    assert [message.attributes["message"] for message in captured_messages] == [
+        "new-1",
+        "new-2",
+    ]
+    assert await redis.xinfo_groups("message-tests") == []
+    assert await redis.xlen("message-tests") < 7
+
+
 @pytest.mark.parametrize("batch_size", [1, 5])
 async def test_publisher_respects_batch_size(
     publisher: Publisher, consumer: Consumer, batch_size: int

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -331,16 +331,80 @@ async def test_ephemeral_subscription(broker: str, publisher: Publisher):
 
 
 async def test_verify_ephemeral_cleanup(redis: Redis, broker: str):
-    """Verify that ephemeral subscriptions clean up after themselves."""
+    """Verify that ephemeral subscriptions do not create consumer groups."""
     async with ephemeral_subscription("message-tests") as consumer_kwargs:
-        group_name = consumer_kwargs["group"]
-        # Verify group exists
-        groups = await redis.xinfo_groups("message-tests")
-        assert any(g["name"] == group_name for g in groups)
+        assert consumer_kwargs["use_consumer_group"] is False
+        assert "group" not in consumer_kwargs
 
-    # Verify group is cleaned up
+        async with create_publisher("message-tests") as p:
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+
+        groups = await redis.xinfo_groups("message-tests")
+        assert groups == []
+
     groups = await redis.xinfo_groups("message-tests")
-    assert not any(g["name"] == group_name for g in groups)
+    assert groups == []
+
+
+async def test_ephemeral_subscription_does_not_replay_old_messages(
+    broker: str, publisher: Publisher
+):
+    """Ephemeral subscriptions should receive live messages, not stream history."""
+    captured_messages: list[Message] = []
+
+    async with publisher as p:
+        await p.publish_data(b"old", {"message": "old"})
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    async with ephemeral_subscription("message-tests") as consumer_kwargs:
+        consumer = create_consumer(**consumer_kwargs)
+        consumer_task = asyncio.create_task(consumer.run(handler))
+
+        try:
+            async with publisher as p:
+                await p.publish_data(b"new", {"message": "new"})
+        finally:
+            await consumer_task
+
+    assert len(captured_messages) == 1
+    assert captured_messages[0].data == "new"
+    assert captured_messages[0].attributes == {"message": "new"}
+
+
+async def test_ephemeral_subscription_does_not_skip_messages_received_during_handler(
+    broker: str,
+):
+    """Ephemeral XREAD consumers should advance from the last seen ID after startup."""
+    captured_messages: list[Message] = []
+    second_message_published = asyncio.Event()
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+
+        if len(captured_messages) == 1:
+            async with create_publisher("message-tests") as p:
+                await p.publish_data(b"second", {"message": "second"})
+            second_message_published.set()
+            await asyncio.sleep(0.1)
+            return
+
+        raise StopConsumer(ack=True)
+
+    async with ephemeral_subscription("message-tests") as consumer_kwargs:
+        consumer = create_consumer(**consumer_kwargs)
+        consumer_task = asyncio.create_task(consumer.run(handler))
+
+        try:
+            async with create_publisher("message-tests") as p:
+                await p.publish_data(b"first", {"message": "first"})
+            await second_message_published.wait()
+        finally:
+            await consumer_task
+
+    assert [message.data for message in captured_messages] == ["first", "second"]
 
 
 @pytest.mark.parametrize("batch_size", [1, 5])


### PR DESCRIPTION
closes #22136

this PR changes Redis-backed ephemeral subscriptions to use `XREAD` from the stream tail instead of creating temporary Redis consumer groups.

<details>
<summary>Details</summary>

- Keeps durable Redis consumers on `XGROUP` / `XREADGROUP`.
- Makes `ephemeral_subscription()` capture the stream's current `last-generated-id` and return consumer kwargs that run without a consumer group.
- Avoids creating or destroying `ephemeral-*` Redis groups, so a hard-killed process has no group state to leak and no customer Redis groups are mutated by cleanup.
- Adds Redis tests for no group creation, no replay of old messages, and not skipping messages published while a handler is running.

Validation:

- `uv run --project src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_messaging.py -q`
- `uv run pytest tests/server/utilities/test_messaging.py -k ephemeral -q`
- `uv run ruff check src/integrations/prefect-redis/prefect_redis/messaging.py src/integrations/prefect-redis/tests/test_messaging.py`
- `uv run ruff format --check src/integrations/prefect-redis/prefect_redis/messaging.py src/integrations/prefect-redis/tests/test_messaging.py`
- HA smoke/load in Kubernetes namespace `prefect-xread-repro` with 3 server replicas, 2 background-service replicas, Postgres, Redis messaging/cache/ordering/lease storage, and Redis Docket:
  - 1000 events before API kill: durable groups at `lag 0`, `EPHEMERAL_COUNT 0`.
  - 1000 events after forced API pod kill: durable groups at `lag 0`, `EPHEMERAL_COUNT 0`.
  - 500 events after forced background-service pod kill: durable groups at `lag 0`, `EPHEMERAL_COUNT 0`.
  - Explicit ephemeral subscriber crash after receiving an event followed by host-level `docker kill --signal=KILL`: subscriber exited 137, Redis still reported `EPHEMERAL_COUNT 0` and durable event groups at `lag 0`.

Related context:

- Supersedes the closed duplicate draft #22200.
- Avoids the idle-consumer cleanup direction from #22138, including the Redis version semantics and live in-flight consumer concerns raised there.

</details>