### PR TITLE
fix: prevent SSRF via remote $ref in JSON schema validation

### DIFF
--- a/src/prefect/_internal/schemas/_registry.py
+++ b/src/prefect/_internal/schemas/_registry.py
@@ -1,0 +1,13 @@
+from referencing import Registry
+
+
+def non_fetching_registry() -> Registry:
+    """An empty `referencing.Registry` that disables remote `$ref` fetching.
+
+    Passing an explicit registry to jsonschema suppresses its default behavior of
+    fetching `$ref` URLs over the network while validating an instance. With an
+    empty registry, external references raise `referencing.exceptions.Unresolvable`
+    without any network request, while in-document references (`#/$defs/...`) still
+    resolve normally.
+    """
+    return Registry()

--- a/src/prefect/_internal/schemas/validators.py
+++ b/src/prefect/_internal/schemas/validators.py
@@ -21,7 +21,9 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 import jsonschema
+import referencing.exceptions
 
+from prefect._internal.schemas._registry import non_fetching_registry
 from prefect.types._datetime import DateTime, create_datetime_instance, get_timezones
 from prefect.utilities.collections import isiterable
 from prefect.utilities.filesystem import relative_path_to_current_platform
@@ -65,7 +67,9 @@ def validate_values_conform_to_schema(
 
     try:
         if schema is not None and values is not None:
-            jsonschema.validate(values, schema)
+            jsonschema.validate(values, schema, registry=non_fetching_registry())
+    except referencing.exceptions.Unresolvable as exc:
+        raise ValueError(f"Validation failed. Failure reason: {exc}") from exc
     except jsonschema.ValidationError as exc:
         if exc.json_path == "$":
             error_message = "Validation failed."

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Callable, Optional, TypeVar, Union
 from uuid import UUID, uuid4
 
 import jsonschema
+import referencing.exceptions
 from pydantic import (
     AfterValidator,
     BaseModel,
@@ -18,6 +19,7 @@ from pydantic import (
 import prefect.client.schemas.objects as objects
 from prefect._internal.result_records import ResultRecordMetadata
 from prefect._internal.schema import ParameterSchema
+from prefect._internal.schemas._registry import non_fetching_registry
 from prefect._internal.schemas.bases import ActionBaseModel
 from prefect._internal.schemas.validators import (
     convert_to_strings,
@@ -324,7 +326,14 @@ class DeploymentCreate(ActionBaseModel):
                     if "default" in v and k in required:
                         required.remove(k)
 
-            jsonschema.validate(self.job_variables, variables_schema)
+            try:
+                jsonschema.validate(
+                    self.job_variables,
+                    variables_schema,
+                    registry=non_fetching_registry(),
+                )
+            except referencing.exceptions.Unresolvable as exc:
+                raise jsonschema.ValidationError(str(exc)) from exc
 
 
 class DeploymentUpdate(ActionBaseModel):
@@ -403,7 +412,14 @@ class DeploymentUpdate(ActionBaseModel):
                         required.remove(k)
 
         if variables_schema is not None:
-            jsonschema.validate(self.job_variables, variables_schema)
+            try:
+                jsonschema.validate(
+                    self.job_variables,
+                    variables_schema,
+                    registry=non_fetching_registry(),
+                )
+            except referencing.exceptions.Unresolvable as exc:
+                raise jsonschema.ValidationError(str(exc)) from exc
 
 
 class DeploymentBranch(ActionBaseModel):

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -311,7 +311,11 @@ async def update_deployment(
             )
             try:
                 deployment.check_valid_configuration(work_pool.base_job_template)
-            except (MissingVariableError, jsonschema.exceptions.ValidationError) as exc:
+            except (
+                MissingVariableError,
+                jsonschema.exceptions.ValidationError,
+                ValidationError,
+            ) as exc:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=f"Error creating deployment: {exc!r}",

--- a/src/prefect/server/api/ui/schemas.py
+++ b/src/prefect/server/api/ui/schemas.py
@@ -10,6 +10,7 @@ from prefect.server.utilities.server import APIRouter
 from prefect.utilities.schema_tools.hydration import HydrationContext, hydrate
 from prefect.utilities.schema_tools.validation import (
     CircularSchemaRefError,
+    ValidationError,
     build_error_obj,
     is_valid_schema,
     preprocess_schema,
@@ -59,6 +60,11 @@ async def validate_obj(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid schema: Unable to validate schema with circular references.",
+        )
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid schema: {exc}",
         )
     error_obj = build_error_obj(errors)
 

--- a/src/prefect/utilities/schema_tools/validation.py
+++ b/src/prefect/utilities/schema_tools/validation.py
@@ -4,10 +4,12 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, cast
 
 import jsonschema
+import referencing.exceptions
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
 from jsonschema.validators import Draft202012Validator, create
 from referencing.jsonschema import ObjectSchema, Schema
 
+from prefect._internal.schemas._registry import non_fetching_registry
 from prefect.utilities.collections import remove_nested_keys
 from prefect.utilities.schema_tools.hydration import HydrationError, Placeholder
 
@@ -87,9 +89,13 @@ def validate(
 
     if raise_on_error:
         try:
-            jsonschema.validate(obj, schema, _VALIDATOR)
+            jsonschema.validate(
+                obj, schema, _VALIDATOR, registry=non_fetching_registry()
+            )
         except RecursionError:
             raise CircularSchemaRefError
+        except referencing.exceptions.Unresolvable as exc:
+            raise ValidationError(f"Validation failed. Failure reason: {exc}") from exc
         except JSONSchemaValidationError as exc:
             if exc.json_path == "$":
                 error_message = "Validation failed."
@@ -102,10 +108,16 @@ def validate(
         return []
     else:
         try:
-            validator = _VALIDATOR(schema, format_checker=_VALIDATOR.FORMAT_CHECKER)
+            validator = _VALIDATOR(
+                schema,
+                format_checker=_VALIDATOR.FORMAT_CHECKER,
+                registry=non_fetching_registry(),
+            )
             errors = list(validator.iter_errors(obj))  # type: ignore
         except RecursionError:
             raise CircularSchemaRefError
+        except referencing.exceptions.Unresolvable as exc:
+            raise ValidationError(f"Validation failed. Failure reason: {exc}") from exc
         return errors
 
 

--- a/tests/_internal/schemas/test_validation.py
+++ b/tests/_internal/schemas/test_validation.py
@@ -1,4 +1,6 @@
 import datetime
+from typing import Any
+from unittest import mock
 
 import dateutil.rrule
 import pytest
@@ -101,6 +103,46 @@ def test_validate_values_conform_to_schema_none_values_or_schema():
     validate_values_conform_to_schema(None, {"type": "string"})
     validate_values_conform_to_schema({"name": "John"}, None)
     validate_values_conform_to_schema(None, None)
+
+
+# Tests guarding against SSRF via remote $ref resolution
+
+
+EXTERNAL_REFS = [
+    "https://a.example.com/schema.json",
+    "http://b.example.com.namespace.svc/schema.json",
+    "http://169.254.169.254/latest/meta-data/",
+]
+
+
+@pytest.mark.parametrize("ref", EXTERNAL_REFS)
+def test_validate_values_external_ref_raises_value_error_without_network(ref: str):
+    schema: dict[str, Any] = {"type": "object", "properties": {"x": {"$ref": ref}}}
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        urlopen.side_effect = AssertionError(
+            "validation attempted an outbound network request"
+        )
+        with pytest.raises(ValueError):
+            validate_values_conform_to_schema({"x": 1}, schema)
+        urlopen.assert_not_called()
+
+
+def test_validate_values_in_document_ref_still_validates():
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"x": {"$ref": "#/$defs/PositiveInt"}},
+        "$defs": {"PositiveInt": {"type": "integer", "minimum": 0}},
+    }
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        urlopen.side_effect = AssertionError(
+            "validation attempted an outbound network request"
+        )
+        # Passing instance validates cleanly
+        validate_values_conform_to_schema({"x": 5}, schema)
+        # Failing instance raises the controlled error
+        with pytest.raises(ValueError):
+            validate_values_conform_to_schema({"x": -1}, schema)
+        urlopen.assert_not_called()
 
 
 # Tests for normalize_rrule_string (#21362)

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import List
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -1002,6 +1003,41 @@ class TestCreateDeployment:
             "Validation failed for field 'foo'. Failure reason: 1 is not of type"
             " 'string'" in response.text
         )
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "https://a.example.com/schema.json",
+            "http://b.example.com.namespace.svc/schema.json",
+            "http://169.254.169.254/latest/meta-data/",
+        ],
+    )
+    async def test_create_deployment_external_ref_schema_does_not_fetch(
+        self,
+        ref,
+        client,
+        flow,
+        work_pool,
+    ):
+        data = dict(
+            name="My Deployment",
+            flow_id=str(flow.id),
+            work_pool_name=work_pool.name,
+            enforce_parameter_schema=True,
+            parameter_openapi_schema={
+                "type": "object",
+                "properties": {"foo": {"$ref": ref}},
+            },
+            parameters={"foo": 1},
+        )
+
+        with mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.side_effect = AssertionError(
+                "validation attempted an outbound network request"
+            )
+            response = await client.post("/deployments/", json=data)
+            urlopen.assert_not_called()
+        assert response.status_code == 422, response.text
 
     async def test_create_deployment_enforces_schema_by_default(
         self,

--- a/tests/server/orchestration/api/ui/test_schemas.py
+++ b/tests/server/orchestration/api/ui/test_schemas.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from httpx import AsyncClient
 
@@ -134,3 +136,34 @@ class TestUISchemasValidate:
             res["detail"]
             == "Invalid schema: Unable to validate schema with circular references."
         )
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "https://a.example.com/schema.json",
+            "http://b.example.com.namespace.svc/schema.json",
+            "http://169.254.169.254/latest/meta-data/",
+        ],
+    )
+    async def test_external_ref_does_not_fetch_remote_schema(
+        self,
+        ref: str,
+        client: AsyncClient,
+    ):
+        with mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.side_effect = AssertionError(
+                "validation attempted an outbound network request"
+            )
+            res = await client.post(
+                "/ui/schemas/validate",
+                json={
+                    "schema": {
+                        "title": "Parameters",
+                        "type": "object",
+                        "properties": {"param": {"$ref": ref}},
+                    },
+                    "values": {"param": 1},
+                },
+            )
+            urlopen.assert_not_called()
+        assert res.status_code == 422, res.text

