### PR TITLE
Make Redis causal ordering cluster-slot safe

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/ordering.py
+++ b/src/integrations/prefect-redis/prefect_redis/ordering.py
@@ -26,7 +26,7 @@ from prefect.server.events.ordering import (
 )
 from prefect.server.events.ordering.memory import EventBeingProcessed
 from prefect.server.events.schemas.events import Event, ReceivedEvent
-from prefect_redis.client import get_async_redis_client
+from prefect_redis.client import cluster_key_prefix, get_async_redis_client
 
 logger = get_logger(__name__)
 
@@ -83,12 +83,17 @@ return followers
 class CausalOrdering(_CausalOrdering):
     def __init__(self, scope: str):
         self.redis = get_async_redis_client()
+        self._cluster_key_prefix = cluster_key_prefix(
+            scope or "prefect:events:ordering"
+        )
         super().__init__(scope=scope)
 
     def _key(self, key: str) -> str:
         if not self.scope:
+            if self._cluster_key_prefix.startswith("{"):
+                return f"{self._cluster_key_prefix}:{key}"
             return key
-        return f"{self.scope}:{key}"
+        return f"{self._cluster_key_prefix}:{key}"
 
     async def record_event_as_processing(self, event: ReceivedEvent) -> bool:
         """
@@ -122,11 +127,9 @@ class CausalOrdering(_CausalOrdering):
         assert event.follows
 
         async with self.redis.pipeline() as p:
-            await p.set(self._key(f"event:{event.id}"), event.model_dump_json())
-            await p.sadd(self._key(f"followers:{event.follows}"), str(event.id))
-            await p.zadd(
-                self._key("waitlist"), {str(event.id): event.received.timestamp()}
-            )
+            p.set(self._key(f"event:{event.id}"), event.model_dump_json())
+            p.sadd(self._key(f"followers:{event.follows}"), str(event.id))
+            p.zadd(self._key("waitlist"), {str(event.id): event.received.timestamp()})
             await p.execute()
 
     async def forget_follower(self, follower: ReceivedEvent):
@@ -134,30 +137,30 @@ class CausalOrdering(_CausalOrdering):
         assert follower.follows
 
         async with self.redis.pipeline() as p:
-            await p.zrem(self._key("waitlist"), str(follower.id))
-            await p.srem(self._key(f"followers:{follower.follows}"), str(follower.id))
-            await p.delete(self._key(f"event:{follower.id}"))
+            p.zrem(self._key("waitlist"), str(follower.id))
+            p.srem(self._key(f"followers:{follower.follows}"), str(follower.id))
+            p.delete(self._key(f"event:{follower.id}"))
             await p.execute()
 
     async def get_lost_followers(self) -> list[ReceivedEvent]:
         """Returns events that were waiting on a leader event that never arrived"""
         async with self.redis.pipeline() as p:
-            temporary_set = str(uuid4())
+            temporary_set = self._key(f"lost-followers:{uuid4()}")
             earlier = (
                 datetime.now(timezone.utc) - PRECEDING_EVENT_LOOKBACK
             ).timestamp()
 
             # Move all of the events that are older than the lookback period into a
             # temporary set...
-            await p.zrangestore(
+            p.zrangestore(
                 temporary_set, self._key("waitlist"), 0, earlier, byscore=True
             )
             # Then remove them from the waitlist set...
-            await p.zremrangebyscore(self._key("waitlist"), 0, earlier)
+            p.zremrangebyscore(self._key("waitlist"), 0, earlier)
             # Then return them...
-            await p.zrange(temporary_set, 0, -1)
+            p.zrange(temporary_set, 0, -1)
             # And finally, remove the temporary set
-            await p.delete(temporary_set)
+            p.delete(temporary_set)
 
             _, _, follower_ids, _ = await p.execute()
 
@@ -169,7 +172,7 @@ class CausalOrdering(_CausalOrdering):
         """Returns the events with the given IDs, in the order they occurred"""
         async with self.redis.pipeline() as p:
             for follower_id in follower_ids:
-                await p.get(self._key(f"event:{follower_id}"))
+                p.get(self._key(f"event:{follower_id}"))
             follower_jsons: list[str] = await p.execute()
 
         return sorted(

--- a/src/integrations/prefect-redis/tests/test_ordering.py
+++ b/src/integrations/prefect-redis/tests/test_ordering.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Sequence
 from uuid import uuid4
@@ -8,6 +9,8 @@ from prefect_redis.ordering import (
     CausalOrdering,
     EventArrivedEarly,
 )
+from redis.asyncio import RedisCluster
+from redis.cluster import key_slot
 
 from prefect.server.events.schemas.events import ReceivedEvent, Resource
 from prefect.types import DateTime
@@ -112,6 +115,84 @@ def example(request: pytest.FixtureRequest) -> Sequence[ReceivedEvent]:
 @pytest.fixture
 def causal_ordering() -> CausalOrdering:
     return CausalOrdering(scope="unit-tests")
+
+
+def test_causal_ordering_keys_share_cluster_hash_slot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(
+        "PREFECT_REDIS_MESSAGING_URL", "redis+cluster://redis.example.com:6379"
+    )
+    monkeypatch.setattr("prefect_redis.ordering.get_async_redis_client", lambda: None)
+
+    ordering = CausalOrdering(scope="unit-tests")
+    keys = [
+        ordering._key("seen:event-id"),
+        ordering._key("processing:event-id"),
+        ordering._key("followers:event-id"),
+        ordering._key("event:event-id"),
+        ordering._key("waitlist"),
+        ordering._key("lost-followers:temporary-set"),
+    ]
+
+    assert keys == [
+        "{unit-tests}:seen:event-id",
+        "{unit-tests}:processing:event-id",
+        "{unit-tests}:followers:event-id",
+        "{unit-tests}:event:event-id",
+        "{unit-tests}:waitlist",
+        "{unit-tests}:lost-followers:temporary-set",
+    ]
+    assert len({key_slot(key.encode()) for key in keys}) == 1
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PREFECT_REDIS_CLUSTER_TEST_URL"),
+    reason="requires PREFECT_REDIS_CLUSTER_TEST_URL",
+)
+async def test_causal_ordering_runs_against_real_redis_cluster(
+    event_one: ReceivedEvent,
+    event_two: ReceivedEvent,
+    event_three_a: ReceivedEvent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cluster_url = os.environ["PREFECT_REDIS_CLUSTER_TEST_URL"]
+    client_url = cluster_url.replace("redis+cluster://", "redis://", 1).replace(
+        "rediss+cluster://", "rediss://", 1
+    )
+    settings_url = cluster_url
+    if settings_url.startswith("redis://"):
+        settings_url = settings_url.replace("redis://", "redis+cluster://", 1)
+    elif settings_url.startswith("rediss://"):
+        settings_url = settings_url.replace("rediss://", "rediss+cluster://", 1)
+
+    redis_client = RedisCluster.from_url(client_url, decode_responses=True)
+    await redis_client.flushall()
+    try:
+        scope = f"cluster-ordering-{uuid4()}"
+        monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", settings_url)
+        monkeypatch.setattr(
+            "prefect_redis.ordering.get_async_redis_client",
+            lambda: redis_client,
+        )
+        ordering = CausalOrdering(scope=scope)
+
+        await ordering.record_follower(event_two)
+        assert await ordering.record_event_as_processing(event_one) is True
+        followers = await ordering.complete_event_and_get_followers(event_one)
+        assert followers == [event_two]
+        await ordering.forget_follower(event_two)
+
+        await ordering.record_follower(event_three_a)
+        monkeypatch.setattr(
+            "prefect_redis.ordering.PRECEDING_EVENT_LOOKBACK",
+            timedelta(minutes=-1),
+        )
+        lost_followers = await ordering.get_lost_followers()
+        assert [follower.id for follower in lost_followers] == [event_three_a.id]
+    finally:
+        await redis_client.flushall()
+        await redis_client.aclose()
 
 
 async def test_ordering_is_correct(


### PR DESCRIPTION
this PR makes the Redis-backed causal ordering keys safe for future Redis Cluster support without enabling Cluster clients yet.

<details>
<summary>Details</summary>

- routes causal ordering keys through the existing cluster-aware key prefix helper
- ensures `seen`, `processing`, `followers`, `event`, `waitlist`, and temporary lost-follower keys for a scope share one Redis Cluster hash slot
- updates ordering pipelines to stage commands in the redis-py style that works for both standalone Redis and `RedisCluster`
- adds an opt-in real Redis Cluster test guarded by `PREFECT_REDIS_CLUSTER_TEST_URL`

Redis Cluster URL client activation remains intentionally gated behind the existing `NotImplementedError`; this is one incremental key-safety slice from the #22211 follow-up list.

</details>

Validation:

- `PREFECT_REDIS_CLUSTER_TEST_URL=redis://prefect-redis-cluster-ordering.orb.local:7000 uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_ordering.py -q`
- `PREFECT_REDIS_CLUSTER_TEST_URL=redis://prefect-redis-cluster-ordering.orb.local:7000 uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/ -q`
- `uv run ruff check src/integrations/prefect-redis/prefect_redis/ordering.py src/integrations/prefect-redis/tests/test_ordering.py`
- `uv run ruff format --check src/integrations/prefect-redis/prefect_redis/ordering.py src/integrations/prefect-redis/tests/test_ordering.py`

Local e2e Redis Cluster was a throwaway OrbStack/Docker `redis:7-alpine` single-node cluster with all slots assigned and hostname announcement via `prefect-redis-cluster-ordering.orb.local`.
