### PR TITLE
fix: support setting logging.yml overrides via prefect config set

### DIFF
--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -248,6 +248,13 @@ def view(
     context = prefect.context.get_settings_context()
     current_profile_settings = context.profile.settings
 
+    valid_logging_overrides = _valid_logging_override_names()
+    profile_override_names = {
+        setting.name
+        for setting in current_profile_settings
+        if setting.name.startswith("PREFECT_LOGGING_")
+    }
+
     ui_url = get_current_settings().ui_url
 
     if ui_url and not (output and output.lower() == "json"):
@@ -329,6 +336,18 @@ def view(
         if (env_value := os.getenv(setting.name)) is None:
             continue
         _process_setting(setting, env_value, "env")
+
+    # Custom logging overrides set via environment variables. The environment takes
+    # precedence over the profile at runtime, so surface it here first (later sources
+    # skip names already processed) to keep the displayed source accurate.
+    for env_name, env_value in os.environ.items():
+        upper = env_name.upper()
+        if not upper.startswith("PREFECT_LOGGING_"):
+            continue
+        if upper in valid_setting_names or upper in processed_settings:
+            continue
+        if upper in valid_logging_overrides or upper in profile_override_names:
+            _process_setting(_logging_override_setting(upper), env_value, "env")
 
     # .env file
     for key, value in (dotenv_values(".env") if Path(".env").is_file() else {}).items():

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -32,6 +32,31 @@ config_app: cyclopts.App = cyclopts.App(
 )
 
 
+def _valid_logging_override_names() -> frozenset[str]:
+    """Valid `PREFECT_LOGGING_*` override keys derived from the logging config file.
+
+    Lazily parses the logging configuration file (CLI-only, cached) so logging.yml
+    keys such as `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL` can be set via
+    `prefect config set`.
+    """
+    from prefect.logging.configuration import (
+        DEFAULT_LOGGING_SETTINGS_PATH,
+        get_valid_setting_overrides,
+    )
+
+    names: set[str] = set(get_valid_setting_overrides(DEFAULT_LOGGING_SETTINGS_PATH))
+    configured = get_current_settings().logging.config_path
+    if configured and Path(configured).exists():
+        names |= get_valid_setting_overrides(Path(configured))
+    return frozenset(names)
+
+
+def _logging_override_setting(name: str) -> Setting:
+    """Build a `Setting` wrapper for a logging override key so it round-trips through
+    profiles and `prefect config view` without being treated as a string."""
+    return Setting(name=name, default=None, type_=str)
+
+
 @config_app.command(name="set")
 def set_(
     settings: Annotated[
@@ -42,6 +67,7 @@ def set_(
     Change the value for a setting by setting the value in the current profile.
     """
     valid_setting_names = _get_valid_setting_names(Settings)
+    valid_logging_overrides = _valid_logging_override_names()
     parsed_settings: dict[Union[str, Setting], Any] = {}
 
     for item in settings:
@@ -52,16 +78,17 @@ def set_(
                 f"Failed to parse argument {item!r}. Use the format 'VAR=VAL'."
             )
 
-        if setting not in valid_setting_names:
+        if setting in valid_setting_names:
+            if setting in {"PREFECT_HOME", "PREFECT_PROFILES_PATH"}:
+                exit_with_error(
+                    f"Setting {setting!r} cannot be changed with this command. "
+                    "Use an environment variable instead."
+                )
+            parsed_settings[setting] = value
+        elif setting in valid_logging_overrides:
+            parsed_settings[_logging_override_setting(setting)] = value
+        else:
             exit_with_error(f"Unknown setting name {setting!r}.")
-
-        if setting in {"PREFECT_HOME", "PREFECT_PROFILES_PATH"}:
-            exit_with_error(
-                f"Setting {setting!r} cannot be changed with this command. "
-                "Use an environment variable instead."
-            )
-
-        parsed_settings[setting] = value
 
     try:
         new_profile = prefect.settings.update_current_profile(parsed_settings)
@@ -76,11 +103,12 @@ def set_(
         exit_with_error(help_message)
 
     for setting, value in parsed_settings.items():
-        _cli.console.print(f"Set {setting!r} to {value!r}.")
-        if setting in os.environ:
+        name = setting.name if isinstance(setting, Setting) else setting
+        _cli.console.print(f"Set {name!r} to {value!r}.")
+        if name in os.environ:
             _cli.console.print(
-                f"[yellow]{setting} is also set by an environment variable which will "
-                f"override your config value. Run `unset {setting}` to clear it."
+                f"[yellow]{name} is also set by an environment variable which will "
+                f"override your config value. Run `unset {name}` to clear it."
             )
 
     exit_with_success(f"Updated profile {new_profile.name!r}.")
@@ -118,15 +146,19 @@ def unset(
     Removes the setting from the current profile.
     """
     valid_setting_names = _get_valid_setting_names(Settings)
+    valid_logging_overrides = _valid_logging_override_names()
     settings_context = prefect.context.get_settings_context()
     profiles = prefect.settings.load_profiles()
     profile = profiles[settings_context.profile.name]
     parsed: set[Setting] = set()
 
     for setting_name in setting_names:
-        if setting_name not in valid_setting_names:
+        if setting_name in valid_setting_names:
+            parsed.add(_get_settings_fields(Settings)[setting_name])
+        elif setting_name in valid_logging_overrides:
+            parsed.add(_logging_override_setting(setting_name))
+        else:
             exit_with_error(f"Unknown setting name {setting_name!r}.")
-        parsed.add(_get_settings_fields(Settings)[setting_name])
 
     for setting in parsed:
         if setting not in profile.settings:

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -35,20 +35,23 @@ config_app: cyclopts.App = cyclopts.App(
 def _valid_logging_override_names() -> frozenset[str]:
     """Valid `PREFECT_LOGGING_*` override keys derived from the logging config file.
 
-    Lazily parses the logging configuration file (CLI-only, cached) so logging.yml
-    keys such as `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL` can be set via
-    `prefect config set`.
+    Mirrors the runtime file selection in `setup_logging`: the custom logging config
+    file is used if it exists, otherwise the packaged default — the two are never
+    merged (see `prefect.logging.configuration.setup_logging`). Lazily parses that
+    single file (CLI-only, cached).
     """
     from prefect.logging.configuration import (
         DEFAULT_LOGGING_SETTINGS_PATH,
         get_valid_setting_overrides,
     )
 
-    names: set[str] = set(get_valid_setting_overrides(DEFAULT_LOGGING_SETTINGS_PATH))
     configured = get_current_settings().logging.config_path
-    if configured and Path(configured).exists():
-        names |= get_valid_setting_overrides(Path(configured))
-    return frozenset(names)
+    path = (
+        Path(configured)
+        if configured and Path(configured).exists()
+        else DEFAULT_LOGGING_SETTINGS_PATH
+    )
+    return get_valid_setting_overrides(path)
 
 
 def _logging_override_setting(name: str) -> Setting:
@@ -311,6 +314,25 @@ def view(
         source: Literal["prefect.toml", "pyproject.toml"],
     ):
         for key, value in settings.items():
+            if (
+                base_path == ["logging"]
+                and key == "overrides"
+                and isinstance(value, dict)
+            ):
+                # `[logging.overrides]` table — each entry is a custom PREFECT_LOGGING_*
+                # override key rather than a declared setting.
+                for override_key, override_value in cast(dict[str, Any], value).items():
+                    upper = override_key.upper()
+                    if upper in valid_setting_names or upper in processed_settings:
+                        continue
+                    if (
+                        upper in valid_logging_overrides
+                        or upper in profile_override_names
+                    ):
+                        _process_setting(
+                            _logging_override_setting(upper), override_value, source
+                        )
+                continue
             if isinstance(value, dict):
                 _process_toml_settings(
                     cast(dict[str, Any], value), base_path + [key], source

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -151,11 +151,17 @@ def unset(
     profiles = prefect.settings.load_profiles()
     profile = profiles[settings_context.profile.name]
     parsed: set[Setting] = set()
+    profile_setting_names = {setting.name for setting in profile.settings}
 
     for setting_name in setting_names:
         if setting_name in valid_setting_names:
             parsed.add(_get_settings_fields(Settings)[setting_name])
-        elif setting_name in valid_logging_overrides:
+        elif setting_name in valid_logging_overrides or (
+            setting_name.startswith("PREFECT_LOGGING_")
+            and setting_name in profile_setting_names
+        ):
+            # Always allow removing a stored logging override, even if it is no longer
+            # a valid override key (e.g. the logging config file changed).
             parsed.add(_logging_override_setting(setting_name))
         else:
             exit_with_error(f"Unknown setting name {setting_name!r}.")

--- a/src/prefect/logging/configuration.py
+++ b/src/prefect/logging/configuration.py
@@ -6,7 +6,7 @@ import os
 import re
 import string
 import warnings
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import Any, Callable
 
@@ -45,14 +45,16 @@ def load_logging_config(path: Path) -> dict[str, Any]:
             )
         )
 
-    # Load overrides from the environment
+    # Load overrides from the environment and from settings (profiles/config files)
     flat_config = dict_to_flatdict(config)
+    setting_overrides = current_settings.logging.overrides
 
     for key_tup, val in flat_config.items():
-        env_val = os.environ.get(
-            # Generate a valid environment variable with nesting indicated with '_'
-            to_envvar("PREFECT_LOGGING_" + "_".join(key_tup)).upper()
-        )
+        env_var = to_envvar("PREFECT_LOGGING_" + "_".join(key_tup)).upper()
+        # Generate a valid environment variable with nesting indicated with '_'
+        env_val = os.environ.get(env_var)
+        if env_val is None:
+            env_val = setting_overrides.get(env_var)
         if env_val:
             if isinstance(val, list):
                 val = env_val.split(",")
@@ -63,6 +65,27 @@ def load_logging_config(path: Path) -> dict[str, Any]:
         flat_config[key_tup] = val
 
     return flatdict_to_dict(flat_config)
+
+
+@lru_cache(maxsize=8)
+def get_valid_setting_overrides(path: Path) -> frozenset[str]:
+    """Return the set of valid `PREFECT_LOGGING_*` override names for a logging
+    configuration file.
+
+    These correspond to every nested key in the logging configuration file
+    (logging.yml), e.g. `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL`. Used by the
+    CLI to validate `prefect config set` keys. The file is parsed lazily (only when
+    this is called) and the result is cached, so it never runs on import.
+    """
+    if not path.exists():
+        return frozenset()
+    config = yaml.safe_load(path.read_text())
+    if not isinstance(config, dict):
+        return frozenset()
+    return frozenset(
+        to_envvar("PREFECT_LOGGING_" + "_".join(key_tup)).upper()
+        for key_tup in dict_to_flatdict(config)
+    )
 
 
 def ensure_logging_setup() -> None:

--- a/src/prefect/settings/_types.py
+++ b/src/prefect/settings/_types.py
@@ -41,6 +41,7 @@ SettingAccessor: TypeAlias = Literal[
     "logging.level",
     "logging.log_prints",
     "logging.markup",
+    "logging.overrides",
     "logging.to_api.batch_interval",
     "logging.to_api.batch_size",
     "logging.to_api.enabled",

--- a/src/prefect/settings/models/logging.py
+++ b/src/prefect/settings/models/logging.py
@@ -17,7 +17,10 @@ from pydantic_settings import (
 from typing_extensions import Self
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
-from prefect.settings.sources import LoggingOverridesSource
+from prefect.settings.sources import (
+    EnvLoggingOverridesSource,
+    ProfileLoggingOverridesSource,
+)
 from prefect.types import LogLevel, validate_set_T_from_delim_string
 
 from ._defaults import default_logging_config_path
@@ -178,4 +181,18 @@ class LoggingSettings(PrefectBaseSettings):
             dotenv_settings,
             file_secret_settings,
         )
-        return (*sources, LoggingOverridesSource(settings_cls))
+        # Collect PREFECT_LOGGING_* override keys at their matching precedence tiers so the
+        # `overrides` dict merges per key (via pydantic's deep_update) as
+        # env > prefect.toml > pyproject.toml > profile. prefect.toml / pyproject.toml
+        # overrides are handled natively by the TOML sources via `[logging.overrides]`.
+        # `sources` is ordered highest→lowest priority:
+        #   (init, env, dotenv, file_secret, prefect.toml, pyproject.toml, profile)
+        env_source = EnvLoggingOverridesSource(settings_cls)
+        profile_source = ProfileLoggingOverridesSource(settings_cls)
+        return (
+            sources[0],  # init
+            sources[1],  # env
+            env_source,  # env-tier logging overrides
+            *sources[2:],  # dotenv, file_secret, prefect.toml, pyproject.toml, profile
+            profile_source,  # profile-tier logging overrides (lowest)
+        )

--- a/src/prefect/settings/models/logging.py
+++ b/src/prefect/settings/models/logging.py
@@ -9,10 +9,15 @@ from pydantic import (
     Field,
     model_validator,
 )
-from pydantic_settings import SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 from typing_extensions import Self
 
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
+from prefect.settings.sources import LoggingOverridesSource
 from prefect.types import LogLevel, validate_set_T_from_delim_string
 
 from ._defaults import default_logging_config_path
@@ -145,3 +150,32 @@ class LoggingSettings(PrefectBaseSettings):
         default_factory=LoggingToAPISettings,
         description="Settings for controlling logging to the API",
     )
+
+    overrides: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Overrides for individual keys in the logging configuration file "
+            "(logging.yml), keyed by their full `PREFECT_LOGGING_*` environment "
+            "variable name (e.g. `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL`). "
+            "Populated from environment variables, profiles, and config files; not "
+            "intended to be set directly."
+        ),
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        sources = super().settings_customise_sources(
+            settings_cls,
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+        )
+        return (*sources, LoggingOverridesSource(settings_cls))

--- a/src/prefect/settings/profiles.py
+++ b/src/prefect/settings/profiles.py
@@ -37,15 +37,19 @@ def _cast_settings(
         raise ValueError("Settings must be a dictionary.")
     casted_settings = {}
     for k, value in settings.items():
-        try:
-            if isinstance(k, str):
-                setting = _get_settings_fields(Settings)[k]
-            else:
-                setting = k
-            casted_settings[setting] = value
-        except KeyError as e:
-            warnings.warn(f"Setting {e} is not recognized")
+        if not isinstance(k, str):
+            casted_settings[k] = value
             continue
+        setting = _get_settings_fields(Settings).get(k)
+        if setting is not None:
+            casted_settings[setting] = value
+        elif k.upper().startswith("PREFECT_LOGGING_"):
+            # Custom logging overrides (e.g. PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL)
+            # map into logging.yml rather than a declared setting field. Wrap them so they
+            # round-trip through profiles and `prefect config view` without warning.
+            casted_settings[Setting(name=k, default=None, type_=str)] = value
+        else:
+            warnings.warn(f"Setting '{k}' is not recognized")
     return casted_settings
 
 

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import warnings
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, get_origin
 
@@ -334,12 +335,14 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSourceBase):
             self.toml_data: dict[str, Any] = self.toml_data.get(key, {})
 
 
-def _declared_env_names(settings_cls: Type[BaseSettings]) -> set[str]:
+@lru_cache(maxsize=None)
+def _declared_env_names(settings_cls: Type[BaseSettings]) -> frozenset[str]:
     """Environment variable names that map to declared fields of a settings model.
 
     Walks nested settings models so that, e.g., `LoggingToAPISettings` fields are
     included. Used to distinguish declared logging settings from arbitrary
-    `PREFECT_LOGGING_*` override keys.
+    `PREFECT_LOGGING_*` override keys. Cached per settings class since the field set
+    is static.
     """
     names: set[str] = set()
     prefix = settings_cls.model_config.get("env_prefix", "") or ""
@@ -354,7 +357,7 @@ def _declared_env_names(settings_cls: Type[BaseSettings]) -> set[str]:
             for choice in alias.choices:
                 if isinstance(choice, str):
                     names.add(choice.upper())
-    return names
+    return frozenset(names)
 
 
 class LoggingOverridesSource(PydanticBaseSettingsSource):

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -3,7 +3,18 @@ import sys
 import warnings
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, get_origin
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    get_origin,
+)
 
 import dotenv
 from cachetools import TTLCache
@@ -360,17 +371,22 @@ def _declared_env_names(settings_cls: Type[BaseSettings]) -> frozenset[str]:
     return frozenset(names)
 
 
-class LoggingOverridesSource(PydanticBaseSettingsSource):
-    """Collect `PREFECT_LOGGING_*` keys that do not map to a declared field into the
-    `overrides` field.
+class _LoggingOverridesSource(PydanticBaseSettingsSource):
+    """Base source that collects `PREFECT_LOGGING_*` keys which do not map to a declared
+    field into the `overrides` field.
 
     This lets logging configuration file (logging.yml) paths such as
-    `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL` be configured through the
-    settings system (environment variables and profiles) and show up in
-    `get_current_settings()` / `prefect config view`.
+    `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL` be configured through the settings
+    system and show up in `get_current_settings()` / `prefect config view`.
 
-    Only cheap key filtering is performed here; the logging configuration file is
-    never read or parsed at this layer.
+    Subclasses provide the origin to read from. Each origin is a separate source so it can
+    be placed at the correct precedence tier (environment vs. profile); pydantic-settings
+    then merges the `overrides` dict per key via `deep_update`, giving environment values
+    precedence over `prefect.toml`/`pyproject.toml` (native `[logging.overrides]`) over the
+    profile — matching the standard settings precedence.
+
+    Only cheap key filtering is performed here; the logging configuration file is never read
+    or parsed at this layer.
     """
 
     def __init__(self, settings_cls: Type[BaseSettings]):
@@ -386,29 +402,34 @@ class LoggingOverridesSource(PydanticBaseSettingsSource):
     def _is_override_key(self, key: str) -> bool:
         return key.startswith("PREFECT_LOGGING_") and key not in self._declared
 
-    def _collect(self) -> Dict[str, str]:
+    def _items(self) -> Iterable[Tuple[str, Any]]:
+        """Return the (key, value) pairs from this source's origin."""
+        raise NotImplementedError
+
+    def __call__(self) -> Dict[str, Any]:
         overrides: Dict[str, str] = {}
-        # Lower priority: profile settings (config set writes here)
-        try:
-            profile_settings = ProfileSettingsTomlLoader(
-                self.settings_cls
-            ).profile_settings
-        except Exception:
-            profile_settings = {}
-        for key, value in profile_settings.items():
+        for key, value in self._items():
             upper = key.upper()
             if self._is_override_key(upper):
                 overrides[upper] = str(value)
-        # Higher priority: environment variables override profile values
-        for key, value in os.environ.items():
-            upper = key.upper()
-            if self._is_override_key(upper):
-                overrides[upper] = value
-        return overrides
-
-    def __call__(self) -> Dict[str, Any]:
-        overrides = self._collect()
         return {"overrides": overrides} if overrides else {}
+
+
+class EnvLoggingOverridesSource(_LoggingOverridesSource):
+    """Collect logging overrides from environment variables (environment priority tier)."""
+
+    def _items(self) -> Iterable[Tuple[str, Any]]:
+        return os.environ.items()
+
+
+class ProfileLoggingOverridesSource(_LoggingOverridesSource):
+    """Collect logging overrides from the active profile (profile priority tier)."""
+
+    def _items(self) -> Iterable[Tuple[str, Any]]:
+        try:
+            return ProfileSettingsTomlLoader(self.settings_cls).profile_settings.items()
+        except Exception:
+            return ()
 
 
 def _is_test_mode() -> bool:

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -334,6 +334,80 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSourceBase):
             self.toml_data: dict[str, Any] = self.toml_data.get(key, {})
 
 
+def _declared_env_names(settings_cls: Type[BaseSettings]) -> set[str]:
+    """Environment variable names that map to declared fields of a settings model.
+
+    Walks nested settings models so that, e.g., `LoggingToAPISettings` fields are
+    included. Used to distinguish declared logging settings from arbitrary
+    `PREFECT_LOGGING_*` override keys.
+    """
+    names: set[str] = set()
+    prefix = settings_cls.model_config.get("env_prefix", "") or ""
+    for field_name, field in settings_cls.model_fields.items():
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, BaseSettings):
+            names |= _declared_env_names(annotation)
+            continue
+        names.add(f"{prefix}{field_name}".upper())
+        alias = field.validation_alias
+        if isinstance(alias, AliasChoices):
+            for choice in alias.choices:
+                if isinstance(choice, str):
+                    names.add(choice.upper())
+    return names
+
+
+class LoggingOverridesSource(PydanticBaseSettingsSource):
+    """Collect `PREFECT_LOGGING_*` keys that do not map to a declared field into the
+    `overrides` field.
+
+    This lets logging configuration file (logging.yml) paths such as
+    `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL` be configured through the
+    settings system (environment variables and profiles) and show up in
+    `get_current_settings()` / `prefect config view`.
+
+    Only cheap key filtering is performed here; the logging configuration file is
+    never read or parsed at this layer.
+    """
+
+    def __init__(self, settings_cls: Type[BaseSettings]):
+        super().__init__(settings_cls)
+        self.settings_cls = settings_cls
+        self._declared = _declared_env_names(settings_cls)
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        return None, field_name, False
+
+    def _is_override_key(self, key: str) -> bool:
+        return key.startswith("PREFECT_LOGGING_") and key not in self._declared
+
+    def _collect(self) -> Dict[str, str]:
+        overrides: Dict[str, str] = {}
+        # Lower priority: profile settings (config set writes here)
+        try:
+            profile_settings = ProfileSettingsTomlLoader(
+                self.settings_cls
+            ).profile_settings
+        except Exception:
+            profile_settings = {}
+        for key, value in profile_settings.items():
+            upper = key.upper()
+            if self._is_override_key(upper):
+                overrides[upper] = str(value)
+        # Higher priority: environment variables override profile values
+        for key, value in os.environ.items():
+            upper = key.upper()
+            if self._is_override_key(upper):
+                overrides[upper] = value
+        return overrides
+
+    def __call__(self) -> Dict[str, Any]:
+        overrides = self._collect()
+        return {"overrides": overrides} if overrides else {}
+
+
 def _is_test_mode() -> bool:
     """Check if the current process is in test mode."""
     return bool(

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -229,6 +229,25 @@ def test_unset_logging_override():
     )
 
 
+def test_unset_stored_logging_override_that_is_no_longer_valid():
+    """A stored logging override can always be removed, even if it is no longer a valid
+    override key (e.g. the logging config file changed)."""
+    stale_key = "PREFECT_LOGGING_LOGGERS_SOME_REMOVED_LOGGER_LEVEL"
+    save_profiles(
+        ProfilesCollection(
+            [Profile(name="foo", settings={stale_key: "ERROR"})], active=None
+        )
+    )
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "unset", stale_key, "-y"],
+        expected_output_contains=f"Unset '{stale_key}'.",
+    )
+
+    profiles = load_profiles()
+    assert all(setting.name != stale_key for setting in profiles["foo"].settings)
+
+
 def test_set_multiple_settings():
     save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -211,6 +211,35 @@ def test_view_shows_logging_override():
     )
 
 
