### PR TITLE
Preserve a paused deployment schedule on redeploy

### DIFF
--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -159,41 +159,36 @@ class DeploymentScheduleCreate(ActionBaseModel):
     @classmethod
     def from_schedule(cls, schedule: Schedule) -> "DeploymentScheduleCreate":
         if schedule.interval is not None:
-            return cls(
-                schedule=IntervalSchedule(
-                    interval=schedule.interval,
-                    timezone=schedule.timezone,
-                    anchor_date=schedule.anchor_date,
-                ),
-                parameters=schedule.parameters,
-                active=schedule.active,
-                slug=schedule.slug,
+            inner_schedule = IntervalSchedule(
+                interval=schedule.interval,
+                timezone=schedule.timezone,
+                anchor_date=schedule.anchor_date,
             )
         elif schedule.cron is not None:
-            return cls(
-                schedule=CronSchedule(
-                    cron=schedule.cron,
-                    timezone=schedule.timezone,
-                    day_or=schedule.day_or,
-                ),
-                parameters=schedule.parameters,
-                active=schedule.active,
-                slug=schedule.slug,
+            inner_schedule = CronSchedule(
+                cron=schedule.cron,
+                timezone=schedule.timezone,
+                day_or=schedule.day_or,
             )
         elif schedule.rrule is not None:
-            return cls(
-                schedule=RRuleSchedule(
-                    rrule=schedule.rrule,
-                    timezone=schedule.timezone,
-                ),
-                parameters=schedule.parameters,
-                active=schedule.active,
-                slug=schedule.slug,
+            inner_schedule = RRuleSchedule(
+                rrule=schedule.rrule,
+                timezone=schedule.timezone,
             )
         else:
-            return cls(
-                schedule=NoSchedule(),
-            )
+            return cls(schedule=NoSchedule())
+
+        # Only forward `active` when the user set it explicitly. Leaving it
+        # unset lets a redeploy preserve a schedule that was paused server-side.
+        active_kwarg = (
+            {"active": schedule.active} if schedule.active is not None else {}
+        )
+        return cls(
+            schedule=inner_schedule,
+            parameters=schedule.parameters,
+            slug=schedule.slug,
+            **active_kwarg,
+        )
 
 
 class DeploymentScheduleUpdate(ActionBaseModel):

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -180,9 +180,7 @@ class DeploymentScheduleCreate(ActionBaseModel):
 
         # Only forward `active` when the user set it explicitly. Leaving it
         # unset lets a redeploy preserve a schedule that was paused server-side.
-        active_kwarg = (
-            {"active": schedule.active} if schedule.active is not None else {}
-        )
+        active_kwarg = {"active": schedule.active} if schedule._active_provided else {}
         return cls(
             schedule=inner_schedule,
             parameters=schedule.parameters,

--- a/src/prefect/deployments/schedules.py
+++ b/src/prefect/deployments/schedules.py
@@ -17,16 +17,17 @@ FlexibleScheduleList = Sequence[
 
 def create_deployment_schedule_create(
     schedule: Union["SCHEDULE_TYPES", "Schedule"],
-    active: Optional[bool] = True,
+    active: Optional[bool] = None,
 ) -> DeploymentScheduleCreate:
     """Create a DeploymentScheduleCreate object from common schedule parameters."""
 
     if isinstance(schedule, Schedule):
         return DeploymentScheduleCreate.from_schedule(schedule)
-    return DeploymentScheduleCreate(
-        schedule=schedule,
-        active=active if active is not None else True,
-    )
+    # Leave `active` unset when not provided so an update payload built with
+    # `exclude_unset=True` doesn't force a paused schedule back to active.
+    if active is None:
+        return DeploymentScheduleCreate(schedule=schedule)
+    return DeploymentScheduleCreate(schedule=schedule, active=active)
 
 
 def normalize_to_deployment_schedule(

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -35,7 +35,9 @@ class Schedule:
             This behaves like fcron and enables you to e.g. define a job that
             executes each 2nd friday of a month by setting the days of month and
             the weekday.
-        active: Whether or not the schedule is active.
+        active: Whether or not the schedule is active. If left unset, the
+            schedule is active when first created and keeps its existing
+            active state when an existing deployment is updated.
         parameters: A dictionary containing parameter overrides for the schedule.
         slug: A unique identifier for the schedule.
     """
@@ -48,7 +50,7 @@ class Schedule:
         default_factory=partial(datetime.datetime.now, tz=datetime.timezone.utc)
     )
     day_or: bool = True
-    active: bool = True
+    active: bool | None = None
     parameters: dict[str, Any] = dataclasses.field(default_factory=dict)
     slug: str | None = None
 
@@ -74,7 +76,7 @@ def Cron(
     /,
     timezone: str | None = None,
     day_or: bool = True,
-    active: bool = True,
+    active: bool | None = None,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,
 ) -> Schedule:
@@ -90,7 +92,9 @@ def Cron(
             This behaves like fcron and enables you to e.g. define a job that
             executes each 2nd friday of a month by setting the days of month and
             the weekday.
-        active: Whether or not the schedule is active.
+        active: Whether or not the schedule is active. If left unset, the
+            schedule is active when first created and keeps its existing
+            active state when an existing deployment is updated.
         parameters: A dictionary containing parameter overrides for the schedule.
         slug: A unique identifier for the schedule.
 
@@ -130,7 +134,7 @@ def Interval(
     /,
     anchor_date: datetime.datetime | None = None,
     timezone: str | None = None,
-    active: bool = True,
+    active: bool | None = None,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,
 ) -> Schedule:
@@ -142,7 +146,9 @@ def Interval(
             it will be interpreted as seconds.
         anchor_date: The anchor date to use for the schedule.
         timezone: A valid timezone string in IANA tzdata format (e.g. America/New_York).
-        active: Whether or not the schedule is active.
+        active: Whether or not the schedule is active. If left unset, the
+            schedule is active when first created and keeps its existing
+            active state when an existing deployment is updated.
         parameters: A dictionary containing parameter overrides for the schedule.
         slug: A unique identifier for the schedule.
 
@@ -188,7 +194,7 @@ def RRule(
     rrule: str,
     /,
     timezone: str | None = None,
-    active: bool = True,
+    active: bool | None = None,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,
 ) -> Schedule:
@@ -198,7 +204,9 @@ def RRule(
     Args:
         rrule: A valid RRule string (e.g. "RRULE:FREQ=DAILY;INTERVAL=1").
         timezone: A valid timezone string in IANA tzdata format (e.g. America/New_York).
-        active: Whether or not the schedule is active.
+        active: Whether or not the schedule is active. If left unset, the
+            schedule is active when first created and keeps its existing
+            active state when an existing deployment is updated.
         parameters: A dictionary containing parameter overrides for the schedule.
         slug: A unique identifier for the schedule.
 

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -15,6 +15,16 @@ from prefect._internal.schemas.validators import (
 )
 
 
+class _Unset:
+    """Sentinel for an `active` argument that was not explicitly provided."""
+
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_UNSET = _Unset()
+
+
 @dataclasses.dataclass(frozen=True)
 class Schedule:
     """
@@ -50,9 +60,13 @@ class Schedule:
         default_factory=partial(datetime.datetime.now, tz=datetime.timezone.utc)
     )
     day_or: bool = True
-    active: bool | None = None
+    active: bool = True
     parameters: dict[str, Any] = dataclasses.field(default_factory=dict)
     slug: str | None = None
+    # Internal: records whether `active` was set explicitly. The factories leave
+    # it False when `active` is omitted so a redeploy can preserve the schedule's
+    # server-side active state instead of forcing it back to True.
+    _active_provided: bool = dataclasses.field(default=True, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         defined_fields = [
@@ -76,7 +90,7 @@ def Cron(
     /,
     timezone: str | None = None,
     day_or: bool = True,
-    active: bool | None = None,
+    active: bool | _Unset = _UNSET,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,
 ) -> Schedule:
@@ -119,13 +133,18 @@ def Cron(
     """
     if parameters is None:
         parameters = {}
+    if isinstance(active, _Unset):
+        resolved_active, active_provided = True, False
+    else:
+        resolved_active, active_provided = active, True
     return Schedule(
         cron=cron,
         timezone=timezone,
         day_or=day_or,
-        active=active,
+        active=resolved_active,
         parameters=parameters,
         slug=slug,
+        _active_provided=active_provided,
     )
 
 
@@ -134,7 +153,7 @@ def Interval(
     /,
     anchor_date: datetime.datetime | None = None,
     timezone: str | None = None,
-    active: bool | None = None,
+    active: bool | _Unset = _UNSET,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,
 ) -> Schedule:
@@ -180,13 +199,18 @@ def Interval(
         anchor_date = datetime.datetime.now(tz=datetime.timezone.utc)
     if parameters is None:
         parameters = {}
+    if isinstance(active, _Unset):
+        resolved_active, active_provided = True, False
+    else:
+        resolved_active, active_provided = active, True
     return Schedule(
         interval=interval,
         anchor_date=anchor_date,
         timezone=timezone,
-        active=active,
+        active=resolved_active,
         parameters=parameters,
         slug=slug,
+        _active_provided=active_provided,
     )
 
 
@@ -194,7 +218,7 @@ def RRule(
     rrule: str,
     /,
     timezone: str | None = None,
-    active: bool | None = None,
+    active: bool | _Unset = _UNSET,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,
 ) -> Schedule:
@@ -230,10 +254,15 @@ def RRule(
     """
     if parameters is None:
         parameters = {}
+    if isinstance(active, _Unset):
+        resolved_active, active_provided = True, False
+    else:
+        resolved_active, active_provided = active, True
     return Schedule(
         rrule=rrule,
         timezone=timezone,
-        active=active,
+        active=resolved_active,
         parameters=parameters,
         slug=slug,
+        _active_provided=active_provided,
     )

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -198,9 +198,14 @@ async def create_deployment(
                 )
 
         right_now = now("UTC")
-        model = await models.deployments.create_deployment(
-            session=session, deployment=deployment
-        )
+        try:
+            model = await models.deployments.create_deployment(
+                session=session, deployment=deployment
+            )
+        except models.deployments.AmbiguousScheduleMatchError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            )
 
         if model.created >= right_now:
             response.status_code = status.HTTP_201_CREATED
@@ -393,11 +398,16 @@ async def update_deployment(
                     detail="Concurrency limit not found",
                 )
 
-        result = await models.deployments.update_deployment(
-            session=session,
-            deployment_id=deployment_id,
-            deployment=deployment,
-        )
+        try:
+            result = await models.deployments.update_deployment(
+                session=session,
+                deployment_id=deployment_id,
+                deployment=deployment,
+            )
+        except models.deployments.AmbiguousScheduleMatchError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            )
 
         # Phase 1: For schedules with `replaces`, look up the row ID by
         # old slug, then NULL out those slugs so the unique index on

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -6,6 +6,7 @@ Intended for internal use by the Prefect REST API.
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
@@ -276,13 +277,23 @@ def _schedule_match_key(slug: Optional[str], schedule: Any) -> str:
     """Build a stable key for matching an updated schedule to an existing one.
 
     Schedules carry a slug; slug-less schedules are matched on their
-    serialized definition so an unchanged schedule can be recognized across
-    a redeploy.
+    recurrence definition so an unchanged schedule can be recognized across a
+    redeploy. The match ignores fields Prefect regenerates during schedule
+    construction — an `IntervalSchedule`'s `anchor_date` and the `DTSTART`
+    injected into rrule strings (#21362) both drift over time even when the
+    user's schedule is unchanged.
     """
     if slug:
         return f"slug:{slug}"
-    definition = schedule.model_dump_json() if schedule is not None else "null"
-    return f"schedule:{definition}"
+    if schedule is None:
+        return "schedule:null"
+    definition = schedule.model_dump(mode="json", exclude={"anchor_date"})
+    rrule = definition.get("rrule")
+    if isinstance(rrule, str):
+        definition["rrule"] = "\n".join(
+            line for line in rrule.splitlines() if not line.startswith("DTSTART")
+        )
+    return f"schedule:{json.dumps(definition, sort_keys=True)}"
 
 
 def _resolve_schedule_active(

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -272,6 +272,35 @@ async def create_deployment(
     return result_deployment
 
 
+def _schedule_match_key(slug: Optional[str], schedule: Any) -> str:
+    """Build a stable key for matching an updated schedule to an existing one.
+
+    Schedules carry a slug; slug-less schedules are matched on their
+    serialized definition so an unchanged schedule can be recognized across
+    a redeploy.
+    """
+    if slug:
+        return f"slug:{slug}"
+    definition = schedule.model_dump_json() if schedule is not None else "null"
+    return f"schedule:{definition}"
+
+
+def _resolve_schedule_active(
+    schedule: "schemas.actions.DeploymentScheduleUpdate",
+    existing_active: dict[str, bool],
+) -> bool:
+    """Determine the active state for a schedule being recreated on update.
+
+    An explicit `active` always wins. When it's omitted, inherit the matching
+    existing schedule's state, falling back to active for a new schedule.
+    """
+    if schedule.active is not None:
+        return schedule.active
+    return existing_active.get(
+        _schedule_match_key(schedule.slug, schedule.schedule), True
+    )
+
+
 @db_injector
 async def update_deployment(
     db: PrefectDBInterface,
@@ -383,7 +412,15 @@ async def update_deployment(
 
     if should_update_schedules:
         # If schedules were provided, remove the existing schedules and
-        # replace them with the new ones.
+        # replace them with the new ones. An update that doesn't specify
+        # `active` should keep a matching schedule's current active state
+        # rather than silently re-activating one that was paused.
+        existing_active = {
+            _schedule_match_key(s.slug, s.schedule): s.active
+            for s in await read_deployment_schedules(
+                session=session, deployment_id=deployment_id
+            )
+        }
         await delete_schedules_for_deployment(
             session=session, deployment_id=deployment_id
         )
@@ -393,7 +430,7 @@ async def update_deployment(
             schedules=[
                 schemas.actions.DeploymentScheduleCreate(
                     schedule=schedule.schedule,
-                    active=schedule.active if schedule.active is not None else True,
+                    active=_resolve_schedule_active(schedule, existing_active),
                     parameters=schedule.parameters,
                     slug=schedule.slug,
                 )

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -218,6 +218,12 @@ async def create_deployment(
         future_only=True,
     )
 
+    # An upsert that doesn't specify `active` should keep a matching schedule's
+    # current active state rather than silently re-activating a paused one.
+    existing_active = _active_state_by_match_key(
+        await read_deployment_schedules(session=session, deployment_id=deployment_id)
+    )
+
     await delete_schedules_for_deployment(session=session, deployment_id=deployment_id)
 
     if schedules:
@@ -227,7 +233,7 @@ async def create_deployment(
             schedules=[
                 schemas.actions.DeploymentScheduleCreate(
                     schedule=schedule.schedule,
-                    active=schedule.active,
+                    active=_resolve_schedule_active(schedule, existing_active),
                     parameters=schedule.parameters,
                     slug=schedule.slug,
                 )
@@ -296,17 +302,44 @@ def _schedule_match_key(slug: Optional[str], schedule: Any) -> str:
     return f"schedule:{json.dumps(definition, sort_keys=True)}"
 
 
+class AmbiguousScheduleMatchError(ValueError):
+    """Raised when slug-less schedules can't be matched one-to-one on redeploy."""
+
+
+def _active_state_by_match_key(
+    schedules: Sequence[schemas.core.DeploymentSchedule],
+) -> dict[str, bool]:
+    """Map each existing schedule's match key to its active state.
+
+    Slug-less schedules can collide on their recurrence definition. Preserving
+    active state across such a collision would silently hand both schedules one
+    state, so an ambiguous match is rejected rather than guessed.
+    """
+    by_key: dict[str, bool] = {}
+    for schedule in schedules:
+        key = _schedule_match_key(schedule.slug, schedule.schedule)
+        if key in by_key:
+            raise AmbiguousScheduleMatchError(
+                "Cannot preserve the active state of multiple schedules that "
+                "share the same definition and have no slug. Assign a slug to "
+                "each schedule to disambiguate them."
+            )
+        by_key[key] = schedule.active
+    return by_key
+
+
 def _resolve_schedule_active(
-    schedule: "schemas.actions.DeploymentScheduleUpdate",
+    schedule: schemas.actions.DeploymentScheduleCreate
+    | schemas.actions.DeploymentScheduleUpdate,
     existing_active: dict[str, bool],
 ) -> bool:
-    """Determine the active state for a schedule being recreated on update.
+    """Determine the active state for a schedule being recreated on upsert.
 
     An explicit `active` always wins. When it's omitted, inherit the matching
     existing schedule's state, falling back to active for a new schedule.
     """
-    if schedule.active is not None:
-        return schedule.active
+    if "active" in schedule.model_fields_set:
+        return bool(schedule.active)
     return existing_active.get(
         _schedule_match_key(schedule.slug, schedule.schedule), True
     )
@@ -426,12 +459,11 @@ async def update_deployment(
         # replace them with the new ones. An update that doesn't specify
         # `active` should keep a matching schedule's current active state
         # rather than silently re-activating one that was paused.
-        existing_active = {
-            _schedule_match_key(s.slug, s.schedule): s.active
-            for s in await read_deployment_schedules(
+        existing_active = _active_state_by_match_key(
+            await read_deployment_schedules(
                 session=session, deployment_id=deployment_id
             )
-        }
+        )
         await delete_schedules_for_deployment(
             session=session, deployment_id=deployment_id
         )

--- a/tests/deployment/test_schedules.py
+++ b/tests/deployment/test_schedules.py
@@ -28,6 +28,35 @@ def test_create_deployment_schedule_create(active: Optional[bool], expected: boo
     assert schedule.active is expected
 
 
+def test_create_deployment_schedule_create_leaves_active_unset_by_default():
+    # When `active` isn't provided, it must stay out of the serialized update
+    # payload so a redeploy doesn't re-activate a paused schedule (#19302).
+    schedule = create_deployment_schedule_create(
+        schedule=CronSchedule(cron="0 0 * * *")
+    )
+    assert "active" not in schedule.model_fields_set
+    assert "active" not in schedule.model_dump(exclude_unset=True)
+
+
+@pytest.mark.parametrize("active", [True, False])
+def test_create_deployment_schedule_create_keeps_explicit_active(active: bool):
+    schedule = create_deployment_schedule_create(
+        schedule=CronSchedule(cron="0 0 * * *"), active=active
+    )
+    assert schedule.model_dump(exclude_unset=True)["active"] is active
+
+
+@pytest.mark.parametrize("active", [None, True, False])
+def test_normalize_schedule_wrapper_active(active: Optional[bool]):
+    from prefect.schedules import Cron
+
+    (normalized,) = normalize_to_deployment_schedule([Cron("0 0 * * *", active=active)])
+    if active is None:
+        assert "active" not in normalized.model_fields_set
+    else:
+        assert normalized.model_dump(exclude_unset=True)["active"] is active
+
+
 def test_normalize_none_returns_empty_list():
     assert normalize_to_deployment_schedule(None) == []
 

--- a/tests/deployment/test_schedules.py
+++ b/tests/deployment/test_schedules.py
@@ -46,15 +46,19 @@ def test_create_deployment_schedule_create_keeps_explicit_active(active: bool):
     assert schedule.model_dump(exclude_unset=True)["active"] is active
 
 
-@pytest.mark.parametrize("active", [None, True, False])
-def test_normalize_schedule_wrapper_active(active: Optional[bool]):
+def test_normalize_schedule_wrapper_omits_unset_active():
+    from prefect.schedules import Cron
+
+    (normalized,) = normalize_to_deployment_schedule([Cron("0 0 * * *")])
+    assert "active" not in normalized.model_fields_set
+
+
+@pytest.mark.parametrize("active", [True, False])
+def test_normalize_schedule_wrapper_keeps_explicit_active(active: bool):
     from prefect.schedules import Cron
 
     (normalized,) = normalize_to_deployment_schedule([Cron("0 0 * * *", active=active)])
-    if active is None:
-        assert "active" not in normalized.model_fields_set
-    else:
-        assert normalized.model_dump(exclude_unset=True)["active"] is active
+    assert normalized.model_dump(exclude_unset=True)["active"] is active
 
 
 def test_normalize_none_returns_empty_list():

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -3380,6 +3380,33 @@ class TestRunnerDeployment:
         assert deployment.paused is False
         assert deployment.global_concurrency_limit is None
 
+    async def test_apply_preserves_paused_slugless_schedule_on_redeploy(
+        self, prefect_client: PrefectClient
+    ):
+        # Regression test for https://github.com/PrefectHQ/prefect/issues/19302.
+        # Re-deploying a flow must not silently re-activate a slug-less schedule
+        # that was paused after the first deploy.
+        deployment = RunnerDeployment.from_flow(
+            dummy_flow_1, "test-19302", cron="10 * * * *"
+        )
+        deployment_id = await deployment.apply()
+
+        read = await prefect_client.read_deployment(deployment_id)
+        assert read.schedules[0].active is True
+        await prefect_client.update_deployment_schedule(
+            deployment_id, read.schedules[0].id, active=False
+        )
+
+        # Re-deploy with the same flow, name, and schedule and no explicit active.
+        redeploy = RunnerDeployment.from_flow(
+            dummy_flow_1, "test-19302", cron="10 * * * *"
+        )
+        assert await redeploy.apply() == deployment_id
+
+        read = await prefect_client.read_deployment(deployment_id)
+        assert len(read.schedules) == 1
+        assert read.schedules[0].active is False
+
     async def test_apply_with_work_pool(
         self, prefect_client: PrefectClient, work_pool, process_work_pool
     ):

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -2107,3 +2107,82 @@ class TestMarkDeploymentsNotReady:
         )
         await session.refresh(deployment)
         assert deployment.status == DeploymentStatus.NOT_READY
+
+
+class TestSchedulePreservationHelpers:
+    """Unit coverage for the slug-less active-state preservation on redeploy
+    (https://github.com/PrefectHQ/prefect/issues/19302)."""
+
+    @staticmethod
+    def _existing(cron: str, active: bool, slug=None):
+        return schemas.core.DeploymentSchedule(
+            id=uuid4(),
+            deployment_id=uuid4(),
+            schedule=schemas.schedules.CronSchedule(cron=cron),
+            active=active,
+            slug=slug,
+        )
+
+    def test_interval_match_key_ignores_regenerated_anchor(self):
+        from prefect.server.models.deployments import _schedule_match_key
+
+        key1 = _schedule_match_key(
+            None,
+            schemas.schedules.IntervalSchedule(interval=datetime.timedelta(hours=1)),
+        )
+        key2 = _schedule_match_key(
+            None,
+            schemas.schedules.IntervalSchedule(interval=datetime.timedelta(hours=1)),
+        )
+        assert key1 == key2
+
+    def test_ambiguous_slugless_schedules_rejected(self):
+        from prefect.server.models.deployments import (
+            AmbiguousScheduleMatchError,
+            _active_state_by_match_key,
+        )
+
+        with pytest.raises(AmbiguousScheduleMatchError):
+            _active_state_by_match_key(
+                [self._existing("0 0 * * *", True), self._existing("0 0 * * *", False)]
+            )
+
+    def test_distinct_schedules_map_to_their_active_state(self):
+        from prefect.server.models.deployments import _active_state_by_match_key
+
+        mapping = _active_state_by_match_key(
+            [self._existing("0 0 * * *", False), self._existing("30 0 * * *", True)]
+        )
+        assert len(mapping) == 2
+
+    def test_omitted_active_inherits_existing_paused_state(self):
+        from prefect.server.models.deployments import (
+            _resolve_schedule_active,
+            _schedule_match_key,
+        )
+
+        incoming = schemas.actions.DeploymentScheduleCreate(
+            schedule=schemas.schedules.CronSchedule(cron="0 0 * * *")
+        )
+        existing = {
+            _schedule_match_key(
+                None, schemas.schedules.CronSchedule(cron="0 0 * * *")
+            ): False
+        }
+        assert _resolve_schedule_active(incoming, existing) is False
+
+    def test_explicit_active_overrides_existing_state(self):
+        from prefect.server.models.deployments import _resolve_schedule_active
+
+        incoming = schemas.actions.DeploymentScheduleCreate(
+            schedule=schemas.schedules.CronSchedule(cron="0 0 * * *"), active=True
+        )
+        assert _resolve_schedule_active(incoming, {}) is True
+
+    def test_unmatched_schedule_defaults_to_active(self):
+        from prefect.server.models.deployments import _resolve_schedule_active
+
+        incoming = schemas.actions.DeploymentScheduleCreate(
+            schedule=schemas.schedules.CronSchedule(cron="0 0 * * *")
+        )
+        assert _resolve_schedule_active(incoming, {}) is True

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -2377,6 +2377,58 @@ class TestUpdateDeployment:
         assert len(response.json()["schedules"]) == 1
         assert response.json()["schedules"][0]["active"] is False
 
+    async def test_update_interval_schedule_without_slug_preserves_paused_state(
+        self,
+        client,
+        flow,
+    ):
+        """A paused slug-less interval schedule stays paused on redeploy even
+        though its `anchor_date` is regenerated each time (#19302)."""
+        create_schedule = schemas.schedules.IntervalSchedule(
+            interval=datetime.timedelta(hours=1)
+        )
+        data = DeploymentCreate(
+            name="My Deployment",
+            flow_id=flow.id,
+            schedules=[
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=create_schedule, active=True
+                ),
+            ],
+            enforce_parameter_schema=False,
+        ).model_dump(mode="json")
+
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+        schedule_id = response.json()["schedules"][0]["id"]
+
+        response = await client.patch(
+            f"/deployments/{deployment_id}/schedules/{schedule_id}",
+            json={"active": False},
+        )
+        assert response.status_code == 204
+
+        # A fresh IntervalSchedule gets a new anchor_date, mirroring what the
+        # client builds on each redeploy.
+        redeploy_schedule = schemas.schedules.IntervalSchedule(
+            interval=datetime.timedelta(hours=1)
+        )
+        assert redeploy_schedule.anchor_date != create_schedule.anchor_date
+        update_data = schemas.actions.DeploymentUpdate(
+            schedules=[
+                schemas.actions.DeploymentScheduleUpdate(schedule=redeploy_schedule)
+            ],
+        ).model_dump(mode="json", exclude_unset=True)
+
+        response = await client.patch(f"/deployments/{deployment_id}", json=update_data)
+        assert response.status_code == 204, response.text
+
+        response = await client.get(f"/deployments/{deployment_id}")
+        assert response.status_code == 200
+        assert len(response.json()["schedules"]) == 1
+        assert response.json()["schedules"][0]["active"] is False
+
     async def test_update_changed_slugless_schedule_defaults_to_active(
         self,
         client,

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -2330,6 +2330,89 @@ class TestUpdateDeployment:
         assert len(response.json()["schedules"]) == 1
         assert response.json()["schedules"][0]["active"] is True
 
+    async def test_update_schedule_without_slug_preserves_paused_state(
+        self,
+        client,
+        flow,
+    ):
+        """Regression test for https://github.com/PrefectHQ/prefect/issues/19302.
+
+        A slug-less schedule that has been paused stays paused when the
+        deployment is redeployed without an explicit `active` value.
+        """
+        schedule = schemas.schedules.CronSchedule(cron="10 * * * *")
+        data = DeploymentCreate(
+            name="My Deployment",
+            flow_id=flow.id,
+            schedules=[
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schedule, active=True
+                ),
+            ],
+            enforce_parameter_schema=False,
+        ).model_dump(mode="json")
+
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+        schedule_id = response.json()["schedules"][0]["id"]
+
+        # The user turns the schedule off, e.g. from the UI.
+        response = await client.patch(
+            f"/deployments/{deployment_id}/schedules/{schedule_id}",
+            json={"active": False},
+        )
+        assert response.status_code == 204
+
+        # Re-deploying with the same schedule and no `active` keeps it off.
+        update_data = schemas.actions.DeploymentUpdate(
+            schedules=[schemas.actions.DeploymentScheduleUpdate(schedule=schedule)],
+        ).model_dump(mode="json", exclude_unset=True)
+
+        response = await client.patch(f"/deployments/{deployment_id}", json=update_data)
+        assert response.status_code == 204, response.text
+
+        response = await client.get(f"/deployments/{deployment_id}")
+        assert response.status_code == 200
+        assert len(response.json()["schedules"]) == 1
+        assert response.json()["schedules"][0]["active"] is False
+
+    async def test_update_changed_slugless_schedule_defaults_to_active(
+        self,
+        client,
+        flow,
+    ):
+        """A slug-less schedule whose definition changes is treated as new and
+        defaults to active, even if the previous one was paused (#19302)."""
+        schedule1 = schemas.schedules.CronSchedule(cron="10 * * * *")
+        schedule2 = schemas.schedules.CronSchedule(cron="20 * * * *")
+        data = DeploymentCreate(
+            name="My Deployment",
+            flow_id=flow.id,
+            schedules=[
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schedule1, active=False
+                ),
+            ],
+            enforce_parameter_schema=False,
+        ).model_dump(mode="json")
+
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+
+        update_data = schemas.actions.DeploymentUpdate(
+            schedules=[schemas.actions.DeploymentScheduleUpdate(schedule=schedule2)],
+        ).model_dump(mode="json", exclude_unset=True)
+
+        response = await client.patch(f"/deployments/{deployment_id}", json=update_data)
+        assert response.status_code == 204, response.text
+
+        response = await client.get(f"/deployments/{deployment_id}")
+        assert response.status_code == 200
+        assert len(response.json()["schedules"]) == 1
+        assert response.json()["schedules"][0]["active"] is True
+
     async def test_update_deployment_with_multiple_schedules_and_existing_slugs_422(
         self,
         client,

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -2465,6 +2465,89 @@ class TestUpdateDeployment:
         assert len(response.json()["schedules"]) == 1
         assert response.json()["schedules"][0]["active"] is True
 
+    async def test_upsert_via_post_preserves_paused_slugless_schedule(
+        self,
+        client,
+        flow,
+    ):
+        """Re-deploying through the POST upsert path (not PATCH) must also keep a
+        paused slug-less schedule paused (#19302)."""
+        schedule = schemas.schedules.CronSchedule(cron="10 * * * *")
+        data = DeploymentCreate(
+            name="My Deployment",
+            flow_id=flow.id,
+            schedules=[
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schedule, active=True
+                ),
+            ],
+            enforce_parameter_schema=False,
+        ).model_dump(mode="json")
+
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+        schedule_id = response.json()["schedules"][0]["id"]
+
+        response = await client.patch(
+            f"/deployments/{deployment_id}/schedules/{schedule_id}",
+            json={"active": False},
+        )
+        assert response.status_code == 204
+
+        # Upsert the same deployment without an explicit `active`.
+        upsert_data = DeploymentCreate(
+            name="My Deployment",
+            flow_id=flow.id,
+            schedules=[schemas.actions.DeploymentScheduleCreate(schedule=schedule)],
+            enforce_parameter_schema=False,
+        ).model_dump(mode="json", exclude_unset=True)
+
+        # 200, not 201: the upsert keeps the original `created` timestamp, so the
+        # route treats it as an update of the existing deployment.
+        response = await client.post("/deployments/", json=upsert_data)
+        assert response.status_code == 200, response.text
+        assert response.json()["id"] == deployment_id
+
+        response = await client.get(f"/deployments/{deployment_id}")
+        assert response.status_code == 200
+        assert len(response.json()["schedules"]) == 1
+        assert response.json()["schedules"][0]["active"] is False
+
+    async def test_redeploy_ambiguous_slugless_schedules_returns_422(
+        self,
+        client,
+        flow,
+    ):
+        """Two slug-less schedules that share a definition can't be matched
+        one-to-one on redeploy, so the request is rejected rather than guessing
+        which active state to preserve (#19302)."""
+        schedule = schemas.schedules.CronSchedule(cron="10 * * * *")
+        data = DeploymentCreate(
+            name="My Deployment",
+            flow_id=flow.id,
+            schedules=[
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schedule, active=True
+                ),
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schedule, active=False
+                ),
+            ],
+            enforce_parameter_schema=False,
+        ).model_dump(mode="json")
+
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+
+        update_data = schemas.actions.DeploymentUpdate(
+            schedules=[schemas.actions.DeploymentScheduleUpdate(schedule=schedule)],
+        ).model_dump(mode="json", exclude_unset=True)
+
+        response = await client.patch(f"/deployments/{deployment_id}", json=update_data)
+        assert response.status_code == 422
+
     async def test_update_deployment_with_multiple_schedules_and_existing_slugs_422(
         self,
         client,

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -29,7 +29,7 @@ class TestSchedule:
         assert schedule.timezone is None
         assert isinstance(schedule.anchor_date, datetime.datetime)
         assert schedule.day_or is True
-        assert schedule.active is True
+        assert schedule.active is None
         assert schedule.parameters == {}
 
 
@@ -39,7 +39,7 @@ class TestCronSchedule:
         assert schedule.cron == "0 0 * * *"
         assert schedule.timezone is None
         assert schedule.day_or is True
-        assert schedule.active is True
+        assert schedule.active is None
         assert schedule.parameters == {}
 
     def test_cron_schedule_with_all_parameters(self):
@@ -65,7 +65,7 @@ class TestIntervalSchedule:
         assert schedule.interval == interval
         assert isinstance(schedule.anchor_date, datetime.datetime)
         assert schedule.timezone is None
-        assert schedule.active is True
+        assert schedule.active is None
         assert schedule.parameters == {}
 
     def test_interval_schedule_with_seconds(self):
@@ -91,7 +91,7 @@ class TestRRuleSchedule:
         schedule = RRule(rrule)
         assert schedule.rrule == rrule
         assert schedule.timezone is None
-        assert schedule.active is True
+        assert schedule.active is None
         assert schedule.parameters == {}
 
     def test_rrule_schedule_with_all_parameters(self):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -29,7 +29,7 @@ class TestSchedule:
         assert schedule.timezone is None
         assert isinstance(schedule.anchor_date, datetime.datetime)
         assert schedule.day_or is True
-        assert schedule.active is None
+        assert schedule.active is True
         assert schedule.parameters == {}
 
 
@@ -39,7 +39,7 @@ class TestCronSchedule:
         assert schedule.cron == "0 0 * * *"
         assert schedule.timezone is None
         assert schedule.day_or is True
-        assert schedule.active is None
+        assert schedule.active is True
         assert schedule.parameters == {}
 
     def test_cron_schedule_with_all_parameters(self):
@@ -65,7 +65,7 @@ class TestIntervalSchedule:
         assert schedule.interval == interval
         assert isinstance(schedule.anchor_date, datetime.datetime)
         assert schedule.timezone is None
-        assert schedule.active is None
+        assert schedule.active is True
         assert schedule.parameters == {}
 
     def test_interval_schedule_with_seconds(self):
@@ -91,7 +91,7 @@ class TestRRuleSchedule:
         schedule = RRule(rrule)
         assert schedule.rrule == rrule
         assert schedule.timezone is None
-        assert schedule.active is None
+        assert schedule.active is True
         assert schedule.parameters == {}
 
     def test_rrule_schedule_with_all_parameters(self):


### PR DESCRIPTION
closes #19302

Pause a deployment schedule, re-`.deploy()` without passing `active`, and it silently turns back on (only for slug-less schedules).

Two things combine, so the fix is on both sides. The client always sent `active=True` when the caller didn't set it, so the `exclude_unset=True` payload still carried it. And on update the server rebuilds slug-less schedules from scratch and defaulted `active` to `True`. (OSS resets too; the slug workaround in the issue looks Cloud-specific.)

### What changed

`active` is left unset when the caller doesn't pass it (the deployment-schedule builders and the `Schedule`/`Cron`/`Interval`/`RRule` factories), so an update no longer forces `True`. On update the server keeps the existing schedule's `active` when none is given, matched by slug or, for slug-less ones, by serialized definition. New/changed schedules still default to active; an explicit `active=` still wins. Added tests for the paused-on-redeploy case (slug + slug-less, client + server); existing suites pass.

<details>
<summary>Design note — your call</summary>

This flips the default of `Schedule.active` (and the factory `active` params) from `True` to `None`. Create behavior is unchanged (unset still resolves to `True` on create); `None` just means "leave active alone on update", but it's a public default change. The bigger alternative is fully idempotent reconciliation, larger and overlapping with the slug-rename work in #19298.
</details>