### PR TITLE
fix(dockerutils): parse_image_tag crashes on a tag with an extra colon

### DIFF
--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -578,9 +578,9 @@ def parse_image_tag(name: str) -> tuple[str, Optional[str]]:
     # - Example: simplename:latest or simplename@sha256:abc123
     if len(name_parts) == 1:
         if "@" in name_parts[0]:
-            image_name, tag = name_parts[0].split("@")
+            image_name, tag = name_parts[0].split("@", 1)
         elif ":" in name_parts[0]:
-            image_name, tag = name_parts[0].split(":")
+            image_name, tag = name_parts[0].split(":", 1)
 
         else:
             image_name = name_parts[0]
@@ -592,9 +592,9 @@ def parse_image_tag(name: str) -> tuple[str, Optional[str]]:
         image_path = "/".join(name_parts[1:])
 
         if "@" in image_path:
-            image_path, tag = image_path.split("@")
+            image_path, tag = image_path.split("@", 1)
         elif ":" in image_path:
-            image_path, tag = image_path.split(":")
+            image_path, tag = image_path.split(":", 1)
 
         image_name = f"{index_name}/{image_path}"
 

--- a/tests/docker/test_image_parsing.py
+++ b/tests/docker/test_image_parsing.py
@@ -37,6 +37,18 @@ def test_parse_image_tag(value, expected):
 @pytest.mark.parametrize(
     "value,expected",
     [
+        ("img:1.0:2.0", ("img", "1.0:2.0")),
+        ("myorg/myimage:1.0:beta", ("myorg/myimage", "1.0:beta")),
+    ],
+)
+def test_parse_image_tag_extra_colon(value, expected):
+    # A second colon in the tag/digest segment must not crash the unpack
+    assert parse_image_tag(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
         ("20.10.0", "20.10.0"),
         ("v20.10.10", "v20.10.10"),
         ("v20.10.0-ce", "v20.10.0"),


### PR DESCRIPTION
## What's broken

`parse_image_tag` splits an image reference on `:` and `@` and unpacks the result into exactly two variables with no `maxsplit`. When the tag or digest segment holds a second colon, the split returns three or more parts and the tuple unpack throws:

```python
>>> from prefect.utilities.dockerutils import parse_image_tag
>>> parse_image_tag("myorg/myimage:1.0:beta")
ValueError: too many values to unpack (expected 2)
```

The single-segment branch crashes the same way on e.g. `img:1.0:2.0`. It's a public utility with no input validation, so malformed input crashes instead of being parsed.

## Why it happens

`str.split(":")` / `str.split("@")` without `maxsplit=1` returns more than two parts when the separator appears more than once.

## Fix

Pass `maxsplit=1` at all four split sites, so only the first separator divides the name from the tag/digest. The remainder stays in the tag.

## Test

Added `test_parse_image_tag_extra_colon` asserting `img:1.0:2.0` -> `("img", "1.0:2.0")` and `myorg/myimage:1.0:beta` -> `("myorg/myimage", "1.0:beta")`. Both raise `ValueError` before the fix and pass after; the existing parametrized cases are unchanged.

Fixes #22222