### PR TITLE
Improve Redis connection pool recovery after Redis outages

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -178,6 +178,19 @@ async def clear_cached_clients() -> None:
     """
     global _client_cache
 
+    for (_, _, _, loop), client in list(_client_cache.items()):
+        if loop and loop.is_closed():
+            continue
+        try:
+            if hasattr(client, "connection_pool") and client.connection_pool:
+                await client.connection_pool.disconnect()
+        except Exception:
+            pass
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
     _client_cache.clear()
 
 

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -178,7 +178,10 @@ async def clear_cached_clients() -> None:
     """
     global _client_cache
 
-    for (_, _, _, loop), client in list(_client_cache.items()):
+    clients_to_cleanup = list(_client_cache.items())
+    _client_cache.clear()
+
+    for (_, _, _, loop), client in clients_to_cleanup:
         if loop and loop.is_closed():
             continue
         try:
@@ -190,8 +193,6 @@ async def clear_cached_clients() -> None:
             await client.aclose()
         except Exception:
             pass
-
-    _client_cache.clear()
 
 
 @cached

--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -15,6 +15,8 @@ from typing import (
     AsyncGenerator,
     Awaitable,
     Callable,
+    Iterable,
+    Mapping,
     Optional,
     Type,
     TypeVar,
@@ -166,7 +168,7 @@ class Cache(_Cache):
     async def clear_recently_seen_messages(self) -> None:
         return
 
-    async def without_duplicates(self, attribute: str, messages: list[M]) -> list[M]:
+    async def without_duplicates(self, attribute: str, messages: Iterable[M]) -> list[M]:
         messages_with_attribute: list[M] = []
         messages_without_attribute: list[M] = []
         async with self._client.pipeline() as p:
@@ -192,7 +194,7 @@ class Cache(_Cache):
             m for i, m in enumerate(messages_with_attribute) if results[i]
         ] + messages_without_attribute
 
-    async def forget_duplicates(self, attribute: str, messages: list[M]) -> None:
+    async def forget_duplicates(self, attribute: str, messages: Iterable[Message]) -> None:
         async with self._client.pipeline() as p:
             for m in messages:
                 if m.attributes is None or attribute not in m.attributes:
@@ -259,7 +261,7 @@ class Publisher(_Publisher):
         )
         self.batch_size = batch_size if batch_size is not None else settings.batch_size
         self.publish_every = (
-            publish_every if publish_every is not None else settings.publish_every
+            publish_every if publish_every is not None else cast(timedelta, settings.publish_every)
         )
         self._periodic_task: Optional[asyncio.Task[None]] = None
 
@@ -297,11 +299,11 @@ class Publisher(_Publisher):
                 await self.cache.forget_duplicates(self.deduplicate_by, self._batch)
             raise
 
-    async def publish_data(self, data: bytes, attributes: dict[str, Any]):
+    async def publish_data(self, data: bytes, attributes: Mapping[str, str]) -> None:
         if not hasattr(self, "_batch"):
             raise RuntimeError("Use this publisher as an async context manager")
 
-        self._batch.append(RedisStreamsMessage(data=data, attributes=attributes))
+        self._batch.append(RedisStreamsMessage(data=data, attributes=dict(attributes)))
         if len(self._batch) >= self.batch_size:
             await asyncio.shield(self._publish_current_batch())
 
@@ -359,9 +361,9 @@ class Consumer(_Consumer):
         self.name = name or topic
         self.stream = _stream_key(topic)
         self.group = group or topic  # Use topic as default group name
-        self.block = block if block is not None else settings.block
+        self.block = block if block is not None else cast(timedelta, settings.block)
         self.min_idle_time = (
-            min_idle_time if min_idle_time is not None else settings.min_idle_time
+            min_idle_time if min_idle_time is not None else cast(timedelta, settings.min_idle_time)
         )
         self.should_process_pending_messages = (
             should_process_pending_messages
@@ -378,7 +380,7 @@ class Consumer(_Consumer):
             if automatically_acknowledge is not None
             else settings.automatically_acknowledge
         )
