### PR TITLE
Add Redis Cluster URL and key groundwork

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -108,7 +108,7 @@ _client_cache: dict[CacheKey, RedisClient] = {}
 
 def is_cluster_url(url: str) -> bool:
     """Return True if the URL uses the Redis Cluster scheme."""
-    return urlparse(url).scheme in {"redis+cluster", "rediss+cluster"}
+    return url.partition("://")[0] in {"redis+cluster", "rediss+cluster"}
 
 
 def normalize_cluster_url(url: str) -> str:

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -221,7 +221,9 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
-        redis_from_url = RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        redis_from_url = (
+            RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        )
         return redis_from_url(
             normalize_cluster_url(url),
             health_check_interval=health_check_interval

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -2,9 +2,11 @@ import asyncio
 import functools
 import warnings
 from typing import Any, Callable, Optional, Union
+from urllib.parse import urlparse, urlunparse
 
 from pydantic import Field, model_validator
 from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
 from typing_extensions import Self, TypeAlias
 
 from prefect.settings.base import (
@@ -99,7 +101,23 @@ CacheKey: TypeAlias = tuple[
     Union[asyncio.AbstractEventLoop, None],
 ]
 
-_client_cache: dict[CacheKey, Redis] = {}
+RedisClient: TypeAlias = Redis | RedisCluster
+
+_client_cache: dict[CacheKey, RedisClient] = {}
+
+
+def is_cluster_url(url: str) -> bool:
+    """Return True if the URL uses the Redis Cluster scheme."""
+    return urlparse(url).scheme in {"redis+cluster", "rediss+cluster"}
+
+
+def normalize_cluster_url(url: str) -> str:
+    """Return a redis-py compatible URL for Redis Cluster connections."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"redis+cluster", "rediss+cluster"}:
+        return url
+
+    return urlunparse(parsed._replace(scheme=parsed.scheme.replace("+cluster", "")))
 
 
 def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
@@ -113,7 +131,7 @@ def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
 
 def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
-    def cached_fn(*args: Any, **kwargs: Any) -> Redis:
+    def cached_fn(*args: Any, **kwargs: Any) -> RedisClient:
         key = (fn, args, tuple(kwargs.items()), _running_loop())
         if key not in _client_cache:
             _client_cache[key] = fn(*args, **kwargs)
@@ -129,7 +147,9 @@ def close_all_cached_connections() -> None:
     for (_, _, _, loop), client in _client_cache.items():
         if not loop or (loop and loop.is_closed()):
             continue
-        loop.run_until_complete(client.connection_pool.disconnect())
+        connection_pool = getattr(client, "connection_pool", None)
+        if connection_pool is not None:
+            loop.run_until_complete(connection_pool.disconnect())
         loop.run_until_complete(client.aclose())
 
 
@@ -159,15 +179,18 @@ def get_async_redis_client(
     socket_timeout: Union[float, None, Any] = _UNSET,
     socket_connect_timeout: Union[float, None, Any] = _UNSET,
     protocol: Union[int, None] = None,
-) -> Redis:
+) -> RedisClient:
     """Retrieves an async Redis client.
 
     When `url` is provided (or configured via
-    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used and
-    the discrete host/port/… arguments are ignored.
+    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used for
+    standalone URLs and `RedisCluster.from_url` is used for
+    `redis+cluster://` or `rediss+cluster://` URLs. The discrete
+    host/port/… arguments are ignored.
 
     Args:
-        url: Full Redis URL (e.g. `redis://localhost:6379/0`).
+        url: Full Redis URL (e.g. `redis://localhost:6379/0` or
+            `redis+cluster://localhost:6379`).
         host: The host location.
         port: The port to connect to the host with.
         db: The Redis database to interact with.
@@ -182,7 +205,7 @@ def get_async_redis_client(
         protocol: RESP protocol version (default 2 from settings).
 
     Returns:
-        Redis: a Redis client
+        Redis: a Redis or Redis Cluster client
     """
     settings = RedisMessagingSettings()
 
@@ -198,8 +221,9 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
-        return Redis.from_url(
-            url,
+        redis_from_url = RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        return redis_from_url(
+            normalize_cluster_url(url),
             health_check_interval=health_check_interval
             or settings.health_check_interval,
             decode_responses=decode_responses,
@@ -226,7 +250,7 @@ def get_async_redis_client(
 @cached
 def async_redis_from_settings(
     settings: RedisMessagingSettings, **options: Any
-) -> Redis:
+) -> RedisClient:
     options = {
         "decode_responses": True,
         "socket_timeout": settings.socket_timeout,
@@ -236,8 +260,11 @@ def async_redis_from_settings(
     }
 
     if settings.url:
-        return Redis.from_url(
-            settings.url,
+        redis_from_url = (
+            RedisCluster.from_url if is_cluster_url(settings.url) else Redis.from_url
+        )
+        return redis_from_url(
+            normalize_cluster_url(settings.url),
             health_check_interval=settings.health_check_interval,
             **options,
         )

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse, urlunparse
 
 from pydantic import Field, model_validator
 from redis.asyncio import Redis
-from redis.asyncio.cluster import RedisCluster
 from typing_extensions import Self, TypeAlias
 
 from prefect.settings.base import (
@@ -101,9 +100,7 @@ CacheKey: TypeAlias = tuple[
     Union[asyncio.AbstractEventLoop, None],
 ]
 
-RedisClient: TypeAlias = Redis | RedisCluster
-
-_client_cache: dict[CacheKey, RedisClient] = {}
+_client_cache: dict[CacheKey, Redis] = {}
 
 
 def is_cluster_url(url: str) -> bool:
@@ -120,6 +117,27 @@ def normalize_cluster_url(url: str) -> str:
     return urlunparse(parsed._replace(scheme=parsed.scheme.replace("+cluster", "")))
 
 
+def cluster_key_prefix(prefix: str, url: str | None = None) -> str:
+    """Return a key prefix, hash-tagged when configured for Redis Cluster."""
+    url = url or RedisMessagingSettings().url
+    if url and is_cluster_url(url):
+        return f"{{{prefix}}}"
+    return prefix
+
+
+def redis_key(prefix: str, suffix: str, url: str | None = None) -> str:
+    """Return a Redis key rooted at a cluster-aware prefix."""
+    return f"{cluster_key_prefix(prefix, url=url)}:{suffix}"
+
+
+def _raise_cluster_not_supported() -> None:
+    raise NotImplementedError(
+        "Redis Cluster URLs are detected but not enabled yet. "
+        "Cluster support requires hash-slot-safe keys across the Redis-backed "
+        "messaging, ordering, lease storage, and cleanup queue subsystems."
+    )
+
+
 def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
     try:
         return asyncio.get_running_loop()
@@ -131,7 +149,7 @@ def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
 
 def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
-    def cached_fn(*args: Any, **kwargs: Any) -> RedisClient:
+    def cached_fn(*args: Any, **kwargs: Any) -> Redis:
         key = (fn, args, tuple(kwargs.items()), _running_loop())
         if key not in _client_cache:
             _client_cache[key] = fn(*args, **kwargs)
@@ -147,9 +165,7 @@ def close_all_cached_connections() -> None:
     for (_, _, _, loop), client in _client_cache.items():
         if not loop or (loop and loop.is_closed()):
             continue
-        connection_pool = getattr(client, "connection_pool", None)
-        if connection_pool is not None:
-            loop.run_until_complete(connection_pool.disconnect())
+        loop.run_until_complete(client.connection_pool.disconnect())
         loop.run_until_complete(client.aclose())
 
 
@@ -179,18 +195,16 @@ def get_async_redis_client(
     socket_timeout: Union[float, None, Any] = _UNSET,
     socket_connect_timeout: Union[float, None, Any] = _UNSET,
     protocol: Union[int, None] = None,
-) -> RedisClient:
+) -> Redis:
     """Retrieves an async Redis client.
 
-    When `url` is provided (or configured via
-    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used for
-    standalone URLs and `RedisCluster.from_url` is used for
-    `redis+cluster://` or `rediss+cluster://` URLs. The discrete
-    host/port/… arguments are ignored.
+    When a standalone `url` is provided (or configured via
+    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used and
+    the discrete host/port/… arguments are ignored. Redis Cluster
+    URLs are detected but intentionally not enabled yet.
 
     Args:
-        url: Full Redis URL (e.g. `redis://localhost:6379/0` or
-            `redis+cluster://localhost:6379`).
+        url: Full Redis URL (e.g. `redis://localhost:6379/0`).
         host: The host location.
         port: The port to connect to the host with.
         db: The Redis database to interact with.
@@ -205,7 +219,7 @@ def get_async_redis_client(
         protocol: RESP protocol version (default 2 from settings).
 
     Returns:
-        Redis: a Redis or Redis Cluster client
+        Redis: a Redis client
     """
     settings = RedisMessagingSettings()
 
@@ -221,11 +235,10 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
-        redis_from_url = (
-            RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
-        )
-        return redis_from_url(
-            normalize_cluster_url(url),
+        if is_cluster_url(url):
+            _raise_cluster_not_supported()
+        return Redis.from_url(
+            url,
             health_check_interval=health_check_interval
             or settings.health_check_interval,
             decode_responses=decode_responses,
@@ -252,7 +265,7 @@ def get_async_redis_client(
 @cached
 def async_redis_from_settings(
     settings: RedisMessagingSettings, **options: Any
-) -> RedisClient:
+) -> Redis:
     options = {
         "decode_responses": True,
         "socket_timeout": settings.socket_timeout,
@@ -262,11 +275,10 @@ def async_redis_from_settings(
     }
 
     if settings.url:
-        redis_from_url = (
-            RedisCluster.from_url if is_cluster_url(settings.url) else Redis.from_url
-        )
-        return redis_from_url(
-            normalize_cluster_url(settings.url),
+        if is_cluster_url(settings.url):
+            _raise_cluster_not_supported()
+        return Redis.from_url(
+            settings.url,
             health_check_interval=settings.health_check_interval,
             **options,
         )

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -7,12 +7,14 @@ from prefect_redis.client import (
     _client_cache,
     async_redis_from_settings,
     close_all_cached_connections,
+    cluster_key_prefix,
     get_async_redis_client,
     is_cluster_url,
     normalize_cluster_url,
+    redis_key,
 )
 from redis.asyncio import Redis
-from redis.asyncio.cluster import RedisCluster
+from redis.cluster import key_slot
 
 
 def test_redis_settings_defaults(isolated_redis_db_number: int):
@@ -70,6 +72,52 @@ def test_cluster_url_detection():
 )
 def test_normalize_cluster_url(url: str, expected: str):
     assert normalize_cluster_url(url) == expected
+
+
+def test_cluster_key_prefix_hash_tags_cluster_urls():
+    assert (
+        cluster_key_prefix(
+            "prefect:events", url="redis+cluster://redis.example.com:6379"
+        )
+        == "{prefect:events}"
+    )
+    assert (
+        cluster_key_prefix(
+            "prefect:events", url="rediss+cluster://redis.example.com:6379"
+        )
+        == "{prefect:events}"
+    )
+    assert (
+        cluster_key_prefix("prefect:events", url="redis://redis.example.com:6379")
+        == "prefect:events"
+    )
+
+
+def test_redis_key_uses_cluster_aware_prefix():
+    assert (
+        redis_key(
+            "prefect:events",
+            "stream",
+            url="redis+cluster://redis.example.com:6379",
+        )
+        == "{prefect:events}:stream"
+    )
+    assert (
+        redis_key("prefect:events", "stream", url="redis://redis.example.com:6379")
+        == "prefect:events:stream"
+    )
+
+
+def test_cluster_keys_share_hash_slot():
+    keys = [
+        redis_key(
+            "prefect:events",
+            suffix,
+            url="redis+cluster://redis.example.com:6379",
+        )
+        for suffix in ["stream", "dlq", "dedupe:abc"]
+    ]
+    assert len({key_slot(key.encode()) for key in keys}) == 1
 
 
 def test_redis_settings_url_warns_on_conflicting_fields():
@@ -130,17 +178,11 @@ async def test_get_async_redis_client_with_url():
     await client.aclose()
 
 
-async def test_get_async_redis_client_with_cluster_url():
-    """Cluster URLs create RedisCluster clients after URL normalization."""
+async def test_get_async_redis_client_with_cluster_url_raises():
+    """Cluster URLs are detected but not enabled until key work is complete."""
     _client_cache.clear()
-    client = get_async_redis_client(url="redis+cluster://clusterhost:7000")
-    assert isinstance(client, RedisCluster)
-    assert client.nodes_manager.startup_nodes["clusterhost:7000"].host == "clusterhost"
-    assert client.nodes_manager.startup_nodes["clusterhost:7000"].port == 7000
-    assert client.get_connection_kwargs()["decode_responses"] is True
-    assert client.get_connection_kwargs()["protocol"] == 2
-    await client.aclose()
-    _client_cache.clear()
+    with pytest.raises(NotImplementedError, match="Redis Cluster URLs"):
+        get_async_redis_client(url="redis+cluster://clusterhost:7000")
 
 
 async def test_get_async_redis_client_url_with_credentials():
@@ -215,19 +257,12 @@ async def test_async_redis_from_settings_with_url():
     await client.aclose()
 
 
-async def test_async_redis_from_settings_with_cluster_url():
-    """Settings URL can create a RedisCluster client."""
+async def test_async_redis_from_settings_with_cluster_url_raises():
+    """Settings URL cluster support is detection-only for now."""
     _client_cache.clear()
     settings = RedisMessagingSettings(url="rediss+cluster://fromurl:6385")
-    client = async_redis_from_settings(settings)
-    assert isinstance(client, RedisCluster)
-    assert client.nodes_manager.startup_nodes["fromurl:6385"].host == "fromurl"
-    assert client.nodes_manager.startup_nodes["fromurl:6385"].port == 6385
-    connection_kwargs = client.get_connection_kwargs()
-    assert connection_kwargs["decode_responses"] is True
-    assert connection_kwargs["protocol"] == 2
-    await client.aclose()
-    _client_cache.clear()
+    with pytest.raises(NotImplementedError, match="Redis Cluster URLs"):
+        async_redis_from_settings(settings)
 
 
 def test_redis_settings_connection_defaults():

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -48,6 +48,7 @@ def test_cluster_url_detection():
     assert is_cluster_url("rediss+cluster://redis.example.com:6379")
     assert not is_cluster_url("redis://redis.example.com:6379")
     assert not is_cluster_url("rediss://redis.example.com:6379")
+    assert not is_cluster_url("redis://host,[::1]:6379")
 
 
 @pytest.mark.parametrize(

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -8,8 +8,11 @@ from prefect_redis.client import (
     async_redis_from_settings,
     close_all_cached_connections,
     get_async_redis_client,
+    is_cluster_url,
+    normalize_cluster_url,
 )
 from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
 
 
 def test_redis_settings_defaults(isolated_redis_db_number: int):
@@ -38,6 +41,34 @@ def test_redis_settings_url_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", "redis://envhost:6381/3")
     settings = RedisMessagingSettings()
     assert settings.url == "redis://envhost:6381/3"
+
+
+def test_cluster_url_detection():
+    assert is_cluster_url("redis+cluster://redis.example.com:6379")
+    assert is_cluster_url("rediss+cluster://redis.example.com:6379")
+    assert not is_cluster_url("redis://redis.example.com:6379")
+    assert not is_cluster_url("rediss://redis.example.com:6379")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "redis+cluster://redis.example.com:6379",
+            "redis://redis.example.com:6379",
+        ),
+        (
+            "rediss+cluster://user:pass@redis.example.com:6380/0?protocol=3",
+            "rediss://user:pass@redis.example.com:6380/0?protocol=3",
+        ),
+        (
+            "redis://redis.example.com:6379/0",
+            "redis://redis.example.com:6379/0",
+        ),
+    ],
+)
+def test_normalize_cluster_url(url: str, expected: str):
+    assert normalize_cluster_url(url) == expected
 
 
 def test_redis_settings_url_warns_on_conflicting_fields():
@@ -96,6 +127,19 @@ async def test_get_async_redis_client_with_url():
     assert conn_kwargs["port"] == 6382
     assert conn_kwargs["db"] == 4
     await client.aclose()
+
+
+async def test_get_async_redis_client_with_cluster_url():
+    """Cluster URLs create RedisCluster clients after URL normalization."""
+    _client_cache.clear()
+    client = get_async_redis_client(url="redis+cluster://clusterhost:7000")
+    assert isinstance(client, RedisCluster)
+    assert client.nodes_manager.startup_nodes["clusterhost:7000"].host == "clusterhost"
+    assert client.nodes_manager.startup_nodes["clusterhost:7000"].port == 7000
+    assert client.get_connection_kwargs()["decode_responses"] is True
+    assert client.get_connection_kwargs()["protocol"] == 2
+    await client.aclose()
+    _client_cache.clear()
 
 
 async def test_get_async_redis_client_url_with_credentials():
@@ -168,6 +212,21 @@ async def test_async_redis_from_settings_with_url():
     assert conn_kwargs["port"] == 6385
     assert conn_kwargs["db"] == 7
     await client.aclose()
+
+
+async def test_async_redis_from_settings_with_cluster_url():
+    """Settings URL can create a RedisCluster client."""
+    _client_cache.clear()
+    settings = RedisMessagingSettings(url="rediss+cluster://fromurl:6385")
+    client = async_redis_from_settings(settings)
+    assert isinstance(client, RedisCluster)
+    assert client.nodes_manager.startup_nodes["fromurl:6385"].host == "fromurl"
+    assert client.nodes_manager.startup_nodes["fromurl:6385"].port == 6385
+    connection_kwargs = client.get_connection_kwargs()
+    assert connection_kwargs["decode_responses"] is True
+    assert connection_kwargs["protocol"] == 2
+    await client.aclose()
+    _client_cache.clear()
 
 
 def test_redis_settings_connection_defaults():


### PR DESCRIPTION
## Summary

this PR adds the first inert groundwork for Redis Cluster support in `prefect-redis`.

It introduces:

- `redis+cluster://` and `rediss+cluster://` URL detection
- URL normalization helpers for the future redis-py `RedisCluster.from_url(...)` path
- cluster-aware key prefix helpers that hash-tag a shared prefix for Redis Cluster slot co-location
- tests that prove related cluster keys share a Redis Cluster hash slot
- an explicit `NotImplementedError` if a cluster URL is used to create a client today

This intentionally does **not** construct `RedisCluster` clients yet. That comes after the Redis-backed subsystems have hash-slot-safe key construction.

<details>
<summary>Why this shape</summary>

Docket's Redis Cluster work first centralized key construction, then centralized connection handling, then enabled cluster clients after the key/hash-slot story was ready.

The relevant Docket sequence was:

- chrisguidry/docket#270 and #274: centralize key construction behind `prefix` / `key()` helpers
- chrisguidry/docket#283: centralize Redis connection helpers and cluster URL detection, with cluster paths still disabled
- chrisguidry/docket#284: enable cluster clients, hash-tagged prefixes, pub/sub handling, and cluster test infrastructure

This PR matches the early groundwork step rather than turning on partial cluster support.

</details>

<details>
<summary>Planned follow-up PRs</summary>

1. Route `prefect-redis` messaging keys through cluster-aware key helpers, including stream keys, dedupe keys, DLQ keys, and any batching behavior that needs slot-aware handling.
2. Make causal ordering cluster-safe by hash-tagging a scope's `seen`, `processing`, `followers`, `event`, and `waitlist` keys together.
3. Make concurrency lease storage cluster-safe by ensuring lease keys, expiration indexes, and holder indexes used by Lua scripts share a hash tag, and by passing script keys explicitly where needed.
4. Make worker cleanup queue cluster-safe. The smallest compatible design is to hash-tag the cleanup queue prefix; a later optimization could shard by work pool, but that is a larger semantic change because the queue has global pool bookkeeping.
5. Add Redis Cluster integration test infrastructure and CI coverage once the multi-key subsystems are ready to run against a cluster.
6. Enable `RedisCluster.from_url(...)` construction from `get_async_redis_client` and `async_redis_from_settings`.
7. Audit Prefect's Docket minimum version for `PREFECT_SERVER_DOCKET_URL=redis+cluster://...`; Docket has cluster support, but Prefect's lower bound should match the first supported release before docs advertise it.

</details>

<details>
<summary>Validation</summary>

- `uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_client.py -q`
- `uv run ruff check src/integrations/prefect-redis/prefect_redis/client.py src/integrations/prefect-redis/tests/test_client.py`
- `uv run ruff format --check src/integrations/prefect-redis/prefect_redis/client.py src/integrations/prefect-redis/tests/test_client.py`
- `git diff --check`

Real Prefect server smoke test on local OrbStack:

- started standalone Redis locally via Docker/OrbStack
- started a Prefect API server from this branch in Docker with:
  - `PREFECT_MESSAGING_BROKER=prefect_redis.messaging`
  - `PREFECT_MESSAGING_CACHE=prefect_redis.messaging`
  - `PREFECT_REDIS_MESSAGING_URL=redis://prefect-pr-22211-redis:6379/0`
- ran real `@flow` / `@task` execution against the server
- emitted custom Prefect events from the flow and task
- verified Redis contained the Prefect `events` stream and messaging cache keys
- verified the Prefect events API returned the emitted smoke events

</details>