--- a/tests/utilities/schema_tools/test_ssrf.py
+++ b/tests/utilities/schema_tools/test_ssrf.py
@@ -1,0 +1,79 @@
+from collections.abc import Iterator
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from prefect.utilities.schema_tools.validation import (
+    ValidationError,
+    validate,
+)
+
+EXTERNAL_REFS = [
+    "https://a.example.com/schema.json",
+    "http://b.example.com.namespace.svc/schema.json",
+    "http://169.254.169.254/latest/meta-data/",
+]
+
+
+@pytest.fixture
+def no_network() -> Iterator[mock.MagicMock]:
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        urlopen.side_effect = AssertionError(
+            "validation attempted an outbound network request"
+        )
+        yield urlopen
+
+
+def external_ref_schema(ref: str) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {"x": {"$ref": ref}},
+    }
+
+
+@pytest.mark.parametrize("ref", EXTERNAL_REFS)
+def test_external_ref_raises_controlled_error_without_network(
+    ref: str, no_network: mock.MagicMock
+):
+    with pytest.raises(ValidationError):
+        validate(
+            {"x": 1}, external_ref_schema(ref), raise_on_error=True, preprocess=False
+        )
+    no_network.assert_not_called()
+
+
+@pytest.mark.parametrize("ref", EXTERNAL_REFS)
+def test_external_ref_non_raise_path_raises_without_network(
+    ref: str, no_network: mock.MagicMock
+):
+    with pytest.raises(ValidationError):
+        validate(
+            {"x": 1}, external_ref_schema(ref), raise_on_error=False, preprocess=False
+        )
+    no_network.assert_not_called()
+
+
+IN_DOCUMENT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"x": {"$ref": "#/$defs/PositiveInt"}},
+    "$defs": {"PositiveInt": {"type": "integer", "minimum": 0}},
+}
+
+
+def test_in_document_ref_passing_instance_validates(no_network: mock.MagicMock):
+    errors = validate({"x": 5}, IN_DOCUMENT_SCHEMA, preprocess=False)
+    assert errors == []
+    no_network.assert_not_called()
+
+
+def test_in_document_ref_failing_instance_reports_error(no_network: mock.MagicMock):
+    errors = validate({"x": -1}, IN_DOCUMENT_SCHEMA, preprocess=False)
+    assert len(errors) == 1
+    no_network.assert_not_called()
+
+
+def test_in_document_ref_failing_instance_raises(no_network: mock.MagicMock):
+    with pytest.raises(ValidationError):
+        validate({"x": -1}, IN_DOCUMENT_SCHEMA, raise_on_error=True, preprocess=False)
+    no_network.assert_not_called()

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -10044,6 +10044,30 @@ export interface components {
             loop_seconds: number;
         };
         /**
+         * ServerServicesCleanupReconcilerSettings
+         * @description Settings for controlling the cleanup reconciler service.
+         */
+        ServerServicesCleanupReconcilerSettings: {
+            /**
+             * Enabled
+             * @description Whether or not to start the cleanup reconciler service in the server application.
+             * @default true
+             */
+            enabled: boolean;
+            /**
+             * Loop Seconds
+             * @description The cleanup reconciler service will look for expired cleanup message leases this often. Defaults to `5`.
+             * @default 5
+             */
+            loop_seconds: number;
+            /**
+             * Batch Size
+             * @description The maximum number of expired cleanup message leases to process per service loop. Defaults to `100`.
+             * @default 100
+             */
+            batch_size: number;
+        };
+        /**
          * ServerServicesDBVacuumSettings
          * @description Settings for controlling the database vacuum service
          */
