### PR TITLE
document programmatic flow run cancellation

### DIFF
--- a/docs/v3/advanced/cancel-workflows.mdx
+++ b/docs/v3/advanced/cancel-workflows.mdx
@@ -68,7 +68,7 @@ Another worker may attempt cancellation.
 - If the worker runs into an unexpected error during cancellation, the flow run may or may not be cancelled 
 depending on where the error occurred. The worker will try again to cancel the flow run. Another worker may attempt cancellation.
 
-### Cancel through the CLI
+## Cancel through the CLI
 
 From the command line in your execution environment, you can cancel a flow run by using the 
 `prefect flow-run cancel` CLI command, passing the ID of the flow run.
@@ -77,8 +77,49 @@ From the command line in your execution environment, you can cancel a flow run b
 prefect flow-run cancel 'a55a4804-9e3c-4042-8b59-b3b6b7618736'
 ```
 
-### Cancel through the UI
+## Cancel through the UI
 
 Navigate to the flow run's detail page and click `Cancel` in the upper right corner.
 
 ![Prefect UI](/v3/img/ui/flow-run-cancellation-ui.png)
+
+## Cancel through the Python client
+
+To request cancellation programmatically, set the flow run state to `CANCELLING`.
+This is the same state used by the CLI, UI, and automation cancellation actions.
+
+{/* pmd-metadata: notest */}
+```python
+from uuid import UUID
+
+from prefect import get_client
+from prefect.client.schemas.objects import State, StateType
+
+
+flow_run_id = UUID("a55a4804-9e3c-4042-8b59-b3b6b7618736")
+
+with get_client(sync_client=True) as client:
+    result = client.set_flow_run_state(
+        flow_run_id=flow_run_id,
+        state=State(type=StateType.CANCELLING, name="Cancelling"),
+    )
+
+print(result.status)
+```
+
+<Warning>
+Do not force a running flow run directly into the terminal `CANCELLED` state
+to request cancellation.
+`CANCELLING` signals that execution should stop and infrastructure should be cleaned up.
+`CANCELLED` is the final state after cancellation is complete, or when there is no running infrastructure to stop.
+</Warning>
+
+## Cancel through the REST API
+
+To request cancellation with the REST API, set the flow run state to `CANCELLING`.
+
+```bash
+curl -X POST "$PREFECT_API_URL/flow_runs/a55a4804-9e3c-4042-8b59-b3b6b7618736/set_state" \
+  -H "Content-Type: application/json" \
+  -d '{"state": {"type": "CANCELLING", "name": "Cancelling"}}'
+```

--- a/docs/v3/concepts/deployments.mdx
+++ b/docs/v3/concepts/deployments.mdx
@@ -12,7 +12,7 @@ They store the crucial metadata for remote orchestration including when, where, 
 
 In addition to manually triggering and managing flow runs, deploying a flow exposes an API and UI that allow you to:
 
-- trigger new runs, [cancel active runs](/v3/how-to-guides/workflows/write-and-run#cancel-a-flow-run), pause scheduled runs, [customize parameters](/v3/concepts/flows#specify-flow-parameters), and more
+- trigger new runs, [cancel active runs](/v3/advanced/cancel-workflows), pause scheduled runs, [customize parameters](/v3/concepts/flows#specify-flow-parameters), and more
 - remotely configure [schedules](/v3/concepts/schedules) and [automation rules](/v3/how-to-guides/automations/creating-deployment-triggers)
 - dynamically provision infrastructure with [work pools](/v3/deploy/infrastructure-concepts/work-pools) - optionally with templated guardrails for other users
 


### PR DESCRIPTION
## Summary

This PR updates the workflow cancellation docs to make the recommended programmatic cancellation path explicit.

- adds Python client and REST API examples that request cancellation with `CANCELLING`
- warns against forcing a running flow run directly into terminal `CANCELLED`
- fixes the deployments concept page to link active-run cancellation to the cancellation guide

## Context

Issue #17482 surfaced confusion around setting a running flow run directly to `CANCELLED` via `set_flow_run_state(..., force=True)`. That updates state metadata but does not follow the supported cancellation signal path used by the UI, CLI, and automations.

## Validation

- `git diff --check -- docs/v3/advanced/cancel-workflows.mdx docs/v3/concepts/deployments.mdx`

