### PR TITLE
support AnyIO 4.14 task group interface

### DIFF
--- a/src/prefect/utilities/asyncutils/__init__.py
+++ b/src/prefect/utilities/asyncutils/__init__.py
@@ -474,6 +474,10 @@ class GatherTaskGroup(anyio.abc.TaskGroup):
         # The concrete task group implementation to use
         self._task_group: anyio.abc.TaskGroup = task_group
 
+    @property
+    def cancel_scope(self) -> Any:
+        return self._task_group.cancel_scope
+
     async def _run_and_store(
         self,
         key: UUID,

--- a/src/prefect/utilities/asyncutils/__init__.py
+++ b/src/prefect/utilities/asyncutils/__init__.py
@@ -8,7 +8,7 @@ import threading
 import warnings
 from collections.abc import AsyncGenerator, Awaitable, Coroutine
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from contextvars import ContextVar
+from contextvars import Context, ContextVar
 from functools import partial, wraps
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Optional, Union, overload
@@ -493,6 +493,20 @@ class GatherTaskGroup(anyio.abc.TaskGroup):
         self._results[key] = GatherIncomplete
         self._task_group.start_soon(self._run_and_store, key, func, *args, name=name)
         return key
+
+    def create_task(
+        self,
+        coro: Coroutine[Any, Any, T],
+        *,
+        name: object = None,
+        context: Context | None = None,
+    ) -> Any:
+        create_task = getattr(self._task_group, "create_task", None)
+        if create_task is None:
+            coro.close()
+            raise RuntimeError("`create_task` requires AnyIO 4.14.0 or newer.")
+
+        return create_task(coro, name=name, context=context)
 
     async def start(self, func: object, *args: object, name: object = None) -> NoReturn:
         """

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -398,6 +398,23 @@ async def test_gather_task_group_get_result_bad_uuid():
         tg.get_result(uuid.uuid4())
 
 
+async def test_gather_task_group_create_task_delegates_when_supported():
+    async with create_gather_task_group() as tg:
+        if not hasattr(tg._task_group, "create_task"):
+            pytest.skip("AnyIO task group does not support create_task")
+
+        completed = False
+
+        async def foo():
+            nonlocal completed
+            completed = True
+
+        handle = tg.create_task(foo(), name="test-gather-task-group-create-task")
+        await handle.wait()
+
+    assert completed
+
+
 async def test_lazy_semaphore_initialization():
     initial_value = 5
     lazy_semaphore = LazySemaphore(lambda: initial_value)

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -399,10 +399,11 @@ async def test_gather_task_group_get_result_bad_uuid():
 
 
 async def test_gather_task_group_create_task_delegates_when_supported():
-    async with create_gather_task_group() as tg:
-        if not hasattr(tg._task_group, "create_task"):
-            pytest.skip("AnyIO task group does not support create_task")
+    tg = create_gather_task_group()
+    if not hasattr(tg._task_group, "create_task"):
+        pytest.skip("AnyIO task group does not support create_task")
 
+    async with tg:
         completed = False
 
         async def foo():
@@ -416,6 +417,10 @@ async def test_gather_task_group_create_task_delegates_when_supported():
 
 
 async def test_gather_task_group_cancel_delegates_cancel_scope_when_supported():
+    tg = create_gather_task_group()
+    if not hasattr(tg, "cancel"):
+        pytest.skip("AnyIO task group does not support cancel")
+
     completed = False
 
     async def wait_forever():
@@ -425,10 +430,7 @@ async def test_gather_task_group_cancel_delegates_cancel_scope_when_supported():
         finally:
             completed = True
 
-    async with create_gather_task_group() as tg:
-        if not hasattr(tg, "cancel"):
-            pytest.skip("AnyIO task group does not support cancel")
-
+    async with tg:
         tg.start_soon(wait_forever)
         await anyio.sleep(0)
         tg.cancel()

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -415,6 +415,27 @@ async def test_gather_task_group_create_task_delegates_when_supported():
     assert completed
 
 
+async def test_gather_task_group_cancel_delegates_cancel_scope_when_supported():
+    completed = False
+
+    async def wait_forever():
+        nonlocal completed
+        try:
+            await anyio.sleep_forever()
+        finally:
+            completed = True
+
+    async with create_gather_task_group() as tg:
+        if not hasattr(tg, "cancel"):
+            pytest.skip("AnyIO task group does not support cancel")
+
+        tg.start_soon(wait_forever)
+        await anyio.sleep(0)
+        tg.cancel()
+
+    assert completed
+
+
 async def test_lazy_semaphore_initialization():
     initial_value = 5
     lazy_semaphore = LazySemaphore(lambda: initial_value)


### PR DESCRIPTION
## Summary

This PR updates `GatherTaskGroup` to implement AnyIO 4.14's new `TaskGroup.create_task` interface while preserving Prefect's existing `start_soon`/`get_result` gather behavior.

## Details

AnyIO 4.14 adds `create_task` as an abstract method on `anyio.abc.TaskGroup`. Since `GatherTaskGroup` subclasses that ABC, environments that resolve AnyIO 4.14 fail when Prefect instantiates the gather task group with:

```text
TypeError: Can't instantiate abstract class GatherTaskGroup with abstract method create_task
```

The implementation delegates `create_task` to the wrapped concrete AnyIO task group. On older AnyIO versions where the concrete group does not expose this method, it closes the coroutine and raises a clear runtime error if called.

## Validation

- `uv run pytest tests/utilities/test_asyncutils.py -q`
- `uv run --with anyio==4.14.0 pytest tests/utilities/test_asyncutils.py -q`
- `uv run ruff check src/prefect/utilities/asyncutils/__init__.py tests/utilities/test_asyncutils.py`