@@ -10345,6 +10369,8 @@ export interface components {
             scheduler?: components["schemas"]["ServerServicesSchedulerSettings"];
             pause_expirations?: components["schemas"]["ServerServicesPauseExpirationsSettings"];
             repossessor?: components["schemas"]["ServerServicesRepossessorSettings"];
+            /** @description Settings for controlling the cleanup reconciler service */
+            cleanup_reconciler?: components["schemas"]["ServerServicesCleanupReconcilerSettings"];
             task_run_recorder?: components["schemas"]["ServerServicesTaskRunRecorderSettings"];
             triggers?: components["schemas"]["ServerServicesTriggersSettings"];
         };


### PR DESCRIPTION
This PR closes an SSRF in our JSON-schema validation. We validate user-supplied schemas with `jsonschema`, which since 4.18 resolves `$ref`s through the `referencing` library. When no registry is passed, jsonschema installs a default that fetches external `$ref` URLs over HTTP while validating an instance — so a schema containing `{"$ref": "https://attacker.example/..."}`, an internal host, or a link-local metadata address triggers a blind outbound request from the server, and the failure surfaces as an uncaught referencing error rather than a clean validation failure.

The fix is a small `non_fetching_registry()` helper that returns an empty `referencing.Registry`, passed everywhere we build a validator or call `jsonschema.validate(...)` on user data. An empty registry suppresses the network fetch: external refs raise `referencing.exceptions.Unresolvable` with no request, while in-document refs (`#/$defs/...`) still resolve so Pydantic-generated schemas keep working. Each call site catches `Unresolvable` and converts it to that module's existing controlled error, so it becomes a clean 4xx instead of a 500.

