### PR TITLE
Preserve custom shell for PowerShell scripts

### DIFF
--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -476,7 +476,7 @@ class ShellOperation(JobBlock[list[str]]):
             )
             temp_file.write(joined_commands.encode())
 
-            if self.shell is None and sys.platform == "win32" or extension == ".ps1":
+            if self.shell is None and (sys.platform == "win32" or extension == ".ps1"):
                 shell = "powershell"
             elif self.shell is None:
                 shell = "bash"


### PR DESCRIPTION
## Summary

Fix shell selection logic in `ShellOperation._prep_trigger_command` when using PowerShell script extensions (`.ps1`).

Previously, the condition:

```python
if self.shell is None and sys.platform == "win32" or extension == ".ps1":
```

could evaluate to `True` whenever `extension == ".ps1"`, even when a custom shell was explicitly provided. This caused Prefect to override the user-specified shell and force `"powershell"`.

The condition has been updated to ensure PowerShell is only selected automatically when no shell has been supplied by the user.

## Changes

Changed:

```python
if self.shell is None and sys.platform == "win32" or extension == ".ps1":
```

to:

```python
if self.shell is None and (
    sys.platform == "win32" or extension == ".ps1"
):
```

## Motivation

This aligns the implementation with the expected behavior described in issue #21808 and preserves user-provided shell values when working with PowerShell scripts.

## Testing

Verified that the existing Windows shell override tests continue to pass:

```bash
pytest src/integrations/prefect-shell/tests/test_commands_windows.py -k override_shell -v
```

Results:

* 3 passed
* 0 failed