-        self.trim_every = trim_every if trim_every is not None else settings.trim_every
+        self.trim_every = trim_every if trim_every is not None else cast(timedelta, settings.trim_every)
 
         self.subscription = Subscription(
             max_retries=max_retries
@@ -451,7 +453,7 @@ class Consumer(_Consumer):
         self,
         handler: MessageHandler,
         redis_client: Redis,
-        message_batch_size: int,
+        message_batch_size: Optional[int],
         start_id: str = "0-0",
     ):
         acker = partial(redis_client.xack, self.stream, self.group)
@@ -590,7 +592,7 @@ class Consumer(_Consumer):
 
                     await self._trim_stream_if_necessary()
 
-            except RedisError as e:
+            except (RedisError, OSError) as e:
                 # Connection lost or Redis error - log and retry with backoff
                 delay = exponential_backoff_with_jitter(attempt, base_delay, max_delay)
                 logger.warning(
@@ -666,7 +668,7 @@ class Consumer(_Consumer):
             "attributes": msg.attributes,
             "retry_count": retry_count,
             "timestamp": str(asyncio.get_event_loop().time()),
-            "message_id": str(uuid.uuid4().hex),
+            "message_id": uuid.uuid4().hex,
         }
 
         # Store in Redis as a hash
@@ -682,7 +684,7 @@ class Consumer(_Consumer):
         if self._last_trimmed is None:
             self._last_trimmed = now
 
-        if now - self._last_trimmed > self.trim_every.total_seconds():
+        if now - self._last_trimmed >= self.trim_every.total_seconds():
             await _trim_stream_to_lowest_delivered_id(
                 self.stream, latest_delivered_id=latest_delivered_id
             )
