### PR TITLE
Update security issue reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Please report security vulnerabilities privately using [GitHub's security adviso
 
 ## Scope
 
-We accept reports for vulnerabilities in Prefect itself — the library code in this repository.
+We accept reports for vulnerabilities in Prefect code and products maintained in this repository, including the Python SDK, self-hosted server/API, and web UI.
 
 The following are **out of scope**:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # How to report a security issue
 
-To report a (suspected) security issue, please email `bugbounty@prefect.io` and follow the instructions for our [bug bounty program](https://www.prefect.io/bug-bounty).
+To report a suspected security vulnerability in Prefect, please email `security@prefect.io` with enough detail for us to understand and reproduce the issue.
 
-Prefect will acknowledge receipt of your report in a timely manner, usually within 48 hours. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+Prefect will acknowledge receipt of your report in a timely manner, usually within 48 hours. After the initial reply, the security team will keep you informed of progress toward a fix and public disclosure, and may ask for additional information or guidance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,13 +5,13 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.x     | :white_check_mark: |
-| 2.x     | :x:                |
+| 2.x     | :white_check_mark: |
 | 1.x     | :x:                |
 | 0.x     | :x:                |
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities privately using [GitHub's security advisory feature](https://github.com/PrefectHQ/fastmcp/security/advisories/new). Do not open public issues for security concerns.
+Please report security vulnerabilities privately using [GitHub's security advisory feature](https://github.com/PrefectHQ/prefect/security/advisories/new). Do not open public issues for security concerns.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,33 @@
-# How to report a security issue
+# Security Policy
 
-To report a suspected security vulnerability in Prefect, please email `security@prefect.io` with enough detail for us to understand and reproduce the issue.
+## Supported Versions
 
-Prefect will acknowledge receipt of your report in a timely manner, usually within 48 hours. After the initial reply, the security team will keep you informed of progress toward a fix and public disclosure, and may ask for additional information or guidance.
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :x:                |
+| 1.x     | :x:                |
+| 0.x     | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately using [GitHub's security advisory feature](https://github.com/PrefectHQ/fastmcp/security/advisories/new). Do not open public issues for security concerns.
+
+## Scope
+
+We accept reports for vulnerabilities in Prefect itself — the library code in this repository.
+
+The following are **out of scope**:
+
+- Vulnerabilities in third-party dependencies. We'll bump version floors for known CVEs, but the fix belongs upstream.
+- Issues that require the attacker to already have server-side access or control of the Prefect server configuration.
+
+## Disclosure Process
+
+When we receive a valid report:
+
+1. We triage the report and determine whether it affects FastMCP directly.
+2. We develop and test a fix on a private branch.
+3. We coordinate CVE assignment through GitHub's advisory process when warranted.
+4. We publish the advisory and release a patched version.
+5. We credit the reporter in the advisory (unless they prefer otherwise).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ The following are **out of scope**:
 
 When we receive a valid report:
 
-1. We triage the report and determine whether it affects FastMCP directly.
+1. We triage the report and determine whether it affects Prefect directly.
 2. We develop and test a fix on a private branch.
 3. We coordinate CVE assignment through GitHub's advisory process when warranted.
 4. We publish the advisory and release a patched version.


### PR DESCRIPTION
This PR updates `SECURITY.md` to point to GitHub's security advisory feature.