<details>
<summary>Details</summary>

Call sites updated:
- `schema_tools.validate` — the canonical validator (both the `raise_on_error` and `iter_errors` paths); `Unresolvable` → `ValidationError`
- `_internal/schemas/validators.validate_values_conform_to_schema` — `Unresolvable` → `ValueError`
- the two `check_valid_configuration` copies in `client/schemas/actions.py` — `Unresolvable` → `jsonschema.ValidationError`

Endpoints/paths:
- `POST /ui/schemas/validate` now returns a clean 422 for external refs
- deployment parameter validation returns a clean 4xx (the `base_job_template` `check_valid_configuration` catch was widened so it's a 409, not a 500)

Meta-validation (`check_schema`) does not resolve user `$ref`s and was left unchanged.

Tests assert that external `$ref`s (an `https` URL, an internal `*.svc` host, and `169.254.169.254`) raise the controlled error with `urllib.request.urlopen` never called, and that in-document `#/$defs` refs still validate (passing and failing instances).

The second commit regenerates `ui-v2/src/api/prefect.ts` for the cleanup-reconciler settings already on `main` — unrelated to this fix, but the pre-push sync hook required it.
</details>

<details>
<summary>Session context</summary>

Confirmed the vulnerability with a repro showing `urlopen` is actually called for an external-`$ref` schema, then drove the fix with TDD. Decided to place the `non_fetching_registry()` helper in a new leaf module (`_internal/schemas/_registry.py`, empty parent `__init__`s) to avoid the circular-import risk for the client-side `actions.py`/`validators.py` importers. Per review feedback, did not introduce any specific `Validator` class — only passed the registry, letting jsonschema select the default validator (and kept the existing placeholder-aware validator in `schema_tools`). Traced the deployment paths and found the user-controlled `parameter_openapi_schema` vector already routes through the fixed functions; widened one `check_valid_configuration` catch so the admin `base_job_template` path is a 409 rather than a 500. Full deployment + flow-run API suites (335 tests) and the schema-validation areas (329 tests) pass.
</details>