### PR TITLE
Make Redis messaging cluster-slot safe

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -39,7 +39,11 @@ from prefect.server.utilities.messaging import (
 )
 from prefect.server.utilities.messaging import Publisher as _Publisher
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
-from prefect_redis.client import clear_cached_clients, get_async_redis_client
+from prefect_redis.client import (
+    clear_cached_clients,
+    cluster_key_prefix,
+    get_async_redis_client,
+)
 
 logger = get_logger(__name__)
 
@@ -122,6 +126,38 @@ class RedisMessagingConsumerSettings(PrefectBaseSettings):
 MESSAGE_DEDUPLICATION_LOOKBACK = timedelta(minutes=5)
 
 
+def _topic_key_prefix(topic: str) -> str:
+    return cluster_key_prefix(f"message:{topic}")
+
+
+def _stream_key(topic: str) -> str:
+    prefix = _topic_key_prefix(topic)
+    if prefix.startswith("{"):
+        return f"{prefix}:stream"
+    return topic
+
+
+def _deduplication_key(topic: str, attribute_value: Any) -> str:
+    prefix = _topic_key_prefix(topic)
+    if prefix.startswith("{"):
+        return f"{prefix}:dedupe:{attribute_value}"
+    return f"message:{topic}:{attribute_value}"
+
+
+def _dlq_key(topic: str) -> str:
+    prefix = _topic_key_prefix(topic)
+    if prefix.startswith("{"):
+        return f"{prefix}:dlq"
+    return "dlq"
+
+
+def _dlq_message_key(topic: str) -> str:
+    prefix = _topic_key_prefix(topic)
+    if prefix.startswith("{"):
+        return f"{prefix}:dlq:{uuid.uuid4().hex}"
+    return f"dlq:{uuid.uuid4().hex}"
+
+
 class Cache(_Cache):
     def __init__(self, topic: str = "messaging-cache"):
         self.topic = topic
@@ -144,7 +180,7 @@ class Cache(_Cache):
                     messages_without_attribute.append(m)
                     continue
                 p.set(
-                    f"message:{self.topic}:{m.attributes[attribute]}",
+                    _deduplication_key(self.topic, m.attributes[attribute]),
                     "1",
                     nx=True,
                     ex=MESSAGE_DEDUPLICATION_LOOKBACK,
@@ -166,7 +202,7 @@ class Cache(_Cache):
                         extra={"event_message": m},
                     )
                     continue
-                p.delete(f"message:{self.topic}:{m.attributes[attribute]}")
+                p.delete(_deduplication_key(self.topic, m.attributes[attribute]))
             await p.execute()
 
 
@@ -215,7 +251,8 @@ class Publisher(_Publisher):
     ):
         settings = RedisMessagingPublisherSettings()
 
-        self.stream = topic  # Use topic as stream name
+        self.topic = topic
+        self.stream = _stream_key(topic)
         self.cache = cache
         self.deduplicate_by = (
             deduplicate_by if deduplicate_by is not None else settings.deduplicate_by
@@ -318,8 +355,9 @@ class Consumer(_Consumer):
     ):
         settings = RedisMessagingConsumerSettings()
 
+        self.topic = topic
         self.name = name or topic
-        self.stream = topic  # Use topic as stream name
+        self.stream = _stream_key(topic)
         self.group = group or topic  # Use topic as default group name
         self.block = block if block is not None else settings.block
         self.min_idle_time = (
@@ -343,7 +381,10 @@ class Consumer(_Consumer):
         self.trim_every = trim_every if trim_every is not None else settings.trim_every
 
         self.subscription = Subscription(
-            max_retries=max_retries if max_retries is not None else settings.max_retries
+            max_retries=max_retries
+            if max_retries is not None
+            else settings.max_retries,
+            dlq_key=_dlq_key(topic),
         )
         self._retry_counts: dict[str, int] = {}
 
@@ -629,7 +670,7 @@ class Consumer(_Consumer):
         }
 
         # Store in Redis as a hash
