### PR TITLE
fix(prefect-gcp): retry transient errors on all Cloud Run V2 worker reads

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/settings.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/settings.py
@@ -69,11 +69,11 @@ class CloudRunV2WorkerSettings(PrefectBaseSettings):
         ),
     )
 
-    transient_read_max_attempts: int = Field(
+    api_read_retry_max_attempts: int = Field(
         default=3,
         ge=1,
         description=(
-            "The maximum number of attempts for transient-error retries on "
+            "The maximum number of attempts for retries on "
             "read-only Cloud Run V2 API calls (job readiness polling, execution "
             "watching, and the submission baseline, recovery, and fetch lookups). "
             "Increase this value to allow more retries when a read fails due to "
@@ -81,7 +81,7 @@ class CloudRunV2WorkerSettings(PrefectBaseSettings):
         ),
     )
 
-    transient_read_initial_delay_seconds: float = Field(
+    api_read_retry_initial_delay_seconds: float = Field(
         default=1.0,
         gt=0,
         description=(
@@ -90,7 +90,7 @@ class CloudRunV2WorkerSettings(PrefectBaseSettings):
         ),
     )
 
-    transient_read_max_delay_seconds: float = Field(
+    api_read_retry_max_delay_seconds: float = Field(
         default=10.0,
         gt=0,
         description=(

--- a/src/integrations/prefect-gcp/prefect_gcp/settings.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/settings.py
@@ -69,6 +69,36 @@ class CloudRunV2WorkerSettings(PrefectBaseSettings):
         ),
     )
 
+    transient_read_max_attempts: int = Field(
+        default=3,
+        ge=1,
+        description=(
+            "The maximum number of attempts for transient-error retries on "
+            "read-only Cloud Run V2 API calls (job readiness polling, execution "
+            "watching, and the submission baseline, recovery, and fetch lookups). "
+            "Increase this value to allow more retries when a read fails due to "
+            "transient issues like HTTP 429/500/503 from the Cloud Run API."
+        ),
+    )
+
+    transient_read_initial_delay_seconds: float = Field(
+        default=1.0,
+        gt=0,
+        description=(
+            "The initial delay in seconds for exponential jitter backoff between "
+            "retries on read-only Cloud Run V2 API calls."
+        ),
+    )
+
+    transient_read_max_delay_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description=(
+            "The maximum delay in seconds for exponential jitter backoff between "
+            "retries on read-only Cloud Run V2 API calls."
+        ),
+    )
+
 
 class CloudRunV2Settings(PrefectBaseSettings):
     """Settings for the Cloud Run V2 integration."""

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -80,20 +80,23 @@ def _is_transient_http_error(exc: Exception) -> bool:
     return False
 
 
+_OperationLabel = Literal[
+    "creating job",
+    "submitting job for execution",
+    "polling job readiness",
+    "watching job execution",
+    "looking up the latest execution",
+    "verifying the submitted execution",
+    "fetching the submitted execution",
+]
+
+
 def _build_transient_retrying(
     *,
     max_attempts: int,
     initial_delay: float,
     max_delay: float,
-    operation_label: Literal[
-        "creating job",
-        "submitting job for execution",
-        "polling job readiness",
-        "watching job execution",
-        "looking up the latest execution",
-        "verifying the submitted execution",
-        "fetching the submitted execution",
-    ],
+    operation_label: _OperationLabel,
     logger: PrefectLogAdapter,
 ) -> Retrying:
     """Build a Retrying that retries transient HTTP errors with exponential jitter."""
@@ -128,14 +131,9 @@ _ReadT = TypeVar("_ReadT")
 def _read_with_retry(
     fn: Callable[[], _ReadT],
     *,
-    operation_label: Literal[
-        "polling job readiness",
-        "watching job execution",
-        "looking up the latest execution",
-        "verifying the submitted execution",
-        "fetching the submitted execution",
-    ],
+    operation_label: _OperationLabel,
     logger: PrefectLogAdapter,
+    settings: CloudRunV2WorkerSettings | None = None,
 ) -> _ReadT:
     """Run an idempotent Cloud Run read through the shared transient-retry policy.
 
@@ -144,8 +142,12 @@ def _read_with_retry(
     retries. Reads are side-effect free, so retrying never risks starting a
     duplicate execution. Non-transient errors (404, 400, ...) are reraised
     immediately for the caller to handle.
+
+    Pass settings to reuse one CloudRunV2WorkerSettings across a polling loop
+    instead of rereading it from disk on every poll.
     """
-    settings = CloudRunV2WorkerSettings()
+    if settings is None:
+        settings = CloudRunV2WorkerSettings()
     retrying = _build_transient_retrying(
         max_attempts=settings.transient_read_max_attempts,
         initial_delay=settings.transient_read_initial_delay_seconds,
@@ -951,6 +953,8 @@ class CloudRunWorkerV2(
                 seconds.
         """
 
+        settings = CloudRunV2WorkerSettings()
+
         def _get_job() -> JobV2:
             return _read_with_retry(
                 lambda: JobV2.get(
@@ -961,6 +965,7 @@ class CloudRunWorkerV2(
                 ),
                 operation_label="polling job readiness",
                 logger=logger,
+                settings=settings,
             )
 
         job = _get_job()
@@ -1324,6 +1329,7 @@ class CloudRunWorkerV2(
         Raises:
             InfrastructureNotFound: If the execution is deleted (e.g., by kill_infrastructure).
         """
+        settings = CloudRunV2WorkerSettings()
         while execution.is_running():
             current_name = execution.name
             try:
@@ -1334,6 +1340,7 @@ class CloudRunWorkerV2(
                     ),
                     operation_label="watching job execution",
                     logger=logger,
+                    settings=settings,
                 )
             except HttpError as exc:
                 if exc.status_code == 404:

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -149,9 +149,9 @@ def _read_with_retry(
     if settings is None:
         settings = CloudRunV2WorkerSettings()
     retrying = _build_transient_retrying(
-        max_attempts=settings.transient_read_max_attempts,
-        initial_delay=settings.transient_read_initial_delay_seconds,
-        max_delay=settings.transient_read_max_delay_seconds,
+        max_attempts=settings.api_read_retry_max_attempts,
+        initial_delay=settings.api_read_retry_initial_delay_seconds,
+        max_delay=settings.api_read_retry_max_delay_seconds,
         operation_label=operation_label,
         logger=logger,
     )

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import re
 import shlex
 import time
-from typing import TYPE_CHECKING, Any, Dict, Final, List, Literal, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    TypeVar,
+)
 from uuid import uuid4
 
 from anyio.abc import TaskStatus
@@ -80,6 +90,9 @@ def _build_transient_retrying(
         "submitting job for execution",
         "polling job readiness",
         "watching job execution",
+        "looking up the latest execution",
+        "verifying the submitted execution",
+        "fetching the submitted execution",
     ],
     logger: PrefectLogAdapter,
 ) -> Retrying:
@@ -107,6 +120,43 @@ def _build_transient_retrying(
         before_sleep=_log_retry,
         sleep=time.sleep,
     )
+
+
+_ReadT = TypeVar("_ReadT")
+
+
+def _read_with_retry(
+    fn: Callable[[], _ReadT],
+    *,
+    operation_label: Literal[
+        "polling job readiness",
+        "watching job execution",
+        "looking up the latest execution",
+        "verifying the submitted execution",
+        "fetching the submitted execution",
+    ],
+    logger: PrefectLogAdapter,
+) -> _ReadT:
+    """Run an idempotent Cloud Run read through the shared transient-retry policy.
+
+    Every read against the Cloud Run API (JobV2.get / ExecutionV2.get) goes
+    through this helper so a new read call site cannot silently skip transient
+    retries. Reads are side-effect free, so retrying never risks starting a
+    duplicate execution. Non-transient errors (404, 400, ...) are reraised
+    immediately for the caller to handle.
+    """
+    settings = CloudRunV2WorkerSettings()
+    retrying = _build_transient_retrying(
+        max_attempts=settings.transient_read_max_attempts,
+        initial_delay=settings.transient_read_initial_delay_seconds,
+        max_delay=settings.transient_read_max_delay_seconds,
+        operation_label=operation_label,
+        logger=logger,
+    )
+    for attempt in retrying:
+        with attempt:
+            return fn()
+    raise AssertionError("unreachable: tenacity always returns or raises")
 
 
 def _get_default_job_body_template() -> Dict[str, Any]:
@@ -803,7 +853,11 @@ class CloudRunWorkerV2(
                 "v2",
                 client_options=options,
                 credentials=gcp_creds,
-                num_retries=3,  # Set to 3 in case of intermittent/connection issues
+                # num_retries only retries fetching the API discovery document used
+                # to build the client, not the operational jobs().run()/get() calls
+                # (which default to num_retries=0). Transient errors on those calls
+                # are handled by the tenacity retries elsewhere in this module.
+                num_retries=3,
             )
             .projects()
             .locations()
@@ -896,25 +950,18 @@ class CloudRunWorkerV2(
             poll_interval: The interval to poll the Cloud Run job, defaults to 5
                 seconds.
         """
-        settings = CloudRunV2WorkerSettings()
-        retrying = _build_transient_retrying(
-            max_attempts=settings.create_job_max_attempts,
-            initial_delay=settings.create_job_initial_delay_seconds,
-            max_delay=settings.create_job_max_delay_seconds,
-            operation_label="polling job readiness",
-            logger=logger,
-        )
 
         def _get_job() -> JobV2:
-            for attempt in retrying:
-                with attempt:
-                    return JobV2.get(
-                        cr_client=cr_client,
-                        project=configuration.project,
-                        location=configuration.region,
-                        job_name=configuration.job_name,
-                    )
-            assert False, "unreachable"  # tenacity always raises or returns
+            return _read_with_retry(
+                lambda: JobV2.get(
+                    cr_client=cr_client,
+                    project=configuration.project,
+                    location=configuration.region,
+                    job_name=configuration.job_name,
+                ),
+                operation_label="polling job readiness",
+                logger=logger,
+            )
 
         job = _get_job()
 
@@ -970,11 +1017,15 @@ class CloudRunWorkerV2(
             job has not run before or the lookup fails.
         """
         try:
-            job = JobV2.get(
-                cr_client=cr_client,
-                project=configuration.project,
-                location=configuration.region,
-                job_name=configuration.job_name,
+            job = _read_with_retry(
+                lambda: JobV2.get(
+                    cr_client=cr_client,
+                    project=configuration.project,
+                    location=configuration.region,
+                    job_name=configuration.job_name,
+                ),
+                operation_label="looking up the latest execution",
+                logger=logger,
             )
         except Exception as exc:
             logger.debug(
@@ -1024,11 +1075,15 @@ class CloudRunWorkerV2(
                 error instead of retrying.
         """
         try:
-            job = JobV2.get(
-                cr_client=cr_client,
-                project=configuration.project,
-                location=configuration.region,
-                job_name=configuration.job_name,
+            job = _read_with_retry(
+                lambda: JobV2.get(
+                    cr_client=cr_client,
+                    project=configuration.project,
+                    location=configuration.region,
+                    job_name=configuration.job_name,
+                ),
+                operation_label="verifying the submitted execution",
+                logger=logger,
             )
         except Exception as lookup_exc:
             logger.warning(
@@ -1124,9 +1179,13 @@ class CloudRunWorkerV2(
                     execution_name = submission["metadata"]["name"]
 
             assert execution_name is not None
-            job_execution = ExecutionV2.get(
-                cr_client=cr_client,
-                execution_id=execution_name,
+            job_execution = _read_with_retry(
+                lambda: ExecutionV2.get(
+                    cr_client=cr_client,
+                    execution_id=execution_name,
+                ),
+                operation_label="fetching the submitted execution",
+                logger=logger,
             )
 
             command_list = configuration.job_body["template"]["template"]["containers"][
@@ -1245,7 +1304,7 @@ class CloudRunWorkerV2(
         configuration: CloudRunWorkerJobV2Configuration,
         execution: ExecutionV2,
         poll_interval: int,
-        logger: PrefectLogAdapter | None = None,
+        logger: PrefectLogAdapter,
     ) -> ExecutionV2:
         """
         Update execution status until it is no longer running.
@@ -1257,7 +1316,7 @@ class CloudRunWorkerV2(
                 the job.
             execution (ExecutionV2): The execution to watch.
             poll_interval (int): The number of seconds to wait between polls.
-            logger: Optional logger for retry warnings.
+            logger: The logger to use for retry warnings.
 
         Returns:
             The execution.
@@ -1265,36 +1324,21 @@ class CloudRunWorkerV2(
         Raises:
             InfrastructureNotFound: If the execution is deleted (e.g., by kill_infrastructure).
         """
-        if logger is not None:
-            settings = CloudRunV2WorkerSettings()
-            retrying = _build_transient_retrying(
-                max_attempts=settings.create_job_max_attempts,
-                initial_delay=settings.create_job_initial_delay_seconds,
-                max_delay=settings.create_job_max_delay_seconds,
-                operation_label="watching job execution",
-                logger=logger,
-            )
-        else:
-            retrying = None
-
         while execution.is_running():
+            current_name = execution.name
             try:
-                if retrying is not None:
-                    for attempt in retrying:
-                        with attempt:
-                            execution = ExecutionV2.get(
-                                cr_client=cr_client,
-                                execution_id=execution.name,
-                            )
-                else:
-                    execution = ExecutionV2.get(
+                execution = _read_with_retry(
+                    lambda: ExecutionV2.get(
                         cr_client=cr_client,
-                        execution_id=execution.name,
-                    )
+                        execution_id=current_name,
+                    ),
+                    operation_label="watching job execution",
+                    logger=logger,
+                )
             except HttpError as exc:
                 if exc.status_code == 404:
                     raise InfrastructureNotFound(
-                        f"Cloud Run V2 execution {execution.name!r} was deleted."
+                        f"Cloud Run V2 execution {current_name!r} was deleted."
                     ) from exc
                 raise
 

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -155,10 +155,7 @@ def _read_with_retry(
         operation_label=operation_label,
         logger=logger,
     )
-    for attempt in retrying:
-        with attempt:
-            return fn()
-    raise AssertionError("unreachable: tenacity always returns or raises")
+    return retrying(fn)
 
 
 def _get_default_job_body_template() -> Dict[str, Any]:

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
@@ -1474,8 +1474,12 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
     def test_falls_back_when_baseline_lookup_raises(
         self, cloud_run_worker_v2_job_config, mock_credentials
     ):
-        # TRANSIENT_READ_MAX_ATTEMPTS=1 keeps the baseline lookup a single shot:
-        # one 503 makes it give up and fall back to None, then submission retries.
+        # TRANSIENT_READ_MAX_ATTEMPTS=1 caps every _read_with_retry call (the
+        # baseline snapshot and the post-submit fetch alike) to a single attempt.
+        # Only the baseline read is made to fail here: one 503 makes it give up
+        # and fall back to None, then submission retries. The post-submit fetch
+        # never fails in this test, so the shared cap is observable only on the
+        # baseline lookup.
         worker = CloudRunWorkerV2("my-work-pool")
         mock_client = MagicMock()
         mock_logger = MagicMock(spec=PrefectLogAdapter)
@@ -1700,6 +1704,64 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
         # the post-submit fetch retried the transient error instead of crashing
         assert mock_exec_get.call_count == 2
         assert result is execution
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+        },
+    )
+    def test_adopts_after_recovery_lookup_retries_transient(
+        self, cloud_run_worker_v2_job_config, mock_credentials
+    ):
+        # The recovery lookup retries a transient error, then succeeds and sees a
+        # new execution already started server-side; the worker adopts it instead
+        # of retrying the submission, avoiding a duplicate run.
+        worker = CloudRunWorkerV2("my-work-pool")
+        mock_client = MagicMock()
+        mock_logger = MagicMock(spec=PrefectLogAdapter)
+
+        mock_resp = MagicMock()
+        mock_resp.status = 503
+        transient_error = HttpError(resp=mock_resp, content=b"Service unavailable")
+        lookup_error = HttpError(resp=mock_resp, content=b"Service unavailable")
+
+        baseline_name = "projects/p/locations/l/jobs/j/executions/exec-baseline"
+        new_name = "projects/p/locations/l/jobs/j/executions/exec-new"
+
+        with mock.patch(
+            "prefect_gcp.workers.cloud_run_v2.JobV2.get",
+            side_effect=[
+                self._job_with_execution(baseline_name),
+                lookup_error,
+                self._job_with_execution(new_name),
+            ],
+        ) as mock_job_get:
+            with mock.patch(
+                "prefect_gcp.workers.cloud_run_v2.JobV2.run",
+                side_effect=transient_error,
+            ) as mock_run:
+                with mock.patch(
+                    "prefect_gcp.workers.cloud_run_v2.ExecutionV2.get"
+                ) as mock_exec_get:
+                    with mock.patch(
+                        "prefect_gcp.workers.cloud_run_v2.time.sleep"
+                    ) as mock_sleep:
+                        result = worker._begin_job_execution(
+                            cr_client=mock_client,
+                            configuration=cloud_run_worker_v2_job_config,
+                            logger=mock_logger,
+                        )
+
+        assert mock_run.call_count == 1
+        # baseline snapshot (1) + recovery lookup retried once (2)
+        assert mock_job_get.call_count == 3
+        mock_sleep.assert_called()
+        mock_exec_get.assert_called_once()
+        assert mock_exec_get.call_args.kwargs["execution_id"] == new_name
+        assert result is mock_exec_get.return_value
+        warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
+        assert any("duplicate run" in msg for msg in warning_messages)
 
 
 class TestCloudRunReadRetryEradication:

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
@@ -695,6 +695,8 @@ class TestCloudRunWorkerV2KillInfrastructure:
         mock_resp.status = 404
         mock_http_error = HttpError(resp=mock_resp, content=b"Execution not found")
 
+        mock_logger = MagicMock(spec=PrefectLogAdapter)
+
         with mock.patch.object(ExecutionV2, "get", side_effect=mock_http_error):
             with pytest.raises(InfrastructureNotFound) as exc_info:
                 CloudRunWorkerV2._watch_job_execution(
@@ -702,6 +704,7 @@ class TestCloudRunWorkerV2KillInfrastructure:
                     configuration=cloud_run_worker_v2_job_config,
                     execution=mock_execution,
                     poll_interval=0,
+                    logger=mock_logger,
                 )
 
             assert "was deleted" in str(exc_info.value)
@@ -1462,9 +1465,17 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
         warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert not any("duplicate run" in msg for msg in warning_messages)
 
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "1"
+        },
+    )
     def test_falls_back_when_baseline_lookup_raises(
         self, cloud_run_worker_v2_job_config, mock_credentials
     ):
+        # TRANSIENT_READ_MAX_ATTEMPTS=1 keeps the baseline lookup a single shot:
+        # one 503 makes it give up and fall back to None, then submission retries.
         worker = CloudRunWorkerV2("my-work-pool")
         mock_client = MagicMock()
         mock_logger = MagicMock(spec=PrefectLogAdapter)
@@ -1500,9 +1511,18 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
         warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert not any("duplicate run" in msg for msg in warning_messages)
 
-    def test_does_not_retry_when_recovery_lookup_fails(
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+        },
+    )
+    def test_fails_fast_after_recovery_lookup_retries_exhausted(
         self, cloud_run_worker_v2_job_config, mock_credentials
     ):
+        # The recovery lookup now retries transient errors. When it still cannot
+        # read the job after exhausting its attempts, the worker fails fast on the
+        # original submission error instead of risking a duplicate run.
         worker = CloudRunWorkerV2("my-work-pool")
         mock_client = MagicMock()
         mock_logger = MagicMock(spec=PrefectLogAdapter)
@@ -1516,7 +1536,11 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
 
         with mock.patch(
             "prefect_gcp.workers.cloud_run_v2.JobV2.get",
-            side_effect=[self._job_with_execution(baseline_name), lookup_error],
+            side_effect=[
+                self._job_with_execution(baseline_name),
+                lookup_error,
+                lookup_error,
+            ],
         ) as mock_job_get:
             with mock.patch(
                 "prefect_gcp.workers.cloud_run_v2.JobV2.run",
@@ -1537,8 +1561,9 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
 
         assert exc_info.value is transient_error
         assert mock_run.call_count == 1
-        assert mock_job_get.call_count == 2
-        mock_sleep.assert_not_called()
+        # baseline lookup (1) + recovery lookup retried to exhaustion (2)
+        assert mock_job_get.call_count == 3
+        mock_sleep.assert_called()
         mock_exec_get.assert_not_called()
         warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert any("Failing fast" in msg for msg in warning_messages)
@@ -1585,3 +1610,151 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
         assert result is mock_exec_get.return_value
         warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert any("duplicate run" in msg for msg in warning_messages)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+        },
+    )
+    def test_baseline_lookup_retries_transient_then_succeeds(
+        self, cloud_run_worker_v2_job_config, mock_credentials
+    ):
+        # The baseline snapshot read now retries a transient error before giving up.
+        worker = CloudRunWorkerV2("my-work-pool")
+        mock_client = MagicMock()
+        mock_logger = MagicMock(spec=PrefectLogAdapter)
+
+        mock_resp = MagicMock()
+        mock_resp.status = 503
+        transient_error = HttpError(resp=mock_resp, content=b"Service unavailable")
+        successful_submission = {"metadata": {"name": "test-execution"}}
+
+        baseline_name = "projects/p/locations/l/jobs/j/executions/exec-baseline"
+
+        with mock.patch(
+            "prefect_gcp.workers.cloud_run_v2.JobV2.get",
+            side_effect=[transient_error, self._job_with_execution(baseline_name)],
+        ) as mock_job_get:
+            with mock.patch(
+                "prefect_gcp.workers.cloud_run_v2.JobV2.run",
+                return_value=successful_submission,
+            ) as mock_run:
+                with mock.patch(
+                    "prefect_gcp.workers.cloud_run_v2.ExecutionV2.get"
+                ) as mock_exec_get:
+                    with mock.patch("prefect_gcp.workers.cloud_run_v2.time.sleep"):
+                        result = worker._begin_job_execution(
+                            cr_client=mock_client,
+                            configuration=cloud_run_worker_v2_job_config,
+                            logger=mock_logger,
+                        )
+
+        # baseline get retried once (transient) before returning the job
+        assert mock_job_get.call_count == 2
+        assert mock_run.call_count == 1
+        assert result is mock_exec_get.return_value
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+        },
+    )
+    def test_post_submit_fetch_retries_transient_then_succeeds(
+        self, cloud_run_worker_v2_job_config, mock_credentials
+    ):
+        # A transient 503 on the post-submission ExecutionV2.get must not crash a
+        # submission that already succeeded; the fetch retries instead.
+        worker = CloudRunWorkerV2("my-work-pool")
+        mock_client = MagicMock()
+        mock_logger = MagicMock(spec=PrefectLogAdapter)
+
+        mock_resp = MagicMock()
+        mock_resp.status = 503
+        transient_error = HttpError(resp=mock_resp, content=b"Service unavailable")
+        successful_submission = {"metadata": {"name": "test-execution"}}
+        execution = MagicMock(spec=ExecutionV2)
+
+        baseline_name = "projects/p/locations/l/jobs/j/executions/exec-baseline"
+
+        with mock.patch(
+            "prefect_gcp.workers.cloud_run_v2.JobV2.get",
+            return_value=self._job_with_execution(baseline_name),
+        ):
+            with mock.patch(
+                "prefect_gcp.workers.cloud_run_v2.JobV2.run",
+                return_value=successful_submission,
+            ):
+                with mock.patch(
+                    "prefect_gcp.workers.cloud_run_v2.ExecutionV2.get",
+                    side_effect=[transient_error, execution],
+                ) as mock_exec_get:
+                    with mock.patch("prefect_gcp.workers.cloud_run_v2.time.sleep"):
+                        result = worker._begin_job_execution(
+                            cr_client=mock_client,
+                            configuration=cloud_run_worker_v2_job_config,
+                            logger=mock_logger,
+                        )
+
+        # the post-submit fetch retried the transient error instead of crashing
+        assert mock_exec_get.call_count == 2
+        assert result is execution
+
+
+class TestCloudRunReadRetryEradication:
+    def test_all_cloud_run_reads_go_through_retry_helper(self):
+        """Guard against the copy-paste mistake of a bare JobV2.get / ExecutionV2.get.
+
+        Every prior retry gap was a literal `JobV2.get(` / `ExecutionV2.get(`
+        that skipped the shared helper. This lints against that specific
+        regression by asserting every such call in the worker module is lexically
+        under a `_read_with_retry` call. It does not defend against indirect
+        calls (getattr, symbol aliasing); it catches the common forgotten-wrap
+        mistake.
+        """
+        import ast
+        import pathlib
+
+        from prefect_gcp.workers import cloud_run_v2
+
+        tree = ast.parse(pathlib.Path(cloud_run_v2.__file__).read_text())
+        parents = {
+            child: parent
+            for parent in ast.walk(tree)
+            for child in ast.iter_child_nodes(parent)
+        }
+
+        def is_read_call(node):
+            return (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"JobV2", "ExecutionV2"}
+            )
+
+        def under_read_helper(node):
+            current = parents.get(node)
+            while current is not None:
+                func = getattr(current, "func", None)
+                if isinstance(current, ast.Call) and (
+                    (isinstance(func, ast.Name) and func.id == "_read_with_retry")
+                    or (
+                        isinstance(func, ast.Attribute)
+                        and func.attr == "_read_with_retry"
+                    )
+                ):
+                    return True
+                current = parents.get(current)
+            return False
+
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if is_read_call(node) and not under_read_helper(node)
+        ]
+        assert not offenders, (
+            "JobV2.get / ExecutionV2.get must be wrapped in _read_with_retry; "
+            f"bare reads found at lines {offenders}"
+        )

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
@@ -1468,13 +1468,13 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
     @mock.patch.dict(
         "os.environ",
         {
-            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "1"
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_ATTEMPTS": "1"
         },
     )
     def test_falls_back_when_baseline_lookup_raises(
         self, cloud_run_worker_v2_job_config, mock_credentials
     ):
-        # TRANSIENT_READ_MAX_ATTEMPTS=1 caps every _read_with_retry call (the
+        # API_READ_RETRY_MAX_ATTEMPTS=1 caps every _read_with_retry call (the
         # baseline snapshot and the post-submit fetch alike) to a single attempt.
         # Only the baseline read is made to fail here: one 503 makes it give up
         # and fall back to None, then submission retries. The post-submit fetch
@@ -1518,7 +1518,7 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
     @mock.patch.dict(
         "os.environ",
         {
-            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_ATTEMPTS": "2"
         },
     )
     def test_fails_fast_after_recovery_lookup_retries_exhausted(
@@ -1618,7 +1618,7 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
     @mock.patch.dict(
         "os.environ",
         {
-            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_ATTEMPTS": "2"
         },
     )
     def test_baseline_lookup_retries_transient_then_succeeds(
@@ -1662,7 +1662,7 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
     @mock.patch.dict(
         "os.environ",
         {
-            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_ATTEMPTS": "2"
         },
     )
     def test_post_submit_fetch_retries_transient_then_succeeds(
@@ -1708,7 +1708,7 @@ class TestCloudRunWorkerV2SubmitJobRecovery:
     @mock.patch.dict(
         "os.environ",
         {
-            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "2"
+            "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_ATTEMPTS": "2"
         },
     )
     def test_adopts_after_recovery_lookup_retries_transient(

--- a/src/integrations/prefect-gcp/tests/test_settings.py
+++ b/src/integrations/prefect-gcp/tests/test_settings.py
@@ -19,9 +19,9 @@ class TestCloudRunV2WorkerSettings:
         assert settings.submit_job_max_attempts == 3
         assert settings.submit_job_initial_delay_seconds == 1.0
         assert settings.submit_job_max_delay_seconds == 10.0
-        assert settings.transient_read_max_attempts == 3
-        assert settings.transient_read_initial_delay_seconds == 1.0
-        assert settings.transient_read_max_delay_seconds == 10.0
+        assert settings.api_read_retry_max_attempts == 3
+        assert settings.api_read_retry_initial_delay_seconds == 1.0
+        assert settings.api_read_retry_max_delay_seconds == 10.0
 
     def test_load_from_env(self):
         with mock.patch.dict(
@@ -44,20 +44,20 @@ class TestCloudRunV2WorkerSettings:
         assert settings.submit_job_initial_delay_seconds == 1.5
         assert settings.submit_job_max_delay_seconds == 30.0
 
-    def test_transient_read_load_from_env(self):
+    def test_api_read_retry_load_from_env(self):
         with mock.patch.dict(
             "os.environ",
             {
-                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "8",
-                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_INITIAL_DELAY_SECONDS": "0.5",
-                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_DELAY_SECONDS": "15.0",
+                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_ATTEMPTS": "8",
+                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_INITIAL_DELAY_SECONDS": "0.5",
+                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_MAX_DELAY_SECONDS": "15.0",
             },
         ):
             settings = CloudRunV2WorkerSettings()
 
-        assert settings.transient_read_max_attempts == 8
-        assert settings.transient_read_initial_delay_seconds == 0.5
-        assert settings.transient_read_max_delay_seconds == 15.0
+        assert settings.api_read_retry_max_attempts == 8
+        assert settings.api_read_retry_initial_delay_seconds == 0.5
+        assert settings.api_read_retry_max_delay_seconds == 15.0
 
     @pytest.mark.parametrize("invalid_value", [0, -1])
     def test_invalid_max_attempts_raises(self, invalid_value):
@@ -90,19 +90,19 @@ class TestCloudRunV2WorkerSettings:
             CloudRunV2WorkerSettings(submit_job_max_delay_seconds=invalid_value)
 
     @pytest.mark.parametrize("invalid_value", [0, -1])
-    def test_invalid_transient_read_max_attempts_raises(self, invalid_value):
+    def test_invalid_api_read_retry_max_attempts_raises(self, invalid_value):
         with pytest.raises(ValidationError):
-            CloudRunV2WorkerSettings(transient_read_max_attempts=invalid_value)
+            CloudRunV2WorkerSettings(api_read_retry_max_attempts=invalid_value)
 
     @pytest.mark.parametrize("invalid_value", [0, -1.0])
-    def test_invalid_transient_read_initial_delay_raises(self, invalid_value):
+    def test_invalid_api_read_retry_initial_delay_raises(self, invalid_value):
         with pytest.raises(ValidationError):
-            CloudRunV2WorkerSettings(transient_read_initial_delay_seconds=invalid_value)
+            CloudRunV2WorkerSettings(api_read_retry_initial_delay_seconds=invalid_value)
 
     @pytest.mark.parametrize("invalid_value", [0, -1.0])
-    def test_invalid_transient_read_max_delay_raises(self, invalid_value):
+    def test_invalid_api_read_retry_max_delay_raises(self, invalid_value):
         with pytest.raises(ValidationError):
-            CloudRunV2WorkerSettings(transient_read_max_delay_seconds=invalid_value)
+            CloudRunV2WorkerSettings(api_read_retry_max_delay_seconds=invalid_value)
 
 
 class TestSettingsHierarchy:

--- a/src/integrations/prefect-gcp/tests/test_settings.py
+++ b/src/integrations/prefect-gcp/tests/test_settings.py
@@ -19,6 +19,9 @@ class TestCloudRunV2WorkerSettings:
         assert settings.submit_job_max_attempts == 3
         assert settings.submit_job_initial_delay_seconds == 1.0
         assert settings.submit_job_max_delay_seconds == 10.0
+        assert settings.transient_read_max_attempts == 3
+        assert settings.transient_read_initial_delay_seconds == 1.0
+        assert settings.transient_read_max_delay_seconds == 10.0
 
     def test_load_from_env(self):
         with mock.patch.dict(
@@ -40,6 +43,21 @@ class TestCloudRunV2WorkerSettings:
         assert settings.submit_job_max_attempts == 6
         assert settings.submit_job_initial_delay_seconds == 1.5
         assert settings.submit_job_max_delay_seconds == 30.0
+
+    def test_transient_read_load_from_env(self):
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_ATTEMPTS": "8",
+                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_INITIAL_DELAY_SECONDS": "0.5",
+                "PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_TRANSIENT_READ_MAX_DELAY_SECONDS": "15.0",
+            },
+        ):
+            settings = CloudRunV2WorkerSettings()
+
+        assert settings.transient_read_max_attempts == 8
+        assert settings.transient_read_initial_delay_seconds == 0.5
+        assert settings.transient_read_max_delay_seconds == 15.0
 
     @pytest.mark.parametrize("invalid_value", [0, -1])
     def test_invalid_max_attempts_raises(self, invalid_value):
@@ -70,6 +88,21 @@ class TestCloudRunV2WorkerSettings:
     def test_invalid_submit_job_max_delay_raises(self, invalid_value):
         with pytest.raises(ValidationError):
             CloudRunV2WorkerSettings(submit_job_max_delay_seconds=invalid_value)
+
+    @pytest.mark.parametrize("invalid_value", [0, -1])
+    def test_invalid_transient_read_max_attempts_raises(self, invalid_value):
+        with pytest.raises(ValidationError):
+            CloudRunV2WorkerSettings(transient_read_max_attempts=invalid_value)
+
+    @pytest.mark.parametrize("invalid_value", [0, -1.0])
+    def test_invalid_transient_read_initial_delay_raises(self, invalid_value):
+        with pytest.raises(ValidationError):
+            CloudRunV2WorkerSettings(transient_read_initial_delay_seconds=invalid_value)
+
+    @pytest.mark.parametrize("invalid_value", [0, -1.0])
+    def test_invalid_transient_read_max_delay_raises(self, invalid_value):
+        with pytest.raises(ValidationError):
+            CloudRunV2WorkerSettings(transient_read_max_delay_seconds=invalid_value)
 
 
 class TestSettingsHierarchy:


### PR DESCRIPTION

The `prefect-gcp` Cloud Run V2 worker has needed five retry-related PRs (#20387, #21722, #21998, #22087, #22113), each adding a retry to one more Cloud Run API call that was missing one. The cause is the same every time: retry is added one call site at a time, so a newly added read is easy to miss, and the next PR finds the next one.

The most recent missing retry crashed a production flow run. A job submission returned HTTP 503. Before retrying, the worker calls `JobV2.get` to check whether that submission had already started an execution, which keeps a retry from starting a duplicate run. That `JobV2.get` also returned 503. With no retry on it, the worker could not confirm the state, so it failed the run immediately.

This PR routes every read (`JobV2.get` and `ExecutionV2.get`) through one `_read_with_retry` helper that retries transient HTTP errors (429, 500, 503). Reads have no side effects, so retrying them cannot start a duplicate execution. A test parses the worker module and fails if any Cloud Run read is not wrapped by the helper, so a future read cannot silently skip the retry.

The helper now covers the four reads that had no retry: the baseline snapshot taken before submission, the recovery lookup that caused the crash, the execution fetch right after a successful submission, and the watch poll whose retry used to depend on whether a logger was passed. The execution fetch is worth calling out: a transient error there could fail a run that had already started successfully. Read retries use a new setting group, `PREFECT_INTEGRATIONS_GCP_CLOUD_RUN_V2_WORKER_API_READ_RETRY_*` (max attempts, initial delay, max delay; defaults 3, 1.0, 10.0). It is independent of the existing `create_job_*` and `submit_job_*` settings, which still control the write retries.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

