### PR TITLE
fix(runner): degrade events WebSocket on transient connection failures

### DIFF
--- a/src/prefect/runner/AGENTS.md
+++ b/src/prefect/runner/AGENTS.md
@@ -15,7 +15,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 | CancelFinalizer | _cancel_finalizer.py | Persist Cancelled state after kill; fall back to Crashed if state cannot be confirmed |
 | ControlChannel | _control_channel.py | Runner-side TCP loopback IPC for delivering cancel intent to child processes before kill |
 | HookRunner | _hook_runner.py | on_cancellation / on_crashed hook execution |
-| EventEmitter | _event_emitter.py | Event emission via EventsClient; degrades to NullEventsClient on WebSocket rejection |
+| EventEmitter | _event_emitter.py | Event emission via EventsClient; degrades to NullEventsClient on any WebSocket connection failure |
 | LimitManager | _limit_manager.py | Concurrency limiting |
 | DeploymentRegistry | _deployment_registry.py | Deployment/flow/storage/bundle maps |
 | ScheduledRunPoller | _scheduled_run_poller.py | Poll loop, run discovery, scheduling |
@@ -49,7 +49,7 @@ These will be removed once internal callers (notably ProcessWorker) are migrated
 
 ## EventEmitter WebSocket Degradation
 
-`EventEmitter.__aenter__` catches `websockets.exceptions.InvalidStatus` (HTTP 4xx rejections) and silently swaps the failed client for a `NullEventsClient`. This handles old clients (≤3.6.13) connecting to servers ≥3.6.14 with `PREFECT_SERVER_API_AUTH_STRING` configured — the server rejects the WebSocket handshake, but events are non-critical telemetry so the flow run must not crash. A `WARNING` is logged. If `__aenter__` raises, `__aexit__` is **not** called on the original client (it was never successfully entered); the replacement `NullEventsClient` is entered instead.
+`EventEmitter.__aenter__` catches connection failures and silently swaps the failed client for a `NullEventsClient` — events are non-critical telemetry (the runner emits only `prefect.runner.cancelled-flow-run`), so the flow run must not crash when the events WebSocket is unreachable. Two failure classes are caught (`_NONFATAL_CONNECTION_EXCEPTIONS`): permanent rejections (`websockets.exceptions.InvalidStatus`, i.e. HTTP 4xx — e.g. a client ≤3.6.13 connecting to a server ≥3.6.14 with `PREFECT_SERVER_API_AUTH_STRING` configured) and transient failures (`RETRYABLE_EXCEPTIONS` from `events/clients.py`: `ConnectionClosed`, `TimeoutError`, `OSError`) that outlive the events client's own reconnection attempts. A `WARNING` is logged. If `__aenter__` raises, `__aexit__` is **not** called on the original client (it was never successfully entered); the replacement `NullEventsClient` is entered instead.
 
 ## AsyncExitStack LIFO Ordering
 

--- a/src/prefect/runner/_event_emitter.py
+++ b/src/prefect/runner/_event_emitter.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from cachetools import TTLCache
 from websockets.exceptions import InvalidStatus as _WsInvalidStatus
 
-from prefect.events.clients import NullEventsClient
+from prefect.events.clients import RETRYABLE_EXCEPTIONS, NullEventsClient
 from prefect.events.related import tags_as_related_resources
 from prefect.events.schemas.events import Event, RelatedResource, Resource
 from prefect.logging import get_logger
@@ -18,12 +18,19 @@ if TYPE_CHECKING:
     from prefect.client.schemas.responses import DeploymentResponse
     from prefect.events.clients import EventsClient
 
-# Exceptions that indicate a permanent connection failure (e.g. auth rejected).
-# On these, EventEmitter degrades gracefully to NullEventsClient rather than
-# crashing the flow run.  This preserves backwards-compatibility with clients
-# running against a server that has PREFECT_SERVER_API_AUTH_STRING configured
-# (server >=3.6.14) where the WS handshake is rejected with HTTP 401/403.
-_NONFATAL_CONNECTION_EXCEPTIONS: tuple[type[Exception], ...] = (_WsInvalidStatus,)
+# Connection failures that must not crash the flow run.  The events WebSocket
+# carries non-critical telemetry, so a failure to connect degrades to
+# NullEventsClient rather than taking the flow run down with it.
+# - _WsInvalidStatus: the server rejected the handshake (HTTP 401/403), e.g. a
+#   client <=3.6.13 connecting to a server >=3.6.14 that has
+#   PREFECT_SERVER_API_AUTH_STRING configured.  A permanent failure.
+# - RETRYABLE_EXCEPTIONS: transient failures (handshake timeout, dropped
+#   connection, network errors) that the events client already retries; once
+#   those retries are exhausted the error must still not be fatal here.
+_NONFATAL_CONNECTION_EXCEPTIONS: tuple[type[Exception], ...] = (
+    _WsInvalidStatus,
+    *RETRYABLE_EXCEPTIONS,
+)
 
 
 def _default_get_events_client() -> "EventsClient":
@@ -60,17 +67,18 @@ class EventEmitter:
         try:
             await self._events_client.__aenter__()
         except _NONFATAL_CONNECTION_EXCEPTIONS as exc:
