### PR TITLE
PLA-2795: migrate prefect workflows to prefect-ci-bot trust-tier Apps

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -147,9 +147,18 @@ jobs:
     # Only trigger on release events (nightly prereleases and official releases)
     if: github.event_name == 'release'
     steps:
+      - name: Generate prefect-ci-bot-bridge token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_BRIDGE_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_BRIDGE_PRIVATE_KEY }}
+          owner: PrefectHQ
+          repositories: cluster-deployment
+
       - name: Dispatch to cluster-deployment
         env:
-          GH_TOKEN: ${{ secrets.CLUSTER_DEPLOYMENT_ACTIONS_RW }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           gh workflow run update-integration-test-image.yaml \
             -R PrefectHQ/cluster-deployment \

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -155,6 +155,8 @@ jobs:
           private-key: ${{ secrets.PREFECT_CI_BOT_BRIDGE_PRIVATE_KEY }}
           owner: PrefectHQ
           repositories: cluster-deployment
+          # Scope to the minimum needed for `gh workflow run`.
+          permission-actions: write
 
       - name: Dispatch to cluster-deployment
         env:

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -19,6 +19,8 @@ jobs:
           private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
           owner: PrefectHQ
           repositories: prefect-helm
+          # Scope to the minimum needed for `gh workflow run`.
+          permission-actions: write
 
       - name: Create prefect-helm release
         run: |

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -11,10 +11,19 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/3.')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate prefect-ci-bot-public token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+          owner: PrefectHQ
+          repositories: prefect-helm
+
       - name: Create prefect-helm release
         run: |
           gh workflow run helm-release.yaml \
             --repo PrefectHQ/prefect-helm \
             --ref main
         env:
-          GH_TOKEN: ${{ secrets.PREFECT_HELM_ACTIONS_RW }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -8,11 +8,24 @@ on:
 jobs:
   nightly-release:
     runs-on: ubuntu-latest
-    permissions:
-      # required for softprops/action-gh-release to create the tag + release
-      contents: write
 
     steps:
+      # The release created below must NOT be authored by the default
+      # GITHUB_TOKEN. GitHub suppresses follow-on workflow runs (except
+      # workflow_dispatch/repository_dispatch) for events produced by
+      # GITHUB_TOKEN, which would prevent docker-images.yaml,
+      # helm-chart-release.yaml, python-package.yaml, and
+      # prefect-client-publish.yaml from triggering off the release event.
+      # Mint a public App token instead.
+      - name: Generate prefect-ci-bot-public token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+          # Scope to the minimum needed for softprops/action-gh-release.
+          permission-contents: write
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -83,4 +96,4 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: true
-          token: ${{ github.token }}
+          token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -9,16 +9,10 @@ jobs:
   nightly-release:
     runs-on: ubuntu-latest
     permissions:
+      # required for softprops/action-gh-release to create the tag + release
       contents: write
 
     steps:
-      - name: Generate prefect-ci-bot-public token
-        id: app_token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -89,4 +83,4 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: true
-          token: ${{ steps.app_token.outputs.token }}
+          token: ${{ github.token }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -12,6 +12,13 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate prefect-ci-bot-public token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -82,4 +89,4 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: true
-          token: ${{ secrets.PREFECT_CONTENTS_RW }}
+          token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/notify-on-failure.yaml
+++ b/.github/workflows/notify-on-failure.yaml
@@ -1,0 +1,46 @@
+---
+name: Notify on Failure
+
+"on":
+  workflow_run:
+    workflows:
+      - Docker images
+      - Nightly Development Release
+      - Create prefect-helm release
+    types: [completed]
+
+permissions:
+  # required to read from the GitHub Actions API
+  actions: read
+  # required to read the repo
+  contents: read
+
+jobs:
+  notify:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Format date
+        run: |
+          formatted_date=$(date -d "${{ github.event.workflow_run.run_started_at }}" "+%b %d at %I:%M %p")
+          echo "FORMATTED_DATE=$formatted_date" >> "$GITHUB_ENV"
+
+      - name: Send Slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          # https://api.slack.com/reference/messaging/attachments
+          custom_payload: |
+            {
+              attachments: [{
+                pretext: ':x: Workflow triggered by ${{ github.actor }} failed',
+                title: '${{ github.event.workflow_run.display_title }} #${{github.event.workflow_run.run_number}}',
+                title_link: '${{ github.event.workflow_run.html_url }}',
+                footer: '${{ github.repository }} | ${{ env.FORMATTED_DATE }} UTC',
+                footer_icon: 'https://slack-imgs.com/?c=1&o1=wi32.he32.si&url=https%3A%2F%2Fslack.github.com%2Fstatic%2Fimg%2Ffavicon-neutral.png',
+                color: 'danger',
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_GHA_JOB_STATUS }}

--- a/.github/workflows/npm_update_latest_prefect.yaml
+++ b/.github/workflows/npm_update_latest_prefect.yaml
@@ -19,7 +19,14 @@
         contents: write
       steps:
         - uses: actions/checkout@v6
-  
+
+        - name: Generate prefect-ci-bot-public token
+          id: app_token
+          uses: actions/create-github-app-token@v3
+          with:
+            client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+            private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+
         - name: Configure Git
           run: |
             git config user.name "$GITHUB_ACTOR"
@@ -72,5 +79,5 @@
           env:
             PACKAGE_NAME: ${{ inputs.package_name }}
             PACKAGE_VERSION: ${{ inputs.package_version }}
-            GITHUB_TOKEN: ${{ secrets.UI_COMPONENTS_CONTENTS_PRS_RW }}
+            GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
   

--- a/.github/workflows/npm_update_latest_prefect.yaml
+++ b/.github/workflows/npm_update_latest_prefect.yaml
@@ -15,17 +15,12 @@
     update_prefect_packages:
       runs-on: ubuntu-latest
       permissions:
-        # required to write to the repo
+        # required to push the dependency-bump branch
         contents: write
+        # required for `gh pr create`
+        pull-requests: write
       steps:
         - uses: actions/checkout@v6
-
-        - name: Generate prefect-ci-bot-public token
-          id: app_token
-          uses: actions/create-github-app-token@v3
-          with:
-            client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
-            private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
 
         - name: Configure Git
           run: |
@@ -79,5 +74,5 @@
           env:
             PACKAGE_NAME: ${{ inputs.package_name }}
             PACKAGE_VERSION: ${{ inputs.package_version }}
-            GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+            GITHUB_TOKEN: ${{ github.token }}
   


### PR DESCRIPTION
## Summary

Migrates 4 workflows away from per-PAT fine-grained tokens (held by `marvin-robot`). Three switch to short-lived installation tokens minted by the `prefect-ci-bot` trust-tier GitHub Apps; one drops the PAT entirely in favor of the default `GITHUB_TOKEN`. Adds a `notify-on-failure.yaml` to alert on failures of the three release workflows. Part of the [GitHub PAT Consolidation project](https://linear.app/prefect/project/github-pat-consolidation-via-github-apps-980cd13b51ff/overview).

| Workflow | Previous PAT | Replacement | Scope |
| --- | --- | --- | --- |
| `docker-images.yaml` | `CLUSTER_DEPLOYMENT_ACTIONS_RW` | **bridge** App (`permission-actions: write`) | `cluster-deployment` |
| `nightly-release.yaml` | `PREFECT_CONTENTS_RW` | public App (`permission-contents: write`) | self |
| `helm-chart-release.yaml` | `PREFECT_HELM_ACTIONS_RW` | public App (`permission-actions: write`) | `prefect-helm` |
| `npm_update_latest_prefect.yaml` | `UI_COMPONENTS_CONTENTS_PRS_RW` | **default `GITHUB_TOKEN`** | self |

### Why `nightly-release.yaml` keeps an App

Initially planned to drop the App and use the default token (the workflow's only `contents:write` need is to create a release tag, which the default token can handle). However, reviewer correctly flagged that GitHub suppresses follow-on workflow runs for events produced by `GITHUB_TOKEN` (exceptions: `workflow_dispatch`/`repository_dispatch`). If the nightly release were authored by `GITHUB_TOKEN`, the four downstream `on: release` workflows (`docker-images.yaml`, `helm-chart-release.yaml`, `python-package.yaml`, `prefect-client-publish.yaml`) would silently stop firing. Reverted to minting a public App token, scoped to `contents:write`.

### Why `npm_update_latest_prefect.yaml` can use the default token

Same-repo operations only: pushes a feature branch (not `prod`) and opens a PR. No chained workflow_run dependency — the workflow is triggered by `workflow_dispatch` and doesn't produce events others listen for. The PAT it replaced was overscoped (cross-repo access to 8 repos for a workflow that only writes to itself).

### Token scoping for App-using workflows

All three App-using workflows request an explicit `permission-*` input when minting. Without that, `actions/create-github-app-token@v3` issues a token that inherits the full installation permission set. Each workflow only needs a single permission for its single operation, so scoping the minted token narrows the blast radius if it's ever exposed.

## Public-repo considerations

`prefect` is a public OSS repo, so the threat model includes:

- **PRs from forks**: GitHub does not pass repository or org secrets to workflows triggered by `pull_request` from forks. All 4 workflows here trigger on `release`, `workflow_dispatch`, or `schedule` (none on `pull_request`), so the App credentials are never exposed to fork-PR code execution.
- **Compromised maintainer / supply-chain via a third-party action**: token lifetime drops from a 180-day PAT to a 1-hour installation token, reducing blast radius by orders of magnitude.
- **Cross-repo reach**: the only place this repo's workflows reach internal repos is the `cluster-deployment` Actions trigger. That goes through the **bridge App** (`prefect-ci-bot-bridge`), which has deliberately minimal install permissions: `actions:write`, `contents:write`, `pull_requests:write`, `metadata:read` only. **No source-read.** With `permission-actions: write` set on the mint call, the minted token is narrowed further to actions-only.

The public App (`prefect-ci-bot-public`) handles same-repo operations that need scope broader than `contents:write` + `pull_requests:write`. It's installed on public repos only.

See [PLA-2825](https://linear.app/prefect/issue/PLA-2825) for the trust-tier design.

## Failure notifications

Adds `notify-on-failure.yaml` mirroring the pattern already used in `customer-managed`, `cluster-deployment`, and `nebula-ui`. Fires a Slack alert when any of `Docker images`, `Nightly Development Release`, or `Create prefect-helm release` complete with `failure`. These three are release-driven and nobody watches them live, so silent failures could go unnoticed. The `SLACK_WEBHOOK_GHA_JOB_STATUS` secret is already distributed to `prefect` via Terraform.

## Test plan

- [x] After merge, monitor next nightly cron / first scheduled run of `nightly-release.yaml` to verify GitHub release creation succeeds with the App token AND that `docker-images.yaml`, `python-package.yaml`, and `prefect-client-publish.yaml` actually trigger off the new release.
- [x] Monitor next `docker-images.yaml` release event to verify cluster-deployment dispatch succeeds via the actions-scoped bridge App token.
- [ ] Monitor next prefect release to verify `prefect-helm` trigger succeeds via the actions-scoped public App token.
- [ ] Verify a manual dispatch of `npm_update_latest_prefect.yaml` succeeds with the default token.
- [ ] Trigger an intentional failure (e.g., dispatch `nightly-release.yaml` after breaking the tag-parse step in a scratch branch) to verify the `notify-on-failure.yaml` Slack alert fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

