### PR TITLE
add dependent parameter form example

### DIFF
--- a/docs/v3/advanced/form-building.mdx
+++ b/docs/v3/advanced/form-building.mdx
@@ -242,6 +242,59 @@ The resulting form looks like this:
 
 ![custom form layout](/v3/img/tutorials/parameters/5.png)
 
+### Requiring fields based on other fields
+
+Some forms need constraints that depend on multiple fields. For example, you may
+want to require `discount_reason` and `approver` whenever a user provides a
+`coupon_code`.
+
+The Prefect UI cannot run arbitrary Python validators, such as a Pydantic
+`model_validator`, before submitting a flow run. However, if you can express the
+constraint in the generated JSON schema, Prefect can validate it before the run
+is submitted.
+
+Use `json_schema_extra` on a `BaseModel` subclass to add a JSON Schema
+`dependencies` rule:
+
+{/* pmd-metadata: notest */}
+```python
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EmailContent(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "dependencies": {
+                "coupon_code": {
+                    "required": ["discount_reason", "approver"],
+                    "properties": {
+                        "discount_reason": {"type": "string", "minLength": 1},
+                        "approver": {"type": "string", "minLength": 1},
+                    },
+                }
+            },
+        }
+    )
+
+    subject: str = Field(max_length=30)
+    body: str
+    coupon_code: str | None = None
+    discount_reason: str | None = None
+    approver: str | None = None
+```
+
+With this schema, a run submitted with `coupon_code` but without
+`discount_reason` or `approver` fails parameter validation before flow run
+infrastructure starts. A run without `coupon_code` can still omit those fields.
+
+<Note>
+JSON Schema `dependencies` checks whether a property is present. The schema above
+uses a schema dependency, rather than only `"coupon_code": ["discount_reason",
+"approver"]`, so `discount_reason` and `approver` must also be non-empty strings
+when `coupon_code` is present.
+</Note>
+
 
 
 ## Using callable and class parameters


### PR DESCRIPTION
## Summary

Adds a new section to the v3 form-building guide showing how to express cross-field parameter requirements with JSON Schema `dependencies` via Pydantic `json_schema_extra`.

The example covers the common case where providing one field, such as `coupon_code`, requires sibling fields, such as `discount_reason` and `approver`, before a flow run can be submitted.

## Validation

- Local server, Prefect `3.7.6.dev4+6.g7165d86955`: registered a disposable deployment with `enforce_parameter_schema=True`; invalid parameters were rejected with `409 Conflict`; valid parameters and omitted-trigger parameters were accepted; deployment was deleted.
- Prefect Cloud, active `bot` profile: registered a disposable deployment with `enforce_parameter_schema=True`; invalid parameters were rejected with `409 Conflict`; valid parameters and omitted-trigger parameters were accepted; deployment was deleted.
- Ran a direct schema validation smoke test with `uv run --python 3.12 --with-editable .` confirming the documented schema rejects missing dependent fields.