### PR TITLE
Bump runtime uv image pins to 0.11.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     (echo "ERROR: git version must be >= 1:2.47.3" && exit 1)
 
 # Install UV from official image - pin to specific version for build caching
-COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /bin/uv
 
 # Copy the repository in; requires full git history for versions to generate correctly
 COPY . ./
@@ -179,7 +179,7 @@ COPY --from=sqlite-builder /usr/local/lib/pkgconfig/sqlite3.pc /usr/local/lib/pk
 RUN ldconfig
 
 # Install UV from official image - pin to specific version for build caching
-COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /bin/uv
 
 # Install prefect from the sdist
 COPY --from=python-builder /opt/prefect/dist ./dist

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install UV from official image - pin to specific version for build caching
-COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /bin/uv
 
 # Copy the repository in; requires full git history for versions to generate correctly
 COPY . ./
@@ -73,7 +73,7 @@ COPY --from=sqlite-builder /usr/local/lib/pkgconfig/sqlite3.pc /usr/local/lib/pk
 RUN ldconfig
 
 # Install UV from official image - pin to specific version for build caching
-COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /bin/uv
 
 # Install prefect from the sdist
 COPY --from=python-builder /opt/prefect/dist ./dist


### PR DESCRIPTION
this PR bumps the uv binary bundled into the Prefect and prefect-client Docker images to 0.11.21.

That bundled binary matters because deployment `pull_steps` run inside the image environment. Unless a user explicitly installs another uv earlier in the image or otherwise changes PATH, any pull step that uses uv will use the version we ship in the runtime image. The old pins predated uv's retry handling for mid-stream broken-pipe failures, so an intermittent PyPI/Fastly connection close could crash dependency installs during managed execution.

uv added broken-pipe retries in 0.7.3 (astral-sh/uv#13281, astral-sh/uv#13260) and UV_HTTP_RETRIES support in 0.7.21 (astral-sh/uv#14544). Updating the runtime image pin gives managed execution dependency installs that retry behavior by default.

This only updates runtime image pins, not CI/setup-uv pins.
