### PR TITLE
Keep TaskRunRecorder periodic flush alive when events are dropped

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -484,13 +484,18 @@ async def consumer(
                 raise
 
     async def flush_periodically():
-        try:
-            while True:
+        while True:
+            try:
                 await asyncio.sleep(flush_every)
                 if queue.qsize():
                     await flush()
-        except asyncio.CancelledError:
-            return
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                # flush() re-raises when events are dropped; this task is never
+                # awaited, so letting that propagate would kill periodic
+                # flushing silently and strand queued events (issue #21057)
+                logger.exception("Error during periodic flush; continuing")
 
     async def message_handler(message: Message):
         event: ReceivedEvent = ReceivedEvent.model_validate_json(message.data)

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.dml import Insert
 
+from prefect._internal.testing import retry_asserts
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.models.flow_runs import create_flow_run
 from prefect.server.models.task_run_states import (
@@ -1149,6 +1150,57 @@ async def test_event_dropped_after_max_retries_exceeded(
     assert "Dropping event" in caplog.text
     assert "after 2 failed attempts" in caplog.text
     assert "1 dropped" in caplog.text
+
+
+async def test_periodic_flush_survives_dropped_events(
+    pending_event: ReceivedEvent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for https://github.com/PrefectHQ/prefect/issues/21057
+
+    `flush()` re-raises when an event is dropped after exhausting persist
+    retries. If that exception propagates out of `flush_periodically`, the
+    periodic flush task dies silently (it is only cancelled, never awaited)
+    and queued events are stranded until the next incoming message — or
+    forever, once the queue backlog exceeds the write batch size.
+    """
+    poison = pending_event
+    good = pending_event.model_copy(update={"id": uuid4()})
+    recorded: list[ReceivedEvent] = []
+    flush_attempts = 0
+
+    async def mock_record_bulk(events: list[ReceivedEvent]):
+        nonlocal flush_attempts
+        flush_attempts += 1
+        if any(e.id == poison.id for e in events):
+            raise Exception("Simulated persistent DB failure")
+        recorded.extend(events)
+
+    monkeypatch.setattr(
+        "prefect.server.services.task_run_recorder.record_bulk_task_run_events",
+        mock_record_bulk,
+    )
+
+    # write_batch_size > 1 so message_handler never flushes; only the
+    # periodic flush task can persist these events
+    async with task_run_recorder.consumer(
+        write_batch_size=10, flush_every=1, max_persist_retries=0
+    ) as handler:
+        await handler(message(poison))
+
+        # first periodic flush drops the poison event and re-raises
+        async for attempt in retry_asserts(max_attempts=10, delay=0.5):
+            with attempt:
+                assert flush_attempts >= 1
+        assert len(recorded) == 0
+
+        await handler(message(good))
+
+        # the periodic flush task must still be alive to persist this event;
+        # assert before exiting the context, since teardown also flushes
+        async for attempt in retry_asserts(max_attempts=10, delay=0.5):
+            with attempt:
+                assert [e.id for e in recorded] == [good.id]
 
 
 def make_event_with_flow_run(


### PR DESCRIPTION
Keeps `TaskRunRecorder`'s periodic flush task alive when `flush()` re-raises after dropping an event, so queued task-run events can no longer be stranded indefinitely.

Fixes #21057

## the failure mode

The reporter of #21057 traced this in production, and we could reproduce it against `main`:

1. `flush()` re-raises when any event is dropped after exhausting persist retries (added in #19855) — e.g. from persistent unique-constraint errors like those described in #19261.
2. `flush_periodically()` only caught `asyncio.CancelledError`, so that raise killed the periodic flush task. The task is only `.cancel()`ed in the consumer's `finally` and never awaited, so the exception was swallowed — nothing appeared in server logs.
3. With the default `batch_size=1`, `message_handler` pops exactly one queued event (the oldest) per incoming message. Once flush retries had re-queued events, the backlog could never drain with the periodic flusher dead: the newest task-run events sat in the queue indefinitely (the reporter observed a backlog of ~890) and their task runs were never written to the database — silent, random-looking missing task runs.

The later fixes in this area (#21717, #21726, #21813, #22112) reduced the *sources* of `IntegrityError`, but none addressed the periodic flush task dying when a drop does occur.

## how this differs from #22440

#22440 changes the server lifespan so background services restart when a cached **ephemeral** app's lifespan is re-entered. That may be a real issue in its own right, but it's a different failure mode: the reporter runs a single hosted server behind nginx, whose lifespan is entered exactly once, so the lifespan change doesn't reach the diagnosed root cause in `task_run_recorder.py`.

## the fix

Move the exception handling inside `flush_periodically`'s loop: `CancelledError` still exits, but any other exception is logged and the loop continues. `flush()` itself is unchanged — it already logs batch failure details and handles requeue/drop bookkeeping before re-raising.

Includes a regression test that fails on `main`: a poison event is dropped by the first periodic flush, then a subsequent good event must still be persisted by the (previously dead) periodic flush task.

<details>
<summary>standalone reproduction script (fails on main, passes with this fix)</summary>

```python
"""repro for https://github.com/PrefectHQ/prefect/issues/21057"""

import asyncio
import uuid
from datetime import datetime, timezone

import prefect.server.services.task_run_recorder as trr
from prefect.server.events.schemas.events import ReceivedEvent


def make_event(name: str) -> ReceivedEvent:
    task_run_id = uuid.uuid4()
    now = datetime.now(timezone.utc)
    return ReceivedEvent(
        occurred=now,
        received=now,
        event="prefect.task-run.Running",
        resource={
            "prefect.resource.id": f"prefect.task-run.{task_run_id}",
            "prefect.resource.name": name,
            "prefect.orchestration": "client",
        },
        payload={},
        id=uuid.uuid4(),
    )


async def main() -> None:
    poison = make_event("poison")
    failing_ids = {poison.id}
    persisted: list[str] = []

    async def failing_record(events):
        if any(e.id in failing_ids for e in events):
            raise RuntimeError("simulated persistent IntegrityError (see #19261)")
        persisted.extend(e.resource.get("prefect.resource.name") for e in events)

    trr.record_bulk_task_run_events = failing_record

    flush_every = 1
    async with trr.consumer(
        write_batch_size=1,  # the default
        flush_every=flush_every,
        max_persist_retries=1,
    ) as handler:
        queue: asyncio.Queue = next(
            c.cell_contents
            for c in handler.__closure__
            if isinstance(c.cell_contents, asyncio.Queue)
        )

        class Msg:
            def __init__(self, event: ReceivedEvent):
                self.data = event.model_dump_json()

        # 1. poison event arrives: flush fails, event is re-queued (attempt 1)
        try:
            await handler(Msg(poison))
        except Exception as exc:
            print(f"message_handler raised (attempt 1 requeued): {exc!r}")

        # 2. periodic flush retries it, exceeds max_persist_retries, drops it,
        #    and the re-raise kills flush_periodically — silently
        await asyncio.sleep(flush_every + 0.5)

        # 3. another failing event creates a backlog via requeue
        poison2 = make_event("poison-2")
        failing_ids.add(poison2.id)
        try:
            await handler(Msg(poison2))
        except Exception as exc:
            print(f"message_handler raised: {exc!r}")

        # 4. good events arrive; each incoming message flushes only the OLDEST
        #    queued event, so the newest is always left behind
        for i in range(3):
            try:
                await handler(Msg(make_event(f"good-{i}")))
            except Exception as exc:
                print(f"message_handler raised: {exc!r}")

        # 5. a live periodic flusher would drain the queue; a dead one won't
        await asyncio.sleep(3 * flush_every)

        print(f"\npersisted events:   {persisted}")
        print(f"stuck in queue:     {queue.qsize()} event(s)")
        if queue.qsize() > 0:
            print("\nBUG REPRODUCED: queued task-run events are never persisted")
        else:
            print("\nnot reproduced: queue drained")


if __name__ == "__main__":
    asyncio.run(main())
```

on `main`:

```
persisted events:   ['good-0', 'good-1']
stuck in queue:     1 event(s)
BUG REPRODUCED: queued task-run events are never persisted
```

with this fix:

```
persisted events:   ['good-0', 'good-1', 'good-2']
stuck in queue:     0 event(s)
not reproduced: queue drained
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
