### PR TITLE
Run db_vacuum maintenance queries without the API statement timeout

### DIFF
--- a/src/prefect/server/services/db_vacuum.py
+++ b/src/prefect/server/services/db_vacuum.py
@@ -26,19 +26,78 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 from datetime import timedelta
+from typing import AsyncIterator
 
 import sqlalchemy as sa
 from docket import CurrentDocket, Depends, Docket, Perpetual
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.logging import get_logger
 from prefect.server.database import PrefectDBInterface, provide_database_interface
+from prefect.server.database.configurations import AsyncPostgresConfiguration
 from prefect.server.schemas.states import TERMINAL_STATES
 from prefect.server.services.perpetual_services import perpetual_service
 from prefect.settings.context import get_current_settings
 from prefect.types._datetime import now
 
 logger: logging.Logger = get_logger(__name__)
+
+
+# Vacuum runs batched maintenance deletes that legitimately scan large tables
+# (e.g. the orphaned-log anti-join). On Postgres these inherit the asyncpg
+# `command_timeout` derived from `PREFECT_API_DATABASE_TIMEOUT` (10s by
+# default) — a latency budget meant for user-facing API queries, not bulk
+# maintenance. When a batch exceeds it asyncpg raises `TimeoutError`, killing
+# the task before it makes progress. Maintenance work runs on a dedicated
+# connection with no statement timeout so it can run to completion; sqlite's
+# `timeout` is a lock-wait, not a statement deadline, so it is left as-is.
+_MAINTENANCE_CONFIGS: dict[str, AsyncPostgresConfiguration] = {}
+
+
+def _maintenance_database_config(
+    db: PrefectDBInterface,
+) -> AsyncPostgresConfiguration | None:
+    """Return a Postgres config with no statement timeout for vacuum work.
+
+    Returns `None` for non-Postgres backends, signalling callers to use the
+    default session.
+    """
+    config = db.database_config
+    if not isinstance(config, AsyncPostgresConfiguration):
+        return None
+    cached = _MAINTENANCE_CONFIGS.get(config.connection_url)
+    if cached is None:
+        cached = AsyncPostgresConfiguration(connection_url=config.connection_url)
+        # Opt out of the API statement timeout and keep a minimal pool, since
+        # vacuum tasks run sequentially on an hourly loop.
+        cached.timeout = None
+        cached.sqlalchemy_pool_size = 1
+        cached.sqlalchemy_max_overflow = 0
+        _MAINTENANCE_CONFIGS[config.connection_url] = cached
+    return cached
+
+
+@asynccontextmanager
+async def _maintenance_session(
+    db: PrefectDBInterface,
+) -> AsyncIterator[AsyncSession]:
+    """A transactional session for vacuum maintenance queries.
+
+    On Postgres this uses a dedicated connection with no statement timeout;
+    other backends fall back to the default session context.
+    """
+    config = _maintenance_database_config(db)
+    if config is None:
+        async with db.session_context(begin_transaction=True) as session:
+            yield session
+        return
+    engine = await config.engine()
+    session = await config.session(engine)
+    async with session:
+        async with config.begin_transaction(session):
+            yield session
 
 
 # ---------------------------------------------------------------------------
@@ -315,7 +374,7 @@ async def _reconcile_artifact_collections(
     )
 
     while True:
