### PR TITLE
Fix parameter name mismatches in docstrings

### DIFF
--- a/src/prefect/server/models/artifacts.py
+++ b/src/prefect/server/models/artifacts.py
@@ -309,7 +309,6 @@ async def read_artifacts(
         task_run_filter: Only select artifacts whose task runs matching this filter
         deployment_filter: Only select artifacts whose flow runs belong to deployments matching this filter
         flow_filter: Only select artifacts whose flow runs belong to flows matching this filter
-        work_pool_filter: Only select artifacts whose flow runs belong to work pools matching this filter
     """
     query = sa.select(db.Artifact).order_by(*sort.as_sql_sort())
 
@@ -357,7 +356,6 @@ async def read_latest_artifacts(
         task_run_filter: Only select artifacts whose task runs matching this filter
         deployment_filter: Only select artifacts whose flow runs belong to deployments matching this filter
         flow_filter: Only select artifacts whose flow runs belong to flows matching this filter
-        work_pool_filter: Only select artifacts whose flow runs belong to work pools matching this filter
     """
     query = sa.select(db.ArtifactCollection).order_by(*sort.as_sql_sort())
     query = await _apply_artifact_collection_filters(

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -294,11 +294,11 @@ async def read_work_queue_by_name(
     db: PrefectDBInterface, session: AsyncSession, name: str
 ) -> Optional[orm_models.WorkQueue]:
     """
-    Reads a WorkQueue by id.
+    Reads a WorkQueue by name.
 
     Args:
         session (AsyncSession): A database session
-        work_queue_id (str): a WorkQueue id
+        name (str): a WorkQueue name
 
     Returns:
         orm_models.WorkQueue: the WorkQueue

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -325,7 +325,7 @@ async def update_work_pool(
     Args:
         session (AsyncSession): A database session
         work_pool_id (UUID): a WorkPool id
-        worker: the work queue data
+        work_pool: the work pool data
         emit_status_change: function to call when work pool
             status is changed
         emit_update_event: whether to emit an event for updated non-status fields

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1046,7 +1046,7 @@ class WorkQueueHealthPolicy(PrefectBaseModel):
         Given empirical information about the state of the work queue, evaluate its health status.
 
         Args:
-            late_runs: the count of late runs for the work queue.
+            late_runs_count: the count of late runs for the work queue.
             last_polled: the last time the work queue was polled, if available.
 
         Returns:


### PR DESCRIPTION
Fixes several server-side docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `server/models/work_queues.py` | `read_work_queue_by_name` | "Reads a WorkQueue by id" / `work_queue_id` | `name` |
| `server/models/workers.py` | `update_work_pool` | `worker` | `work_pool` |
| `server/schemas/core.py` | `WorkQueueStatusDetail.evaluate_health_status` | `late_runs` | `late_runs_count` |
| `server/models/artifacts.py` | `read_artifacts`, `read_latest_artifacts` | stale `work_pool_filter` | not a parameter |

Doc-only change; no behavior modified.