### PR TITLE
docs: redirects for removed SDK stubs + fix databricks broken link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1821,6 +1821,334 @@
   },
   "redirects": [
     {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-bundles-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-deployments-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-experimental-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-experimental-bundles-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-experimental-bundles-execute"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-experimental-bundles-upload"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-experimental-decorators"
+    },
+    {
+      "destination": "/integrations/prefect-aws/index",
+      "source": "/integrations/prefect-aws/api-ref/prefect_aws-workers-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-bundles-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-deployments-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-experimental-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-experimental-bundles-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-experimental-bundles-execute"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-experimental-bundles-upload"
+    },
+    {
+      "destination": "/integrations/prefect-azure/index",
+      "source": "/integrations/prefect-azure/api-ref/prefect_azure-experimental-decorators"
+    },
+    {
+      "destination": "/integrations/prefect-databricks/index",
+      "source": "/integrations/prefect-databricks/api-ref/prefect_databricks-models-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-databricks/index",
+      "source": "/integrations/prefect-databricks/api-ref/prefect_databricks-models-jobs"
+    },
+    {
+      "destination": "/integrations/prefect-dbt/index",
+      "source": "/integrations/prefect-dbt/api-ref/prefect_dbt-cli-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-dbt/index",
+      "source": "/integrations/prefect-dbt/api-ref/prefect_dbt-cli-configs-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-dbt/index",
+      "source": "/integrations/prefect-dbt/api-ref/prefect_dbt-cloud-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-dbt/index",
+      "source": "/integrations/prefect-dbt/api-ref/prefect_dbt-core-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-docker/index",
+      "source": "/integrations/prefect-docker/api-ref/prefect_docker-deployments-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-docker/index",
+      "source": "/integrations/prefect-docker/api-ref/prefect_docker-experimental-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-docker/index",
+      "source": "/integrations/prefect-docker/api-ref/prefect_docker-experimental-decorators"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-bundles-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-deployments-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-experimental-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-experimental-bundles-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-experimental-bundles-execute"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-experimental-bundles-upload"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-experimental-decorators"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-models-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-gcp/index",
+      "source": "/integrations/prefect-gcp/api-ref/prefect_gcp-workers-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-github/index",
+      "source": "/integrations/prefect-github/api-ref/prefect_github-schemas-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-kubernetes/index",
+      "source": "/integrations/prefect-kubernetes/api-ref/prefect_kubernetes-experimental-__init__"
+    },
+    {
+      "destination": "/integrations/prefect-kubernetes/index",
+      "source": "/integrations/prefect-kubernetes/api-ref/prefect_kubernetes-experimental-decorators"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-assets-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-blocks-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-blocks-fields"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-cli-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-client-constants"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-client-orchestration-routes"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-client-schemas-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-client-types-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-client-types-flexible_schedule_list"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-concurrency-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-concurrency-v1-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-deployments-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-deployments-deployments"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-deployments-steps-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-docker-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-events-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-events-schemas-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-input-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-locking-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-logging-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-main"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-runner-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-api-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-database-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-events-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-events-models-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-events-schemas-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-events-services-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-logs-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-models-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-orchestration-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-schemas-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-services-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-utilities-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-server-utilities-schemas-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-settings-constants"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-settings-models-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-settings-models-server-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-telemetry-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-testing-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-testing-standard_test_suites"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-utilities-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-utilities-schema_tools-__init__"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-utilities-slugify"
+    },
+    {
+      "destination": "/v3/api-ref/index",
+      "source": "/v3/api-ref/python/prefect-workers-__init__"
+    },
+    {
       "destination": "/v3/advanced/plugins",
       "source": "/v3/advanced/experimental-plugins"
     },

--- a/docs/integrations/prefect-databricks/api-ref/prefect_databricks-jobs.mdx
+++ b/docs/integrations/prefect-databricks/api-ref/prefect_databricks-jobs.mdx
@@ -388,9 +388,7 @@ than 25\. The default value is 25\. If a request specifies a
 limit of 0, the service instead uses the maximum limit.
 - `run_type`: 
 The type of runs to return. For a description of run types, see
-[Run](https\://docs.databricks.com/dev-
-tools/api/latest/jobs.html
-operation/JobsRunsGet).
+[Run](https\://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsGet).
 - `expand_tasks`: 
 Whether to include task and cluster details in the response.
 - `start_time_from`: 
@@ -407,7 +405,7 @@ _start_time_from_ to filter by a time range.
 - (`List["models.Run"]`) and `has_more` (`bool`).
 
 
-### `jobs_runs_repair` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-databricks/prefect_databricks/jobs.py#L864" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `jobs_runs_repair` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-databricks/prefect_databricks/jobs.py#L862" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 jobs_runs_repair(databricks_credentials: 'DatabricksCredentials', run_id: Optional[int] = None, rerun_tasks: Optional[List[str]] = None, latest_repair_id: Optional[int] = None, rerun_all_failed_tasks: bool = False, jar_params: Optional[List[str]] = None, notebook_params: Optional[Dict] = None, python_params: Optional[List[str]] = None, spark_submit_params: Optional[List[str]] = None, python_named_params: Optional[Dict] = None, pipeline_params: Optional[str] = None, sql_params: Optional[Dict] = None, dbt_commands: Optional[List] = None, job_parameters: Optional[Dict] = None) -> Dict[str, Any]
@@ -464,7 +462,7 @@ A map of job-level parameter overrides for the run.
 - (`int`).
 
 
-### `jobs_runs_submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-databricks/prefect_databricks/jobs.py#L974" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `jobs_runs_submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-databricks/prefect_databricks/jobs.py#L972" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 jobs_runs_submit(databricks_credentials: 'DatabricksCredentials', tasks: Optional[List['models.RunSubmitTaskSettings']] = None, run_name: Optional[str] = None, webhook_notifications: 'models.WebhookNotifications' = None, git_source: 'models.GitSource' = None, timeout_seconds: Optional[int] = None, idempotency_token: Optional[str] = None, access_control_list: Optional[List['models.AccessControlRequest']] = None) -> Dict[str, Any]
@@ -506,7 +504,7 @@ A list of permissions (`AccessControlRequest`) to set on the run.
 - (`int`).
 
 
-### `jobs_update` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-databricks/prefect_databricks/jobs.py#L1057" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `jobs_update` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-databricks/prefect_databricks/jobs.py#L1055" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 jobs_update(databricks_credentials: 'DatabricksCredentials', job_id: Optional[int] = None, new_settings: 'models.JobSettings' = None, fields_to_remove: Optional[List[str]] = None) -> Dict[str, Any]

--- a/src/integrations/prefect-databricks/prefect_databricks/jobs.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/jobs.py
@@ -803,9 +803,7 @@ async def jobs_runs_list(
             limit of 0, the service instead uses the maximum limit.
         run_type:
             The type of runs to return. For a description of run types, see
-            [Run](https://docs.databricks.com/dev-
-            tools/api/latest/jobs.html
-            operation/JobsRunsGet).
+            [Run](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsGet).
         expand_tasks:
             Whether to include task and cluster details in the response.
         start_time_from:


### PR DESCRIPTION
Follow-up to #22339 / #22344 (empty-stub removal).

**(1) Redirects for removed stub pages.** The 82 empty-module stub pages removed in those PRs (46 core + 36 integration) had no redirects, so their old URLs soft-fell-back to the docs home. This adds a redirect for each → its package's reference index (`/v3/api-ref/index` for core, `/integrations/<pkg>/index` for integrations), following the convention of adding redirect settings when docs files are removed.

**(2) Fix a broken databricks link.** `prefect_databricks.jobs.jobs_runs_list`'s docstring split the Databricks API URL across three lines, rendering it unclickable. Restored to the canonical single-line form (matching the same URL elsewhere in the package) and regenerated the doc.

**Verified:** `npx mint broken-links` → "success no broken links found" — all 82 redirect destinations resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)