### PR TITLE
Fix CANCEL_NEW allowing Late runs when concurrency slots appear free

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1810,6 +1810,10 @@ class EnforceDeploymentConcurrencyOnLate(FlowRunOrchestrationRule):
     This closes the gap where CANCEL_NEW is normally enforced at the * -> PENDING
     transition (by SecureFlowConcurrencySlots), but runs that never reach PENDING
     because they go late would accumulate in a Late state instead of being cancelled.
+
+    That gap commonly appears when a worker or work-pool concurrency limit prevents
+    pickup: scheduled runs sit until MarkLateRuns proposes Late, and without this
+    rule they would pile up as Late even though the deployment uses CANCEL_NEW.
     """
 
     FROM_STATES = {StateType.SCHEDULED}
@@ -1852,6 +1856,11 @@ class EnforceDeploymentConcurrencyOnLate(FlowRunOrchestrationRule):
         limit = deployment.global_concurrency_limit
         if not limit:
             return
+
+        # Server sessions use expire_on_commit=False, and concurrency slot updates use
+        # synchronize_session=False. Refresh so we never decide on a stale active_slots
+        # value from the identity map (e.g. after earlier transitions in the same session).
+        await context.session.refresh(limit)
 
         if limit.active_slots >= limit.limit:
             await self.reject_transition(

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -30,6 +30,7 @@ from prefect.server.orchestration.core_policy import (
     CopyScheduledTime,
     CopyTaskParametersID,
     EnforceCancellingToCancelledTransition,
+    EnforceDeploymentConcurrencyOnLate,
     EnsureOnlyScheduledFlowsMarkedLate,
     HandleFlowTerminalStateTransitions,
     HandlePausingFlows,
@@ -1814,6 +1815,204 @@ class TestEnsureOnlyScheduledFlowMarkedLate:
             await ctx.validate_proposed_state()
 
         assert ctx.response_status == SetStateStatus.REJECT
+
+
+class TestEnforceDeploymentConcurrencyOnLate:
+    """Unit tests for CANCEL_NEW enforcement when marking runs Late.
+
+    CANCEL_NEW is normally enforced on * → PENDING by SecureFlowConcurrencySlots.
+    When a worker or work-pool concurrency limit prevents pickup, runs never reach
+    PENDING and would otherwise accumulate as Late. This rule cancels them instead
+    when the deployment concurrency limit is full.
+
+    Regression coverage for https://github.com/PrefectHQ/prefect/issues/16984
+    and https://github.com/PrefectHQ/prefect/issues/21060
+    """
+
+    late_transition = (StateType.SCHEDULED, StateType.SCHEDULED)
+
+    async def create_deployment_with_concurrency_limit(
+        self,
+        session,
+        limit,
+        flow,
+        collision_strategy: Optional[schemas.core.ConcurrencyLimitStrategy] = None,
+    ):
+        deployment_kwargs = {
+            "name": f"test-deployment-{uuid4()}",
+            "flow_id": flow.id,
+            "concurrency_limit": limit,
+        }
+        if collision_strategy is not None:
+            deployment_kwargs["concurrency_options"] = {
+                "collision_strategy": collision_strategy
+            }
+
+        deployment = await deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(**deployment_kwargs),
+        )
+        await session.flush()
+        return deployment
+
+    async def test_cancels_when_cancel_new_and_limit_is_full(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        deployment = await self.create_deployment_with_concurrency_limit(
+            session, 1, flow, schemas.core.ConcurrencyLimitStrategy.CANCEL_NEW
+        )
+        await concurrency_limits_v2.bulk_increment_active_slots(
+            session=session,
+            concurrency_limit_ids=[deployment.concurrency_limit_id],
+            slots=1,
+        )
+        await session.commit()
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *self.late_transition,
+            proposed_state_name="Late",
+            deployment_id=deployment.id,
+        )
+
+        async with EnforceDeploymentConcurrencyOnLate(
+            ctx, *self.late_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.REJECT
+        assert ctx.proposed_state is not None
+        assert ctx.proposed_state.is_cancelled()
+        assert ctx.proposed_state.message == "Deployment concurrency limit reached."
+        assert "CANCEL_NEW" in ctx.response_details.reason
+
+    async def test_allows_late_when_cancel_new_but_slots_available(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        deployment = await self.create_deployment_with_concurrency_limit(
+            session, 1, flow, schemas.core.ConcurrencyLimitStrategy.CANCEL_NEW
+        )
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *self.late_transition,
+            proposed_state_name="Late",
+            deployment_id=deployment.id,
+        )
+
+        async with EnforceDeploymentConcurrencyOnLate(
+            ctx, *self.late_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+        assert ctx.proposed_state is not None
+        assert ctx.proposed_state.name == "Late"
+
+    async def test_allows_late_when_enqueue_strategy_even_if_full(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        deployment = await self.create_deployment_with_concurrency_limit(
+            session, 1, flow, schemas.core.ConcurrencyLimitStrategy.ENQUEUE
+        )
+        await concurrency_limits_v2.bulk_increment_active_slots(
+            session=session,
+            concurrency_limit_ids=[deployment.concurrency_limit_id],
+            slots=1,
+        )
+        await session.commit()
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *self.late_transition,
+            proposed_state_name="Late",
+            deployment_id=deployment.id,
+        )
+
+        async with EnforceDeploymentConcurrencyOnLate(
+            ctx, *self.late_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+        assert ctx.proposed_state is not None
+        assert ctx.proposed_state.name == "Late"
+
+    async def test_allows_late_when_no_deployment_concurrency(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        deployment = await deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name=f"no-limit-{uuid4()}",
+                flow_id=flow.id,
+            ),
+        )
+        await session.flush()
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *self.late_transition,
+            proposed_state_name="Late",
+            deployment_id=deployment.id,
+        )
+
+        async with EnforceDeploymentConcurrencyOnLate(
+            ctx, *self.late_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+        assert ctx.proposed_state is not None
+        assert ctx.proposed_state.name == "Late"
+
+    async def test_ignores_non_late_scheduled_transitions(
+        self,
+        session,
+        initialize_orchestration,
+        flow,
+    ):
+        """Non-Late Scheduled→Scheduled transitions (e.g. reschedule) are unaffected."""
+        deployment = await self.create_deployment_with_concurrency_limit(
+            session, 1, flow, schemas.core.ConcurrencyLimitStrategy.CANCEL_NEW
+        )
+        await concurrency_limits_v2.bulk_increment_active_slots(
+            session=session,
+            concurrency_limit_ids=[deployment.concurrency_limit_id],
+            slots=1,
+        )
+        await session.commit()
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *self.late_transition,
+            proposed_state_name="AwaitingConcurrencySlot",
+            deployment_id=deployment.id,
+        )
+
+        async with EnforceDeploymentConcurrencyOnLate(
+            ctx, *self.late_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
 
 
 @pytest.mark.parametrize("run_type", ["flow"])

--- a/tests/server/services/test_late_runs.py
+++ b/tests/server/services/test_late_runs.py
@@ -190,7 +190,11 @@ async def test_cancels_late_run_when_deployment_has_cancel_new_and_limit_is_full
     """When a deployment uses CANCEL_NEW and its concurrency limit is full,
     mark_flow_run_late should cancel the run instead of marking it Late.
 
