### PR TITLE
Send workspace resolver pull step logs to the API

### DIFF
--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -298,8 +298,6 @@ async def prepare_workspace(
             f"Deployment {deployment.id} does not have an entrypoint and can not be run."
         )
 
-    # Bind pull-step logging to the flow run so `APILogHandler` ships it to the
-    # API; the handler drops records that don't carry a `flow_run_id`.
     run_logger = flow_run_logger(flow_run)
 
     source_cwd = Path.cwd().resolve()
@@ -442,8 +440,6 @@ async def _main_async(argv: list[str] | None = None) -> int:
         sys.stdout.write("\n")
         return 1
     finally:
-        # This process exits right after writing its result; flush the API log
-        # worker so buffered pull-step logs are delivered before then.
         await APILogHandler.aflush()
 
     result = PreparedWorkspaceResult(status="success", workspace=workspace)

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -298,10 +298,8 @@ async def prepare_workspace(
             f"Deployment {deployment.id} does not have an entrypoint and can not be run."
         )
 
-    # Log through a flow-run-bound logger so records carry a `flow_run_id` and the
-    # `APILogHandler` ships them to the API; a plain module logger's records are
-    # dropped by the handler and pull-step logs never reach the flow run's log
-    # stream in the UI.
+    # Bind pull-step logging to the flow run so `APILogHandler` ships it to the
+    # API; the handler drops records that don't carry a `flow_run_id`.
     run_logger = flow_run_logger(flow_run)
 
     source_cwd = Path.cwd().resolve()

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import builtins
 import contextlib
 import os
 import sys
@@ -20,7 +19,8 @@ from prefect.deployments.steps.core import (
     run_steps,
 )
 from prefect.filesystems import LocalFileSystem
-from prefect.logging.loggers import get_logger
+from prefect.logging.handlers import APILogHandler
+from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger
 from prefect.utilities.filesystem import relative_path_to_current_platform
 from prefect.utilities.processutils import get_sys_executable
 
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
     from prefect.client.schemas.responses import DeploymentResponse
 
-LOGGER = get_logger("prefect.runner.workspace_resolver")
 STORAGE_BASE_PATH_PLACEHOLDER = "$STORAGE_BASE_PATH"
 
 
@@ -65,11 +64,6 @@ def get_workspace_resolver_command(
         str(flow_run_id),
         str(workspace_root),
     ]
-
-
-def _stderr_print(*args: Any, **kwargs: Any) -> None:
-    kwargs.pop("style", None)
-    builtins.print(*args, file=sys.stderr, **kwargs)
 
 
 def _resolve_runtime_entrypoint(entrypoint: str) -> str:
@@ -211,6 +205,7 @@ async def _ensure_entrypoint_in_workspace(
     workspace_root: Path,
     source_cwd: Path,
     storage_base_path: Path | None,
+    logger: PrefectLogAdapter,
 ) -> Path:
     if _has_entrypoint_file(deployment.entrypoint, workspace_root):
         return workspace_root
@@ -229,6 +224,7 @@ async def _ensure_entrypoint_in_workspace(
         workspace_root,
         source_cwd,
         storage_base_path,
+        logger,
     )
     return workspace_root
 