-        async with db.session_context(begin_transaction=True) as session:
+        async with _maintenance_session(db) as session:
             rows = (
                 await session.execute(
                     sa.select(db.ArtifactCollection.id, db.ArtifactCollection.key)
@@ -376,7 +435,7 @@ async def _batch_delete(
     """Delete matching rows in batches. Each batch gets its own DB transaction."""
     total = 0
     while True:
-        async with db.session_context(begin_transaction=True) as session:
+        async with _maintenance_session(db) as session:
             subquery = (
                 sa.select(model.id).where(condition).limit(batch_size).scalar_subquery()
             )

--- a/tests/server/services/test_db_vacuum.py
+++ b/tests/server/services/test_db_vacuum.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import uuid
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 import sqlalchemy as sa
@@ -702,3 +703,68 @@ class TestNoOp:
         await vacuum_old_flow_runs(db=db)
         await vacuum_events_with_retention_overrides(db=db)
         await vacuum_old_events(db=db)
+
+
+class TestMaintenanceSession:
+    """The maintenance session opts vacuum queries out of the API statement
+    timeout on Postgres (see PrefectHQ/prefect#XXXXX), where bulk deletes that
+    scan large tables would otherwise be killed by asyncpg's `command_timeout`.
+    """
+
+    def setup_method(self) -> None:
+        from prefect.server.services import db_vacuum
+
+        db_vacuum._MAINTENANCE_CONFIGS.clear()
+
+    def test_postgres_config_disables_statement_timeout(self) -> None:
+        from prefect.server.database.configurations import AsyncPostgresConfiguration
+        from prefect.server.services.db_vacuum import _maintenance_database_config
+
+        base = AsyncPostgresConfiguration(
+            connection_url="postgresql+asyncpg://u:p@host/db", timeout=10.0
+        )
+        db = SimpleNamespace(database_config=base)
+
+        config = _maintenance_database_config(db)
+
+        assert config is not None
+        assert config is not base
+        assert config.timeout is None
+        assert config.sqlalchemy_pool_size == 1
+        assert config.sqlalchemy_max_overflow == 0
+
+    def test_postgres_config_is_cached_per_url(self) -> None:
+        from prefect.server.database.configurations import AsyncPostgresConfiguration
+        from prefect.server.services.db_vacuum import _maintenance_database_config
+
+        db = SimpleNamespace(
+            database_config=AsyncPostgresConfiguration(
+                connection_url="postgresql+asyncpg://u:p@host/db"
+            )
+        )
+
+        first = _maintenance_database_config(db)
+        second = _maintenance_database_config(db)
+
+        assert first is second
+
+    def test_non_postgres_returns_none(self) -> None:
+        from prefect.server.database.configurations import AioSqliteConfiguration
+        from prefect.server.services.db_vacuum import _maintenance_database_config
+
+        db = SimpleNamespace(
+            database_config=AioSqliteConfiguration(
+                connection_url="sqlite+aiosqlite:///:memory:"
+            )
+        )
+
+        assert _maintenance_database_config(db) is None
+
+    async def test_maintenance_session_is_usable(self):
+        """The maintenance session yields a working transactional session
+        regardless of backend (falls back to the default on non-Postgres)."""
+        db = provide_database_interface()
+        from prefect.server.services.db_vacuum import _maintenance_session
+
+        async with _maintenance_session(db) as session:
+            assert await session.execute(sa.select(sa.literal(1))) is not None

--- a/tests/server/services/test_db_vacuum.py
+++ b/tests/server/services/test_db_vacuum.py
@@ -12,10 +12,17 @@ import sqlalchemy as sa
 
 from prefect.server import models, schemas
 from prefect.server.database import PrefectDBInterface, provide_database_interface
+from prefect.server.database.configurations import (
+    AioSqliteConfiguration,
+    AsyncPostgresConfiguration,
+)
 from prefect.server.events.schemas.events import ReceivedEvent, Resource
 from prefect.server.events.storage.database import write_events
 from prefect.server.schemas.actions import LogCreate
+from prefect.server.services import db_vacuum
 from prefect.server.services.db_vacuum import (
+    _maintenance_database_config,
+    _maintenance_session,
     vacuum_events_with_retention_overrides,
     vacuum_old_events,
     vacuum_old_flow_runs,
@@ -707,19 +714,14 @@ class TestNoOp:
 
 class TestMaintenanceSession:
     """The maintenance session opts vacuum queries out of the API statement
-    timeout on Postgres (see PrefectHQ/prefect#XXXXX), where bulk deletes that
-    scan large tables would otherwise be killed by asyncpg's `command_timeout`.
+    timeout on Postgres, where bulk deletes that scan large tables would
+    otherwise be killed by asyncpg's `command_timeout`.
     """
 
     def setup_method(self) -> None:
-        from prefect.server.services import db_vacuum
-
         db_vacuum._MAINTENANCE_CONFIGS.clear()
 
     def test_postgres_config_disables_statement_timeout(self) -> None:
-        from prefect.server.database.configurations import AsyncPostgresConfiguration
-        from prefect.server.services.db_vacuum import _maintenance_database_config
-
         base = AsyncPostgresConfiguration(
             connection_url="postgresql+asyncpg://u:p@host/db", timeout=10.0
         )
@@ -734,9 +736,6 @@ class TestMaintenanceSession:
         assert config.sqlalchemy_max_overflow == 0
 
     def test_postgres_config_is_cached_per_url(self) -> None:
-        from prefect.server.database.configurations import AsyncPostgresConfiguration
-        from prefect.server.services.db_vacuum import _maintenance_database_config
-
         db = SimpleNamespace(
             database_config=AsyncPostgresConfiguration(
                 connection_url="postgresql+asyncpg://u:p@host/db"
@@ -749,9 +748,6 @@ class TestMaintenanceSession:
         assert first is second
 
     def test_non_postgres_returns_none(self) -> None:
-        from prefect.server.database.configurations import AioSqliteConfiguration
-        from prefect.server.services.db_vacuum import _maintenance_database_config
-
         db = SimpleNamespace(
             database_config=AioSqliteConfiguration(
                 connection_url="sqlite+aiosqlite:///:memory:"
@@ -764,7 +760,6 @@ class TestMaintenanceSession:
         """The maintenance session yields a working transactional session
         regardless of backend (falls back to the default on non-Postgres)."""
         db = provide_database_interface()
-        from prefect.server.services.db_vacuum import _maintenance_session
 
         async with _maintenance_session(db) as session:
             assert await session.execute(sa.select(sa.literal(1))) is not None


### PR DESCRIPTION
The `db_vacuum` service was failing every loop with `TimeoutError` on a high-volume self-hosted instance. This PR runs its batched maintenance deletes on a dedicated Postgres connection with no statement timeout, so they can run to completion instead of being killed mid-batch.

<details>
<summary>Diagnosis</summary>

Observed on a self-hosted OSS server (Cloud SQL Postgres 15, ~4k flow runs/day, 90-day retention): the background-services pod logged `TimeoutError` from `db_vacuum._batch_delete` on every hourly cycle — `vacuum_orphaned_logs`, `vacuum_old_events`, `vacuum_events_with_retention_overrides`.

Root cause:
- Vacuum issues `DELETE ... WHERE id IN (SELECT id WHERE <condition> LIMIT batch_size)`. For the orphan conditions (`vacuum_orphaned_logs`/`vacuum_orphaned_artifacts`), `<condition>` is a `NOT EXISTS` anti-join with no usable index, so Postgres resolves it as a parallel hash anti-join that **seq-scans the entire `log` table** (here ~7.9 GB) on every batch:

  ```
  Limit → Gather → Parallel Hash Anti Join
            → Parallel Seq Scan on log  (rows≈900k)
            → Parallel Index Only Scan on pk_flow_run
     cost=35273..540953
  ```

- Every query inherits the asyncpg `command_timeout` set from `PREFECT_API_DATABASE_TIMEOUT` (default **10s**), applied as a connect arg in `server/database/configurations.py`. The scan exceeds 10s → `TimeoutError` → the task dies before deleting anything. `statement_timeout` on the server is `0`, confirming the cap is asyncpg client-side, not Postgres.
- Notably `BaseDatabaseConfiguration.__init__` does `self.timeout = timeout or PREFECT_API_DATABASE_TIMEOUT.value()`, so the maintenance path can't even opt out by passing `None`/`0` — it always falls back to the 10s default.

The 10s budget is right for user-facing API queries but wrong for bulk maintenance that legitimately scans large tables. The work itself is small (in our case only ~11 orphaned rows) — it's the *find* that's expensive, and it never gets to finish.
</details>

<details>
<summary>Change</summary>

- Add `_maintenance_database_config()` / `_maintenance_session()` in `db_vacuum.py`. On Postgres these use a cached `AsyncPostgresConfiguration` with `timeout=None` and a minimal pool (`pool_size=1`, `max_overflow=0`), since vacuum tasks run sequentially on an hourly loop.
- `_batch_delete` and `_reconcile_artifact_collections` now use `_maintenance_session()`.
- Non-Postgres backends (sqlite) fall back to the default session unchanged — sqlite's `timeout` is a lock-wait, not a statement deadline.
- Tests cover timeout opt-out, per-URL caching, the sqlite fall-through, and that the session is usable.
</details>

**Open question for review:** I implemented this as an implicit invariant ("maintenance never shares the API statement timeout"). Would you prefer an explicit `server.services.db_vacuum.statement_timeout` setting instead? Also happy to consider the alternative angle (making orphan detection index-friendly) if you'd rather attack the scan than the timeout. Drafting for direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)