### PR TITLE
fix(server): prevent duplicate Late state transitions in MarkLateRuns

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1789,10 +1789,15 @@ class EnsureOnlyScheduledFlowsMarkedLate(FlowRunOrchestrationRule):
         marking_flow_late = (
             proposed_state.is_scheduled() and proposed_state.name == "Late"
         )
-        if marking_flow_late and not initial_state.is_scheduled():
-            await self.reject_transition(
-                state=None, reason="Only scheduled flows can be marked late."
-            )
+        if marking_flow_late:
+            if not initial_state.is_scheduled():
+                await self.reject_transition(
+                    state=None, reason="Only scheduled flows can be marked late."
+                )
+            elif initial_state.name == "Late":
+                await self.reject_transition(
+                    state=None, reason="This flow run is already marked late."
+                )
 
 
 class EnforceDeploymentConcurrencyOnLate(FlowRunOrchestrationRule):

--- a/src/prefect/server/services/late_runs.py
+++ b/src/prefect/server/services/late_runs.py
@@ -82,4 +82,6 @@ async def monitor_late_runs(
         runs = result.all()
 
         for run in runs:
-            await docket.add(mark_flow_run_late)(run.id)
+            await docket.add(mark_flow_run_late, key=f"mark-flow-run-late:{run.id}")(
+                run.id
+            )

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -1786,6 +1786,35 @@ class TestEnsureOnlyScheduledFlowMarkedLate:
 
         assert ctx.response_status == SetStateStatus.ACCEPT
 
+    @pytest.mark.parametrize(
+        "intended_transition",
+        [
+            (StateType.SCHEDULED, StateType.SCHEDULED),
+        ],
+        ids=transition_names,
+    )
+    async def test_reject_marking_already_late_flow_as_late(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+        intended_transition,
+    ):
+        ctx = await initialize_orchestration(
+            session,
+            run_type,
+            *intended_transition,
+            initial_state_name="Late",
+            proposed_state_name="Late",
+        )
+
+        state_protection = EnsureOnlyScheduledFlowsMarkedLate(ctx, *intended_transition)
+
+        async with state_protection as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.REJECT
+
 
 @pytest.mark.parametrize("run_type", ["flow"])
 class TestPreventPendingTransitions:

--- a/tests/server/services/test_late_runs.py
+++ b/tests/server/services/test_late_runs.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from prefect.server import models, schemas
-from prefect.server.services.late_runs import mark_flow_run_late
+from prefect.server.services.late_runs import mark_flow_run_late, monitor_late_runs
 
 pytestmark = pytest.mark.clear_db
 
@@ -138,6 +138,50 @@ async def test_monitor_query_filters_already_late_runs(session, late_run, db):
     # The monitor query would not select this run again because:
     # - state_name is now "Late", not "Scheduled"
     # This is tested by verifying the query filter behavior, not by calling the task twice
+
+
+async def test_mark_already_late_run_is_rejected(session, late_run, db):
+    """Re-marking an already-Late run does not perform a Late -> Late transition.
+
+    Regression test for https://github.com/PrefectHQ/prefect/issues/22139
+    """
+    await mark_flow_run_late(late_run.id, db=db)
+    await session.refresh(late_run)
+    assert late_run.state.name == "Late"
+    first_state_id = late_run.state.id
+
+    await mark_flow_run_late(late_run.id, db=db)
+    await session.refresh(late_run)
+    # The run is still Late, and no new Late state was committed.
+    assert late_run.state.name == "Late"
+    assert late_run.state.id == first_state_id
+
+
+async def test_monitor_enqueues_with_deterministic_dedup_key(session, late_run, db):
+    """monitor_late_runs enqueues mark tasks with a per-run dedup key so repeated
+    monitor loops over the same still-Scheduled run do not enqueue duplicate tasks.
+
+    Regression test for https://github.com/PrefectHQ/prefect/issues/22139
+    """
+
+    class FakeDocket:
+        def __init__(self):
+            self.keys: list[str | None] = []
+
+        def add(self, function, key=None):
+            self.keys.append(key)
+
+            async def _enqueue(*args, **kwargs):
+                return None
+
+            return _enqueue
+
+    docket = FakeDocket()
+    await monitor_late_runs(docket=docket, db=db)
+    await monitor_late_runs(docket=docket, db=db)
+
+    expected_key = f"mark-flow-run-late:{late_run.id}"
+    assert docket.keys == [expected_key, expected_key]
 
 
 async def test_cancels_late_run_when_deployment_has_cancel_new_and_limit_is_full(


### PR DESCRIPTION
closes #22139

## Root cause

`MarkLateRuns` re-marks the same Scheduled flow run multiple times under a docket-worker backlog, emitting redundant `prefect.flow-run.Late` events that fan out to `reactive-triggers`. Two independent gaps cause this:

1. **No dedup key on the enqueue.** `monitor_late_runs` enqueues a `mark_flow_run_late` docket task per overdue run with no `key=`, so every monitor loop gets a fresh UUID7 and is treated as a distinct task. While a run is still `Scheduled` (its task enqueued but not yet processed), successive loops re-enqueue duplicate tasks for the same `run.id`.

   ```python
   for run in runs:
       await docket.add(mark_flow_run_late)(run.id)
   ```

2. **`Late → Late` is accepted by orchestration.** `EnsureOnlyScheduledFlowsMarkedLate` only rejects a late-marking whose *initial* state is not scheduled. `Late` is a scheduled-typed state (`is_scheduled() == True`), so when duplicate tasks run, the first transitions `Scheduled → Late` and every subsequent one performs an accepted no-op `Late → Late` transition — which still flows through `InstrumentFlowRunStateTransitions` and emits a fresh `prefect.flow-run.Late` event.

This is a regression from #19722, which converted `MarkLateRuns` from a `LoopService` (select-and-transition in one iteration, no queueing) to a docket perpetual function.

## Fix

**1. Add a deterministic per-run dedup key** so a still-pending task is not re-enqueued by later monitor loops (mirrors the `key=` pattern already used for self-rescheduling perpetual functions in `perpetual_services.py`):

```diff
     for run in runs:
-        await docket.add(mark_flow_run_late)(run.id)
+        await docket.add(
+            mark_flow_run_late, key=f"mark-flow-run-late:{run.id}"
+        )(run.id)
```

**2. Reject `Late → Late`** in the orchestration rule. Because `EnsureOnlyScheduledFlowsMarkedLate` runs *before* `InstrumentFlowRunStateTransitions` in `MarkLateRunsPolicy`, rejecting the no-op transition prevents the spurious event entirely:

```diff
-        if marking_flow_late and not initial_state.is_scheduled():
-            await self.reject_transition(
-                state=None, reason="Only scheduled flows can be marked late."
-            )
+        if marking_flow_late:
+            if not initial_state.is_scheduled():
+                await self.reject_transition(
+                    state=None, reason="Only scheduled flows can be marked late."
+                )
+            elif initial_state.name == "Late":
+                await self.reject_transition(
+                    state=None, reason="This flow run is already marked late."
+                )
```

## Verification

Verify-first: the new policy test was written to assert `Late → Late` is rejected and confirmed **failing** on `main` (the transition was accepted) before the fix, then passing after. Added regression tests:

- `test_reject_marking_already_late_flow_as_late` (orchestration rule)
- `test_mark_already_late_run_is_rejected` (no new state committed on re-mark)
- `test_monitor_enqueues_with_deterministic_dedup_key` (per-run dedup key)

Full affected suites pass (`tests/server/services/test_late_runs.py`, `tests/server/orchestration/test_core_policy.py`); ruff and mypy clean.

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