@@ -259,6 +255,7 @@ async def _pull_storage_into_workspace(
     workspace_root: Path,
     source_cwd: Path,
     storage_base_path: Path | None,
+    logger: PrefectLogAdapter,
 ) -> Path:
     local_path = _workspace_destination_for_deployment_path(
         deployment.path, workspace_root, storage_base_path
@@ -285,7 +282,7 @@ async def _pull_storage_into_workspace(
         )
         storage_block = LocalFileSystem(basepath=from_path)
 
-    LOGGER.info("Downloading flow code from storage at %r", from_path)
+    logger.info("Downloading flow code from storage at %r", from_path)
     await storage_block.get_directory(from_path=from_path, local_path=str(local_path))
     return local_path
 
@@ -301,6 +298,12 @@ async def prepare_workspace(
             f"Deployment {deployment.id} does not have an entrypoint and can not be run."
         )
 
+    # Log through a flow-run-bound logger so records carry a `flow_run_id` and the
+    # `APILogHandler` ships them to the API; a plain module logger's records are
+    # dropped by the handler and pull-step logs never reach the flow run's log
+    # stream in the UI.
+    run_logger = flow_run_logger(flow_run)
+
     source_cwd = Path.cwd().resolve()
     storage_base_path = _get_configured_storage_base_path()
     resolved_workspace_root = Path(workspace_root).expanduser().resolve()
@@ -314,6 +317,7 @@ async def prepare_workspace(
             resolved_workspace_root,
             source_cwd,
             storage_base_path,
+            run_logger,
         )
         local_runtime_directory = _resolve_local_runtime_directory(
             deployment.path, source_cwd, storage_base_path
@@ -326,7 +330,9 @@ async def prepare_workspace(
         working_directory = resolved_workspace_root
         step_selected_working_directory = False
         os.chdir(resolved_workspace_root)
-        LOGGER.info("Running %s deployment pull step(s)", len(deployment.pull_steps))
+        run_logger.info(
+            "Running %s deployment pull step(s)", len(deployment.pull_steps)
+        )
 
         def _track_step_workspace(
             _step: dict[str, Any],
@@ -359,10 +365,10 @@ async def prepare_workspace(
             with _observe_step_completion(_track_step_workspace):
                 await run_steps(
                     deployment.pull_steps,
-                    print_function=_stderr_print,
+                    print_function=run_logger.info,
                     deployment=deployment,
                     flow_run=flow_run,
-                    logger=LOGGER,
+                    logger=run_logger,
                 )
         finally:
             _PULL_STEP_SOURCE_CWD.reset(source_cwd_token)
@@ -374,6 +380,7 @@ async def prepare_workspace(
                 resolved_workspace_root,
                 source_cwd,
                 storage_base_path,
+                run_logger,
             )
 
     os.chdir(working_directory)
@@ -436,6 +443,10 @@ async def _main_async(argv: list[str] | None = None) -> int:
         sys.stdout.write(result.model_dump_json())
         sys.stdout.write("\n")
         return 1
+    finally:
+        # This process exits right after writing its result; flush the API log
+        # worker so buffered pull-step logs are delivered before then.
+        await APILogHandler.aflush()
 
     result = PreparedWorkspaceResult(status="success", workspace=workspace)
     sys.stdout.write(result.model_dump_json())

--- a/src/prefect/runner/_workspace_resolver.py
+++ b/src/prefect/runner/_workspace_resolver.py
@@ -361,7 +361,7 @@ async def prepare_workspace(
             with _observe_step_completion(_track_step_workspace):
                 await run_steps(
                     deployment.pull_steps,
-                    print_function=run_logger.info,
+                    print_function=run_logger.warning,
                     deployment=deployment,
                     flow_run=flow_run,
                     logger=run_logger,

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -839,8 +839,6 @@ class TestWorkspaceResolverProcess:
         process = _run_workspace_resolver(
             flow_run.id,
             tmp_path / "logged-workspace",
-            # The test session disables API logging globally; the subprocess must
-            # have it on to exercise log delivery.
             extra_env={"PREFECT_LOGGING_TO_API_ENABLED": "True"},
         )
         result = _parse_result(process)

--- a/tests/runner/test__workspace_resolver.py
+++ b/tests/runner/test__workspace_resolver.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from prefect.client.schemas.filters import LogFilter, LogFilterFlowRunId
 from prefect.filesystems import LocalFileSystem
 from prefect.runner._workspace_resolver import (
     PreparedWorkspaceResult,
@@ -25,11 +26,12 @@ CUSTOM_STEP_FQN = "tests.utilities.workspace_resolver_steps"
 
 
 def _run_workspace_resolver(
-    flow_run_id, workspace_root: Path
+    flow_run_id, workspace_root: Path, extra_env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
     env = {
         **os.environ,
         **get_current_settings().to_environment_variables(exclude_unset=True),
+        **(extra_env or {}),
     }
     pythonpath = str(REPO_ROOT)
     if env.get("PYTHONPATH"):
@@ -804,6 +806,95 @@ class TestWorkspaceResolverProcess:
         assert "resolver-step-noise" not in process.stdout
         assert result.workspace is not None
         assert result.workspace.project_root == local_project.resolve()
+
+    async def test_pull_step_logs_are_sent_to_the_api(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        local_project = tmp_path / "logged-project"
+        flow_file = local_project / "flows" / "hello.py"
+        flow_file.parent.mkdir(parents=True, exist_ok=True)
+        flow_file.write_text(
+            "from prefect import flow\n\n@flow\ndef hello():\n    return 'logged'\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("logged-hello")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="logged-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    "prefect.deployments.steps.set_working_directory": {
+                        "directory": str(local_project)
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(
+            flow_run.id,
+            tmp_path / "logged-workspace",
+            # The test session disables API logging globally; the subprocess must
+            # have it on to exercise log delivery.
+            extra_env={"PREFECT_LOGGING_TO_API_ENABLED": "True"},
+        )
+        result = _parse_result(process)
+
+        assert process.returncode == 0, process.stderr
+        assert result.status == "success"
+
+        logs = await prefect_client.read_logs(
+            log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=[flow_run.id]))
+        )
+        messages = [log.message for log in logs]
+        assert "Running 1 deployment pull step(s)" in messages
+        assert "Executing deployment step: set_working_directory" in messages
+        assert (
+            "Deployment step 'set_working_directory' completed successfully" in messages
+        )
+
+    async def test_pull_step_logs_are_sent_to_the_api_when_a_step_fails(
+        self,
+        prefect_client,
+        tmp_path: Path,
+    ) -> None:
+        flow_id = await prefect_client.create_flow_from_name("failing-logged-flow")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="failing-logged-deployment",
+            entrypoint="flows/hello.py:hello",
+            pull_steps=[
+                {
+                    f"{CUSTOM_STEP_FQN}.raise_error": {
+                        "message": "resolver exploded",
+                    }
+                }
+            ],
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        process = _run_workspace_resolver(
+            flow_run.id,
+            tmp_path / "failing-workspace",
+            extra_env={"PREFECT_LOGGING_TO_API_ENABLED": "True"},
+        )
+        result = _parse_result(process)
+
+        assert process.returncode == 1
+        assert result.status == "error"
+
+        logs = await prefect_client.read_logs(
+            log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=[flow_run.id]))
+        )
+        messages = [log.message for log in logs]
+        assert "Executing deployment step: raise_error" in messages
 
 
 class TestRelativePathSetWorkingDirectory:


### PR DESCRIPTION
Since 3.7.0 (#21699 / #21796), deployment pull steps run in the isolated workspace resolver subprocess. That path used a plain module logger with no `flow_run_id`, so `APILogHandler` dropped messages like "Running 1 deployment pull step(s)", "Executing deployment step: pull_from_s3", and "Downloading flow code from storage" from the flow run log stream. Users still saw them in container stderr, but the UI made slow pull steps look like a silent provisioning hang.

This PR binds resolver pull-step logging to `flow_run_logger(flow_run)` and flushes the API log worker before the short-lived subprocess exits, on both success and failure. Console output still goes to stderr, and stdout remains reserved for the JSON result payload.

Tests run the resolver as a real subprocess and assert pull-step logs reach `/logs/filter`, including when a later step fails. They re-enable API logging for the subprocess despite the suite-wide override.

<details>
<summary>Session context</summary>

This started from a Prefect Cloud support triage for 6-10 minute managed execution "provisioning" delays. Container logs showed the delay was `pull_from_s3`, but the UI had no matching flow run logs. The regression came from the 3.7 workspace resolver subprocess refactor; the pre-3.7 path shipped these logs through `flow_run_logger`.
</details>