+def test_view_shows_env_precedence_for_logging_override(monkeypatch):
+    """When a logging override is set in both the profile and the environment,
+    `config view` shows the environment value and source, matching runtime precedence.
+    """
+    save_profiles(
+        ProfilesCollection(
+            [Profile(name="foo", settings={LOGGING_OVERRIDE_KEY: "WARNING"})],
+            active=None,
+        )
+    )
+    monkeypatch.setenv(LOGGING_OVERRIDE_KEY, "ERROR")
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "view"],
+        expected_output_contains=f"{LOGGING_OVERRIDE_KEY}='ERROR' (from env)",
+    )
+
+
+def test_view_shows_logging_override_set_only_in_env(monkeypatch):
+    """A logging override present only in the environment is shown by `config view`."""
+    save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
+    monkeypatch.setenv(LOGGING_OVERRIDE_KEY, "ERROR")
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "view"],
+        expected_output_contains=f"{LOGGING_OVERRIDE_KEY}='ERROR' (from env)",
+    )
+
+
 def test_unset_logging_override():
     save_profiles(
         ProfilesCollection(

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -164,6 +164,71 @@ def test_set_setting_with_equal_sign_in_value():
     assert profiles["foo"].settings == {PREFECT_API_KEY: "foo=bar"}
 
 
+LOGGING_OVERRIDE_KEY = "PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL"
+
+
+def test_set_logging_override():
+    """Custom logging.yml override keys can be set via `config set` (closes #18666)."""
+    save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "set", f"{LOGGING_OVERRIDE_KEY}=ERROR"],
+        expected_output=f"""
+            Set '{LOGGING_OVERRIDE_KEY}' to 'ERROR'.
+            Updated profile 'foo'.
+            """,
+    )
+
+    profiles = load_profiles()
+    stored = {
+        setting.name: value for setting, value in profiles["foo"].settings.items()
+    }
+    assert stored.get(LOGGING_OVERRIDE_KEY) == "ERROR"
+
+
+def test_set_logging_override_rejects_unknown_key():
+    """A `PREFECT_LOGGING_*` key not present in logging.yml is rejected."""
+    save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "set", "PREFECT_LOGGING_NOT_A_REAL_KEY=ERROR"],
+        expected_output_contains="Unknown setting name 'PREFECT_LOGGING_NOT_A_REAL_KEY'.",
+        expected_code=1,
+    )
+
+
+def test_view_shows_logging_override():
+    """`config view` renders a logging override without crashing (regression for #18670)."""
+    save_profiles(
+        ProfilesCollection(
+            [Profile(name="foo", settings={LOGGING_OVERRIDE_KEY: "ERROR"})], active=None
+        )
+    )
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "view"],
+        expected_output_contains=f"{LOGGING_OVERRIDE_KEY}='ERROR'",
+    )
+
+
+def test_unset_logging_override():
+    save_profiles(
+        ProfilesCollection(
+            [Profile(name="foo", settings={LOGGING_OVERRIDE_KEY: "ERROR"})], active=None
+        )
+    )
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "unset", LOGGING_OVERRIDE_KEY, "-y"],
+        expected_output_contains=f"Unset '{LOGGING_OVERRIDE_KEY}'.",
+    )
+
+    profiles = load_profiles()
+    assert all(
+        setting.name != LOGGING_OVERRIDE_KEY for setting in profiles["foo"].settings
+    )
+
+
 def test_set_multiple_settings():
     save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -240,6 +240,37 @@ def test_view_shows_logging_override_set_only_in_env(monkeypatch):
     )
 
 
