### PR TITLE
feat(prefect-redis): add optional key_ttl to RedisDatabase

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/blocks.py
+++ b/src/integrations/prefect-redis/prefect_redis/blocks.py
@@ -24,6 +24,8 @@ class RedisDatabase(WritableFileSystem):
         username: The username to use when connecting to the Redis server
         password: The password to use when connecting to the Redis server
         ssl: Whether to use SSL when connecting to the Redis server
+        key_ttl: Optional per-key TTL in seconds applied to every written key
+            (`SET ... EX`); `None` (default) means keys never expire
 
     Example:
         Create a new block from hostname, username and password:
@@ -59,6 +61,15 @@ class RedisDatabase(WritableFileSystem):
     username: Optional[SecretStr] = Field(default=None, description="Redis username")
     password: Optional[SecretStr] = Field(default=None, description="Redis password")
     ssl: bool = Field(default=False, description="Whether to use SSL")
+    key_ttl: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional per-key time-to-live in seconds, applied to every written "
+            "key (Redis `SET ... EX`). When `None` (the default) keys never "
+            "expire. Useful when using the block as `result_storage`/cache on a "
+            "Redis with a `maxmemory` + `volatile-lru` eviction policy."
+        ),
+    )
 
     def block_initialization(self) -> None:
         """Validate parameters"""
@@ -91,7 +102,7 @@ class RedisDatabase(WritableFileSystem):
             content: Binary object to write
         """
         client = self.get_async_client()
-        ret = await client.set(path, content)
+        ret = await client.set(path, content, ex=self.key_ttl)
 
         await client.close()
         return ret
@@ -163,6 +174,8 @@ class RedisDatabase(WritableFileSystem):
         """
         data = self.model_dump()
         data.pop("block_type_slug", None)
+        # `key_ttl` governs write behavior, not the connection — never a client kwarg.
+        data.pop("key_ttl", None)
         # Unwrap SecretStr fields
         if self.username is not None:
             data["username"] = self.username.get_secret_value()

--- a/src/integrations/prefect-redis/prefect_redis/blocks.py
+++ b/src/integrations/prefect-redis/prefect_redis/blocks.py
@@ -63,11 +63,13 @@ class RedisDatabase(WritableFileSystem):
     ssl: bool = Field(default=False, description="Whether to use SSL")
     key_ttl: Optional[int] = Field(
         default=None,
+        gt=0,
         description=(
             "Optional per-key time-to-live in seconds, applied to every written "
-            "key (Redis `SET ... EX`). When `None` (the default) keys never "
-            "expire. Useful when using the block as `result_storage`/cache on a "
-            "Redis with a `maxmemory` + `volatile-lru` eviction policy."
+            "key (Redis `SET ... EX`). Must be positive; when `None` (the "
+            "default) keys never expire. Useful when using the block as "
+            "`result_storage`/cache on a Redis with a `maxmemory` + "
+            "`volatile-lru` eviction policy."
         ),
     )
 

--- a/src/integrations/prefect-redis/tests/test_blocks.py
+++ b/src/integrations/prefect-redis/tests/test_blocks.py
@@ -28,3 +28,18 @@ def test_as_connection_params():
     assert params == {"host": "localhost", "port": 6379, "db": 0, "ssl": False}
     assert "username" not in params
     assert "password" not in params
+    assert "key_ttl" not in params  # write behavior, not a connection param
+
+
+async def test_key_ttl_sets_expiry_on_written_keys(isolated_redis_db_number, redis):
+    block = RedisDatabase(
+        host="localhost", port=6379, db=isolated_redis_db_number, key_ttl=100
+    )
+    await block.write_path("ttl-key", b"value")
+    assert 0 < await redis.ttl("ttl-key") <= 100
+
+
+async def test_no_key_ttl_leaves_keys_without_expiry(isolated_redis_db_number, redis):
+    block = RedisDatabase(host="localhost", port=6379, db=isolated_redis_db_number)
+    await block.write_path("no-ttl-key", b"value")
+    assert await redis.ttl("no-ttl-key") == -1

--- a/src/integrations/prefect-redis/tests/test_blocks.py
+++ b/src/integrations/prefect-redis/tests/test_blocks.py
@@ -1,5 +1,6 @@
+import pytest
 from prefect_redis.blocks import RedisDatabase
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 
 def test_as_connection_params():
@@ -43,3 +44,10 @@ async def test_no_key_ttl_leaves_keys_without_expiry(isolated_redis_db_number, r
     block = RedisDatabase(host="localhost", port=6379, db=isolated_redis_db_number)
     await block.write_path("no-ttl-key", b"value")
     assert await redis.ttl("no-ttl-key") == -1
+
+
+@pytest.mark.parametrize("bad_ttl", [0, -1])
+def test_key_ttl_must_be_positive(bad_ttl):
+    # Redis rejects SET ... EX <= 0; fail fast at construction, not at write time.
+    with pytest.raises(ValidationError):
+        RedisDatabase(host="localhost", port=6379, key_ttl=bad_ttl)


### PR DESCRIPTION
closes #15530

Adds an optional `key_ttl` field to `RedisDatabase` so written keys can expire, addressing the long-standing request in #15530 (Redis result storage grows unbounded because expired cache entries are never reclaimed).

When `key_ttl` is set, every write uses `SET ... EX=<key_ttl>`; when it's `None` (the default), behavior is unchanged (keys never expire). This makes `RedisDatabase` practical as an ephemeral `result_storage`/cache on a Redis configured with `maxmemory` + a `volatile-lru` eviction policy.

<details>
<summary>Details</summary>

- `key_ttl: Optional[int] = None` — additive and non-breaking; default preserves today's behavior.
- `write_path` passes `ex=self.key_ttl` to `client.set` (`ex=None` is a no-op in redis-py, so no branching needed).
- Excluded from `as_connection_params` — it governs write behavior, not the connection, so it must not be passed as a client kwarg.
- Tests added in `tests/test_blocks.py`: a key written with `key_ttl=100` has a TTL in `(0, 100]`; without `key_ttl`, the key has no expiry (`ttl == -1`).
- Full `prefect-redis` suite passes (161 passed); `ruff check`/`ruff format` clean.

Note: this PR is independent of #22394 (the sync `result_storage` bugfix). They touch the same file; whichever merges second will need a trivial rebase, which I'm happy to do.

</details>
