### PR TITLE
Add Redis Sentinel support to prefect-redis

### DIFF
--- a/docs/integrations/prefect-redis/index.mdx
+++ b/docs/integrations/prefect-redis/index.mdx
@@ -85,7 +85,9 @@ export PREFECT_SERVER_DOCKET_URL="redis+sentinel://sentinel-a:26379,sentinel-b:2
 
 ### Lock manager
 
-```python
+{/* notest: requires a prefect-redis release with Sentinel support */}
+
+```python notest
 from prefect_redis import RedisLockManager
 
 lock_manager = RedisLockManager(
@@ -95,7 +97,9 @@ lock_manager = RedisLockManager(
 
 ### `RedisDatabase` block
 
-```python
+{/* notest: requires a prefect-redis release with Sentinel support */}
+
+```python notest
 from prefect_redis import RedisDatabase
 
 block = RedisDatabase.from_connection_string(

--- a/docs/integrations/prefect-redis/index.mdx
+++ b/docs/integrations/prefect-redis/index.mdx
@@ -30,6 +30,80 @@ Register the block types in the `prefect-redis` module to make them available fo
 prefect block register -m prefect_redis
 ```
 
+## Connecting with a URL (including Redis Sentinel)
+
+Every `prefect-redis` connection point — the server messaging client, the
+`RedisLockManager`, and the `RedisDatabase` block — accepts a full connection URL in
+addition to the individual `host`/`port`/`db`/`username`/`password`/`ssl` fields. When
+a URL is provided it is authoritative and the scalar fields are ignored.
+
+The following schemes are supported:
+
+| Scheme | Behavior |
+| --- | --- |
+| `redis://` | Single-node TCP connection |
+| `rediss://` | Single-node TLS connection |
+| `redis+sentinel://` | [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) discovery (TCP data nodes) |
+| `rediss+sentinel://` | Redis Sentinel discovery (TLS data nodes) |
+
+The Sentinel schemes accept a comma-separated list of Sentinel members and a master
+group name, and the resulting client resolves the current master through the Sentinel
+daemons and follows failover automatically:
+
+```
+redis+sentinel://[user:pass@]sentinel-a:26379,sentinel-b:26379/<master-name>[/<db>][?params]
+```
+
+Sentinel-specific query parameters configure the connections to the Sentinel daemons
+separately from the data nodes: `sentinel_username`, `sentinel_password`, `sentinel_ssl`,
+`sentinel_tls_insecure`, and `sentinel_tls_ca_file`. Single-node TLS URLs additionally
+accept `tls_insecure` and `tls_ca_file`.
+
+### Server messaging (events / streams)
+
+Point the Prefect server's Redis messaging at a Sentinel topology with a single
+environment variable:
+
+```bash
+export PREFECT_REDIS_MESSAGING_URL="redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster"
+```
+
+The same setting also accepts single-node `redis://` / `rediss://` URLs and the
+`redis+cluster://` / `rediss+cluster://` Redis Cluster schemes.
+
+### Background services (Docket)
+
+Multi-server deployments also point `PREFECT_SERVER_DOCKET_URL` at the same shared
+Redis so the server's background services coordinate through it. That URL is
+resolved by [Docket](https://github.com/chrisguidry/docket) rather than
+`prefect-redis`, so Sentinel URLs require a `pydocket` release that includes Redis
+Sentinel support:
+
+```bash
+export PREFECT_SERVER_DOCKET_URL="redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0"
+```
+
+### Lock manager
+
+```python
+from prefect_redis import RedisLockManager
+
+lock_manager = RedisLockManager(
+    connection_url="redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster"
+)
+```
+
+### `RedisDatabase` block
+
+```python
+from prefect_redis import RedisDatabase
+
+block = RedisDatabase.from_connection_string(
+    "redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster"
+)
+block.save("BLOCK_NAME")
+```
+
 ## Resources
 
 Refer to the [SDK documentation](/integrations/prefect-redis/api-ref/prefect_redis-blocks) to explore all the capabilities of `prefect-redis`.

--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -189,6 +189,14 @@ For Redis instances that require SSL/TLS:
 export PREFECT_SERVER_DOCKET_URL="rediss://redis-host:6379/0"
 ```
 
+For a Redis deployment fronted by [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/), use the `redis+sentinel://` scheme with a comma-separated list of Sentinel daemons and the master group name. Docket discovers the current master through Sentinel and follows failover automatically:
+
+```bash
+export PREFECT_SERVER_DOCKET_URL="redis+sentinel://sentinel-a:26379,sentinel-b:26379,sentinel-c:26379/mymaster/0"
+```
+
+Use the `rediss+sentinel://` scheme for SSL/TLS. This requires `pydocket>=0.22.0`.
+
 <Note>
 The Docket URL can use the same Redis instance as the messaging configuration above, but you may use a different database number (e.g., `/1` instead of `/0`) to keep the data separate.
 </Note>

--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1691,7 +1691,7 @@ The name of the Docket instance.
 `PREFECT_SERVER_DOCKET_NAME`
 
 ### `url`
-The URL of the Redis server to use for Docket.
+The URL of the Redis server to use for Docket. Supports the memory:// (single-server only), redis://, rediss://, redis+sentinel:// and rediss+sentinel:// schemes; the Sentinel schemes discover the current master through the listed Sentinel daemons and follow failover automatically (requires pydocket>=0.22.0).
 
 **Type**: `string`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "whenever>=0.7.3,<0.11.0; python_version>='3.13'",
     "semver>=3.0.4",
     "pluggy>=1.6.0",
-    "pydocket>=0.19.0",
+    "pydocket>=0.22.0",
 ]
 [project.urls]
 Changelog = "https://github.com/PrefectHQ/prefect/releases"

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1502,7 +1502,7 @@
                 },
                 "url": {
                     "default": "memory://",
-                    "description": "The URL of the Redis server to use for Docket.",
+                    "description": "The URL of the Redis server to use for Docket. Supports the memory:// (single-server only), redis://, rediss://, redis+sentinel:// and rediss+sentinel:// schemes; the Sentinel schemes discover the current master through the listed Sentinel daemons and follow failover automatically (requires pydocket>=0.22.0).",
                     "supported_environment_variables": [
                         "PREFECT_SERVER_DOCKET_URL"
                     ],

--- a/src/integrations/prefect-redis/prefect_redis/blocks.py
+++ b/src/integrations/prefect-redis/prefect_redis/blocks.py
@@ -1,6 +1,7 @@
 """Redis credentials handling"""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, cast
+from urllib.parse import urlsplit
 
 import redis
 import redis.asyncio
@@ -9,6 +10,11 @@ from pydantic.types import SecretStr
 from redis.asyncio.connection import parse_url
 
 from prefect.filesystems import WritableFileSystem
+from prefect_redis.connection import (
+    SCHEME_SENTINEL,
+    build_redis_client,
+    parse_redis_url,
+)
 
 DEFAULT_PORT = 6379
 
@@ -59,10 +65,24 @@ class RedisDatabase(WritableFileSystem):
     username: Optional[SecretStr] = Field(default=None, description="Redis username")
     password: Optional[SecretStr] = Field(default=None, description="Redis password")
     ssl: bool = Field(default=False, description="Whether to use SSL")
+    connection_url: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "Full Redis connection URL, authoritative over the scalar connection fields "
+            "when set. Supports the redis://, rediss://, redis+sentinel:// and "
+            "rediss+sentinel:// schemes; the Sentinel schemes resolve the current master "
+            "through the listed Sentinel daemons and follow failover automatically, e.g. "
+            "redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster."
+        ),
+    )
 
     def block_initialization(self) -> None:
         """Validate parameters"""
 
+        if self.connection_url is not None:
+            # Fail fast on a malformed URL rather than at first connection.
+            parse_redis_url(self.connection_url.get_secret_value())
+            return
         if not self.host:
             raise ValueError("Missing hostname")
         if self.username and not self.password:
@@ -100,8 +120,16 @@ class RedisDatabase(WritableFileSystem):
         """Get Redis Client
 
         Returns:
-            An initialized Redis async client
+            An initialized Redis client
         """
+        if self.connection_url is not None:
+            return cast(
+                redis.Redis,
+                build_redis_client(
+                    parse_redis_url(self.connection_url.get_secret_value()),
+                    asynchronous=False,
+                ),
+            )
         return redis.Redis(
             host=self.host,
             port=self.port,
@@ -117,6 +145,14 @@ class RedisDatabase(WritableFileSystem):
         Returns:
             An initialized Redis async client
         """
+        if self.connection_url is not None:
+            return cast(
+                redis.asyncio.Redis,
+                build_redis_client(
+                    parse_redis_url(self.connection_url.get_secret_value()),
+                    asynchronous=True,
+                ),
+            )
         return redis.asyncio.Redis(
             host=self.host,
             port=self.port,
@@ -135,18 +171,27 @@ class RedisDatabase(WritableFileSystem):
         Supports the following URL schemes:
         - `redis://` creates a TCP socket connection
         - `rediss://` creates a SSL wrapped TCP socket connection
+        - `redis+sentinel://` / `rediss+sentinel://` discover the master through
+          Redis Sentinel and follow failover automatically
 
         Args:
             connection_string: Redis connection string
 
         Returns:
-            `RedisCredentials` instance
+            `RedisDatabase` instance
         """
-        connection_kwargs = parse_url(
+        raw_connection_string = (
             connection_string
             if isinstance(connection_string, str)
             else connection_string.get_secret_value()
         )
+
+        # Sentinel URLs cannot be flattened to scalar host/port fields, so they are
+        # retained verbatim and resolved through the Sentinel daemons at connect time.
+        if urlsplit(raw_connection_string).scheme.lower() in SCHEME_SENTINEL:
+            return cls(connection_url=SecretStr(raw_connection_string))
+
+        connection_kwargs = parse_url(raw_connection_string)
         ssl = connection_kwargs.get("connection_class") == redis.asyncio.SSLConnection
         return cls(
             host=connection_kwargs.get("host", "localhost"),
@@ -173,5 +218,10 @@ class RedisDatabase(WritableFileSystem):
             data["password"] = self.password.get_secret_value()
         else:
             data.pop("password", None)
+
+        if self.connection_url is not None:
+            data["connection_url"] = self.connection_url.get_secret_value()
+        else:
+            data.pop("connection_url", None)
 
         return data

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -221,7 +221,9 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
-        redis_from_url = RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        redis_from_url = (
+            RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        )
         return redis_from_url(
             normalize_cluster_url(url),
             health_check_interval=health_check_interval

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -2,9 +2,11 @@ import asyncio
 import functools
 import warnings
 from typing import Any, Callable, Optional, Union
+from urllib.parse import urlparse, urlunparse
 
 from pydantic import Field, model_validator
 from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
 from typing_extensions import Self, TypeAlias
 
 from prefect.settings.base import (
@@ -99,7 +101,23 @@ CacheKey: TypeAlias = tuple[
     Union[asyncio.AbstractEventLoop, None],
 ]
 
-_client_cache: dict[CacheKey, Redis] = {}
+RedisClient: TypeAlias = Redis | RedisCluster
+
+_client_cache: dict[CacheKey, RedisClient] = {}
+
+
+def is_cluster_url(url: str) -> bool:
+    """Return True if the URL uses the Redis Cluster scheme."""
+    return urlparse(url).scheme in {"redis+cluster", "rediss+cluster"}
+
+
+def normalize_cluster_url(url: str) -> str:
+    """Return a redis-py compatible URL for Redis Cluster connections."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"redis+cluster", "rediss+cluster"}:
+        return url
+
+    return urlunparse(parsed._replace(scheme=parsed.scheme.replace("+cluster", "")))
 
 
 def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
@@ -113,7 +131,7 @@ def _running_loop() -> Union[asyncio.AbstractEventLoop, None]:
 
 def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
-    def cached_fn(*args: Any, **kwargs: Any) -> Redis:
+    def cached_fn(*args: Any, **kwargs: Any) -> RedisClient:
         key = (fn, args, tuple(kwargs.items()), _running_loop())
         if key not in _client_cache:
             _client_cache[key] = fn(*args, **kwargs)
@@ -129,7 +147,9 @@ def close_all_cached_connections() -> None:
     for (_, _, _, loop), client in _client_cache.items():
         if not loop or (loop and loop.is_closed()):
             continue
-        loop.run_until_complete(client.connection_pool.disconnect())
+        connection_pool = getattr(client, "connection_pool", None)
+        if connection_pool is not None:
+            loop.run_until_complete(connection_pool.disconnect())
         loop.run_until_complete(client.aclose())
 
 
@@ -159,15 +179,18 @@ def get_async_redis_client(
     socket_timeout: Union[float, None, Any] = _UNSET,
     socket_connect_timeout: Union[float, None, Any] = _UNSET,
     protocol: Union[int, None] = None,
-) -> Redis:
+) -> RedisClient:
     """Retrieves an async Redis client.
 
     When `url` is provided (or configured via
-    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used and
-    the discrete host/port/… arguments are ignored.
+    `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used for
+    standalone URLs and `RedisCluster.from_url` is used for
+    `redis+cluster://` or `rediss+cluster://` URLs. The discrete
+    host/port/… arguments are ignored.
 
     Args:
-        url: Full Redis URL (e.g. `redis://localhost:6379/0`).
+        url: Full Redis URL (e.g. `redis://localhost:6379/0` or
+            `redis+cluster://localhost:6379`).
         host: The host location.
         port: The port to connect to the host with.
         db: The Redis database to interact with.
@@ -182,7 +205,7 @@ def get_async_redis_client(
         protocol: RESP protocol version (default 2 from settings).
 
     Returns:
-        Redis: a Redis client
+        Redis: a Redis or Redis Cluster client
     """
     settings = RedisMessagingSettings()
 
@@ -198,8 +221,9 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
-        return Redis.from_url(
-            url,
+        redis_from_url = RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
+        return redis_from_url(
+            normalize_cluster_url(url),
             health_check_interval=health_check_interval
             or settings.health_check_interval,
             decode_responses=decode_responses,
@@ -226,7 +250,7 @@ def get_async_redis_client(
 @cached
 def async_redis_from_settings(
     settings: RedisMessagingSettings, **options: Any
-) -> Redis:
+) -> RedisClient:
     options = {
         "decode_responses": True,
         "socket_timeout": settings.socket_timeout,
@@ -236,8 +260,11 @@ def async_redis_from_settings(
     }
 
     if settings.url:
-        return Redis.from_url(
-            settings.url,
+        redis_from_url = (
+            RedisCluster.from_url if is_cluster_url(settings.url) else Redis.from_url
+        )
+        return redis_from_url(
+            normalize_cluster_url(settings.url),
             health_check_interval=settings.health_check_interval,
             **options,
         )

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
 import warnings
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, cast
 from urllib.parse import urlparse, urlunparse
 
 from pydantic import Field, model_validator
@@ -12,6 +12,11 @@ from typing_extensions import Self, TypeAlias
 from prefect.settings.base import (
     PrefectBaseSettings,
     build_settings_config,  # type: ignore[reportPrivateUsage]
+)
+from prefect_redis.connection import (
+    SCHEME_SENTINEL,
+    build_redis_client,
+    parse_redis_url,
 )
 
 _UNSET: Any = object()
@@ -40,8 +45,13 @@ class RedisMessagingSettings(PrefectBaseSettings):
         default=None,
         description=(
             "Full Redis URL (e.g. redis://user:pass@host:6379/0 or "
-            "rediss://… for TLS). When set, host/port/db/username/"
-            "password/ssl are ignored."
+            "rediss://… for TLS). Also supports redis+cluster:// and "
+            "rediss+cluster:// for Redis Cluster, and redis+sentinel:// "
+            "and rediss+sentinel:// for Redis Sentinel; the Sentinel "
+            "schemes accept a comma-separated list of members and a "
+            "master group name, e.g. "
+            "redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster. "
+            "When set, host/port/db/username/password/ssl are ignored."
         ),
     )
     host: str = Field(default="localhost")
@@ -109,6 +119,11 @@ _client_cache: dict[CacheKey, RedisClient] = {}
 def is_cluster_url(url: str) -> bool:
     """Return True if the URL uses the Redis Cluster scheme."""
     return urlparse(url).scheme in {"redis+cluster", "rediss+cluster"}
+
+
+def is_sentinel_url(url: str) -> bool:
+    """Return True if the URL uses a Redis Sentinel scheme."""
+    return urlparse(url).scheme in SCHEME_SENTINEL
 
 
 def normalize_cluster_url(url: str) -> str:
@@ -184,13 +199,17 @@ def get_async_redis_client(
 
     When `url` is provided (or configured via
     `PREFECT_REDIS_MESSAGING_URL`), `Redis.from_url` is used for
-    standalone URLs and `RedisCluster.from_url` is used for
-    `redis+cluster://` or `rediss+cluster://` URLs. The discrete
-    host/port/… arguments are ignored.
+    standalone URLs, `RedisCluster.from_url` is used for
+    `redis+cluster://` or `rediss+cluster://` URLs, and a
+    Sentinel-backed client that resolves the current master through the
+    listed Sentinel daemons is used for `redis+sentinel://` or
+    `rediss+sentinel://` URLs. The discrete host/port/… arguments are
+    ignored.
 
     Args:
-        url: Full Redis URL (e.g. `redis://localhost:6379/0` or
-            `redis+cluster://localhost:6379`).
+        url: Full Redis URL (e.g. `redis://localhost:6379/0`,
+            `redis+cluster://localhost:6379` or
+            `redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster`).
         host: The host location.
         port: The port to connect to the host with.
         db: The Redis database to interact with.
@@ -221,6 +240,20 @@ def get_async_redis_client(
 
     url = url or settings.url
     if url:
+        if is_sentinel_url(url):
+            return cast(
+                Redis,
+                build_redis_client(
+                    parse_redis_url(url),
+                    asynchronous=True,
+                    health_check_interval=health_check_interval
+                    or settings.health_check_interval,
+                    decode_responses=decode_responses,
+                    socket_timeout=resolved_socket_timeout,
+                    socket_connect_timeout=resolved_socket_connect_timeout,
+                    protocol=resolved_protocol,
+                ),
+            )
         redis_from_url = (
             RedisCluster.from_url if is_cluster_url(url) else Redis.from_url
         )
@@ -262,6 +295,16 @@ def async_redis_from_settings(
     }
 
     if settings.url:
+        if is_sentinel_url(settings.url):
+            return cast(
+                Redis,
+                build_redis_client(
+                    parse_redis_url(settings.url),
+                    asynchronous=True,
+                    health_check_interval=settings.health_check_interval,
+                    **options,
+                ),
+            )
         redis_from_url = (
             RedisCluster.from_url if is_cluster_url(settings.url) else Redis.from_url
         )

--- a/src/integrations/prefect-redis/prefect_redis/connection.py
+++ b/src/integrations/prefect-redis/prefect_redis/connection.py
@@ -1,0 +1,329 @@
+"""Redis connection URL parsing and client construction.
+
+This module centralizes how ``prefect_redis`` turns a connection URL into a Redis
+client so that the messaging client, the lock manager, and the ``RedisDatabase``
+block all share a single parser and builder rather than each constructing a
+``redis.Redis`` from scalar host/port settings.
+
+A ``+sentinel`` suffix on the scheme selects Sentinel discovery: the current master
+is resolved through the listed Sentinel daemons via ``Sentinel.master_for()`` and
+failover is followed automatically. A ``rediss`` prefix turns on TLS for the data
+nodes. The grammar follows the ``redis-sentinel-url`` convention::
+
+    redis://[user:pass@]host:port[/db][?params]
+    rediss://[user:pass@]host:port[/db][?params]
+    redis+sentinel://[user:pass@]host:port[,host2:port2,...]/service_name[/db][?params]
+    rediss+sentinel://[user:pass@]host:port[,host2:port2,...]/service_name[/db][?params]
+
+Ports are optional and default to 6379 for single-node URLs and 26379 (the
+Sentinel convention) for Sentinel members.
+
+Single-node URLs accept ``tls_insecure`` and ``tls_ca_file`` query parameters; the
+Sentinel schemes additionally accept ``sentinel_username``, ``sentinel_password``,
+``sentinel_ssl``, ``sentinel_tls_insecure`` and ``sentinel_tls_ca_file`` to configure
+the connections to the Sentinel daemons separately from the data nodes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Union
+from urllib.parse import parse_qs, unquote, urlsplit, urlunsplit
+
+import redis
+import redis.asyncio
+from redis.asyncio.sentinel import Sentinel as AsyncSentinel
+from redis.sentinel import Sentinel as SyncSentinel
+
+# Connection URL schemes. A ``+sentinel`` suffix selects Sentinel discovery; a
+# ``rediss`` prefix turns on TLS for the data nodes.
+SCHEME_SENTINEL = frozenset({"redis+sentinel", "rediss+sentinel"})
+SCHEME_TLS = frozenset({"rediss", "rediss+sentinel"})
+SCHEME_ALL = frozenset({"redis", "rediss"}) | SCHEME_SENTINEL
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+_SECRET_QUERY_KEYS = frozenset({"password", "sentinel_password"})
+_REDACTED = "***"
+_DEFAULT_PORT = 6379
+# Sentinel daemons listen on 26379 by default, so sentinel members without an
+# explicit port assume that rather than the data-node port.
+_DEFAULT_SENTINEL_PORT = 26379
+
+
+class RedisUrlError(ValueError):
+    """Raised when a Redis connection URL cannot be parsed into a valid connection."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class RedisConnectionConfig:
+    """Validated description of a Redis connection parsed from a URL.
+
+    ``connection_kwargs`` and ``sentinel_kwargs`` hold redis-py-native keys
+    (``username``, ``password``, ``ssl``, ``ssl_cert_reqs``, ``ssl_check_hostname``,
+    ``ssl_ca_certs``) so a caller can splat them directly. In Sentinel mode
+    ``connection_kwargs`` applies to the data-node (master) connections and
+    ``sentinel_kwargs`` to the Sentinel daemons.
+    """
+
+    db: int
+    is_sentinel: bool
+    host: Union[str, None] = None
+    port: Union[int, None] = None
+    service_name: Union[str, None] = None
+    sentinels: tuple[tuple[str, int], ...] = ()
+    connection_kwargs: dict[str, Any] = field(default_factory=dict)
+    sentinel_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+def redact_redis_url(url: str) -> str:
+    """Return ``url`` with the userinfo password and sensitive query values masked."""
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return _REDACTED
+
+    netloc = parts.netloc
+    if "@" in netloc:
+        userinfo, hostpart = netloc.rsplit("@", 1)
+        if ":" in userinfo:
+            user, _ = userinfo.split(":", 1)
+            userinfo = f"{user}:{_REDACTED}"
+        netloc = f"{userinfo}@{hostpart}"
+
+    query = ""
+    if parts.query:
+        pairs: list[str] = []
+        for key, values in parse_qs(parts.query, keep_blank_values=True).items():
+            value = (
+                _REDACTED
+                if key in _SECRET_QUERY_KEYS
+                else (values[0] if values else "")
+            )
+            pairs.append(f"{key}={value}")
+        query = "&".join(pairs)
+
+    return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
+
+
+def _to_bool(value: str, *, url: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise RedisUrlError(
+        f"Invalid boolean value {value!r} in connection URL: {redact_redis_url(url)}"
+    )
+
+
+def _parse_db(segment: str, *, url: str) -> int:
+    try:
+        db = int(segment)
+    except ValueError as exc:
+        raise RedisUrlError(
+            f"Invalid database index {segment!r} in connection URL: {redact_redis_url(url)}"
+        ) from exc
+    if not 0 <= db <= 15:
+        raise RedisUrlError(
+            f"Database index {db} out of range (0-15) in connection URL: {redact_redis_url(url)}"
+        )
+    return db
+
+
+def _split_members(
+    hostpart: str, *, url: str, default_port: int = _DEFAULT_PORT
+) -> list[tuple[str, int]]:
+    """Split a comma-separated ``host:port,host2:port2`` netloc into members.
+
+    ``urlsplit`` only exposes the segment before the first comma through
+    ``.hostname``/``.port``, so the multi-host netloc is split by hand.
+    """
+    members: list[tuple[str, int]] = []
+    for raw_entry in hostpart.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        if entry.startswith("["):
+            # Bracketed IPv6 member, e.g. [::1] or [::1]:26380
+            host, _, rest = entry[1:].partition("]")
+            port_str = rest.removeprefix(":") or str(default_port)
+        else:
+            host, separator, port_str = entry.rpartition(":")
+            if not separator:
+                host, port_str = entry, str(default_port)
+        if not host:
+            raise RedisUrlError(
+                f"Missing host in connection URL: {redact_redis_url(url)}"
+            )
+        try:
+            port = int(port_str)
+        except ValueError as exc:
+            raise RedisUrlError(
+                f"Invalid port {port_str!r} in connection URL: {redact_redis_url(url)}"
+            ) from exc
+        members.append((host, port))
+    if not members:
+        raise RedisUrlError(f"No host found in connection URL: {redact_redis_url(url)}")
+    return members
+
+
+def _build_ssl_kwargs(
+    *, enabled: bool, query: dict[str, list[str]], url: str, prefix: str = ""
+) -> dict[str, Any]:
+    if not enabled:
+        return {"ssl": False}
+    insecure = _to_bool(query.get(f"{prefix}tls_insecure", ["false"])[0], url=url)
+    return {
+        "ssl": True,
+        "ssl_cert_reqs": "none" if insecure else "optional",
+        "ssl_check_hostname": not insecure,
+        "ssl_ca_certs": query.get(f"{prefix}tls_ca_file", [None])[0],
+    }
+
+
+def parse_redis_url(url: str) -> RedisConnectionConfig:
+    """Parse a Redis connection URL into a validated ``RedisConnectionConfig``.
+
+    Raises:
+        RedisUrlError: With secrets redacted, for any unsupported scheme, malformed
+            member list, missing Sentinel service name, or out-of-range database index.
+    """
+    parts = urlsplit(url)
+    scheme = parts.scheme.lower()
+    if scheme not in SCHEME_ALL:
+        raise RedisUrlError(
+            f"Unsupported scheme {parts.scheme!r} in connection URL: {redact_redis_url(url)}"
+        )
+
+    is_sentinel = scheme in SCHEME_SENTINEL
+    tls_default = scheme in SCHEME_TLS
+
+    netloc = parts.netloc
+    userinfo = ""
+    hostpart = netloc
+    if "@" in netloc:
+        userinfo, hostpart = netloc.rsplit("@", 1)
+
+    username: Union[str, None] = None
+    password: Union[str, None] = None
+    if userinfo:
+        if ":" in userinfo:
+            raw_user, raw_password = userinfo.split(":", 1)
+            username = unquote(raw_user) or None
+            password = unquote(raw_password)
+        else:
+            username = unquote(userinfo) or None
+
+    members = _split_members(
+        hostpart,
+        url=url,
+        default_port=_DEFAULT_SENTINEL_PORT if is_sentinel else _DEFAULT_PORT,
+    )
+    path_segments = [segment for segment in parts.path.split("/") if segment]
+    query = parse_qs(parts.query, keep_blank_values=True)
+
+    connection_kwargs: dict[str, Any] = {}
+    if username is not None:
+        connection_kwargs["username"] = username
+    if password is not None:
+        connection_kwargs["password"] = password
+    connection_kwargs.update(
+        _build_ssl_kwargs(enabled=tls_default, query=query, url=url)
+    )
+
+    if not is_sentinel:
+        if len(members) > 1:
+            raise RedisUrlError(
+                f"Multiple hosts require a +sentinel scheme: {redact_redis_url(url)}"
+            )
+        db = _parse_db(path_segments[0], url=url) if path_segments else 0
+        host, port = members[0]
+        return RedisConnectionConfig(
+            db=db,
+            is_sentinel=False,
+            host=host,
+            port=port,
+            connection_kwargs=connection_kwargs,
+        )
+
+    if not path_segments:
+        raise RedisUrlError(
+            f"A Sentinel connection URL requires a service name: {redact_redis_url(url)}"
+        )
+    service_name = path_segments[0]
+    db = _parse_db(path_segments[1], url=url) if len(path_segments) > 1 else 0
+
+    sentinel_kwargs: dict[str, Any] = {}
+    sentinel_username = query.get("sentinel_username", [None])[0]
+    sentinel_password = query.get("sentinel_password", [None])[0]
+    if sentinel_username:
+        sentinel_kwargs["username"] = sentinel_username
+    if sentinel_password:
+        sentinel_kwargs["password"] = sentinel_password
+    sentinel_ssl_raw = query.get("sentinel_ssl", [None])[0]
+    sentinel_tls = (
+        tls_default if sentinel_ssl_raw is None else _to_bool(sentinel_ssl_raw, url=url)
+    )
+    sentinel_kwargs.update(
+        _build_ssl_kwargs(
+            enabled=sentinel_tls, query=query, url=url, prefix="sentinel_"
+        )
+    )
+
+    return RedisConnectionConfig(
+        db=db,
+        is_sentinel=True,
+        service_name=service_name,
+        sentinels=tuple(members),
+        connection_kwargs=connection_kwargs,
+        sentinel_kwargs=sentinel_kwargs,
+    )
+
+
+def build_redis_client(
+    config: RedisConnectionConfig, *, asynchronous: bool, **extra: Any
+) -> Union[redis.Redis, redis.asyncio.Redis]:
+    """Build a Redis client from a parsed ``RedisConnectionConfig``.
+
+    When ``config.is_sentinel`` is set the current master is resolved through the
+    Sentinel daemons and the returned client follows failover automatically.
+    Otherwise a plain single-node client is returned.
+
+    ``extra`` holds additional redis-py connection kwargs the caller wants applied to
+    the data-node connection (e.g. ``decode_responses`` or ``health_check_interval``).
+    """
+    if config.is_sentinel:
+        assert config.service_name is not None  # guaranteed by parse_redis_url
+        if asynchronous:
+            async_sentinel = AsyncSentinel(
+                list(config.sentinels),
+                sentinel_kwargs=dict(config.sentinel_kwargs),
+                **config.connection_kwargs,
+            )
+            return async_sentinel.master_for(config.service_name, db=config.db, **extra)
+        sync_sentinel = SyncSentinel(
+            list(config.sentinels),
+            sentinel_kwargs=dict(config.sentinel_kwargs),
+            **config.connection_kwargs,
+        )
+        return sync_sentinel.master_for(config.service_name, db=config.db, **extra)
+
+    redis_class = redis.asyncio.Redis if asynchronous else redis.Redis
+    return redis_class(
+        host=config.host,
+        port=config.port,
+        db=config.db,
+        **{**config.connection_kwargs, **extra},
+    )
+
+
+def redis_client_from_url(
+    url: str, *, asynchronous: bool, **extra: Any
+) -> Union[redis.Redis, redis.asyncio.Redis]:
+    """Convenience wrapper: ``build_redis_client(parse_redis_url(url), ...)``."""
+    return build_redis_client(parse_redis_url(url), asynchronous=asynchronous, **extra)

--- a/src/integrations/prefect-redis/prefect_redis/connection.py
+++ b/src/integrations/prefect-redis/prefect_redis/connection.py
@@ -1,14 +1,14 @@
 """Redis connection URL parsing and client construction.
 
-This module centralizes how ``prefect_redis`` turns a connection URL into a Redis
-client so that the messaging client, the lock manager, and the ``RedisDatabase``
+This module centralizes how `prefect_redis` turns a connection URL into a Redis
+client so that the messaging client, the lock manager, and the `RedisDatabase`
 block all share a single parser and builder rather than each constructing a
-``redis.Redis`` from scalar host/port settings.
+`redis.Redis` from scalar host/port settings.
 
-A ``+sentinel`` suffix on the scheme selects Sentinel discovery: the current master
-is resolved through the listed Sentinel daemons via ``Sentinel.master_for()`` and
-failover is followed automatically. A ``rediss`` prefix turns on TLS for the data
-nodes. The grammar follows the ``redis-sentinel-url`` convention::
+A `+sentinel` suffix on the scheme selects Sentinel discovery: the current master
+is resolved through the listed Sentinel daemons via `Sentinel.master_for()` and
+failover is followed automatically. A `rediss` prefix turns on TLS for the data
+nodes. The grammar follows the `redis-sentinel-url` convention::
 
     redis://[user:pass@]host:port[/db][?params]
     rediss://[user:pass@]host:port[/db][?params]
@@ -18,9 +18,9 @@ nodes. The grammar follows the ``redis-sentinel-url`` convention::
 Ports are optional and default to 6379 for single-node URLs and 26379 (the
 Sentinel convention) for Sentinel members.
 
-Single-node URLs accept ``tls_insecure`` and ``tls_ca_file`` query parameters; the
-Sentinel schemes additionally accept ``sentinel_username``, ``sentinel_password``,
-``sentinel_ssl``, ``sentinel_tls_insecure`` and ``sentinel_tls_ca_file`` to configure
+Single-node URLs accept `tls_insecure` and `tls_ca_file` query parameters; the
+Sentinel schemes additionally accept `sentinel_username`, `sentinel_password`,
+`sentinel_ssl`, `sentinel_tls_insecure` and `sentinel_tls_ca_file` to configure
 the connections to the Sentinel daemons separately from the data nodes.
 """
 
@@ -28,15 +28,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Union
-from urllib.parse import parse_qs, unquote, urlsplit, urlunsplit
+from urllib.parse import SplitResult, parse_qs, unquote, urlsplit, urlunsplit
 
 import redis
 import redis.asyncio
 from redis.asyncio.sentinel import Sentinel as AsyncSentinel
 from redis.sentinel import Sentinel as SyncSentinel
 
-# Connection URL schemes. A ``+sentinel`` suffix selects Sentinel discovery; a
-# ``rediss`` prefix turns on TLS for the data nodes.
+# Connection URL schemes. A `+sentinel` suffix selects Sentinel discovery; a
+# `rediss` prefix turns on TLS for the data nodes.
 SCHEME_SENTINEL = frozenset({"redis+sentinel", "rediss+sentinel"})
 SCHEME_TLS = frozenset({"rediss", "rediss+sentinel"})
 SCHEME_ALL = frozenset({"redis", "rediss"}) | SCHEME_SENTINEL
@@ -63,11 +63,11 @@ class RedisUrlError(ValueError):
 class RedisConnectionConfig:
     """Validated description of a Redis connection parsed from a URL.
 
-    ``connection_kwargs`` and ``sentinel_kwargs`` hold redis-py-native keys
-    (``username``, ``password``, ``ssl``, ``ssl_cert_reqs``, ``ssl_check_hostname``,
-    ``ssl_ca_certs``) so a caller can splat them directly. In Sentinel mode
-    ``connection_kwargs`` applies to the data-node (master) connections and
-    ``sentinel_kwargs`` to the Sentinel daemons.
+    `connection_kwargs` and `sentinel_kwargs` hold redis-py-native keys
+    (`username`, `password`, `ssl`, `ssl_cert_reqs`, `ssl_check_hostname`,
+    `ssl_ca_certs`) so a caller can splat them directly. In Sentinel mode
+    `connection_kwargs` applies to the data-node (master) connections and
+    `sentinel_kwargs` to the Sentinel daemons.
     """
 
     db: int
@@ -80,14 +80,35 @@ class RedisConnectionConfig:
     sentinel_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
+def _split_connection_url(url: str) -> "tuple[SplitResult, str]":
+    """Split a connection URL, tolerating multi-host netlocs with IPv6 members.
+
+    Recent CPython releases reject netlocs like `s1:26379,[::1]:26379` with
+    "Invalid IPv6 URL" because data precedes a bracket, so the netloc is carved
+    off by hand and `urlsplit` parses the URL with a placeholder host instead.
+
+    Returns:
+        The parsed parts (scheme, path, query, fragment) and the raw netloc.
+    """
+    scheme, separator, remainder = url.partition("://")
+    if not separator:
+        return urlsplit(url), ""
+    end = len(remainder)
+    for terminator in "/?#":
+        index = remainder.find(terminator)
+        if index != -1:
+            end = min(end, index)
+    netloc, tail = remainder[:end], remainder[end:]
+    return urlsplit(f"{scheme}://netloc-placeholder{tail}"), netloc
+
+
 def redact_redis_url(url: str) -> str:
-    """Return ``url`` with the userinfo password and sensitive query values masked."""
+    """Return `url` with the userinfo password and sensitive query values masked."""
     try:
-        parts = urlsplit(url)
+        parts, netloc = _split_connection_url(url)
     except ValueError:
         return _REDACTED
 
-    netloc = parts.netloc
     if "@" in netloc:
         userinfo, hostpart = netloc.rsplit("@", 1)
         if ":" in userinfo:
@@ -138,10 +159,10 @@ def _parse_db(segment: str, *, url: str) -> int:
 def _split_members(
     hostpart: str, *, url: str, default_port: int = _DEFAULT_PORT
 ) -> list[tuple[str, int]]:
-    """Split a comma-separated ``host:port,host2:port2`` netloc into members.
+    """Split a comma-separated `host:port,host2:port2` netloc into members.
 
-    ``urlsplit`` only exposes the segment before the first comma through
-    ``.hostname``/``.port``, so the multi-host netloc is split by hand.
+    `urlsplit` only exposes the segment before the first comma through
+    `.hostname`/`.port`, so the multi-host netloc is split by hand.
     """
     members: list[tuple[str, int]] = []
     for raw_entry in hostpart.split(","):
@@ -187,13 +208,13 @@ def _build_ssl_kwargs(
 
 
 def parse_redis_url(url: str) -> RedisConnectionConfig:
-    """Parse a Redis connection URL into a validated ``RedisConnectionConfig``.
+    """Parse a Redis connection URL into a validated `RedisConnectionConfig`.
 
     Raises:
         RedisUrlError: With secrets redacted, for any unsupported scheme, malformed
             member list, missing Sentinel service name, or out-of-range database index.
     """
-    parts = urlsplit(url)
+    parts, netloc = _split_connection_url(url)
     scheme = parts.scheme.lower()
     if scheme not in SCHEME_ALL:
         raise RedisUrlError(
@@ -203,7 +224,6 @@ def parse_redis_url(url: str) -> RedisConnectionConfig:
     is_sentinel = scheme in SCHEME_SENTINEL
     tls_default = scheme in SCHEME_TLS
 
-    netloc = parts.netloc
     userinfo = ""
     hostpart = netloc
     if "@" in netloc:
@@ -288,14 +308,14 @@ def parse_redis_url(url: str) -> RedisConnectionConfig:
 def build_redis_client(
     config: RedisConnectionConfig, *, asynchronous: bool, **extra: Any
 ) -> Union[redis.Redis, redis.asyncio.Redis]:
-    """Build a Redis client from a parsed ``RedisConnectionConfig``.
+    """Build a Redis client from a parsed `RedisConnectionConfig`.
 
-    When ``config.is_sentinel`` is set the current master is resolved through the
+    When `config.is_sentinel` is set the current master is resolved through the
     Sentinel daemons and the returned client follows failover automatically.
     Otherwise a plain single-node client is returned.
 
-    ``extra`` holds additional redis-py connection kwargs the caller wants applied to
-    the data-node connection (e.g. ``decode_responses`` or ``health_check_interval``).
+    `extra` holds additional redis-py connection kwargs the caller wants applied to
+    the data-node connection (e.g. `decode_responses` or `health_check_interval`).
     """
     if config.is_sentinel:
         assert config.service_name is not None  # guaranteed by parse_redis_url
@@ -325,5 +345,5 @@ def build_redis_client(
 def redis_client_from_url(
     url: str, *, asynchronous: bool, **extra: Any
 ) -> Union[redis.Redis, redis.asyncio.Redis]:
-    """Convenience wrapper: ``build_redis_client(parse_redis_url(url), ...)``."""
+    """Convenience wrapper: `build_redis_client(parse_redis_url(url), ...)`."""
     return build_redis_client(parse_redis_url(url), asynchronous=asynchronous, **extra)

--- a/src/integrations/prefect-redis/prefect_redis/connection.py
+++ b/src/integrations/prefect-redis/prefect_redis/connection.py
@@ -22,10 +22,19 @@ Single-node URLs accept `tls_insecure` and `tls_ca_file` query parameters; the
 Sentinel schemes additionally accept `sentinel_username`, `sentinel_password`,
 `sentinel_ssl`, `sentinel_tls_insecure` and `sentinel_tls_ca_file` to configure
 the connections to the Sentinel daemons separately from the data nodes.
+
+The `redis+sentinel://` grammar and the Sentinel data-node TCP keepalive defaults
+(`SENTINEL_SOCKET_KEEPALIVE_OPTIONS`) deliberately mirror docket's `_redis_sentinel`
+module (https://github.com/chrisguidry/docket/pull/431). prefect connects to the
+same Sentinel topologies as docket and needs sync clients as well, so it keeps its
+own parser/builder rather than importing docket's currently-private async-only
+helpers; matching the convention keeps the two convergent and makes adopting
+docket's helpers a drop-in change if they are promoted to a public API.
 """
 
 from __future__ import annotations
 
+import socket
 from dataclasses import dataclass, field
 from typing import Any, Union
 from urllib.parse import SplitResult, parse_qs, unquote, urlsplit, urlunsplit
@@ -49,6 +58,35 @@ _DEFAULT_PORT = 6379
 # Sentinel daemons listen on 26379 by default, so sentinel members without an
 # explicit port assume that rather than the data-node port.
 _DEFAULT_SENTINEL_PORT = 26379
+
+# Tight TCP keepalive probes for the data-node (master) connections in Sentinel
+# mode. A master that dies *silently* — a network partition or frozen host that
+# never sends a FIN/RST — would otherwise leave a blocking read (e.g. the
+# messaging client's XREADGROUP, which runs with no socket read timeout) waiting
+# on the OS-default keepalive (~2 hours on Linux) while Sentinel completes
+# failover in seconds. Pinning these probes means a dead peer is noticed in
+# roughly TCP_KEEPIDLE + TCP_KEEPCNT * TCP_KEEPINTVL seconds. The probes only
+# fire on an otherwise-idle socket and a healthy peer answers them, so they don't
+# disturb a legitimately long blocking read. These match redis-py 8.0's own
+# defaults; pinning them keeps behaviour identical on the older redis-py releases
+# that default to no keepalive. This mirrors docket's `_redis_sentinel` module so
+# the two stay convergent (see the module docstring).
+_SENTINEL_KEEPALIVE_TIMERS: tuple[tuple[str, int], ...] = (
+    ("TCP_KEEPIDLE", 30),
+    ("TCP_KEEPINTVL", 5),
+    ("TCP_KEEPCNT", 3),
+)
+SENTINEL_SOCKET_KEEPALIVE_OPTIONS: dict[int, int] = {
+    int(getattr(socket, name)): value
+    for name, value in _SENTINEL_KEEPALIVE_TIMERS
+    if hasattr(socket, name)
+}
+# Applied to the data-node connections as defaults; URL query options and caller
+# kwargs override them, just as a socket_keepalive in a standalone URL would win.
+_SENTINEL_DATA_NODE_DEFAULTS: dict[str, Any] = {
+    "socket_keepalive": True,
+    "socket_keepalive_options": SENTINEL_SOCKET_KEEPALIVE_OPTIONS,
+}
 
 
 class RedisUrlError(ValueError):
@@ -319,17 +357,24 @@ def build_redis_client(
     """
     if config.is_sentinel:
         assert config.service_name is not None  # guaranteed by parse_redis_url
+        # Tight TCP keepalive is applied to the data-node (master) connections so
+        # a silently-dead master is noticed promptly while Sentinel fails over
+        # (see SENTINEL_SOCKET_KEEPALIVE_OPTIONS). Defaults go first so URL options
+        # win, and `extra` (passed through master_for) overrides both. Keepalive is
+        # deliberately not applied to the Sentinel daemon connections, which only
+        # carry short discovery polls.
+        data_node_kwargs = {**_SENTINEL_DATA_NODE_DEFAULTS, **config.connection_kwargs}
         if asynchronous:
             async_sentinel = AsyncSentinel(
                 list(config.sentinels),
                 sentinel_kwargs=dict(config.sentinel_kwargs),
-                **config.connection_kwargs,
+                **data_node_kwargs,
             )
             return async_sentinel.master_for(config.service_name, db=config.db, **extra)
         sync_sentinel = SyncSentinel(
             list(config.sentinels),
             sentinel_kwargs=dict(config.sentinel_kwargs),
-            **config.connection_kwargs,
+            **data_node_kwargs,
         )
         return sync_sentinel.master_for(config.service_name, db=config.db, **extra)
 

--- a/src/integrations/prefect-redis/prefect_redis/locking.py
+++ b/src/integrations/prefect-redis/prefect_redis/locking.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
@@ -6,6 +6,7 @@ from redis.asyncio.lock import Lock as AsyncLock
 from redis.lock import Lock
 
 from prefect.locking.protocol import LockManager
+from prefect_redis.connection import build_redis_client, parse_redis_url
 
 
 class RedisLockManager(LockManager):
@@ -19,6 +20,12 @@ class RedisLockManager(LockManager):
         username: The username to use when connecting to the Redis server
         password: The password to use when connecting to the Redis server
         ssl: Whether to use SSL when connecting to the Redis server
+        connection_url: Full Redis connection URL, authoritative over the scalar
+            connection fields when set. Supports the redis://, rediss://,
+            redis+sentinel:// and rediss+sentinel:// schemes; the Sentinel schemes
+            resolve the current master through the listed Sentinel daemons and follow
+            failover automatically (e.g.
+            redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster).
         client: The Redis client used to communicate with the Redis server
         async_client: The asynchronous Redis client used to communicate with the Redis server
 
@@ -58,6 +65,7 @@ class RedisLockManager(LockManager):
         username: Optional[str] = None,
         password: Optional[str] = None,
         ssl: bool = False,
+        connection_url: Optional[str] = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -65,6 +73,7 @@ class RedisLockManager(LockManager):
         self.username = username
         self.password = password
         self.ssl = ssl
+        self.connection_url = connection_url
         # Clients are initialized by _init_clients
         self.client: Redis
         self.async_client: AsyncRedis
@@ -75,7 +84,15 @@ class RedisLockManager(LockManager):
     def __getstate__(self) -> dict[str, Any]:
         return {
             k: getattr(self, k)
-            for k in ("host", "port", "db", "username", "password", "ssl")
+            for k in (
+                "host",
+                "port",
+                "db",
+                "username",
+                "password",
+                "ssl",
+                "connection_url",
+            )
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -86,6 +103,15 @@ class RedisLockManager(LockManager):
     # ------------------------------------
 
     def _init_clients(self) -> None:
+        # A connection URL is authoritative over the scalar fields and selects single-node
+        # or Sentinel mode from its scheme; Sentinel connections follow master failover.
+        if self.connection_url is not None:
+            config = parse_redis_url(self.connection_url)
+            self.client = cast(Redis, build_redis_client(config, asynchronous=False))
+            self.async_client = cast(
+                AsyncRedis, build_redis_client(config, asynchronous=True)
+            )
+            return
         self.client = Redis(
             host=self.host,
             port=self.port,

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -8,8 +8,11 @@ from prefect_redis.client import (
     async_redis_from_settings,
     close_all_cached_connections,
     get_async_redis_client,
+    is_cluster_url,
+    normalize_cluster_url,
 )
 from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
 
 
 def test_redis_settings_defaults(isolated_redis_db_number: int):
@@ -38,6 +41,34 @@ def test_redis_settings_url_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", "redis://envhost:6381/3")
     settings = RedisMessagingSettings()
     assert settings.url == "redis://envhost:6381/3"
+
+
+def test_cluster_url_detection():
+    assert is_cluster_url("redis+cluster://redis.example.com:6379")
+    assert is_cluster_url("rediss+cluster://redis.example.com:6379")
+    assert not is_cluster_url("redis://redis.example.com:6379")
+    assert not is_cluster_url("rediss://redis.example.com:6379")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "redis+cluster://redis.example.com:6379",
+            "redis://redis.example.com:6379",
+        ),
+        (
+            "rediss+cluster://user:pass@redis.example.com:6380/0?protocol=3",
+            "rediss://user:pass@redis.example.com:6380/0?protocol=3",
+        ),
+        (
+            "redis://redis.example.com:6379/0",
+            "redis://redis.example.com:6379/0",
+        ),
+    ],
+)
+def test_normalize_cluster_url(url: str, expected: str):
+    assert normalize_cluster_url(url) == expected
 
 
 def test_redis_settings_url_warns_on_conflicting_fields():
@@ -96,6 +127,19 @@ async def test_get_async_redis_client_with_url():
     assert conn_kwargs["port"] == 6382
     assert conn_kwargs["db"] == 4
     await client.aclose()
+
+
+async def test_get_async_redis_client_with_cluster_url():
+    """Cluster URLs create RedisCluster clients after URL normalization."""
+    _client_cache.clear()
+    client = get_async_redis_client(url="redis+cluster://clusterhost:7000")
+    assert isinstance(client, RedisCluster)
+    assert client.nodes_manager.startup_nodes["clusterhost:7000"].host == "clusterhost"
+    assert client.nodes_manager.startup_nodes["clusterhost:7000"].port == 7000
+    assert client.get_connection_kwargs()["decode_responses"] is True
+    assert client.get_connection_kwargs()["protocol"] == 2
+    await client.aclose()
+    _client_cache.clear()
 
 
 async def test_get_async_redis_client_url_with_credentials():
@@ -168,6 +212,21 @@ async def test_async_redis_from_settings_with_url():
     assert conn_kwargs["port"] == 6385
     assert conn_kwargs["db"] == 7
     await client.aclose()
+
+
+async def test_async_redis_from_settings_with_cluster_url():
+    """Settings URL can create a RedisCluster client."""
+    _client_cache.clear()
+    settings = RedisMessagingSettings(url="rediss+cluster://fromurl:6385")
+    client = async_redis_from_settings(settings)
+    assert isinstance(client, RedisCluster)
+    assert client.nodes_manager.startup_nodes["fromurl:6385"].host == "fromurl"
+    assert client.nodes_manager.startup_nodes["fromurl:6385"].port == 6385
+    connection_kwargs = client.get_connection_kwargs()
+    assert connection_kwargs["decode_responses"] is True
+    assert connection_kwargs["protocol"] == 2
+    await client.aclose()
+    _client_cache.clear()
 
 
 def test_redis_settings_connection_defaults():

--- a/src/integrations/prefect-redis/tests/test_connection.py
+++ b/src/integrations/prefect-redis/tests/test_connection.py
@@ -1,0 +1,351 @@
+from dataclasses import dataclass
+
+import pytest
+import redis
+import redis.asyncio
+from prefect_redis.connection import (
+    RedisConnectionConfig,
+    RedisUrlError,
+    build_redis_client,
+    parse_redis_url,
+    redact_redis_url,
+    redis_client_from_url,
+)
+from redis.asyncio.sentinel import SentinelConnectionPool as AsyncSentinelPool
+from redis.sentinel import SentinelConnectionPool as SyncSentinelPool
+
+# ---------------------------------------------------------------------------
+# parse_redis_url
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParseCase:
+    name: str
+    url: str
+    expected: RedisConnectionConfig
+
+
+PARSE_CASES = [
+    ParseCase(
+        name="single_node_minimal",
+        url="redis://localhost:6379/0",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=False,
+            host="localhost",
+            port=6379,
+            connection_kwargs={"ssl": False},
+        ),
+    ),
+    ParseCase(
+        name="single_node_default_port_and_db",
+        url="redis://cache",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=False,
+            host="cache",
+            port=6379,
+            connection_kwargs={"ssl": False},
+        ),
+    ),
+    ParseCase(
+        name="single_node_tls_with_auth_and_encoded_password",
+        url="rediss://user:pa%40ss@cache:6380/2",
+        expected=RedisConnectionConfig(
+            db=2,
+            is_sentinel=False,
+            host="cache",
+            port=6380,
+            connection_kwargs={
+                "username": "user",
+                "password": "pa@ss",
+                "ssl": True,
+                "ssl_cert_reqs": "optional",
+                "ssl_check_hostname": True,
+                "ssl_ca_certs": None,
+            },
+        ),
+    ),
+    ParseCase(
+        name="single_node_username_only",
+        url="redis://user@cache:6379",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=False,
+            host="cache",
+            port=6379,
+            connection_kwargs={"username": "user", "ssl": False},
+        ),
+    ),
+    ParseCase(
+        name="single_node_tls_insecure_and_ca_file",
+        url="rediss://cache:6379?tls_insecure=true&tls_ca_file=/etc/ca.pem",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=False,
+            host="cache",
+            port=6379,
+            connection_kwargs={
+                "ssl": True,
+                "ssl_cert_reqs": "none",
+                "ssl_check_hostname": False,
+                "ssl_ca_certs": "/etc/ca.pem",
+            },
+        ),
+    ),
+    ParseCase(
+        name="sentinel_multi_member_with_data_and_sentinel_auth",
+        url="redis+sentinel://app:secret@s1:26379,s2:26379,s3:26379/mymaster/1"
+        "?sentinel_username=su&sentinel_password=sp",
+        expected=RedisConnectionConfig(
+            db=1,
+            is_sentinel=True,
+            service_name="mymaster",
+            sentinels=(("s1", 26379), ("s2", 26379), ("s3", 26379)),
+            connection_kwargs={"username": "app", "password": "secret", "ssl": False},
+            sentinel_kwargs={"username": "su", "password": "sp", "ssl": False},
+        ),
+    ),
+    ParseCase(
+        name="sentinel_members_default_to_sentinel_port",
+        url="redis+sentinel://s1,s2:26380,[::1]/mymaster",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=True,
+            service_name="mymaster",
+            sentinels=(("s1", 26379), ("s2", 26380), ("::1", 26379)),
+            connection_kwargs={"ssl": False},
+            sentinel_kwargs={"ssl": False},
+        ),
+    ),
+    ParseCase(
+        name="sentinel_tls_data_nodes_follows_scheme",
+        url="rediss+sentinel://s1:26379/svc",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=True,
+            service_name="svc",
+            sentinels=(("s1", 26379),),
+            connection_kwargs={
+                "ssl": True,
+                "ssl_cert_reqs": "optional",
+                "ssl_check_hostname": True,
+                "ssl_ca_certs": None,
+            },
+            sentinel_kwargs={
+                "ssl": True,
+                "ssl_cert_reqs": "optional",
+                "ssl_check_hostname": True,
+                "ssl_ca_certs": None,
+            },
+        ),
+    ),
+    ParseCase(
+        name="sentinel_ssl_override_disables_daemon_tls",
+        url="rediss+sentinel://s1:26379/svc?tls_insecure=true&sentinel_ssl=false",
+        expected=RedisConnectionConfig(
+            db=0,
+            is_sentinel=True,
+            service_name="svc",
+            sentinels=(("s1", 26379),),
+            connection_kwargs={
+                "ssl": True,
+                "ssl_cert_reqs": "none",
+                "ssl_check_hostname": False,
+                "ssl_ca_certs": None,
+            },
+            sentinel_kwargs={"ssl": False},
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", PARSE_CASES, ids=lambda case: case.name)
+def test_parse_redis_url(case: ParseCase) -> None:
+    assert parse_redis_url(case.url) == case.expected
+
+
+@dataclass
+class ErrorCase:
+    name: str
+    url: str
+    match: str
+
+
+ERROR_CASES = [
+    ErrorCase(
+        name="unknown_scheme", url="http://cache:6379", match="Unsupported scheme"
+    ),
+    ErrorCase(
+        name="sentinel_without_service",
+        url="redis+sentinel://s1:26379",
+        match="requires a service name",
+    ),
+    ErrorCase(
+        name="multiple_hosts_without_sentinel",
+        url="redis://h1:6379,h2:6379",
+        match="require a \\+sentinel",
+    ),
+    ErrorCase(name="invalid_port", url="redis://cache:notaport", match="Invalid port"),
+    ErrorCase(
+        name="db_out_of_range", url="redis://cache:6379/99", match="out of range"
+    ),
+    ErrorCase(
+        name="invalid_db", url="redis://cache:6379/abc", match="Invalid database index"
+    ),
+    ErrorCase(name="no_host", url="redis://", match="No host found"),
+    ErrorCase(
+        name="invalid_bool",
+        url="rediss://cache:6379?tls_insecure=maybe",
+        match="Invalid boolean",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", ERROR_CASES, ids=lambda case: case.name)
+def test_parse_redis_url_errors(case: ErrorCase) -> None:
+    with pytest.raises(RedisUrlError, match=case.match):
+        parse_redis_url(case.url)
+
+
+def test_redis_url_error_is_value_error() -> None:
+    # Useful so callers (e.g. block validators) can treat it as a ValueError.
+    assert issubclass(RedisUrlError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# redact_redis_url
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RedactCase:
+    name: str
+    url: str
+    expected: str
+
+
+REDACT_CASES = [
+    RedactCase(
+        name="no_secret_unchanged",
+        url="redis://cache:6379/0",
+        expected="redis://cache:6379/0",
+    ),
+    RedactCase(
+        name="userinfo_password_masked",
+        url="redis://app:secret@cache:6379/0",
+        expected="redis://app:***@cache:6379/0",
+    ),
+    RedactCase(
+        name="username_only_kept",
+        url="redis://app@cache:6379/0",
+        expected="redis://app@cache:6379/0",
+    ),
+    RedactCase(
+        name="sensitive_query_params_masked",
+        url="redis+sentinel://app:secret@s1:26379/mymaster?sentinel_password=sp&sentinel_username=su",
+        expected="redis+sentinel://app:***@s1:26379/mymaster?sentinel_password=***&sentinel_username=su",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", REDACT_CASES, ids=lambda case: case.name)
+def test_redact_redis_url(case: RedactCase) -> None:
+    assert redact_redis_url(case.url) == case.expected
+
+
+@dataclass
+class NoLeakCase:
+    name: str
+    url: str
+    secret: str
+
+
+NO_LEAK_CASES = [
+    NoLeakCase(
+        name="sentinel_no_service",
+        url="redis+sentinel://u:topsecret@s1:26379",
+        secret="topsecret",
+    ),
+    NoLeakCase(
+        name="bad_port", url="redis://u:topsecret@cache:nope", secret="topsecret"
+    ),
+    NoLeakCase(
+        name="bad_bool",
+        url="rediss://u:topsecret@cache:6379?tls_insecure=maybe",
+        secret="topsecret",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", NO_LEAK_CASES, ids=lambda case: case.name)
+def test_parse_redis_url_errors_redact_secrets(case: NoLeakCase) -> None:
+    with pytest.raises(RedisUrlError) as exc_info:
+        parse_redis_url(case.url)
+    assert case.secret not in str(exc_info.value)
+
+
+def test_connection_config_is_frozen() -> None:
+    config = RedisConnectionConfig(db=0, is_sentinel=False, host="cache", port=6379)
+    with pytest.raises(AttributeError):
+        config.host = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# build_redis_client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_build_single_node_client(asynchronous: bool) -> None:
+    client = build_redis_client(
+        parse_redis_url("redis://cache:6380/3"), asynchronous=asynchronous
+    )
+    expected_type = redis.asyncio.Redis if asynchronous else redis.Redis
+    assert isinstance(client, expected_type)
+    conn = client.connection_pool.connection_kwargs
+    assert conn["host"] == "cache"
+    assert conn["port"] == 6380
+    assert conn["db"] == 3
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_build_sentinel_client_discovers_master(asynchronous: bool) -> None:
+    client = build_redis_client(
+        parse_redis_url("redis+sentinel://s1:26379,s2:26379/mymaster/1"),
+        asynchronous=asynchronous,
+    )
+    expected_type = redis.asyncio.Redis if asynchronous else redis.Redis
+    expected_pool = AsyncSentinelPool if asynchronous else SyncSentinelPool
+    assert isinstance(client, expected_type)
+    pool = client.connection_pool
+    assert isinstance(pool, expected_pool)
+    assert pool.service_name == "mymaster"
+    assert pool.is_master is True
+    assert pool.connection_kwargs["db"] == 1
+    sentinel_hosts = [
+        (
+            s.connection_pool.connection_kwargs["host"],
+            s.connection_pool.connection_kwargs["port"],
+        )
+        for s in pool.sentinel_manager.sentinels
+    ]
+    assert sentinel_hosts == [("s1", 26379), ("s2", 26379)]
+
+
+def test_build_client_passes_extra_kwargs_to_data_connection() -> None:
+    client = build_redis_client(
+        parse_redis_url("redis://cache:6379/0"),
+        asynchronous=True,
+        decode_responses=True,
+        health_check_interval=42,
+    )
+    conn = client.connection_pool.connection_kwargs
+    assert conn["decode_responses"] is True
+    assert conn["health_check_interval"] == 42
+
+
+def test_redis_client_from_url_helper() -> None:
+    client = redis_client_from_url("redis://cache:6379/0", asynchronous=True)
+    assert isinstance(client, redis.asyncio.Redis)

--- a/src/integrations/prefect-redis/tests/test_connection.py
+++ b/src/integrations/prefect-redis/tests/test_connection.py
@@ -4,6 +4,7 @@ import pytest
 import redis
 import redis.asyncio
 from prefect_redis.connection import (
+    SENTINEL_SOCKET_KEEPALIVE_OPTIONS,
     RedisConnectionConfig,
     RedisUrlError,
     build_redis_client,
@@ -349,3 +350,72 @@ def test_build_client_passes_extra_kwargs_to_data_connection() -> None:
 def test_redis_client_from_url_helper() -> None:
     client = redis_client_from_url("redis://cache:6379/0", asynchronous=True)
     assert isinstance(client, redis.asyncio.Redis)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel data-node TCP keepalive (mirrors docket's _redis_sentinel defaults)
+# ---------------------------------------------------------------------------
+
+
+def test_keepalive_options_match_expected_timers() -> None:
+    # 30s idle, 5s interval, 3 probes — names guarded for platforms that lack
+    # them, so the dict holds only the constants this OS actually defines.
+    assert SENTINEL_SOCKET_KEEPALIVE_OPTIONS
+    assert all(
+        isinstance(option, int) and isinstance(value, int)
+        for option, value in SENTINEL_SOCKET_KEEPALIVE_OPTIONS.items()
+    )
+
+
+# redis-py 8 already defaults socket_keepalive to True, while the redis 6/7
+# releases prefect also supports default to no keepalive. So the version-stable
+# signal that our pinned timers were applied is the explicit options dict, not
+# the bool: only the Sentinel data-node connections carry our exact options.
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_sentinel_data_node_gets_keepalive_defaults(asynchronous: bool) -> None:
+    client = build_redis_client(
+        parse_redis_url("redis+sentinel://s1:26379,s2:26379/mymaster/1"),
+        asynchronous=asynchronous,
+    )
+    conn = client.connection_pool.connection_kwargs
+    assert conn["socket_keepalive"] is True
+    assert conn["socket_keepalive_options"] == SENTINEL_SOCKET_KEEPALIVE_OPTIONS
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_sentinel_daemon_connections_have_no_pinned_keepalive(
+    asynchronous: bool,
+) -> None:
+    # Keepalive is pinned only on the long-lived data-node connections, not on
+    # the short discovery polls to the Sentinel daemons.
+    client = build_redis_client(
+        parse_redis_url("redis+sentinel://s1:26379/mymaster"),
+        asynchronous=asynchronous,
+    )
+    sentinel_manager = client.connection_pool.sentinel_manager
+    for sentinel in sentinel_manager.sentinels:
+        conn = sentinel.connection_pool.connection_kwargs
+        assert conn.get("socket_keepalive_options") != SENTINEL_SOCKET_KEEPALIVE_OPTIONS
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_single_node_has_no_pinned_keepalive(asynchronous: bool) -> None:
+    client = build_redis_client(
+        parse_redis_url("redis://cache:6379/0"), asynchronous=asynchronous
+    )
+    conn = client.connection_pool.connection_kwargs
+    assert conn.get("socket_keepalive_options") != SENTINEL_SOCKET_KEEPALIVE_OPTIONS
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_caller_kwargs_override_keepalive_defaults(asynchronous: bool) -> None:
+    # The pinned defaults go in first, so a caller (or URL) can still turn
+    # keepalive off; this overrides the True our builder would otherwise set.
+    client = build_redis_client(
+        parse_redis_url("redis+sentinel://s1:26379/mymaster"),
+        asynchronous=asynchronous,
+        socket_keepalive=False,
+    )
+    assert client.connection_pool.connection_kwargs["socket_keepalive"] is False

--- a/src/integrations/prefect-redis/tests/test_connection_url_integration.py
+++ b/src/integrations/prefect-redis/tests/test_connection_url_integration.py
@@ -1,5 +1,5 @@
 """Tests that a connection URL (including Sentinel) flows through the messaging
-client, the lock manager, and the ``RedisDatabase`` block.
+client, the lock manager, and the `RedisDatabase` block.
 
 These exercise client construction only; they do not require a live Sentinel
 topology (building a Sentinel-backed client is lazy and does not connect).

--- a/src/integrations/prefect-redis/tests/test_connection_url_integration.py
+++ b/src/integrations/prefect-redis/tests/test_connection_url_integration.py
@@ -1,0 +1,166 @@
+"""Tests that a connection URL (including Sentinel) flows through the messaging
+client, the lock manager, and the ``RedisDatabase`` block.
+
+These exercise client construction only; they do not require a live Sentinel
+topology (building a Sentinel-backed client is lazy and does not connect).
+"""
+
+import pickle
+
+import pytest
+import redis
+import redis.asyncio
+from prefect_redis import client as client_module
+from prefect_redis.blocks import RedisDatabase
+from prefect_redis.client import (
+    RedisMessagingSettings,
+    async_redis_from_settings,
+    get_async_redis_client,
+)
+from prefect_redis.connection import RedisUrlError
+from prefect_redis.locking import RedisLockManager
+from redis.asyncio.sentinel import SentinelConnectionPool as AsyncSentinelPool
+from redis.sentinel import SentinelConnectionPool as SyncSentinelPool
+
+SENTINEL_URL = "redis+sentinel://s1:26379,s2:26379/mymaster/1"
+
+
+# ---------------------------------------------------------------------------
+# messaging client
+# ---------------------------------------------------------------------------
+
+
+def test_messaging_settings_sentinel_url_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", SENTINEL_URL)
+    assert RedisMessagingSettings().url == SENTINEL_URL
+
+
+async def test_async_redis_from_settings_sentinel_url() -> None:
+    settings = RedisMessagingSettings(url=SENTINEL_URL)
+    client = async_redis_from_settings(settings)
+    assert isinstance(client.connection_pool, AsyncSentinelPool)
+    assert client.connection_pool.service_name == "mymaster"
+    # decode_responses defaulted by async_redis_from_settings is applied to the master
+    assert client.connection_pool.connection_kwargs["decode_responses"] is True
+
+
+async def test_get_async_redis_client_sentinel_url_from_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", SENTINEL_URL)
+    # The no-arg client is cached globally; clear it so the URL branch is taken.
+    client_module._client_cache.clear()
+    try:
+        client = get_async_redis_client()
+        assert isinstance(client.connection_pool, AsyncSentinelPool)
+        assert client.connection_pool.service_name == "mymaster"
+    finally:
+        client_module._client_cache.clear()
+
+
+async def test_get_async_redis_client_sentinel_url_param() -> None:
+    client_module._client_cache.clear()
+    try:
+        client = get_async_redis_client(url=SENTINEL_URL)
+        assert isinstance(client.connection_pool, AsyncSentinelPool)
+        assert client.connection_pool.service_name == "mymaster"
+    finally:
+        client_module._client_cache.clear()
+
+
+async def test_get_async_redis_client_sentinel_url_wins_over_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured URL is authoritative; discrete host/port arguments are ignored."""
+    monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", SENTINEL_URL)
+    client_module._client_cache.clear()
+    try:
+        client = get_async_redis_client(host="explicit.host")
+        assert isinstance(client.connection_pool, AsyncSentinelPool)
+        assert client.connection_pool.service_name == "mymaster"
+    finally:
+        client_module._client_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# lock manager
+# ---------------------------------------------------------------------------
+
+
+def test_lock_manager_connection_url_builds_sentinel_clients() -> None:
+    manager = RedisLockManager(connection_url=SENTINEL_URL)
+    assert isinstance(manager.client, redis.Redis)
+    assert isinstance(manager.async_client, redis.asyncio.Redis)
+    assert isinstance(manager.client.connection_pool, SyncSentinelPool)
+    assert isinstance(manager.async_client.connection_pool, AsyncSentinelPool)
+    assert manager.client.connection_pool.service_name == "mymaster"
+
+
+def test_lock_manager_connection_url_survives_pickling() -> None:
+    manager = RedisLockManager(connection_url=SENTINEL_URL)
+    restored = pickle.loads(pickle.dumps(manager))
+    assert restored.connection_url == SENTINEL_URL
+    assert isinstance(restored.client.connection_pool, SyncSentinelPool)
+    assert isinstance(restored.async_client.connection_pool, AsyncSentinelPool)
+
+
+def test_lock_manager_without_url_uses_scalar_fields() -> None:
+    manager = RedisLockManager(host="scalar.host", port=6390, db=4)
+    assert not isinstance(manager.client.connection_pool, SyncSentinelPool)
+    conn = manager.client.connection_pool.connection_kwargs
+    assert conn["host"] == "scalar.host"
+    assert conn["port"] == 6390
+    assert conn["db"] == 4
+
+
+# ---------------------------------------------------------------------------
+# RedisDatabase block
+# ---------------------------------------------------------------------------
+
+
+def test_block_connection_url_builds_sentinel_clients() -> None:
+    block = RedisDatabase(connection_url="redis+sentinel://s1:26379/mymaster")
+    assert isinstance(block.get_client().connection_pool, SyncSentinelPool)
+    assert isinstance(block.get_async_client().connection_pool, AsyncSentinelPool)
+
+
+def test_block_invalid_connection_url_rejected() -> None:
+    with pytest.raises(RedisUrlError, match="requires a service name"):
+        RedisDatabase(connection_url="redis+sentinel://s1:26379")
+
+
+def test_block_from_connection_string_sentinel() -> None:
+    block = RedisDatabase.from_connection_string(
+        "redis+sentinel://user:secret@s1:26379,s2:26379/mymaster"
+    )
+    assert block.connection_url is not None
+    assert (
+        block.connection_url.get_secret_value()
+        == "redis+sentinel://user:secret@s1:26379,s2:26379/mymaster"
+    )
+    assert isinstance(block.get_async_client().connection_pool, AsyncSentinelPool)
+
+
+def test_block_from_connection_string_single_node_unchanged() -> None:
+    block = RedisDatabase.from_connection_string("redis://cache:6380/2")
+    assert block.connection_url is None
+    assert block.host == "cache"
+    assert block.port == 6380
+    assert block.db == 2
+
+
+def test_block_as_connection_params_round_trips_into_lock_manager() -> None:
+    block = RedisDatabase(connection_url=SENTINEL_URL)
+    params = block.as_connection_params()
+    assert params["connection_url"] == SENTINEL_URL
+    manager = RedisLockManager(**params)
+    assert manager.connection_url == SENTINEL_URL
+    assert isinstance(manager.client.connection_pool, SyncSentinelPool)
+
+
+def test_block_as_connection_params_omits_connection_url_when_unset() -> None:
+    params = RedisDatabase(host="cache").as_connection_params()
+    assert "connection_url" not in params
+    assert params["host"] == "cache"

--- a/src/prefect/settings/models/server/docket.py
+++ b/src/prefect/settings/models/server/docket.py
@@ -22,5 +22,12 @@ class ServerDocketSettings(PrefectBaseSettings):
 
     url: str = Field(
         default="memory://",
-        description="The URL of the Redis server to use for Docket.",
+        description=(
+            "The URL of the Redis server to use for Docket. Supports the "
+            "memory:// (single-server only), redis://, rediss://, "
+            "redis+sentinel:// and rediss+sentinel:// schemes; the Sentinel "
+            "schemes discover the current master through the listed Sentinel "
+            "daemons and follow failover automatically (requires "
+            "pydocket>=0.22.0)."
+        ),
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3008,6 +3008,26 @@ def test_prefect_custom_sources_satisfy_pydantic_warning_check() -> None:
     assert not caught
 
 
+class TestServerDocketUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "memory://",
+            "redis://redis-host:6379/0",
+            "rediss://redis-host:6379/0",
+            "redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0",
+            "rediss+sentinel://sentinel-a:26379/mymaster",
+        ],
+    )
+    def test_docket_url_accepts_supported_schemes(self, url: str):
+        # The URL is parsed by Docket, not prefect, so the setting must accept
+        # every documented scheme unchanged — in particular the redis+sentinel://
+        # schemes that pydocket>=0.22.0 resolves through Sentinel (see
+        # docs/v3/advanced/self-hosted.mdx).
+        settings = Settings(server={"docket": {"url": url}})
+        assert settings.server.docket.url == url
+
+
 class TestWorkerDebugMode:
     def test_worker_debug_mode_defaults_to_false(self):
         settings = Settings()

--- a/uv.lock
+++ b/uv.lock
@@ -4260,7 +4260,7 @@ requires-dist = [
     { name = "pydantic-core", specifier = ">=2.12.0,<3.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.8.2,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.9.1,<3.0.0" },
-    { name = "pydocket", specifier = ">=0.19.0" },
+    { name = "pydocket", specifier = ">=0.22.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "python-on-whales", marker = "extra == 'buildx'", specifier = ">=0.81" },
     { name = "python-slugify", specifier = ">=5.0,<9.0" },
@@ -5105,7 +5105,7 @@ wheels = [
 
 [[package]]
 name = "pydocket"
-version = "0.21.1"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "burner-redis" },
@@ -5124,9 +5124,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uncalled-for" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/5f/2f68c38ac3fdbff3cdec3ccfe31303ae5972f3e3f1c365d0ec71573dfd2e/pydocket-0.21.1.tar.gz", hash = "sha256:79d19d5f3be29caa23eba95226a516f8b2aed3ba1ad7830095fdce59f49b51f7", size = 399652, upload-time = "2026-05-29T21:04:10.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/c0/800c602c01a3fea829b2cb564b1ce667f983ac191ef6faf9dac8ba86bd30/pydocket-0.22.0.tar.gz", hash = "sha256:de6a6011df94e3da30279ff0b9732a793feaf77f9e6b23a09f2ae12b134993d6", size = 407557, upload-time = "2026-06-15T12:56:01.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/ca/6bd186338cf4abb318825d9e8d2d2cf069432f9217d17f78f61204eaba70/pydocket-0.21.1-py3-none-any.whl", hash = "sha256:7f3b12c307488efbfde96f76dac533babf5dff4ce72dc0a108a49de03ab39564", size = 117222, upload-time = "2026-05-29T21:04:09.375Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8e/35d61a731524557269052de721ace1a2576cb8232def60795b798c3dd9f0/pydocket-0.22.0-py3-none-any.whl", hash = "sha256:a8ee4d08be5eb40b99b945ba72583364b26a5c6b197520bb2379216b79f36a07", size = 122198, upload-time = "2026-06-15T12:56:00.071Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
this PR adds Redis Sentinel support to `prefect-redis`, so the server messaging client, the concurrency lease storage, the `RedisLockManager`, and the `RedisDatabase` block can discover the current master through Sentinel and follow failover automatically.

It is based on (and targets) the `prefect-redis-cluster-client-foundation` branch from #22211, extending that PR's URL dispatch in `prefect_redis.client` rather than introducing a parallel setting — `PREFECT_REDIS_MESSAGING_URL` now accepts single-node, `redis+cluster://`, and `redis+sentinel://` URLs through one code path. If #22211 merges first, this can be retargeted to `main`.

- new shared connection URL parser and client builder (`prefect_redis/connection.py`) supporting `redis://`, `rediss://`, `redis+sentinel://`, and `rediss+sentinel://`, for both sync and async clients
- `RedisMessagingSettings.url` dispatches sentinel URLs through the shared builder, alongside #22211's cluster dispatch
- `RedisLockManager` gains a `connection_url` parameter (preserved across pickling); `RedisDatabase` gains a `connection_url` field wired through `from_connection_string` and `as_connection_params`
- docs for the URL schemes, including a note that `PREFECT_SERVER_DOCKET_URL` requires a Docket release with Sentinel support (proposed upstream in chrisguidry/docket#431)

<details>
<summary>URL grammar and behavior</summary>

The grammar follows the `redis-sentinel-url` convention:

```
redis+sentinel://[user:pass@]host[:port][,host2[:port2],...]/service_name[/db][?params]
```

- member ports default to 26379 (the Sentinel convention); single-node URLs keep 6379
- URL userinfo applies to the data nodes; `sentinel_username` / `sentinel_password` query parameters configure authentication to the Sentinel daemons separately
- a `rediss` prefix turns on TLS for the data nodes (and the Sentinels, overridable via `sentinel_ssl`); `tls_insecure` / `tls_ca_file` and their `sentinel_`-prefixed variants tune verification
- parse errors redact credentials before they reach the message
- when a URL is set it is authoritative and the scalar host/port/db fields are ignored, matching #22211's documented semantics

All configuration is additive and backward compatible: single-node setups and the existing scalar fields are unchanged.

</details>

<details>
<summary>Validation</summary>

- `uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/` — 194 passed (46 new connection/integration tests)
- `uv run ruff check` / `ruff format --check` on `src/integrations/prefect-redis/`
- end-to-end smoke against a real master + Sentinel topology in Docker: the messaging client (`async_redis_from_settings`) and `RedisLockManager` both connect, read/write, and lock through `redis+sentinel://localhost:26379/mymaster/0`

</details>

Related links:
- #22211 (base): Redis Cluster URL handling foundation
- chrisguidry/docket#431: Redis Sentinel support for Docket, needed before `PREFECT_SERVER_DOCKET_URL` can use a sentinel URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)