### PR TITLE
Add Redis Cluster URL handling to prefect-redis client

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -2,9 +2,11 @@ import asyncio
 import functools
 import warnings
 from typing import Any, Callable, Optional, Union
+from urllib.parse import urlparse, urlunparse
 
 from pydantic import Field, model_validator
 from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
 from typing_extensions import Self, TypeAlias
 
 from prefect.settings.base import (
@@ -99,7 +101,23 @@ CacheKey: TypeAlias = tuple[
     Union[asyncio.AbstractEventLoop, None],
 ]
 
-_client_cache: dict[CacheKey, Redis] = {}
+RedisClient: TypeAlias = Redis | RedisCluster
+
+_client_cache: dict[CacheKey, RedisClient] = {}
+
+
+def is_cluster_url(url: str) -> bool:
+    """Return True if the URL uses the Redis Cluster scheme."""
+    return urlparse(url).scheme in {"redis+cluster", "rediss+cluster"}
+
+
+def normalize_cluster_url(url: str) -> str:
+    """Return a redis-py compatible URL for Redis Cluster connections."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"redis+cluster", "rediss+cluster"}:
+        return url
+
+    return urlunparse(parsed._replace(scheme=parsed.scheme.replace("+cluster", "")))
 
 
 def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
@@ -113,7 +131,7 @@ def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
 
 def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
-    def cached_fn(*args: Any, **kwargs: Any) -> Redis:
+    def cached_fn(*args: Any, **kwargs: Any) -> RedisClient:
         key = (fn, args, tuple(kwargs.items()), _running_loop())
         if key not in _client_cache:
             _client_cache[key] = fn(*args, **kwargs)
@@ -129,7 +147,9 @@ def close_all_cached_connections() -> None:
     for (_, _, _, loop), client in _client_cache.items():
         if not loop or (loop and loop.is_closed()):
             continue
-        loop.run_until_complete(client.connection_pool.disconnect())
+        connection_pool = getattr(client, "connection_pool", None)
+        if connection_pool is not None:
+            loop.run_until_complete(connection_pool.disconnect())
         loop.run_until_complete(client.aclose())
 
 
@@ -159,15 +179,18 @@ def get_async_redis_client(
     socket_timeout: Union[float, None, Any] = _UNSET,
     socket_connect_timeout: Union[float, None, Any] = _UNSET,
     protocol: Union[int, None] = None,
-) -> Redis:
+) -> RedisClient:
     """Retrieves an async Redis client.
 
     When `url` is provided (or configured via
-    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used and
-    the discrete host/port/… arguments are ignored.
+    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used for
+    standalone URLs and `RedisCluster.from_url` is used for
+    `redis+cluster://` or `rediss+cluster://` URLs. The discrete
+    host/port/… arguments are ignored.
 
     Args:
-        url: Full Redis URL (e.g. `redis://localhost:6379/0`).
+        url: Full Redis URL (e.g. `redis://localhost:6379/0` or
+            `redis+cluster://localhost:6379`).
         host: The host location.
         port: The port to connect to the host with.
         db: The Redis database to interact with.
@@ -182,7 +205,7 @@ def get_async_redis_client(
         protocol: RESP protocol version (default 2 from settings).
 
     Returns:
-        Redis: a Redis client
+        Redis: a Redis or Redis Cluster client
     """
     settings = RedisMessagingSettings()
 
@@ -198,8 +221,9 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
-        return Redis.from_url(
-            url,
+        redis_from_url = RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        return redis_from_url(
+            normalize_cluster_url(url),
             health_check_interval=health_check_interval
             or settings.health_check_interval,
             decode_responses=decode_responses,
@@ -226,7 +250,7 @@ def get_async_redis_client(
 @cached
 def async_redis_from_settings(
     settings: RedisMessagingSettings, **options: Any
-) -> Redis:
+) -> RedisClient:
     options = {
         "decode_responses": True,
         "socket_timeout": settings.socket_timeout,
@@ -236,8 +260,11 @@ def async_redis_from_settings(
     }
 
     if settings.url:
-        return Redis.from_url(
-            settings.url,
+        redis_from_url = (
+            RedisCluster.from_url if is_cluster_url(settings.url) else Redis.from_url
+        )
+        return redis_from_url(
+            normalize_cluster_url(settings.url),
             health_check_interval=settings.health_check_interval,
             **options,
         )

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -8,8 +8,11 @@ from prefect_redis.client import (
     async_redis_from_settings,
     close_all_cached_connections,
     get_async_redis_client,
+    is_cluster_url,
+    normalize_cluster_url,
 )
 from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
 
 
 def test_redis_settings_defaults(isolated_redis_db_number: int):
@@ -38,6 +41,34 @@ def test_redis_settings_url_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", "redis://envhost:6381/3")
     settings = RedisMessagingSettings()
     assert settings.url == "redis://envhost:6381/3"
+
+
+def test_cluster_url_detection():
+    assert is_cluster_url("redis+cluster://redis.example.com:6379")
+    assert is_cluster_url("rediss+cluster://redis.example.com:6379")
+    assert not is_cluster_url("redis://redis.example.com:6379")
+    assert not is_cluster_url("rediss://redis.example.com:6379")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "redis+cluster://redis.example.com:6379",
+            "redis://redis.example.com:6379",
+        ),
+        (
+            "rediss+cluster://user:pass@redis.example.com:6380/0?protocol=3",
+            "rediss://user:pass@redis.example.com:6380/0?protocol=3",
+        ),
+        (
+            "redis://redis.example.com:6379/0",
+            "redis://redis.example.com:6379/0",
+        ),
+    ],
+)
+def test_normalize_cluster_url(url: str, expected: str):
+    assert normalize_cluster_url(url) == expected
 
 
 def test_redis_settings_url_warns_on_conflicting_fields():
@@ -96,6 +127,19 @@ async def test_get_async_redis_client_with_url():
     assert conn_kwargs["port"] == 6382
     assert conn_kwargs["db"] == 4
     await client.aclose()
+
+
+async def test_get_async_redis_client_with_cluster_url():
+    """Cluster URLs create RedisCluster clients after URL normalization."""
+    _client_cache.clear()
+    client = get_async_redis_client(url="redis+cluster://clusterhost:7000")
+    assert isinstance(client, RedisCluster)
+    assert client.nodes_manager.startup_nodes["clusterhost:7000"].host == "clusterhost"
+    assert client.nodes_manager.startup_nodes["clusterhost:7000"].port == 7000
+    assert client.get_connection_kwargs()["decode_responses"] is True
+    assert client.get_connection_kwargs()["protocol"] == 2
+    await client.aclose()
+    _client_cache.clear()
 
 
 async def test_get_async_redis_client_url_with_credentials():
@@ -168,6 +212,21 @@ async def test_async_redis_from_settings_with_url():
     assert conn_kwargs["port"] == 6385
     assert conn_kwargs["db"] == 7
     await client.aclose()
+
+
+async def test_async_redis_from_settings_with_cluster_url():
+    """Settings URL can create a RedisCluster client."""
+    _client_cache.clear()
+    settings = RedisMessagingSettings(url="rediss+cluster://fromurl:6385")
+    client = async_redis_from_settings(settings)
+    assert isinstance(client, RedisCluster)
+    assert client.nodes_manager.startup_nodes["fromurl:6385"].host == "fromurl"
+    assert client.nodes_manager.startup_nodes["fromurl:6385"].port == 6385
+    connection_kwargs = client.get_connection_kwargs()
+    assert connection_kwargs["decode_responses"] is True
+    assert connection_kwargs["protocol"] == 2
+    await client.aclose()
+    _client_cache.clear()
 
 
 def test_redis_settings_connection_defaults():


### PR DESCRIPTION
## Summary

this PR adds the first small foundation for Redis Cluster support in `prefect-redis` by teaching the shared Redis client helper to recognize cluster URLs.

It introduces:
- `redis+cluster://` and `rediss+cluster://` URL detection
- URL normalization before passing cluster URLs to redis-py
- `RedisCluster.from_url(...)` construction from `get_async_redis_client` and `async_redis_from_settings`
- cache shutdown handling for clients that do not expose a standalone `connection_pool`

## Why this shape

Docket handled Redis Cluster by first centralizing Redis key construction and connection management, then making those central paths cluster-aware. The relevant Docket sequence was:
- chrisguidry/docket#270 and #274: centralize key construction behind `prefix` / `key()` helpers
- chrisguidry/docket#283: centralize Redis connection helpers and cluster URL detection
- chrisguidry/docket#284: turn on cluster clients, hash-tagged prefixes, pub/sub handling, and cluster test infrastructure

This PR follows that pattern on the Prefect side by making `prefect_redis.client` the first connection-level choke point. It does not yet claim the higher-level Redis subsystems are cluster-safe.

## Planned follow-up PRs

1. Add cluster-aware key helpers for `prefect_redis` subsystems that perform multi-key operations. Start with helper-only/key-format tests so review can focus on hash-slot semantics.
2. Make messaging cluster-safe, including stream key naming, dedupe keys, DLQ keys, and non-transactional batching where appropriate.
3. Make causal ordering cluster-safe by hash-tagging a scope's `seen`, `processing`, `followers`, `event`, and `waitlist` keys together.
4. Make concurrency lease storage cluster-safe by ensuring lease keys, expiration indexes, and holder indexes used by Lua scripts share a hash tag, and by passing script keys explicitly where needed.
5. Make worker cleanup queue cluster-safe. The smallest compatible design is to hash-tag the cleanup queue prefix; a later optimization could shard by work pool, but that is a larger semantic change because the queue has global pool bookkeeping.
6. Add real Redis Cluster integration test infrastructure and CI coverage once the multi-key subsystems are ready to run against a cluster.
7. Audit Prefect's Docket minimum version for `PREFECT_SERVER_DOCKET_URL=redis+cluster://...`; Docket has cluster support, but Prefect's lower bound should match the first supported release before docs advertise it.

## Validation

- `uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_client.py -q`
- `uv run ruff check src/integrations/prefect-redis/prefect_redis/client.py src/integrations/prefect-redis/tests/test_client.py`
- `git diff --check`
