### PR TITLE
fix: Preserve original exception cause in timeout context managers (closes #16299)

### DIFF
--- a/src/prefect/utilities/timeout.py
+++ b/src/prefect/utilities/timeout.py
@@ -28,8 +28,8 @@ def timeout_async(
     try:
         with cancel_async_after(timeout=seconds):
             yield
-    except CancelledError:
-        raise timeout_exc_type(f"Scope timed out after {seconds} second(s).")
+    except CancelledError as e:
+        raise timeout_exc_type(f"Scope timed out after {seconds} second(s).") from e
 
 
 @contextmanager


### PR DESCRIPTION
## What
When a timeout occurs in the `timeout_async` or `timeout` context managers, the original `CancelledError` is caught and re-raised as a generic `TimeoutError`, losing the underlying cause (e.g., an asyncpg database timeout). This makes debugging difficult, as seen in issue #16299 where database communication timeouts are masked.

## Fix
Use `raise ... from e` to chain the original `CancelledError` as the cause of the new `timeout_exc_type` exception. This preserves the full traceback and allows users to see the original error that triggered the timeout.

Closes #16299