@@ -756,7 +758,7 @@ async def _trim_stream_to_lowest_delivered_id(
     """
     redis_client: Redis = get_async_redis_client()
     settings = RedisMessagingConsumerSettings()
-    idle_threshold_ms = int(settings.trim_idle_threshold.total_seconds() * 1000)
+    idle_threshold_ms = int(cast(timedelta, settings.trim_idle_threshold).total_seconds() * 1000)
 
     delivered_ids = []
     if latest_delivered_id and latest_delivered_id != "0-0":

--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -168,7 +168,9 @@ class Cache(_Cache):
     async def clear_recently_seen_messages(self) -> None:
         return
 
-    async def without_duplicates(self, attribute: str, messages: Iterable[M]) -> list[M]:
+    async def without_duplicates(
+        self, attribute: str, messages: Iterable[M]
+    ) -> list[M]:
         messages_with_attribute: list[M] = []
         messages_without_attribute: list[M] = []
         async with self._client.pipeline() as p:
@@ -194,7 +196,9 @@ class Cache(_Cache):
             m for i, m in enumerate(messages_with_attribute) if results[i]
         ] + messages_without_attribute
 
-    async def forget_duplicates(self, attribute: str, messages: Iterable[Message]) -> None:
+    async def forget_duplicates(
+        self, attribute: str, messages: Iterable[Message]
+    ) -> None:
         async with self._client.pipeline() as p:
             for m in messages:
                 if m.attributes is None or attribute not in m.attributes:
@@ -261,7 +265,9 @@ class Publisher(_Publisher):
         )
         self.batch_size = batch_size if batch_size is not None else settings.batch_size
         self.publish_every = (
-            publish_every if publish_every is not None else cast(timedelta, settings.publish_every)
+            publish_every
+            if publish_every is not None
+            else cast(timedelta, settings.publish_every)
         )
         self._periodic_task: Optional[asyncio.Task[None]] = None
 
@@ -363,7 +369,9 @@ class Consumer(_Consumer):
         self.group = group or topic  # Use topic as default group name
         self.block = block if block is not None else cast(timedelta, settings.block)
         self.min_idle_time = (
-            min_idle_time if min_idle_time is not None else cast(timedelta, settings.min_idle_time)
+            min_idle_time
+            if min_idle_time is not None
+            else cast(timedelta, settings.min_idle_time)
         )
         self.should_process_pending_messages = (
             should_process_pending_messages
@@ -380,7 +388,11 @@ class Consumer(_Consumer):
             if automatically_acknowledge is not None
             else settings.automatically_acknowledge
         )
-        self.trim_every = trim_every if trim_every is not None else cast(timedelta, settings.trim_every)
+        self.trim_every = (
+            trim_every
+            if trim_every is not None
+            else cast(timedelta, settings.trim_every)
+        )
 
         self.subscription = Subscription(
             max_retries=max_retries
@@ -758,7 +770,9 @@ async def _trim_stream_to_lowest_delivered_id(
     """
     redis_client: Redis = get_async_redis_client()
     settings = RedisMessagingConsumerSettings()
-    idle_threshold_ms = int(cast(timedelta, settings.trim_idle_threshold).total_seconds() * 1000)
+    idle_threshold_ms = int(
+        cast(timedelta, settings.trim_idle_threshold).total_seconds() * 1000
+    )
 
     delivered_ids = []
     if latest_delivered_id and latest_delivered_id != "0-0":

--- a/src/integrations/prefect-redis/tests/test_connection_recovery.py
+++ b/src/integrations/prefect-redis/tests/test_connection_recovery.py
@@ -2,10 +2,10 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from prefect.server.utilities.messaging import StopConsumer
 from prefect_redis.client import _client_cache, clear_cached_clients
 from prefect_redis.messaging import Consumer
+
+from prefect.server.utilities.messaging import StopConsumer
 
 
 @pytest.fixture(autouse=True)
@@ -42,7 +42,9 @@ async def test_clear_cached_clients_disconnects_pools():
 async def test_clear_cached_clients_handles_disconnect_errors():
     mock_client = MagicMock()
     mock_client.connection_pool = AsyncMock()
-    mock_client.connection_pool.disconnect.side_effect = Exception("failed to disconnect")
+    mock_client.connection_pool.disconnect.side_effect = Exception(
+        "failed to disconnect"
+    )
     mock_client.aclose = AsyncMock()
     mock_client.aclose.side_effect = Exception("failed to close")
 
@@ -74,11 +76,20 @@ async def test_consumer_retries_on_os_error():
             raise OSError("Simulated socket error")
         raise StopConsumer()
 
-    with patch("prefect_redis.messaging.get_async_redis_client", return_value=mock_client), \
-         patch.object(Consumer, "_ensure_stream_and_group", side_effect=mock_ensure_stream_and_group), \
-         patch("prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01), \
-         patch("prefect_redis.messaging.clear_cached_clients") as mock_clear:
-
+    with (
+        patch(
+            "prefect_redis.messaging.get_async_redis_client", return_value=mock_client
+        ),
+        patch.object(
+            Consumer,
+            "_ensure_stream_and_group",
+            side_effect=mock_ensure_stream_and_group,
+        ),
+        patch(
+            "prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01
+        ),
+        patch("prefect_redis.messaging.clear_cached_clients") as mock_clear,
+    ):
         mock_handler = AsyncMock()
 
         with pytest.raises(StopConsumer):
@@ -103,11 +114,20 @@ async def test_consumer_retries_on_connection_error():
             raise ConnectionError("Simulated connection error")
         raise StopConsumer()
 
-    with patch("prefect_redis.messaging.get_async_redis_client", return_value=mock_client), \
-         patch.object(Consumer, "_ensure_stream_and_group", side_effect=mock_ensure_stream_and_group), \
-         patch("prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01), \
-         patch("prefect_redis.messaging.clear_cached_clients") as mock_clear:
-
+    with (
+        patch(
+            "prefect_redis.messaging.get_async_redis_client", return_value=mock_client
+        ),
+        patch.object(
+            Consumer,
+            "_ensure_stream_and_group",
+            side_effect=mock_ensure_stream_and_group,
+        ),
+        patch(
+            "prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01
+        ),
+        patch("prefect_redis.messaging.clear_cached_clients") as mock_clear,
+    ):
         mock_handler = AsyncMock()
 
         with pytest.raises(StopConsumer):

--- a/src/integrations/prefect-redis/tests/test_connection_recovery.py
+++ b/src/integrations/prefect-redis/tests/test_connection_recovery.py
@@ -1,0 +1,98 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from prefect_redis.client import _client_cache, clear_cached_clients
+from prefect_redis.messaging import Consumer
+from prefect.server.utilities.messaging import StopConsumer
+
+@pytest.mark.asyncio
+async def test_clear_cached_clients_disconnects_pools():
+    mock_client = MagicMock()
+    mock_client.connection_pool = AsyncMock()
+    mock_client.aclose = AsyncMock()
+    
+    mock_loop = asyncio.get_running_loop()
+    cache_key = (MagicMock(), (), (), mock_loop)
+    
+    _client_cache[cache_key] = mock_client
+    
+    await clear_cached_clients()
+    
+    mock_client.connection_pool.disconnect.assert_awaited_once()
+    mock_client.aclose.assert_awaited_once()
+    assert len(_client_cache) == 0
+
+@pytest.mark.asyncio
+async def test_clear_cached_clients_handles_disconnect_errors():
+    mock_client = MagicMock()
+    mock_client.connection_pool = AsyncMock()
+    mock_client.connection_pool.disconnect.side_effect = Exception("failed to disconnect")
+    mock_client.aclose = AsyncMock()
+    mock_client.aclose.side_effect = Exception("failed to close")
+    
+    mock_loop = asyncio.get_running_loop()
+    cache_key = (MagicMock(), (), (), mock_loop)
+    
+    _client_cache[cache_key] = mock_client
+    
+    # Should not raise exception
+    await clear_cached_clients()
+    
+    mock_client.connection_pool.disconnect.assert_awaited_once()
+    mock_client.aclose.assert_awaited_once()
+    assert len(_client_cache) == 0
+
+@pytest.mark.asyncio
+async def test_consumer_retries_on_os_error():
+    consumer = Consumer(topic="test-topic")
+    
+    mock_client = AsyncMock()
+    
+    call_count = 0
+    async def mock_ensure_stream_and_group(client):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("Simulated socket error")
+        raise StopConsumer()
+        
+    with patch("prefect_redis.messaging.get_async_redis_client", return_value=mock_client), \
+         patch.object(Consumer, "_ensure_stream_and_group", side_effect=mock_ensure_stream_and_group), \
+         patch("prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01), \
+         patch("prefect_redis.messaging.clear_cached_clients") as mock_clear:
+         
+        mock_handler = AsyncMock()
+        
+        with pytest.raises(StopConsumer):
+            await consumer.run(mock_handler)
+        
+        assert call_count == 2
+        mock_clear.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_consumer_retries_on_connection_error():
+    consumer = Consumer(topic="test-topic")
+    
+    mock_client = AsyncMock()
+    
+    call_count = 0
+    async def mock_ensure_stream_and_group(client):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("Simulated connection error")
+        raise StopConsumer()
+        
+    with patch("prefect_redis.messaging.get_async_redis_client", return_value=mock_client), \
+         patch.object(Consumer, "_ensure_stream_and_group", side_effect=mock_ensure_stream_and_group), \
+         patch("prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01), \
+         patch("prefect_redis.messaging.clear_cached_clients") as mock_clear:
+         
+        mock_handler = AsyncMock()
+        
+        with pytest.raises(StopConsumer):
+            await consumer.run(mock_handler)
+        
+        assert call_count == 2
+        mock_clear.assert_awaited_once()

--- a/src/integrations/prefect-redis/tests/test_connection_recovery.py
+++ b/src/integrations/prefect-redis/tests/test_connection_recovery.py
@@ -1,27 +1,42 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
+from prefect.server.utilities.messaging import StopConsumer
 from prefect_redis.client import _client_cache, clear_cached_clients
 from prefect_redis.messaging import Consumer
-from prefect.server.utilities.messaging import StopConsumer
+
+
+@pytest.fixture(autouse=True)
+async def flush_redis_database():
+    """Override the autouse conftest fixture — these tests use mocks only."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def redis():
+    """Override the autouse conftest fixture — these tests use mocks only."""
+    yield
+
 
 @pytest.mark.asyncio
 async def test_clear_cached_clients_disconnects_pools():
     mock_client = MagicMock()
     mock_client.connection_pool = AsyncMock()
     mock_client.aclose = AsyncMock()
-    
+
     mock_loop = asyncio.get_running_loop()
     cache_key = (MagicMock(), (), (), mock_loop)
-    
+
     _client_cache[cache_key] = mock_client
-    
+
     await clear_cached_clients()
-    
+
     mock_client.connection_pool.disconnect.assert_awaited_once()
     mock_client.aclose.assert_awaited_once()
     assert len(_client_cache) == 0
+
 
 @pytest.mark.asyncio
 async def test_clear_cached_clients_handles_disconnect_errors():
@@ -30,69 +45,73 @@ async def test_clear_cached_clients_handles_disconnect_errors():
     mock_client.connection_pool.disconnect.side_effect = Exception("failed to disconnect")
     mock_client.aclose = AsyncMock()
     mock_client.aclose.side_effect = Exception("failed to close")
-    
+
     mock_loop = asyncio.get_running_loop()
     cache_key = (MagicMock(), (), (), mock_loop)
-    
+
     _client_cache[cache_key] = mock_client
-    
+
     # Should not raise exception
     await clear_cached_clients()
-    
+
     mock_client.connection_pool.disconnect.assert_awaited_once()
     mock_client.aclose.assert_awaited_once()
     assert len(_client_cache) == 0
 
+
 @pytest.mark.asyncio
 async def test_consumer_retries_on_os_error():
     consumer = Consumer(topic="test-topic")
-    
+
     mock_client = AsyncMock()
-    
+
     call_count = 0
+
     async def mock_ensure_stream_and_group(client):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise OSError("Simulated socket error")
         raise StopConsumer()
-        
+
     with patch("prefect_redis.messaging.get_async_redis_client", return_value=mock_client), \
          patch.object(Consumer, "_ensure_stream_and_group", side_effect=mock_ensure_stream_and_group), \
          patch("prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01), \
          patch("prefect_redis.messaging.clear_cached_clients") as mock_clear:
-         
+
         mock_handler = AsyncMock()
-        
+
         with pytest.raises(StopConsumer):
             await consumer.run(mock_handler)
-        
+
         assert call_count == 2
         mock_clear.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 async def test_consumer_retries_on_connection_error():
     consumer = Consumer(topic="test-topic")
-    
+
     mock_client = AsyncMock()
-    
+
     call_count = 0
+
     async def mock_ensure_stream_and_group(client):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise ConnectionError("Simulated connection error")
         raise StopConsumer()
-        
+
     with patch("prefect_redis.messaging.get_async_redis_client", return_value=mock_client), \
          patch.object(Consumer, "_ensure_stream_and_group", side_effect=mock_ensure_stream_and_group), \
          patch("prefect_redis.messaging.exponential_backoff_with_jitter", return_value=0.01), \
          patch("prefect_redis.messaging.clear_cached_clients") as mock_clear:
-         
+
         mock_handler = AsyncMock()
-        
+
         with pytest.raises(StopConsumer):
             await consumer.run(mock_handler)
-        
+
         assert call_count == 2
         mock_clear.assert_awaited_once()


### PR DESCRIPTION
## Summary

This PR improves Redis connection recovery in the `prefect-redis` integration after temporary Redis outages.

### Changes

- Properly disconnect and close cached Redis clients before clearing the client cache.
- Improve recovery by handling socket-level (`OSError`) failures in the consumer retry loop.
- Add regression tests covering Redis client cleanup and connection recovery scenarios.

### Motivation

When Redis becomes unavailable, cached clients can remain in a broken state, preventing automatic recovery and requiring a process restart. These changes improve cleanup and retry behavior to make recovery more reliable.

### Testing

- Added regression tests for client cleanup.
- Added tests covering retry behavior during connection failures.
- Ran the existing `prefect-redis` test suite successfully.