-            # The events WebSocket was rejected by the server (e.g. HTTP 401/403).
-            # This happens when an old client (<=3.6.13) connects to a server
-            # >=3.6.14 that has PREFECT_SERVER_API_AUTH_STRING configured: the
-            # server now requires the "prefect" subprotocol + auth handshake, but
-            # old clients omit it.  Events are non-critical telemetry, so we
-            # degrade gracefully instead of crashing the flow run.
+            # The events WebSocket could not be established -- either rejected by
+            # the server (HTTP 401/403, e.g. a client <=3.6.13 connecting to a
+            # server >=3.6.14 with PREFECT_SERVER_API_AUTH_STRING configured) or a
+            # transient connection failure that outlived the events client's own
+            # retries.  Events are non-critical telemetry, so degrade gracefully
+            # instead of crashing the flow run.
             self._logger.warning(
                 "Unable to connect to the events WebSocket (%s). "
-                "Event data will not be emitted for this runner. "
-                "Upgrade the Prefect client to >=3.6.14 to restore event support "
-                "when the server has authentication configured.",
+                "Event data will not be emitted for this runner; the flow run "
+                "will continue. Upgrade the Prefect client to >=3.6.14 to "
+                "restore event support if the server has authentication "
+                "configured.",
                 exc,
             )
             # __aenter__ failed, so __aexit__ must NOT be called on the original

--- a/tests/runner/test__event_emitter.py
+++ b/tests/runner/test__event_emitter.py
@@ -129,6 +129,42 @@ class TestEventEmitterLifecycle:
         assert "Unable to connect to the events WebSocket" in caplog.text
         assert "Upgrade the Prefect client" in caplog.text
 
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            TimeoutError("timed out during opening handshake"),
+            OSError("connection refused"),
+        ],
+        ids=["timeout", "oserror"],
+    )
+    async def test_transient_connection_failure_degrades_to_null_client(
+        self, exc: Exception, caplog: pytest.LogCaptureFixture
+    ):
+        """EventEmitter falls back to NullEventsClient on a transient events
+        WebSocket failure (handshake timeout, dropped connection, network error)
+        that outlived the events client's own retries.  The flow run must not
+        crash — fixes the asymmetry where only HTTP 4xx rejections were caught."""
+        failing_client = AssertingEventsClient()
+
+        async def _raise_on_enter(self_inner):  # noqa: N803
+            raise exc
+
+        emitter = EventEmitter(
+            runner_name="test-runner",
+            client=AsyncMock(),
+            get_events_client=lambda: failing_client,
+        )
+
+        with (
+            patch.object(type(failing_client), "__aenter__", _raise_on_enter),
+            caplog.at_level(logging.WARNING, logger="prefect.runner.event_emitter"),
+        ):
+            async with emitter:
+                # Must not raise; should have fallen back to NullEventsClient
+                assert isinstance(emitter._events_client, NullEventsClient)
+
+        assert "Unable to connect to the events WebSocket" in caplog.text
+
 
 class TestEventEmitterEmitFlowRunCancelled:
     async def test_emits_cancelled_event(self):


### PR DESCRIPTION
`EventEmitter.__aenter__` swaps a failed events client for `NullEventsClient` so a runner can start a flow run when the events WebSocket is unreachable. It only caught `websockets.exceptions.InvalidStatus` (HTTP 4xx rejection). A transient failure — handshake timeout, dropped connection, or network error — was not caught: it propagated out of `FlowRunExecutorContext.__aenter__` and exited the `prefect flow-run execute` process with code 1, so the worker reported the run as crashed before any flow code ran.

This is the same crash as #19902. #20328 added `RETRYABLE_EXCEPTIONS` retries inside `PrefectEventsClient.__aenter__`, but once those retries are exhausted the client re-raises, and `EventEmitter` did not catch that.

This PR adds `RETRYABLE_EXCEPTIONS` (`ConnectionClosed`, `TimeoutError`, `OSError`) to `_NONFATAL_CONNECTION_EXCEPTIONS`, reusing the set from `events/clients.py` so the retryable and non-fatal definitions stay in one place. Any connection failure now degrades to `NullEventsClient` instead of crashing the run.

#21767 considered this and kept the catch narrow, to avoid swallowing "transient-but-recoverable errors that should propagate". But by the time `EventEmitter` sees the exception, `PrefectEventsClient.__aenter__` has already spent its reconnection attempts (default 10), so the recoverable retries are gone. This connection carries only `prefect.runner.cancelled-flow-run` — non-critical telemetry — and the cancelled state is set through the API before that event is emitted (see `_cancellation_manager.py`), so dropping it does not affect cancellation. Crashing the run is the worse trade.

The degradation warning's "upgrade the client" hint is now conditional on server auth, so it no longer misleads on a timeout. No public API change; affects both `serve()` and the `prefect flow-run execute` path.

### Checklist

- [x] References #19902 (the same crash, reported against the events client).
- [x] Adds unit tests covering `TimeoutError` / `OSError` degradation.
- [ ] ~~Removes docs files~~ — N/A.
- [ ] ~~Adds functions or classes~~ — N/A (extends an existing constant).
