### PR TITLE
fix(engine): avoid subflow tracking key collisions

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -620,6 +620,15 @@ class BaseFlowRunEngine(Generic[P, R]):
             yield flow_run_suspension_request
 
 
+def _is_subflow_call_from_current_task_context(flow_run_ctx: FlowRunContext) -> bool:
+    task_run_ctx = TaskRunContext.get()
+    return bool(
+        task_run_ctx
+        and flow_run_ctx.flow_run
+        and task_run_ctx.task_run.flow_run_id == flow_run_ctx.flow_run.id
+    )
+
+
 @dataclass
 class FlowRunEngine(BaseFlowRunEngine[P, R]):
     _client: Optional[SyncPrefectClient] = None
@@ -982,7 +991,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             # counter-based dynamic_key would let a retried subflow adopt the
             # wrong sibling's completed tracking task run.  Use a UUID instead.
             dynamic_key: str | None = None
-            if TaskRunContext.get() is not None:
+            if _is_subflow_call_from_current_task_context(flow_run_ctx):
                 dynamic_key = dynamic_key_for_task_run(
                     context=flow_run_ctx, task=parent_task, stable=False
                 )
@@ -1687,7 +1696,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             # counter-based dynamic_key would let a retried subflow adopt the
             # wrong sibling's completed tracking task run.  Use a UUID instead.
             dynamic_key: str | None = None
-            if TaskRunContext.get() is not None:
+            if _is_subflow_call_from_current_task_context(flow_run_ctx):
                 dynamic_key = dynamic_key_for_task_run(
                     context=flow_run_ctx, task=parent_task, stable=False
                 )

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -53,7 +53,11 @@ from prefect._flow_run_suspension import (
 )
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.control_listener import Intent, configure_from_env, get_intent
-from prefect._internal.engine import get_hook_name, resolve_custom_flow_run_name
+from prefect._internal.engine import (
+    dynamic_key_for_task_run,
+    get_hook_name,
+    resolve_custom_flow_run_name,
+)
 from prefect._internal.metrics import RunMetrics
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas import FlowRun, TaskRun
@@ -71,6 +75,7 @@ from prefect.context import (
     SettingsContext,
     SyncClientContext,
     TagsContext,
+    TaskRunContext,
     _deployment_id,
     _deployment_parameters,
     get_settings_context,
@@ -973,11 +978,21 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                 name=self.flow.name, fn=self.flow.fn, version=self.flow.version
             )
 
+            # In a task context, sibling call order is nondeterministic so a
+            # counter-based dynamic_key would let a retried subflow adopt the
+            # wrong sibling's completed tracking task run.  Use a UUID instead.
+            dynamic_key: str | None = None
+            if TaskRunContext.get() is not None:
+                dynamic_key = dynamic_key_for_task_run(
+                    context=flow_run_ctx, task=parent_task, stable=False
+                )
+
             parent_task_run = run_coro_as_sync(
                 parent_task.create_run(
                     flow_run_context=flow_run_ctx,
                     parameters=self.parameters,
                     wait_for=self.wait_for,
+                    dynamic_key=dynamic_key,
                 )
             )
 
@@ -1668,10 +1683,20 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                 name=self.flow.name, fn=self.flow.fn, version=self.flow.version
             )
 
