### PR TITLE
Reconnect events client from time-based checkpoint when connection is lost

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -436,8 +436,17 @@ class PrefectEventsClient(EventsClient):
         # Clear the unconfirmed events here, because they are going back through emit
         # and will be added again through the normal checkpointing process
         self._unconfirmed_events = []
-        for event in events_to_resend:
-            await self.emit(event)
+        try:
+            while events_to_resend:
+                event = events_to_resend.pop(0)
+                await self.emit(event)
+        except Exception:
+            # If a resend fails partway through (emit() has its own retry
+            # budget), restore the events that were never attempted so a later
+            # reconnect can retry them. The event whose emit() failed was
+            # already added back to the buffer by emit() itself.
+            self._unconfirmed_events.extend(events_to_resend)
+            raise
         logger.debug("Finished resending unconfirmed events.")
         self._start_checkpoint_task()
 

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -452,17 +452,44 @@ class PrefectEventsClient(EventsClient):
 
     async def _checkpoint_loop(self) -> None:
         """Periodically checkpoint unconfirmed events on a time interval,
-        independent of the count-based checkpoint in _checkpoint."""
+        independent of the count-based checkpoint in _checkpoint.
+
+        If the connection has been lost (e.g. a server restart closed it),
+        reconnects and resends the unconfirmed events rather than leaving them
+        stranded until the next emit."""
         while True:
             await asyncio.sleep(self._checkpoint_interval)
-            if self._websocket and self._unconfirmed_events:
-                try:
+            if not self._unconfirmed_events:
+                continue
+            try:
+                if self._websocket:
                     await self._force_checkpoint()
+                    continue
+                # The connection was lost while events were still unconfirmed;
+                # reconnect to resend them rather than waiting for the next emit.
+                await self._reconnect()
+            except ConnectionClosed:
+                # The connection died since the last checkpoint; reconnect and
+                # resend the unconfirmed events. _reconnect() tears down the
+                # dead connection before connecting again.
+                try:
+                    await self._reconnect()
                 except Exception:
                     logger.debug(
-                        "Time-based checkpoint failed, will retry next interval.",
+                        "Reconnecting during time-based checkpoint failed, "
+                        "will retry next interval.",
                         exc_info=True,
                     )
+                    continue
+            except Exception:
+                logger.debug(
+                    "Time-based checkpoint failed, will retry next interval.",
+                    exc_info=True,
+                )
+                continue
+            # A successful _reconnect() resent the unconfirmed events and
+            # started a replacement checkpoint task, so this task is done.
+            return
 
     async def _force_checkpoint(self) -> None:
         """Checkpoint all unconfirmed events unconditionally."""

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -784,3 +784,63 @@ async def test_reconnect_only_resends_events_after_interval_checkpoint(
         recorder,
         [example_event_1, example_event_2, example_event_3],
     )
+
+
+async def test_background_checkpoint_reconnects_after_connection_loss(
+    Client: Type[PrefectEventsClient],
+    example_event_1: Event,
+    recorder: Recorder,
+    puppeteer: Puppeteer,
+):
+    """If the connection dies while events are unconfirmed (e.g. a server
+    restart) and nothing else is emitted, the background checkpoint task should
+    reconnect and resend them instead of pinging the dead connection forever."""
+    client = Client(
+        checkpoint_every=1000,
+        checkpoint_interval=0.1,
+    )
+    async with client:
+        # Sever the connection server-side as soon as the event is received,
+        # before any checkpoint can confirm it
+        puppeteer.hard_disconnect_after = example_event_1.id
+        await client.emit(example_event_1)
+        assert client._unconfirmed_events == [example_event_1]
+
+        # Wait for the background checkpoint to notice the dead connection,
+        # reconnect, resend, and confirm
+        await asyncio.sleep(0.5)
+        assert len(client._unconfirmed_events) == 0
+
+    # The event was received once before the disconnect and once as a resend
+    assert recorder.events == [example_event_1, example_event_1]
+    assert recorder.connections == 2
+
+
+async def test_background_checkpoint_retries_reconnect_until_server_available(
+    Client: Type[PrefectEventsClient],
+    example_event_1: Event,
+    recorder: Recorder,
+    puppeteer: Puppeteer,
+):
+    """If the server is unavailable when the background checkpoint tries to
+    reconnect, it should keep retrying each interval and deliver the
+    unconfirmed events once the server comes back."""
+    client = Client(
+        checkpoint_every=1000,
+        checkpoint_interval=0.1,
+    )
+    async with client:
+        puppeteer.hard_disconnect_after = example_event_1.id
+        puppeteer.refuse_any_further_connections = True
+        await client.emit(example_event_1)
+
+        # Several intervals of failed reconnects: the event is still held and
+        # the checkpoint task is still alive
+        await asyncio.sleep(0.35)
+        assert client._unconfirmed_events == [example_event_1]
+
+        puppeteer.refuse_any_further_connections = False
+        await asyncio.sleep(0.5)
+        assert len(client._unconfirmed_events) == 0
+
+    assert recorder.events[-1] == example_event_1

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -844,3 +844,47 @@ async def test_background_checkpoint_retries_reconnect_until_server_available(
         assert len(client._unconfirmed_events) == 0
 
     assert recorder.events[-1] == example_event_1
+
+
+async def test_failed_resend_does_not_drop_unattempted_events(
+    Client: Type[PrefectEventsClient],
+    example_event_1: Event,
+    example_event_2: Event,
+    example_event_3: Event,
+    recorder: Recorder,
+    puppeteer: Puppeteer,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If the connection dies again partway through resending unconfirmed
+    events, the events whose resend was never attempted must be restored to
+    the buffer (not silently dropped) so a later reconnect can retry them."""
+    client = Client(
+        checkpoint_every=1000,
+        checkpoint_interval=60,  # keep the background loop out of the way
+    )
+    async with client:
+        # Fail the second resend, as if the connection died mid-batch
+        emit_calls = 0
+        real_emit = client.emit
+
+        async def flaky_emit(event: Event) -> None:
+            nonlocal emit_calls
+            emit_calls += 1
+            if emit_calls == 2:
+                raise ConnectionClosedError(None, None)
+            await real_emit(event)
+
+        monkeypatch.setattr(client, "emit", flaky_emit)
+        client._unconfirmed_events = [
+            example_event_1,
+            example_event_2,
+            example_event_3,
+        ]
+
+        with pytest.raises(ConnectionClosedError):
+            await client._reconnect()
+
+        # event 1 was resent (and is buffered again until confirmed); event 3
+        # was never attempted and must have been restored, not dropped
+        assert example_event_1 in client._unconfirmed_events
+        assert example_event_3 in client._unconfirmed_events


