### PR TITLE
fix(databricks): conform partner User-Agent to Databricks telemetry attribution format

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/credentials.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/credentials.py
@@ -8,8 +8,14 @@ from httpx import AsyncClient, Client, Headers
 from pydantic import Field, PrivateAttr, SecretStr, model_validator
 
 from prefect.blocks.core import Block
+from prefect_databricks._version import __version__
 
-_DATABRICKS_PARTNER_USER_AGENT = "prefect+prefect-databricks"
+# Databricks partner telemetry attribution. The format
+# `<isv-name_product-name>/<product-version>` (underscore between company and
+# product) is required so Databricks can attribute API usage to Prefect across
+# all connectors and languages.
+# See https://databrickslabs.github.io/partner-architecture/isv-partners/telemetry-attribution
+_DATABRICKS_PARTNER_USER_AGENT = f"Prefect_PrefectDatabricks/{__version__}"
 
 
 class DatabricksCredentials(Block):

--- a/src/integrations/prefect-databricks/tests/test_credentials.py
+++ b/src/integrations/prefect-databricks/tests/test_credentials.py
@@ -15,7 +15,7 @@ class TestDatabricksCredentialsPATAuth:
         ).get_client()
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer token_value"
-        assert client.headers["user-agent"] == "prefect+prefect-databricks"
+        assert client.headers["user-agent"].startswith("Prefect_PrefectDatabricks/")
 
     def test_backward_compatibility_with_token(self):
         """Test backward compatibility - existing PAT-based credentials work unchanged."""
@@ -49,10 +49,24 @@ class TestDatabricksCredentialsPATAuth:
         client = credentials.get_client()
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer token_value"
-        assert (
-            client.headers["user-agent"]
-            == "custom-client/1.0 prefect+prefect-databricks"
-        )
+        user_agent = client.headers["user-agent"]
+        assert user_agent.startswith("custom-client/1.0 Prefect_PrefectDatabricks/")
+
+    def test_partner_user_agent_matches_databricks_format(self):
+        """The partner identifier must follow Databricks' required telemetry
+        attribution format: `<isv-name_product-name>/<product-version>`.
+
+        See https://databrickslabs.github.io/partner-architecture/isv-partners/telemetry-attribution
+        """
+        from prefect_databricks._version import __version__
+        from prefect_databricks.credentials import _DATABRICKS_PARTNER_USER_AGENT
+
+        identifier, _, version = _DATABRICKS_PARTNER_USER_AGENT.partition("/")
+        # underscore separates the (consistent) ISV name from the product name
+        assert identifier == "Prefect_PrefectDatabricks"
+        assert "_" in identifier
+        # version segment is present and tracks the package version
+        assert version == __version__
 
 
 class TestDatabricksCredentialsServicePrincipalAuth:
@@ -145,6 +159,7 @@ class TestDatabricksCredentialsServicePrincipalAuth:
 
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer oauth-access-token"
+        assert client.headers["user-agent"].startswith("Prefect_PrefectDatabricks/")
 
         mock_client_instance.post.assert_called_once()
         call_args = mock_client_instance.post.call_args


### PR DESCRIPTION
This PR brings the `prefect-databricks` partner `User-Agent` into compliance with Databricks' [telemetry attribution spec](https://databrickslabs.github.io/partner-architecture/isv-partners/telemetry-attribution).

Databricks requires partners to set a programmatic `User-Agent` in the format `<isv-name_product-name>/<product-version>` — an **underscore** between company and product names, with an optional version. The previous identifier `prefect+prefect-databricks` used a `+` separator and no version, so it would not attribute correctly in Databricks' telemetry (Query History UI / `system.access.audit`).

It now emits `Prefect_PrefectDatabricks/<version>` (e.g. `Prefect_PrefectDatabricks/0.4.1`), built from `__version__` so it tracks releases automatically. This is set on every API client in `DatabricksCredentials.get_client()`, satisfying the requirement that attribution be programmatic and not left to customers.

<details>
<summary>Details</summary>

- `credentials.py`: `_DATABRICKS_PARTNER_USER_AGENT` is now `f"Prefect_PrefectDatabricks/{__version__}"`. The existing logic that preserves a user-supplied `User-Agent` (appending ours if absent) is unchanged.
- Tests: updated existing assertions to the new format and added `test_partner_user_agent_matches_databricks_format`, which pins the spec contract (underscore-separated ISV/product identifier + version segment tracking the package version). Also asserts the UA on the service-principal auth path. 23 passing.

Scope note: the broader Databricks Connected-ISV well-architected pillars (Unity Catalog namespace handling, Genie/MCP attribution) are N/A for this Jobs/REST API wrapper; OAuth M2M (service principals + Azure Entra ID) and secret redaction are already implemented. Telemetry was the one conformance gap that was also a small, self-contained fix.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)