+            # In a task context, sibling call order is nondeterministic so a
+            # counter-based dynamic_key would let a retried subflow adopt the
+            # wrong sibling's completed tracking task run.  Use a UUID instead.
+            dynamic_key: str | None = None
+            if TaskRunContext.get() is not None:
+                dynamic_key = dynamic_key_for_task_run(
+                    context=flow_run_ctx, task=parent_task, stable=False
+                )
+
             parent_task_run = await parent_task.create_run(
                 flow_run_context=flow_run_ctx,
                 parameters=self.parameters,
                 wait_for=self.wait_for,
+                dynamic_key=dynamic_key,
             )
 
             # check if there is already a flow run for this subflow

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -53,11 +53,7 @@ from prefect._flow_run_suspension import (
 )
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.control_listener import Intent, configure_from_env, get_intent
-from prefect._internal.engine import (
-    dynamic_key_for_task_run,
-    get_hook_name,
-    resolve_custom_flow_run_name,
-)
+from prefect._internal.engine import get_hook_name, resolve_custom_flow_run_name
 from prefect._internal.metrics import RunMetrics
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas import FlowRun, TaskRun
@@ -75,7 +71,6 @@ from prefect.context import (
     SettingsContext,
     SyncClientContext,
     TagsContext,
-    TaskRunContext,
     _deployment_id,
     _deployment_parameters,
     get_settings_context,
@@ -620,15 +615,6 @@ class BaseFlowRunEngine(Generic[P, R]):
             yield flow_run_suspension_request
 
 
-def _is_subflow_call_from_current_task_context(flow_run_ctx: FlowRunContext) -> bool:
-    task_run_ctx = TaskRunContext.get()
-    return bool(
-        task_run_ctx
-        and flow_run_ctx.flow_run
-        and task_run_ctx.task_run.flow_run_id == flow_run_ctx.flow_run.id
-    )
-
-
 @dataclass
 class FlowRunEngine(BaseFlowRunEngine[P, R]):
     _client: Optional[SyncPrefectClient] = None
@@ -986,22 +972,13 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             parent_task = Task(
                 name=self.flow.name, fn=self.flow.fn, version=self.flow.version
             )
-
-            # In a task context, sibling call order is nondeterministic so a
-            # counter-based dynamic_key would let a retried subflow adopt the
-            # wrong sibling's completed tracking task run.  Use a UUID instead.
-            dynamic_key: str | None = None
-            if _is_subflow_call_from_current_task_context(flow_run_ctx):
-                dynamic_key = dynamic_key_for_task_run(
-                    context=flow_run_ctx, task=parent_task, stable=False
-                )
+            setattr(parent_task, "_is_subflow_tracking_task", True)
 
             parent_task_run = run_coro_as_sync(
                 parent_task.create_run(
                     flow_run_context=flow_run_ctx,
                     parameters=self.parameters,
                     wait_for=self.wait_for,
-                    dynamic_key=dynamic_key,
                 )
             )
 
@@ -1691,21 +1668,12 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             parent_task = Task(
                 name=self.flow.name, fn=self.flow.fn, version=self.flow.version
             )
-
-            # In a task context, sibling call order is nondeterministic so a
-            # counter-based dynamic_key would let a retried subflow adopt the
-            # wrong sibling's completed tracking task run.  Use a UUID instead.
-            dynamic_key: str | None = None
-            if _is_subflow_call_from_current_task_context(flow_run_ctx):
-                dynamic_key = dynamic_key_for_task_run(
-                    context=flow_run_ctx, task=parent_task, stable=False
-                )
+            setattr(parent_task, "_is_subflow_tracking_task", True)
 
             parent_task_run = await parent_task.create_run(
                 flow_run_context=flow_run_ctx,
                 parameters=self.parameters,
                 wait_for=self.wait_for,
-                dynamic_key=dynamic_key,
             )
 
             # check if there is already a flow run for this subflow

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -883,7 +883,19 @@ class Task(Generic[P, R]):
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         extra_task_inputs: Optional[dict[str, set[RunInput]]] = None,
         deferred: bool = False,
+        dynamic_key: Optional[str] = None,
     ) -> TaskRun:
+        """Create a task run for this task.
+
+        Args:
+            dynamic_key: Explicit dynamic key for the task run.  When provided,
+                bypasses the internal call-counter and uses this value directly
+                as the `dynamic_key` component of the task-run natural key
+                `(flow_run_id, task_key, dynamic_key)` that drives idempotent
+                creation.  Used by the flow engine to assign UUID keys to
+                subflow tracking task runs in concurrent contexts where
+                counter-based keys are unreliable.
+        """
         from prefect._internal.engine import dynamic_key_for_task_run
         from prefect.utilities.engine import collect_task_run_inputs_sync
 
@@ -900,6 +912,8 @@ class Task(Generic[P, R]):
             if not flow_run_context:
                 dynamic_key = f"{self.task_key}-{str(uuid4().hex)}"
                 task_run_name = self.name
+            elif dynamic_key is not None:
+                task_run_name = f"{self.name}-{dynamic_key}"
             else:
                 dynamic_key = dynamic_key_for_task_run(
                     context=flow_run_context, task=self

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -883,19 +883,7 @@ class Task(Generic[P, R]):
         wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
         extra_task_inputs: Optional[dict[str, set[RunInput]]] = None,
         deferred: bool = False,
-        dynamic_key: Optional[str] = None,
     ) -> TaskRun:
-        """Create a task run for this task.
-
-        Args:
-            dynamic_key: Explicit dynamic key for the task run.  When provided,
-                bypasses the internal call-counter and uses this value directly
-                as the `dynamic_key` component of the task-run natural key
-                `(flow_run_id, task_key, dynamic_key)` that drives idempotent
-                creation.  Used by the flow engine to assign UUID keys to
-                subflow tracking task runs in concurrent contexts where
-                counter-based keys are unreliable.
-        """
         from prefect._internal.engine import dynamic_key_for_task_run
         from prefect.utilities.engine import collect_task_run_inputs_sync
 