+def test_view_shows_logging_override_from_prefect_toml(tmp_path):
+    """A logging override set in `prefect.toml [logging.overrides]` is shown by view."""
+    save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
+
+    with tmpchdir(tmp_path):
+        with open("prefect.toml", "w") as f:
+            f.write(f'[logging.overrides]\n{LOGGING_OVERRIDE_KEY} = "ERROR"\n')
+
+        res = invoke_and_assert(["--profile", "foo", "config", "view"])
+
+    assert f"{LOGGING_OVERRIDE_KEY}='ERROR'" in res.stdout
+    assert FROM_PREFECT_TOML in res.stdout
+
+
+def test_view_env_takes_precedence_over_prefect_toml_logging_override(
+    monkeypatch, tmp_path
+):
+    """When a logging override is in both the environment and `prefect.toml`, view shows
+    the environment value/source (matching runtime precedence: env > prefect.toml)."""
+    save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
+    monkeypatch.setenv(LOGGING_OVERRIDE_KEY, "FROM_ENV")
+
+    with tmpchdir(tmp_path):
+        with open("prefect.toml", "w") as f:
+            f.write(f'[logging.overrides]\n{LOGGING_OVERRIDE_KEY} = "FROM_TOML"\n')
+
+        res = invoke_and_assert(["--profile", "foo", "config", "view"])
+
+    assert f"{LOGGING_OVERRIDE_KEY}='FROM_ENV' {FROM_ENV}" in res.stdout
+
+
 def test_unset_logging_override():
     save_profiles(
         ProfilesCollection(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -282,6 +282,44 @@ def test_collecting_overrides_does_not_parse_logging_config(
     spy.assert_not_called()
 
 
+def test_logging_overrides_env_takes_precedence_over_prefect_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Logging overrides resolve per key as env > prefect.toml, with unique keys from
+    each source preserved (via pydantic's deep_update merge across sources)."""
+    (tmp_path / "prefect.toml").write_text(
+        "[logging.overrides]\n"
+        'PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL = "TOML"\n'
+        'PREFECT_LOGGING_LOGGERS_PREFECT_TASK_RUNS_LEVEL = "TOML_ONLY"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL", "ENV")
+
+    from prefect.settings import Settings
+
+    overrides = Settings().logging.overrides
+    assert overrides["PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL"] == "ENV"
+    assert overrides["PREFECT_LOGGING_LOGGERS_PREFECT_TASK_RUNS_LEVEL"] == "TOML_ONLY"
+
+
+def test_valid_logging_override_names_uses_custom_file_only(tmp_path: Path):
+    """Override-key validation mirrors runtime file selection: when a custom logging
+    config file is set, only its keys are valid — the default file is ignored, not merged.
+    """
+    custom = tmp_path / "logging.yml"
+    custom.write_text("loggers:\n  my.custom.logger:\n    level: INFO\n")
+
+    with temporary_settings({PREFECT_LOGGING_SETTINGS_PATH: custom}):
+        from prefect.cli.config import _valid_logging_override_names
+
+        names = _valid_logging_override_names()
+
+    # A key from the custom file is valid...
+    assert "PREFECT_LOGGING_LOGGERS_MY_CUSTOM_LOGGER_LEVEL" in names
+    # ...but a key only in the packaged default is not (runtime ignores the default).
+    assert "PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL" not in names
+
+
 def test_setup_logging_preserves_existing_root_logger_configuration(
     dictConfigMock: MagicMock,
 ):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -235,6 +235,53 @@ def test_setup_logging_uses_env_var_overrides(
     dictConfigMock.assert_called_once_with(expected_config)
 
 
+def test_load_logging_config_applies_settings_overrides():
+    """Overrides stored in `settings.logging.overrides` are applied to the logging
+    config, so `prefect config set PREFECT_LOGGING_*` (which persists to the profile and
+    flows through settings) takes effect. Regression for #18666.
+    """
+    with temporary_settings(
+        {
+            "logging.overrides": {
+                "PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL": "ERROR"
+            }
+        }
+    ):
+        config = load_logging_config(DEFAULT_LOGGING_SETTINGS_PATH)
+
+    assert config["loggers"]["prefect.flow_runs"]["level"] == "ERROR"
+    # An untargeted logger keeps its default value
+    assert config["loggers"]["prefect.task_runs"]["level"] != "ERROR"
+
+
+def test_collecting_overrides_does_not_parse_logging_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Collecting `PREFECT_LOGGING_*` overrides into settings must not parse the logging
+    configuration file. Guards against the import-time perf regression in #18670.
+    """
+    monkeypatch.setenv("PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL", "ERROR")
+
+    spy = MagicMock(
+        side_effect=prefect.logging.configuration.get_valid_setting_overrides
+    )
+    monkeypatch.setattr(
+        "prefect.logging.configuration.get_valid_setting_overrides", spy
+    )
+
+    from prefect.settings import Settings
+
+    settings = Settings()
+
+    assert (
+        settings.logging.overrides.get(
+            "PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL"
+        )
+        == "ERROR"
+    )
+    spy.assert_not_called()
+
+
 def test_setup_logging_preserves_existing_root_logger_configuration(
     dictConfigMock: MagicMock,
 ):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -308,6 +308,9 @@ SUPPORTED_SETTINGS = {
     "PREFECT_LOGGING_LEVEL": {"test_value": "INFO"},
     "PREFECT_LOGGING_LOG_PRINTS": {"test_value": True},
     "PREFECT_LOGGING_MARKUP": {"test_value": True},
+    "PREFECT_LOGGING_OVERRIDES": {
+        "test_value": {"PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL": "ERROR"}
+    },
     "PREFECT_LOGGING_SERVER_LEVEL": {"test_value": "INFO", "legacy": True},
     "PREFECT_LOGGING_SETTINGS_PATH": {
         "test_value": Path("/path/to/settings.toml"),
@@ -2726,6 +2729,10 @@ class TestSettingValues:
         setting, value, expected_value = setting_and_value_and_expected_value
         if setting == "PREFECT_PROFILES_PATH":
             pytest.skip("Profiles path cannot be set via a profile")
+        if setting == "PREFECT_LOGGING_OVERRIDES":
+            # Derived field populated from individual PREFECT_LOGGING_* keys, not set
+            # directly as a dict via a profile.
+            pytest.skip("PREFECT_LOGGING_OVERRIDES is not set directly via a profile")
         if (
             setting == "PREFECT_TEST_SETTING"
             or setting == "PREFECT_TESTING_TEST_SETTING"


### PR DESCRIPTION
closes #18666

> Draft for early feedback. This follows @desertaxle's suggestion on #18670 to make custom logging settings load through `LoggingSettings` / a custom source, and is built to avoid the three issues that closed #18670.

## Root cause

`prefect config set` validates keys against registered `Settings` fields. `PREFECT_LOGGING_LEVEL` maps to a real field, but `PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL` is a dotted path into `logging.yml`, not a Pydantic field — so it's rejected with `Unknown setting name`. The runtime honors these keys only when read directly from `os.environ` (in `load_logging_config`), which is why the env-var workaround works but `config set` (which writes to a profile) does not.

## Fix

Make custom `PREFECT_LOGGING_*` keys first-class settings:

- **`LoggingSettings.overrides`** (`settings/models/logging.py`) — a `dict[str, str]` holding override keys → values. Because it's a real field, the values integrate with `get_current_settings()` and render in `prefect config view`.
- **`LoggingOverridesSource`** (`settings/sources.py`) — collects `PREFECT_LOGGING_*` keys that don't match a declared field, from the environment and the active profile, into `overrides`. **Cheap key filtering only — it never reads or parses `logging.yml`.**
- **`load_logging_config`** (`logging/configuration.py`) — applies overrides from `get_current_settings().logging.overrides` (existing `os.environ` behavior preserved as the higher-priority source). This is lazy (runs at `setup_logging`, not import).
- **CLI** (`cli/config.py`) — `config set` / `unset` accept logging-override keys (validated against `logging.yml`, parsed lazily and cached, CLI-only) and persist them as `Setting` objects; `config view` renders them.
- **`_cast_settings`** (`settings/profiles.py`) — wraps unknown `PREFECT_LOGGING_*` profile keys as `Setting` objects (cheap prefix check) so they round-trip through profiles and `config view` without warnings.

## How this avoids #18670's failure modes

| #18670 failure | This PR |
|---|---|
| 12% import perf regression (parsed logging.yml on import) | Override collection does cheap key filtering only; `logging.yml` is parsed lazily and only in the CLI. Guard test: `test_collecting_overrides_does_not_parse_logging_config`. |
| `config view` crashed (`'str' has no attribute 'name'`) | Logging keys are stored/loaded as `Setting` objects, not raw strings. Test: `test_view_shows_logging_override`. |
| Runtime ignored the value | `load_logging_config` reads from `get_current_settings().logging.overrides`. Test: `test_load_logging_config_applies_settings_overrides`. |

## Verification

```
$ prefect config set PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL=ERROR
Set 'PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL' to 'ERROR'.
$ prefect config view
PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL='ERROR' (from profile)
# load_logging_config -> prefect.flow_runs level = ERROR, prefect.task_runs unchanged
```

Regression tests added in `tests/cli/test_config.py`, `tests/test_logging.py`. `tests/test_settings.py` updated (`SUPPORTED_SETTINGS`, regenerated `_types.py`). Full `tests/test_settings.py`, `tests/cli/test_config.py`, `tests/test_logging.py` pass; ruff clean; no new mypy errors.

## Open questions for maintainers

- Naming of the field (`logging.overrides`) — happy to rename.
- Storing override keys as `Setting` wrappers in profiles vs. a dedicated mechanism — feedback welcome.

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
