### PR TITLE
Handle PowerShell shell arguments

### DIFF
--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -476,7 +476,7 @@ class ShellOperation(JobBlock[list[str]]):
             )
             temp_file.write(joined_commands.encode())
 
-            if self.shell is None and sys.platform == "win32" or extension == ".ps1":
+            if self.shell is None and (sys.platform == "win32" or extension == ".ps1"):
                 shell = "powershell"
             elif self.shell is None:
                 shell = "bash"

--- a/src/integrations/prefect-shell/prefect_shell/commands.py
+++ b/src/integrations/prefect-shell/prefect_shell/commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -12,6 +13,7 @@ import tempfile
 import threading
 from contextlib import AsyncExitStack, ExitStack, contextmanager
 from contextvars import copy_context
+from pathlib import PureWindowsPath
 from typing import IO, Any, Generator, Optional, Union
 
 import anyio
@@ -26,6 +28,20 @@ from prefect.logging import get_run_logger
 from prefect.utilities.processutils import open_process
 
 _SHELL_TERMINATE_GRACE_SECONDS = 5.0
+
+
+def _split_shell_command(shell: str) -> list[str]:
+    return shlex.split(shell.lower(), posix=sys.platform != "win32") or [shell.lower()]
+
+
+def _shell_command(shell: str, temp_file_name: str) -> list[str]:
+    return [*_split_shell_command(shell), temp_file_name]
+
+
+def _is_powershell(shell: str) -> bool:
+    command = _split_shell_command(shell)[0]
+    executable = PureWindowsPath(command).name
+    return executable in {"powershell", "powershell.exe", "pwsh", "pwsh.exe"}
 
 
 def _process_isolation_kwargs() -> dict[str, Any]:
@@ -483,12 +499,12 @@ class ShellOperation(JobBlock[list[str]]):
             else:
                 shell = self.shell.lower()
 
-            if shell == "powershell":
+            if _is_powershell(shell):
                 # if powershell, set exit code to that of command
                 temp_file.write("\r\nExit $LastExitCode".encode())
             temp_file.close()
 
-            trigger_command = [shell, temp_file.name]
+            trigger_command = _shell_command(shell, temp_file.name)
             yield trigger_command
         finally:
             if temp_file is not None and os.path.exists(temp_file.name):

--- a/src/integrations/prefect-shell/tests/test_commands.py
+++ b/src/integrations/prefect-shell/tests/test_commands.py
@@ -285,6 +285,33 @@ class TestShellOperation:
         )
         assert open_process_mock.call_args_list[0][0][0][0] == "powershell"
 
+    @pytest.mark.parametrize("method", ["run", "trigger"])
+    async def test_custom_powershell_with_arguments_is_preserved(
+        self, monkeypatch: pytest.MonkeyPatch, method: str
+    ):
+        open_process_mock = AsyncMock(name="open_process")
+        stdout_mock = AsyncMock(name="stdout_mock")
+        stdout_mock.receive.side_effect = lambda: b"received"
+        open_process_mock.return_value.__aenter__.return_value = AsyncMock(
+            stdout=stdout_mock
+        )
+        open_process_mock.return_value.returncode = 0
+        monkeypatch.setattr("anyio.open_process", open_process_mock)
+        monkeypatch.setattr("prefect_shell.commands.TextReceiveStream", AsyncIter)
+
+        await self.execute(
+            ShellOperation(
+                commands=["echo 'hey'"],
+                extension=".ps1",
+                shell="powershell.exe -executionpolicy bypass",
+            ),
+            method,
+        )
+
+        command = open_process_mock.call_args_list[0][0][0]
+        assert command[0:3] == ["powershell.exe", "-executionpolicy", "bypass"]
+        assert command[3].endswith(".ps1")
+
     async def test_context_manager(self):
         async with ShellOperation(commands=["echo 'testing'"]) as op:
             proc = await op.trigger()

--- a/src/integrations/prefect-shell/tests/test_commands_windows.py
+++ b/src/integrations/prefect-shell/tests/test_commands_windows.py
@@ -257,6 +257,33 @@ class TestShellOperation:
         op = ShellOperation(commands=["Get-Location"], working_dir=Path.home())
         assert os.fspath(Path.home()) in (await self.execute(op, method))
 
+    @pytest.mark.parametrize("method", ["run", "trigger"])
+    async def test_custom_powershell_with_arguments_is_preserved(
+        self, monkeypatch, method
+    ):
+        open_process_mock = AsyncMock(name="open_process")
+        stdout_mock = AsyncMock(name="stdout_mock")
+        stdout_mock.receive.side_effect = lambda: b"received"
+        open_process_mock.return_value.__aenter__.return_value = AsyncMock(
+            stdout=stdout_mock
+        )
+        open_process_mock.return_value.returncode = 0
+        monkeypatch.setattr("anyio.open_process", open_process_mock)
+        monkeypatch.setattr("prefect_shell.commands.TextReceiveStream", AsyncIter)
+
+        await self.execute(
+            ShellOperation(
+                commands=["echo 'hey'"],
+                extension=".ps1",
+                shell="powershell.exe -executionpolicy bypass",
+            ),
+            method,
+        )
+
+        command = open_process_mock.call_args_list[0][0][0]
+        assert command[0:3] == ["powershell.exe", "-executionpolicy", "bypass"]
+        assert command[3].endswith(".ps1")
+
     async def test_context_manager(self):
         async with ShellOperation(commands=["echo 'testing'"]) as op:
             proc = await op.trigger()


### PR DESCRIPTION
closes #21808

this PR preserves custom PowerShell shell arguments for `ShellOperation` when running `.ps1` scripts.

<details>
<summary>Details</summary>

PR #22336 fixed the operator precedence bug that caused `.ps1` scripts to override an explicitly provided shell. However, the issue example still failed on Windows because `ShellOperation` passed a shell string like `powershell.exe -executionpolicy bypass` as a single executable name.

This updates `ShellOperation` to split custom shell strings into argv before appending the temporary script path. It also recognizes `powershell.exe` and `pwsh` as PowerShell executables so the `$LastExitCode` footer is still added when those executables are used.

Added regression coverage for `ShellOperation(shell="powershell.exe -executionpolicy bypass", extension=".ps1")` in both the standard and Windows command test modules.

</details>

Validation:

- `uv run --project src/integrations/prefect-shell pytest src/integrations/prefect-shell/tests/test_commands.py`
- `uv run ruff check src/integrations/prefect-shell/prefect_shell/commands.py src/integrations/prefect-shell/tests/test_commands.py src/integrations/prefect-shell/tests/test_commands_windows.py`
- `git diff --check`
- Windows GHA repro against PR #22336 failed with `[WinError 2]`: https://github.com/zzstoatzz/prefect-pack/actions/runs/27969751529/job/82772662185
- Windows GHA repro against this fix passed: https://github.com/zzstoatzz/prefect-pack/actions/runs/27969869936/job/82773055038