@@ -912,7 +900,18 @@ class Task(Generic[P, R]):
             if not flow_run_context:
                 dynamic_key = f"{self.task_key}-{str(uuid4().hex)}"
                 task_run_name = self.name
-            elif dynamic_key is not None:
+            elif (
+                getattr(self, "_is_subflow_tracking_task", False)
+                and parent_task_run_context
+                and flow_run_context.flow_run
+                and parent_task_run_context.task_run.flow_run_id
+                == flow_run_context.flow_run.id
+            ):
+                # Subflows called from a task context need UUID keys because
+                # sibling call order is not a reliable identity across retries.
+                dynamic_key = dynamic_key_for_task_run(
+                    context=flow_run_context, task=self, stable=False
+                )
                 task_run_name = f"{self.name}-{dynamic_key}"
             else:
                 dynamic_key = dynamic_key_for_task_run(

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -1762,6 +1762,47 @@ class TestSubflowDynamicKeyRace:
             f"Expected stable key '0', got: {task_run.dynamic_key}"
         )
 
+    async def test_nested_direct_subflow_from_task_keeps_stable_key(
+        self, sync_prefect_client: SyncPrefectClient
+    ):
+        """A direct nested subflow should keep stable tracking identity even
+        when its parent flow was called from a task context."""
+        grandchild_flow_run_ids: list[UUID] = []
+        child_attempt = 0
+
+        @flow(persist_result=True)
+        def grandchild() -> str:
+            grandchild_flow_run_ids.append(FlowRunContext.get().flow_run.id)
+            return "hello"
+
+        @flow(retries=1, persist_result=True)
+        def child() -> str:
+            nonlocal child_attempt
+            child_attempt += 1
+            result = grandchild()
+            if child_attempt == 1:
+                raise ValueError("child fails after grandchild")
+            return result
+
+        @task
+        def run_child() -> str:
+            return child()
+
+        @flow
+        def parent() -> str:
+            return run_child()
+
+        assert parent() == "hello"
+
+        assert child_attempt == 2
+        assert len(set(grandchild_flow_run_ids)) == 1
+        grandchild_run = sync_prefect_client.read_flow_run(grandchild_flow_run_ids[0])
+        assert grandchild_run.parent_task_run_id is not None
+        task_run = sync_prefect_client.read_task_run(grandchild_run.parent_task_run_id)
+        assert task_run.dynamic_key == "0", (
+            f"Expected stable key '0', got: {task_run.dynamic_key}"
+        )
+
 
 class TestFlowCrashDetection:
     @pytest.mark.parametrize("interrupt_type", [KeyboardInterrupt, SystemExit])

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -23,6 +23,7 @@ from prefect._flow_run_suspension import (
     FlowRunSuspensionRequest,
     mark_flow_run_suspension_requested,
 )
+from prefect.cache_policies import INPUTS
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter
 from prefect.client.schemas.objects import StateType
