### PR TITLE
[codex] Redirect legacy docs subdomains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,7 +38,17 @@ status = 301
 
 [[redirects]]
 from = "https://orion-docs.prefect.io/*"
-to = "https://docs.prefect.io/:splat"
+to = "https://docs.prefect.io/"
+status = 301
+
+[[redirects]]
+from = "https://reference.prefect.io/prefect_databricks/jobs/"
+to = "https://docs.prefect.io/integrations/prefect-databricks/api-ref/prefect_databricks-jobs"
+status = 301
+
+[[redirects]]
+from = "https://reference.prefect.io/*"
+to = "https://docs.prefect.io/v3/api-ref/python"
 status = 301
 
 # Netlify redirect rules match on the first rule, 


### PR DESCRIPTION
this PR redirects legacy docs subdomains to the current docs host.

<details>
<summary>Details</summary>

Claude surfaced stale URLs on `reference.prefect.io` and `orion-docs.prefect.io` in search results. I checked the live behavior on June 25, 2026:

- `https://reference.prefect.io/prefect_databricks/jobs/` returns 200 from Netlify on the legacy reference site.
- `https://orion-docs.prefect.io/2.7/` redirects to `https://docs-2.prefect.io/2.7/`, which returns 404.

The Netlify redirect config for these legacy docs lives on the `2.x` branch, so this PR updates `netlify.toml` there. It changes Orion docs traffic to land on the current docs host, adds an exact redirect for the Databricks jobs reference URL to the current Mintlify API reference page, and adds a broad `reference.prefect.io/*` fallback to the current Python API reference index.

</details>

Validation:

- `uv run python` TOML parse of `netlify.toml`
