### PR TITLE
fix: handle RecursionError in Flow.serialize_parameters

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -706,7 +706,11 @@ class Flow(Generic[P, R]):
                 from fastapi.encoders import jsonable_encoder
 
                 serialized_parameters[key] = jsonable_encoder(value)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, RecursionError):
+                # `jsonable_encoder` recurses into unknown objects with no cycle
+                # or depth limit, so a deeply-nested or self-referential value
+                # raises `RecursionError`. Treat it like any other unserializable
+                # value and fall back to the placeholder below.
                 logger.debug(
                     f"Parameter {key!r} for flow {self.name!r} is unserializable. "
                     f"Type {type(value).__name__!r} and will not be stored "

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1803,6 +1803,22 @@ class TestFlowParameterTypes:
         # See #1638.
         assert my_flow(data) == data
 
+    def test_serialize_parameters_falls_back_on_self_referential_types(self):
+        @flow
+        def my_flow(x):
+            return x
+
+        class Cyclic:
+            def __init__(self):
+                self.me = self
+
+        data = Cyclic()
+        # jsonable_encoder recurses into unknown objects with no cycle limit, so a
+        # self-referential value raises RecursionError instead of TypeError/ValueError.
+        # serialize_parameters should fall back to the placeholder rather than crash.
+        # See #22244.
+        assert my_flow.serialize_parameters({"x": data}) == {"x": "<Cyclic>"}
+
     def test_flow_parameter_annotations_can_be_non_pydantic_classes(self):
         class Test:
             pass


### PR DESCRIPTION
`Flow.serialize_parameters` records a flow's parameters for the backend with FastAPI's `jsonable_encoder`, which recurses into unknown objects with no cycle or depth limit. It already wraps the call in `except (TypeError, ValueError)` and substitutes a `"<Type>"` placeholder when a value can't be encoded. But a deeply-nested or self-referential argument overflows the stack with `RecursionError` — a `RuntimeError`, not `TypeError`/`ValueError` — so it escaped the fallback and crashed the flow run.

Add `RecursionError` to the caught tuple so a value that recurses forever lands on the same placeholder path as any other unserializable value. The placeholder branch runs with a shallow stack (the deep encoder frames unwind before it's reached), so logging and formatting the type name are safe. This mirrors the precedent in #1638, where `ValueError` was added for the same reason.

```python
from prefect import flow


@flow
def my_flow(x):
    return x


class Cyclic:
    def __init__(self):
        self.me = self


# Before: RecursionError. After: {"x": "<Cyclic>"}
my_flow.serialize_parameters({"x": Cyclic()})
```

Closes https://github.com/PrefectHQ/prefect/issues/22244

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
