### PR TITLE
docs: bump mdxify to >=0.2.42, drop empty API-ref stubs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1236,7 +1236,6 @@
                   "v3/api-ref/python/prefect-flow_runs",
                   "v3/api-ref/python/prefect-flows",
                   "v3/api-ref/python/prefect-futures",
-                  "v3/api-ref/python/prefect-main",
                   "v3/api-ref/python/prefect-plugins",
                   "v3/api-ref/python/prefect-results",
                   "v3/api-ref/python/prefect-schedules",
@@ -1252,7 +1251,6 @@
                   {
                     "group": "prefect.assets",
                     "pages": [
-                      "v3/api-ref/python/prefect-assets-__init__",
                       "v3/api-ref/python/prefect-assets-core",
                       "v3/api-ref/python/prefect-assets-materialize"
                     ]
@@ -1260,10 +1258,8 @@
                   {
                     "group": "prefect.blocks",
                     "pages": [
-                      "v3/api-ref/python/prefect-blocks-__init__",
                       "v3/api-ref/python/prefect-blocks-abstract",
                       "v3/api-ref/python/prefect-blocks-core",
-                      "v3/api-ref/python/prefect-blocks-fields",
                       "v3/api-ref/python/prefect-blocks-notifications",
                       "v3/api-ref/python/prefect-blocks-redis",
                       "v3/api-ref/python/prefect-blocks-system",
@@ -1280,7 +1276,6 @@
                   {
                     "group": "prefect.cli",
                     "pages": [
-                      "v3/api-ref/python/prefect-cli-__init__",
                       "v3/api-ref/python/prefect-cli-api",
                       "v3/api-ref/python/prefect-cli-artifact",
                       "v3/api-ref/python/prefect-cli-automation",
@@ -1297,7 +1292,7 @@
                       "v3/api-ref/python/prefect-cli-concurrency_limit",
                       "v3/api-ref/python/prefect-cli-config",
                       "v3/api-ref/python/prefect-cli-dashboard",
-                      "v3/api-ref/python/prefect-cli-deploy",
+                      "v3/api-ref/python/prefect-cli-deploy-__init__",
                       "v3/api-ref/python/prefect-cli-deployment",
                       "v3/api-ref/python/prefect-cli-dev",
                       "v3/api-ref/python/prefect-cli-events",
@@ -1314,7 +1309,7 @@
                       "v3/api-ref/python/prefect-cli-shell",
                       "v3/api-ref/python/prefect-cli-task",
                       "v3/api-ref/python/prefect-cli-task_run",
-                      "v3/api-ref/python/prefect-cli-transfer",
+                      "v3/api-ref/python/prefect-cli-transfer-__init__",
                       "v3/api-ref/python/prefect-cli-variable",
                       "v3/api-ref/python/prefect-cli-version",
                       "v3/api-ref/python/prefect-cli-work_pool",
@@ -1330,19 +1325,16 @@
                       "v3/api-ref/python/prefect-client-base",
                       "v3/api-ref/python/prefect-client-cloud",
                       "v3/api-ref/python/prefect-client-collections",
-                      "v3/api-ref/python/prefect-client-constants",
                       {
                         "group": "orchestration",
                         "pages": [
                           "v3/api-ref/python/prefect-client-orchestration-__init__",
-                          "v3/api-ref/python/prefect-client-orchestration-base",
-                          "v3/api-ref/python/prefect-client-orchestration-routes"
+                          "v3/api-ref/python/prefect-client-orchestration-base"
                         ]
                       },
                       {
                         "group": "schemas",
                         "pages": [
-                          "v3/api-ref/python/prefect-client-schemas-__init__",
                           "v3/api-ref/python/prefect-client-schemas-actions",
                           "v3/api-ref/python/prefect-client-schemas-events",
                           "v3/api-ref/python/prefect-client-schemas-filters",
@@ -1354,20 +1346,12 @@
                         ]
                       },
                       "v3/api-ref/python/prefect-client-subscriptions",
-                      {
-                        "group": "types",
-                        "pages": [
-                          "v3/api-ref/python/prefect-client-types-__init__",
-                          "v3/api-ref/python/prefect-client-types-flexible_schedule_list"
-                        ]
-                      },
                       "v3/api-ref/python/prefect-client-utilities"
                     ]
                   },
                   {
                     "group": "prefect.concurrency",
                     "pages": [
-                      "v3/api-ref/python/prefect-concurrency-__init__",
                       "v3/api-ref/python/prefect-concurrency-asyncio",
                       "v3/api-ref/python/prefect-concurrency-context",
                       "v3/api-ref/python/prefect-concurrency-services",
@@ -1375,7 +1359,6 @@
                       {
                         "group": "v1",
                         "pages": [
-                          "v3/api-ref/python/prefect-concurrency-v1-__init__",
                           "v3/api-ref/python/prefect-concurrency-v1-asyncio",
                           "v3/api-ref/python/prefect-concurrency-v1-context",
                           "v3/api-ref/python/prefect-concurrency-v1-services",
@@ -1387,16 +1370,13 @@
                   {
                     "group": "prefect.deployments",
                     "pages": [
-                      "v3/api-ref/python/prefect-deployments-__init__",
                       "v3/api-ref/python/prefect-deployments-base",
-                      "v3/api-ref/python/prefect-deployments-deployments",
                       "v3/api-ref/python/prefect-deployments-flow_runs",
                       "v3/api-ref/python/prefect-deployments-runner",
                       "v3/api-ref/python/prefect-deployments-schedules",
                       {
                         "group": "steps",
                         "pages": [
-                          "v3/api-ref/python/prefect-deployments-steps-__init__",
                           "v3/api-ref/python/prefect-deployments-steps-core",
                           "v3/api-ref/python/prefect-deployments-steps-pull",
                           "v3/api-ref/python/prefect-deployments-steps-utility"
@@ -1407,14 +1387,12 @@
                   {
                     "group": "prefect.docker",
                     "pages": [
-                      "v3/api-ref/python/prefect-docker-__init__",
                       "v3/api-ref/python/prefect-docker-docker_image"
                     ]
                   },
                   {
                     "group": "prefect.events",
                     "pages": [
-                      "v3/api-ref/python/prefect-events-__init__",
                       "v3/api-ref/python/prefect-events-actions",
                       "v3/api-ref/python/prefect-events-clients",
                       "v3/api-ref/python/prefect-events-filters",
@@ -1422,7 +1400,6 @@
                       {
                         "group": "schemas",
                         "pages": [
-                          "v3/api-ref/python/prefect-events-schemas-__init__",
                           "v3/api-ref/python/prefect-events-schemas-automations",
                           "v3/api-ref/python/prefect-events-schemas-deployment_triggers",
                           "v3/api-ref/python/prefect-events-schemas-events",
@@ -1455,7 +1432,6 @@
                   {
                     "group": "prefect.input",
                     "pages": [
-                      "v3/api-ref/python/prefect-input-__init__",
                       "v3/api-ref/python/prefect-input-actions",
                       "v3/api-ref/python/prefect-input-run_input"
                     ]
@@ -1463,7 +1439,6 @@
                   {
                     "group": "prefect.locking",
                     "pages": [
-                      "v3/api-ref/python/prefect-locking-__init__",
                       "v3/api-ref/python/prefect-locking-filesystem",
                       "v3/api-ref/python/prefect-locking-memory",
                       "v3/api-ref/python/prefect-locking-protocol"
@@ -1472,7 +1447,6 @@
                   {
                     "group": "prefect.logging",
                     "pages": [
-                      "v3/api-ref/python/prefect-logging-__init__",
                       "v3/api-ref/python/prefect-logging-clients",
                       "v3/api-ref/python/prefect-logging-configuration",
                       "v3/api-ref/python/prefect-logging-filters",
@@ -1485,7 +1459,6 @@
                   {
                     "group": "prefect.runner",
                     "pages": [
-                      "v3/api-ref/python/prefect-runner-__init__",
                       "v3/api-ref/python/prefect-runner-runner",
                       "v3/api-ref/python/prefect-runner-server",
                       "v3/api-ref/python/prefect-runner-storage"
@@ -1503,11 +1476,9 @@
                   {
                     "group": "prefect.server",
                     "pages": [
-                      "v3/api-ref/python/prefect-server-__init__",
                       {
                         "group": "api",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-api-__init__",
                           "v3/api-ref/python/prefect-server-api-admin",
                           "v3/api-ref/python/prefect-server-api-artifacts",
                           "v3/api-ref/python/prefect-server-api-automations",
@@ -1556,7 +1527,6 @@
                       {
                         "group": "database",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-database-__init__",
                           "v3/api-ref/python/prefect-server-database-alembic_commands",
                           "v3/api-ref/python/prefect-server-database-configurations",
                           "v3/api-ref/python/prefect-server-database-dependencies",
@@ -1568,7 +1538,6 @@
                       {
                         "group": "events",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-events-__init__",
                           "v3/api-ref/python/prefect-server-events-actions",
                           "v3/api-ref/python/prefect-server-events-clients",
                           "v3/api-ref/python/prefect-server-events-counting",
@@ -1578,7 +1547,6 @@
                           {
                             "group": "models",
                             "pages": [
-                              "v3/api-ref/python/prefect-server-events-models-__init__",
                               "v3/api-ref/python/prefect-server-events-models-automations",
                               "v3/api-ref/python/prefect-server-events-models-composite_trigger_child_firing"
                             ]
@@ -1595,7 +1563,6 @@
                           {
                             "group": "schemas",
                             "pages": [
-                              "v3/api-ref/python/prefect-server-events-schemas-__init__",
                               "v3/api-ref/python/prefect-server-events-schemas-automations",
                               "v3/api-ref/python/prefect-server-events-schemas-events",
                               "v3/api-ref/python/prefect-server-events-schemas-labelling",
@@ -1605,7 +1572,6 @@
                           {
                             "group": "services",
                             "pages": [
-                              "v3/api-ref/python/prefect-server-events-services-__init__",
                               "v3/api-ref/python/prefect-server-events-services-actions",
                               "v3/api-ref/python/prefect-server-events-services-event_logger",
                               "v3/api-ref/python/prefect-server-events-services-event_persister",
@@ -1627,7 +1593,6 @@
                       {
                         "group": "logs",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-logs-__init__",
                           "v3/api-ref/python/prefect-server-logs-messaging",
                           "v3/api-ref/python/prefect-server-logs-stream"
                         ]
@@ -1635,7 +1600,6 @@
                       {
                         "group": "models",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-models-__init__",
                           "v3/api-ref/python/prefect-server-models-artifacts",
                           "v3/api-ref/python/prefect-server-models-block_documents",
                           "v3/api-ref/python/prefect-server-models-block_registration",
@@ -1665,7 +1629,6 @@
                       {
                         "group": "orchestration",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-orchestration-__init__",
                           "v3/api-ref/python/prefect-server-orchestration-core_policy",
                           "v3/api-ref/python/prefect-server-orchestration-dependencies",
                           "v3/api-ref/python/prefect-server-orchestration-global_policy",
@@ -1677,7 +1640,6 @@
                       {
                         "group": "schemas",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-schemas-__init__",
                           "v3/api-ref/python/prefect-server-schemas-actions",
                           "v3/api-ref/python/prefect-server-schemas-core",
                           "v3/api-ref/python/prefect-server-schemas-filters",
@@ -1694,7 +1656,6 @@
                       {
                         "group": "services",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-services-__init__",
                           "v3/api-ref/python/prefect-server-services-base",
                           "v3/api-ref/python/prefect-server-services-cancellation_cleanup",
                           "v3/api-ref/python/prefect-server-services-cleanup_reconciler",
@@ -1713,7 +1674,6 @@
                       {
                         "group": "utilities",
                         "pages": [
-                          "v3/api-ref/python/prefect-server-utilities-__init__",
                           "v3/api-ref/python/prefect-server-utilities-database",
                           "v3/api-ref/python/prefect-server-utilities-encryption",
                           "v3/api-ref/python/prefect-server-utilities-http",
@@ -1730,7 +1690,6 @@
                           {
                             "group": "schemas",
                             "pages": [
-                              "v3/api-ref/python/prefect-server-utilities-schemas-__init__",
                               "v3/api-ref/python/prefect-server-utilities-schemas-bases",
                               "v3/api-ref/python/prefect-server-utilities-schemas-serializers"
                             ]
@@ -1763,13 +1722,11 @@
                     "pages": [
                       "v3/api-ref/python/prefect-settings-__init__",
                       "v3/api-ref/python/prefect-settings-base",
-                      "v3/api-ref/python/prefect-settings-constants",
                       "v3/api-ref/python/prefect-settings-context",
                       "v3/api-ref/python/prefect-settings-legacy",
                       {
                         "group": "models",
                         "pages": [
-                          "v3/api-ref/python/prefect-settings-models-__init__",
                           "v3/api-ref/python/prefect-settings-models-api",
                           "v3/api-ref/python/prefect-settings-models-cli",
                           "v3/api-ref/python/prefect-settings-models-client",
@@ -1787,7 +1744,6 @@
                           {
                             "group": "server",
                             "pages": [
-                              "v3/api-ref/python/prefect-settings-models-server-__init__",
                               "v3/api-ref/python/prefect-settings-models-server-api",
                               "v3/api-ref/python/prefect-settings-models-server-concurrency",
                               "v3/api-ref/python/prefect-settings-models-server-database",
@@ -1817,18 +1773,15 @@
                   {
                     "group": "prefect.telemetry",
                     "pages": [
-                      "v3/api-ref/python/prefect-telemetry-__init__",
                       "v3/api-ref/python/prefect-telemetry-run_telemetry"
                     ]
                   },
                   {
                     "group": "prefect.testing",
                     "pages": [
-                      "v3/api-ref/python/prefect-testing-__init__",
                       "v3/api-ref/python/prefect-testing-cli",
                       "v3/api-ref/python/prefect-testing-docker",
                       "v3/api-ref/python/prefect-testing-fixtures",
-                      "v3/api-ref/python/prefect-testing-standard_test_suites",
                       "v3/api-ref/python/prefect-testing-utilities"
                     ]
                   },
@@ -1843,7 +1796,6 @@
                   {
                     "group": "prefect.utilities",
                     "pages": [
-                      "v3/api-ref/python/prefect-utilities-__init__",
                       "v3/api-ref/python/prefect-utilities-annotations",
                       "v3/api-ref/python/prefect-utilities-asyncutils",
                       "v3/api-ref/python/prefect-utilities-callables",
@@ -1865,13 +1817,11 @@
                       {
                         "group": "schema_tools",
                         "pages": [
-                          "v3/api-ref/python/prefect-utilities-schema_tools-__init__",
                           "v3/api-ref/python/prefect-utilities-schema_tools-hydration",
                           "v3/api-ref/python/prefect-utilities-schema_tools-validation"
                         ]
                       },
                       "v3/api-ref/python/prefect-utilities-services",
-                      "v3/api-ref/python/prefect-utilities-slugify",
                       "v3/api-ref/python/prefect-utilities-templating",
                       "v3/api-ref/python/prefect-utilities-text",
                       "v3/api-ref/python/prefect-utilities-timeout",
@@ -1882,7 +1832,6 @@
                   {
                     "group": "prefect.workers",
                     "pages": [
-                      "v3/api-ref/python/prefect-workers-__init__",
                       "v3/api-ref/python/prefect-workers-base",
                       "v3/api-ref/python/prefect-workers-block",
                       "v3/api-ref/python/prefect-workers-cloud",

--- a/docs/v3/api-ref/python/prefect-assets-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-assets-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.assets`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-blocks-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.blocks`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-blocks-fields.mdx
+++ b/docs/v3/api-ref/python/prefect-blocks-fields.mdx
@@ -1,8 +1,0 @@
----
-title: fields
-sidebarTitle: fields
----
-
-# `prefect.blocks.fields`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-cli-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-cli-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.cli`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-client-constants.mdx
+++ b/docs/v3/api-ref/python/prefect-client-constants.mdx
@@ -1,8 +1,0 @@
----
-title: constants
-sidebarTitle: constants
----
-
-# `prefect.client.constants`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-client-orchestration-routes.mdx
+++ b/docs/v3/api-ref/python/prefect-client-orchestration-routes.mdx
@@ -1,8 +1,0 @@
----
-title: routes
-sidebarTitle: routes
----
-
-# `prefect.client.orchestration.routes`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-client-schemas-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-client-schemas-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.client.schemas`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-client-types-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-client-types-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.client.types`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-client-types-flexible_schedule_list.mdx
+++ b/docs/v3/api-ref/python/prefect-client-types-flexible_schedule_list.mdx
@@ -1,8 +1,0 @@
----
-title: flexible_schedule_list
-sidebarTitle: flexible_schedule_list
----
-
-# `prefect.client.types.flexible_schedule_list`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-concurrency-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.concurrency`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-concurrency-v1-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-concurrency-v1-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.concurrency.v1`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-deployments-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.deployments`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-deployments-deployments.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-deployments.mdx
@@ -1,8 +1,0 @@
----
-title: deployments
-sidebarTitle: deployments
----
-
-# `prefect.deployments.deployments`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-deployments-steps-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-deployments-steps-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.deployments.steps`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-docker-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-docker-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.docker`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-events-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-events-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.events`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-events-schemas-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-events-schemas-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.events.schemas`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-input-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-input-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.input`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-locking-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-locking-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.locking`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-logging-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-logging-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.logging`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-main.mdx
+++ b/docs/v3/api-ref/python/prefect-main.mdx
@@ -1,8 +1,0 @@
----
-title: main
-sidebarTitle: main
----
-
-# `prefect.main`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-runner-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-runner-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.runner`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-api-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-api-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.api`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-database-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-database-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.database`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-events-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.events`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-events-models-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-models-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.events.models`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-events-schemas-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-schemas-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.events.schemas`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-events-services-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-events-services-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.events.services`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-logs-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-logs-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.logs`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-models-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-models-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.models`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-orchestration-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.orchestration`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-orchestration-core_policy.mdx
+++ b/docs/v3/api-ref/python/prefect-server-orchestration-core_policy.mdx
@@ -551,7 +551,7 @@ before_transition(self, initial_state: states.State[Any] | None, proposed_state:
 before_transition(self, initial_state: states.State[Any] | None, proposed_state: states.State[Any] | None, context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy]) -> None
 ```
 
-### `EnforceDeploymentConcurrencyOnLate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1798" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EnforceDeploymentConcurrencyOnLate` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1803" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Enforce the CANCEL_NEW deployment concurrency strategy when marking runs late.
@@ -567,13 +567,13 @@ because they go late would accumulate in a Late state instead of being cancelled
 
 **Methods:**
 
-#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1813" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1818" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 before_transition(self, initial_state: states.State[Any] | None, proposed_state: states.State[Any] | None, context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy]) -> None
 ```
 
-### `PreventRunningTasksFromStoppedFlows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1861" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `PreventRunningTasksFromStoppedFlows` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1866" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Prevents running tasks from stopped flows.
@@ -584,13 +584,13 @@ flow's tasks cannot be run unless the flow is also running.
 
 **Methods:**
 
-#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1872" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1877" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 before_transition(self, initial_state: states.State[Any] | None, proposed_state: states.State[Any] | None, context: OrchestrationContext[orm_models.TaskRun, core.TaskRunPolicy]) -> None
 ```
 
-### `EnforceCancellingToCancelledTransition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1908" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `EnforceCancellingToCancelledTransition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1913" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Rejects transitions from Cancelling to any terminal state except for Cancelled.
@@ -598,13 +598,13 @@ Rejects transitions from Cancelling to any terminal state except for Cancelled.
 
 **Methods:**
 
-#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1916" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1921" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 before_transition(self, initial_state: states.State[Any] | None, proposed_state: states.State[Any] | None, context: OrchestrationContext[orm_models.TaskRun, core.TaskRunPolicy]) -> None
 ```
 
-### `BypassCancellingFlowRunsWithNoInfra` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1932" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `BypassCancellingFlowRunsWithNoInfra` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1937" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Rejects transitions from Scheduled to Cancelling, and instead sets the state to Cancelled,
@@ -621,13 +621,13 @@ Runs that are `AwaitingRetry` are a `Scheduled` state that may have associated i
 
 **Methods:**
 
-#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1948" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1953" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 before_transition(self, initial_state: states.State[Any] | None, proposed_state: states.State[Any] | None, context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy]) -> None
 ```
 
-### `PreserveDeploymentConcurrencyLeaseId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1976" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `PreserveDeploymentConcurrencyLeaseId` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1981" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Preserves the deployment concurrency lease ID across state transitions.
@@ -641,13 +641,13 @@ and the proposed state does not.
 
 **Methods:**
 
-#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1987" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L1992" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 before_transition(self, context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy]) -> None
 ```
 
-### `PreventDuplicateTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L2004" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `PreventDuplicateTransitions` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L2009" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Prevent duplicate transitions from being made right after one another.
@@ -665,7 +665,7 @@ the following case:
 
 **Methods:**
 
-#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L2022" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `before_transition` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/orchestration/core_policy.py#L2027" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 before_transition(self, initial_state: states.State[Any] | None, proposed_state: states.State[Any] | None, context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy]) -> None

--- a/docs/v3/api-ref/python/prefect-server-schemas-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-schemas-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.schemas`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-services-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-services-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.services`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-utilities-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.utilities`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-server-utilities-schemas-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-server-utilities-schemas-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.server.utilities.schemas`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-settings-constants.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-constants.mdx
@@ -1,8 +1,0 @@
----
-title: constants
-sidebarTitle: constants
----
-
-# `prefect.settings.constants`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-settings-models-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.settings.models`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-settings-models-server-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-settings-models-server-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.settings.models.server`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-telemetry-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-telemetry-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.telemetry`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-testing-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-testing-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.testing`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-testing-standard_test_suites.mdx
+++ b/docs/v3/api-ref/python/prefect-testing-standard_test_suites.mdx
@@ -1,8 +1,0 @@
----
-title: standard_test_suites
-sidebarTitle: standard_test_suites
----
-
-# `prefect.testing.standard_test_suites`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-utilities-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.utilities`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-utilities-schema_tools-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-schema_tools-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.utilities.schema_tools`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-utilities-slugify.mdx
+++ b/docs/v3/api-ref/python/prefect-utilities-slugify.mdx
@@ -1,8 +1,0 @@
----
-title: slugify
-sidebarTitle: slugify
----
-
-# `prefect.utilities.slugify`
-
-*This module is empty or contains only private/internal implementations.*

--- a/docs/v3/api-ref/python/prefect-workers-__init__.mdx
+++ b/docs/v3/api-ref/python/prefect-workers-__init__.mdx
@@ -1,8 +1,0 @@
----
-title: __init__
-sidebarTitle: __init__
----
-
-# `prefect.workers`
-
-*This module is empty or contains only private/internal implementations.*

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ api-ref-all:
     uvx --with-editable . \
         --python 3.12 \
         --isolated \
-        mdxify \
+        'mdxify>=0.2.42' \
         --all \
         --root-module prefect \
         --output-dir docs/v3/api-ref/python \
@@ -54,7 +54,7 @@ api-ref-all:
 api-ref *MODULES:
     uvx --with-editable . \
         --refresh-package mdxify \
-        mdxify@latest \
+        'mdxify>=0.2.42' \
         {{MODULES}} \
         --root-module prefect \
         --output-dir docs/v3/api-ref/python \

--- a/scripts/generate_api_ref.py
+++ b/scripts/generate_api_ref.py
@@ -12,7 +12,7 @@ def main() -> None:
         "uvx",
         "--with-editable",
         ".",
-        "mdxify@latest",
+        "mdxify>=0.2.42",
         "--all",
         "--root-module",
         "prefect",


### PR DESCRIPTION
Bumps the mdxify floor to `>=0.2.42` and regenerates the Python SDK API reference. [mdxify 0.2.42](https://github.com/zzstoatzz/mdxify/releases/tag/v0.2.42) stops generating placeholder pages for empty modules and fixes related navigation dead links. The regen removes **46 dead stub pages** (e.g. the `prefect-cli-__init__` page that just read *"This module is empty…"*) and cleans up their navigation entries.

**Verified: 0 dead links and 0 orphans across all 360 API-ref nav entries.**

<details>
<summary>What changed</summary>

- **Pin floor → `>=0.2.42`** in `justfile` (`api-ref-all`, `api-ref`) and `scripts/generate_api_ref.py`. Previously these used bare `mdxify` / `mdxify@latest` with no lower bound.
- **Regen output** (`just api-ref-all`):
  - 46 empty `.mdx` stubs deleted
  - `docs/docs.json` nav trimmed and repointed: packages whose only submodules are private (`prefect.cli.deploy`, `prefect.cli.transfer`) now link to their actual `-__init__` pages instead of a 404
</details>

<details>
<summary>mdxify fixes this depends on</summary>

- zzstoatzz/mdxify#42 — stop generating empty-module pages (v0.2.40)
- zzstoatzz/mdxify#43 — empty modules left in nav via `--include-inheritance` (v0.2.41)
- zzstoatzz/mdxify#44 — dead link for packages with only private submodules (v0.2.42)
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)