-    Regression test for https://github.com/PrefectHQ/prefect/issues/21060
+    This is the path taken when worker or work-pool concurrency limits prevent
+    runs from reaching PENDING, so CANCEL_NEW never fires at SecureFlowConcurrencySlots.
+
+    Regression test for https://github.com/PrefectHQ/prefect/issues/16984
+    and https://github.com/PrefectHQ/prefect/issues/21060
     """
     # create a deployment with CANCEL_NEW, limit=1
     deployment = await models.deployments.create_deployment(
@@ -255,7 +259,8 @@ async def test_marks_late_not_cancelled_when_cancel_new_but_limit_not_full(
     """When a deployment uses CANCEL_NEW but the concurrency limit has
     available slots, runs should be marked Late normally (not cancelled).
 
-    Regression test for https://github.com/PrefectHQ/prefect/issues/21060
+    Regression test for https://github.com/PrefectHQ/prefect/issues/16984
+    and https://github.com/PrefectHQ/prefect/issues/21060
     """
     deployment = await models.deployments.create_deployment(
         session=session,
@@ -294,7 +299,8 @@ async def test_marks_late_when_deployment_has_enqueue_strategy(session, flow, db
     """Runs on ENQUEUE deployments should always be marked Late, even when
     the concurrency limit is full.
 
-    Regression test for https://github.com/PrefectHQ/prefect/issues/21060
+    Regression test for https://github.com/PrefectHQ/prefect/issues/16984
+    and https://github.com/PrefectHQ/prefect/issues/21060
     """
     deployment = await models.deployments.create_deployment(
         session=session,


### PR DESCRIPTION
closes #16984

## Summary

this PR ensures the `CANCEL_NEW` deployment concurrency strategy still cancels excess runs when worker or work-pool concurrency limits prevent them from reaching `PENDING`.

## Details

`CANCEL_NEW` is normally enforced by `SecureFlowConcurrencySlots` on `* → PENDING`. When a worker or work-pool concurrency limit is full, scheduled runs never reach that transition and instead sit until `MarkLateRuns` proposes `Late`.

`EnforceDeploymentConcurrencyOnLate` (from #21086) already intercepts that path, but it decided whether the limit was full from the ORM identity map. Server sessions use `expire_on_commit=False`, and concurrency slot updates use `synchronize_session=False`, so `active_slots` can be stale. The rule could accept `Late` even when the deployment concurrency limit was already full — which is the behavior reported in #16984 when worker/work-pool limits keep runs from being claimed.

This PR:

- refreshes the concurrency limit before the full-slot check
- adds direct unit tests for `EnforceDeploymentConcurrencyOnLate` covering CANCEL_NEW / ENQUEUE / empty-slot cases
- documents the worker and work-pool concurrency interaction in the rule and regression tests

### Test plan

- [x] `uv run pytest tests/server/orchestration/test_core_policy.py::TestEnforceDeploymentConcurrencyOnLate -v`
- [x] `uv run pytest tests/server/services/test_late_runs.py -v`