@@ -1632,6 +1633,133 @@ class TestLoadSubflowRun:
         assert result.id == child_run.id
         assert engine._return_value is not NotSet, (
             "_return_value should be set for final parent task runs"
+        )
+
+
+class TestSubflowDynamicKeyRace:
+    """Regression tests for concurrent subflow calls adopting the wrong
+    persisted result on parent flow retry (OSS-8038 / #22259).
+
+    When subflows are called from within submitted tasks, the tracking
+    task run now uses UUID dynamic keys so that on retry, a re-executed
+    subflow call cannot match a different subflow's completed task run.
+    """
+
+    async def test_concurrent_subflow_retry_returns_correct_result(
+        self, sync_prefect_client: SyncPrefectClient
+    ):
+        """Regression test for #22259: on attempt 2 of a parent flow,
+        an uncached wrapper task re-executes and calls its child subflow.
+        Without the fix, the child's tracking task run adopts a sibling's
+        completed tracking task run (due to positional dynamic_key
+        collision) and silently returns the wrong persisted result.
+
+        Shape:
+        - Attempt 1: chunk-1, chunk-2, chunk-3 complete; chunk-0 fails
+          *before* calling child, so siblings occupy counter keys first.
+        - Attempt 2: chunk-1..3 are served from INPUTS cache; chunk-0
+          re-executes and must create/run its own child flow run.
+        - Assert the final result for chunk-0 is correct and that the
+          child flow actually executed for chunk-0 on the second attempt.
+        """
+        # per-test nonce avoids cache pollution across test runs
+        nonce = uuid.uuid4().hex[:8]
+        child_executions: list[str] = []
+        attempt = 0
+
+        @flow(persist_result=True)
+        def child(chunk: str, nonce: str) -> str:
+            child_executions.append(chunk)
+            return f"result-for-{chunk}"
+
+        @task(persist_result=True, cache_policy=INPUTS)
+        def run_chunk(chunk: str, nonce: str) -> str:
+            # On attempt 1, chunk-0 fails before calling child so it
+            # never caches.  Siblings complete and their subflows occupy
+            # counter-based tracking task keys.
+            if chunk == "chunk-0" and attempt == 1:
+                raise ValueError(f"{chunk} fails on first attempt")
+            return child(chunk, nonce)
+
+        @flow(retries=1, persist_result=True)
+        def parent():
+            nonlocal attempt
+            attempt += 1
+
+            # Submit chunk-1..3 first so their subflows complete and
+            # occupy counter-based tracking task keys on attempt 1,
+            # then submit chunk-0 which will fail.
+            order = ["chunk-1", "chunk-2", "chunk-3", "chunk-0"]
+            futures = {name: run_chunk.submit(name, nonce) for name in order}
+            return {name: f.result() for name, f in futures.items()}
+
+        final = parent()
+
+        assert attempt == 2
+        # chunk-0 must have its own correct result, not an adopted sibling's
+        for name in ["chunk-0", "chunk-1", "chunk-2", "chunk-3"]:
+            assert final[name] == f"result-for-{name}", (
+                f"{name} got wrong result: {final[name]}"
+            )
+        # The child flow must have actually executed for chunk-0
+        assert "chunk-0" in child_executions, (
+            "child flow never executed for chunk-0 on retry"
+        )
+
+    async def test_async_subflow_from_task_uses_uuid_dynamic_key(
+        self, prefect_client: PrefectClient
+    ):
+        """Async path: subflow tracking task runs called from within a
+        task context get UUID dynamic keys (mirrors sync behaviour)."""
+        child_flow_run_ids: list[UUID] = []
+
+        @flow
+        async def child(x: int) -> int:
+            child_flow_run_ids.append(FlowRunContext.get().flow_run.id)
+            return x
+
+        @task
+        async def run_child(x: int) -> int:
+            return await child(x)
+
+        @flow
+        async def parent():
+            return await run_child(1)
+
+        await parent()
+
+        assert len(child_flow_run_ids) == 1
+        child_run = await prefect_client.read_flow_run(child_flow_run_ids[0])
+        assert child_run.parent_task_run_id is not None
+        task_run = await prefect_client.read_task_run(child_run.parent_task_run_id)
+        assert len(task_run.dynamic_key) > 8, (
+            f"Expected UUID dynamic key, got: {task_run.dynamic_key}"
+        )
+
+    async def test_direct_subflow_keeps_stable_key_for_retry_optimisation(
+        self, sync_prefect_client: SyncPrefectClient
+    ):
+        """Direct subflow calls (no task context) keep stable sequential
+        keys so the retry optimisation (reuse completed subflow result)
+        still works."""
+        child_flow_run_ids: list[UUID] = []
+
+        @flow
+        def child() -> str:
+            child_flow_run_ids.append(FlowRunContext.get().flow_run.id)
+            return "hello"
+
+        @flow
+        def parent():
+            child()
+
+        parent()
+
+        child_run = sync_prefect_client.read_flow_run(child_flow_run_ids[0])
+        assert child_run.parent_task_run_id is not None
+        task_run = sync_prefect_client.read_task_run(child_run.parent_task_run_id)
+        assert task_run.dynamic_key == "0", (
+            f"Expected stable key '0', got: {task_run.dynamic_key}"
         )
 
 


### PR DESCRIPTION
closes #22259
supersedes #22260

This PR fixes a subflow retry bug where a subflow called from inside a task context could reuse the wrong completed subflow tracking task run.

The tracking task run is idempotent on `(flow_run_id, task_key, dynamic_key)`. Counter-based dynamic keys are useful for direct sequential subflow calls because they let retries reattach to completed subflow runs. They are not reliable identity for subflows called from the current flow's task context, where sibling call order can vary across attempts.

This PR keeps counter-based dynamic keys for direct subflow calls, including nested direct subflows that may inherit an outer `TaskRunContext`. For the synthetic subflow tracking task created from a task run belonging to the current flow run, `Task.create_run` assigns a UUID dynamic key internally.

Validation:
- `uv run ruff check src/prefect/flow_engine.py src/prefect/tasks.py tests/test_flow_engine.py`
- `uv run pytest tests/test_flow_engine.py -k "SubflowDynamicKeyRace"`