### PR DESCRIPTION
Closes #22450

The time-based checkpoint loop (#21264) only pinged the existing websocket. If the connection died while events were unconfirmed (e.g. a server restart) and nothing further was emitted, the loop pinged the dead connection every interval indefinitely — logging `ConnectionClosedError` every 30s and never delivering the unconfirmed events. Reconnection only lived in the `emit()` path.

### Change

In `_checkpoint_loop`, detect a closed connection (either `_force_checkpoint` raising `ConnectionClosed`, or `_websocket` already cleared by a previous failed attempt) and route recovery through the existing `_reconnect()` — which already tears down the dead connection, re-authenticates, resends unconfirmed events via `emit()`, and starts a replacement checkpoint task (so the current task returns once it has handed off). If reconnecting fails (server still down), log at debug and retry next interval.

No new locks, settings, or signatures; healthy-path behavior is unchanged (ticks with no unconfirmed events or a live connection behave exactly as before). Note: a checkpoint-loop reconnect can theoretically interleave with an emit-path reconnect, but `emit()` is already single-caller in practice (`EventsWorker` drains a queue in one task), matching the existing concurrency assumptions of this class.

### Tests

- `test_background_checkpoint_reconnects_after_connection_loss` — server hard-disconnects after receiving an event, before it is confirmed; the loop reconnects, resends, and confirms it (previously: pinged the dead socket forever).
- `test_background_checkpoint_retries_reconnect_until_server_available` — the server refuses reconnections; the loop keeps retrying each interval without dying and delivers the event once the server accepts connections again.

Full `tests/events/client/test_events_client.py` passes (43 tests). Also validated end-to-end against a real `prefect server start` + restart: pre-patch, the client logged `ConnectionClosedError: received 1012` every 30s indefinitely; post-patch it reconnects on the first tick after the restart, resends, and the next checkpoint confirms.