-        message_id = f"dlq:{uuid.uuid4().hex}"
+        message_id = _dlq_message_key(self.topic)
         await redis_client.hset(message_id, mapping={"data": json.dumps(dlq_message)})
         # Add to a Redis set for easy retrieval
         await redis_client.sadd(self.subscription.dlq_key, message_id)
@@ -654,11 +695,12 @@ async def ephemeral_subscription(
     topic: str, source: Optional[str] = None, group: Optional[str] = None
 ) -> AsyncGenerator[dict[str, Any], None]:
     source = source or topic
+    source_stream = _stream_key(source)
     name = group or f"ephemeral-{socket.gethostname()}-{uuid.uuid4().hex}"
     redis_client: Redis = get_async_redis_client()
 
     try:
-        stream_info = await redis_client.xinfo_stream(source)
+        stream_info = await redis_client.xinfo_stream(source_stream)
         starting_message_id = stream_info["last-generated-id"]
     except ResponseError as exc:
         if "no such key" not in str(exc).lower():

--- a/src/integrations/prefect-redis/tests/test_messaging.py
+++ b/src/integrations/prefect-redis/tests/test_messaging.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import uuid
 from datetime import datetime, timedelta, timezone
 from functools import partial
@@ -16,11 +17,17 @@ from prefect_redis.messaging import (
     Publisher,
     RedisMessagingConsumerSettings,
     RedisMessagingPublisherSettings,
+    RedisStreamsMessage,
     StopConsumer,
     _cleanup_empty_consumer_groups,
+    _deduplication_key,
+    _dlq_key,
+    _dlq_message_key,
+    _stream_key,
     _trim_stream_to_lowest_delivered_id,
 )
-from redis.asyncio import Redis
+from redis.asyncio import Redis, RedisCluster
+from redis.cluster import key_slot
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from prefect.server.events import Event
@@ -119,6 +126,109 @@ async def drain_one(consumer: Consumer) -> Optional[Message]:
         await consumer.run(handler)
 
     return captured_messages[0] if captured_messages else None
+
+
+def test_messaging_keys_share_cluster_hash_slot(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "PREFECT_REDIS_MESSAGING_URL", "redis+cluster://redis.example.com:6379"
+    )
+
+    topic = "message-tests"
+    dlq_message_key = _dlq_message_key(topic)
+    keys = [
+        _stream_key(topic),
+        _deduplication_key(topic, "dedupe-id"),
+        _dlq_key(topic),
+        dlq_message_key,
+    ]
+
+    assert keys[:3] == [
+        "{message:message-tests}:stream",
+        "{message:message-tests}:dedupe:dedupe-id",
+        "{message:message-tests}:dlq",
+    ]
+    assert dlq_message_key.startswith("{message:message-tests}:dlq:")
+    assert len({key_slot(key.encode()) for key in keys}) == 1
+
+
+def test_messaging_keys_preserve_standalone_names(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("PREFECT_REDIS_MESSAGING_URL", raising=False)
+
+    topic = "message-tests"
+    assert _stream_key(topic) == topic
+    assert _deduplication_key(topic, "dedupe-id") == "message:message-tests:dedupe-id"
+    assert _dlq_key(topic) == "dlq"
+    assert _dlq_message_key(topic).startswith("dlq:")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PREFECT_REDIS_CLUSTER_TEST_URL"),
+    reason="requires PREFECT_REDIS_CLUSTER_TEST_URL",
+)
+async def test_messaging_runs_against_real_redis_cluster(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cluster_url = os.environ["PREFECT_REDIS_CLUSTER_TEST_URL"]
+    client_url = cluster_url.replace("redis+cluster://", "redis://", 1).replace(
+        "rediss+cluster://", "rediss://", 1
+    )
+    settings_url = cluster_url
+    if settings_url.startswith("redis://"):
+        settings_url = settings_url.replace("redis://", "redis+cluster://", 1)
+    elif settings_url.startswith("rediss://"):
+        settings_url = settings_url.replace("rediss://", "rediss+cluster://", 1)
+
+    redis_client = RedisCluster.from_url(client_url, decode_responses=True)
+    await redis_client.flushall()
+    try:
+        monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", settings_url)
+        monkeypatch.setattr(
+            "prefect_redis.messaging.get_async_redis_client",
+            lambda: redis_client,
+        )
+
+        topic = f"cluster-message-tests-{uuid.uuid4()}"
+        cache = Cache(topic=topic)
+        publisher = Publisher(
+            topic,
+            cache=cache,
+            deduplicate_by="message-id",
+            batch_size=1,
+            publish_every=None,
+        )
+        consumer = Consumer(topic, group=f"group-{uuid.uuid4()}")
+        captured_messages: list[Message] = []
+
+        async def handler(message: Message):
+            captured_messages.append(message)
+            raise StopConsumer(ack=True)
+
+        async with publisher as p:
+            await p.publish_data(b"hello", {"message-id": "A"})
+            await p.publish_data(b"duplicate", {"message-id": "A"})
+
+        await consumer.run(handler)
+
+        assert [message.data for message in captured_messages] == ["hello"]
+        assert await redis_client.xlen(_stream_key(topic)) == 1
+        assert await redis_client.scard(_dlq_key(topic)) == 0
+
+        failed_message = RedisStreamsMessage(
+            data="failed",
+            attributes={"message-id": "B"},
+            acker=lambda: asyncio.sleep(0),
+        )
+        await consumer._send_to_dlq(failed_message, retry_count=4)
+
+        dlq_message_ids = await redis_client.smembers(_dlq_key(topic))
+        assert len(dlq_message_ids) == 1
+        dlq_message_key = next(iter(dlq_message_ids))
+        assert dlq_message_key.startswith(f"{{message:{topic}}}:dlq:")
+        dlq_data = await redis_client.hget(dlq_message_key, "data")
+        assert json.loads(dlq_data)["data"] == "failed"
+    finally:
+        await redis_client.flushall()
+        await redis_client.aclose()
 
 
 async def test_publishing_and_consuming_a_single_message(


### PR DESCRIPTION
this PR makes Redis-backed messaging keys safe for future Redis Cluster support without enabling Cluster clients yet.

<details>
<summary>Details</summary>

- routes Redis stream names through a cluster-aware topic key helper
- routes deduplication keys and DLQ keys through the same topic hash slot under `redis+cluster://`
- preserves existing standalone Redis key names (`message-tests`, `message:<topic>:<id>`, `dlq`, `dlq:<uuid>`)
- updates ephemeral subscription startup to inspect the transformed stream key
- adds an opt-in real Redis Cluster messaging test guarded by `PREFECT_REDIS_CLUSTER_TEST_URL`

Redis Cluster URL client activation remains intentionally gated behind the existing `NotImplementedError`; this is another incremental key-safety slice from the #22211 follow-up list.

</details>

Validation:

- `uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_messaging.py -q`
- `PREFECT_REDIS_CLUSTER_TEST_URL=redis://prefect-redis-cluster-messaging.orb.local:7000 uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/test_messaging.py -q`
- `PREFECT_REDIS_CLUSTER_TEST_URL=redis://prefect-redis-cluster-messaging.orb.local:7000 uv run --project ./src/integrations/prefect-redis pytest src/integrations/prefect-redis/tests/ -q`
- `uv run ruff check src/integrations/prefect-redis/prefect_redis/messaging.py src/integrations/prefect-redis/tests/test_messaging.py`
- `uv run ruff format --check src/integrations/prefect-redis/prefect_redis/messaging.py src/integrations/prefect-redis/tests/test_messaging.py`

Local e2e Redis Cluster was a throwaway OrbStack/Docker `redis:7-alpine` single-node cluster with all slots assigned and hostname announcement via `prefect-redis-cluster-messaging.orb.local`.
