### PR TITLE
fix(ui): keep pause form description visible

### DIFF
--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
@@ -213,7 +213,7 @@ describe("ResumeFlowRunDialog", () => {
 		});
 	});
 
-	it("keeps markdown description outside the scrollable form with many fields", async () => {
+	it("bounds the markdown description separately from a scrollable form", async () => {
 		const manyFieldProperties: Record<
 			string,
 			{ type: string; title: string; default?: number }
@@ -279,14 +279,17 @@ describe("ResumeFlowRunDialog", () => {
 			).toBeInTheDocument();
 		});
 
-		// Keep validation context visible while the long form itself scrolls.
+		// Keep validation context visible and independently bounded while the long
+		// form uses the remaining dialog space.
 		const descriptionElement = screen.getByText(
 			"One or more of your inputs were invalid.",
 		);
 		expect(descriptionElement).toBeVisible();
-		expect(descriptionElement.closest(".overflow-y-auto")).toBeNull();
+		const descriptionScroller = descriptionElement.closest(".overflow-y-auto");
+		expect(descriptionScroller).not.toBeNull();
+		expect(descriptionScroller).toHaveClass("max-h-48");
 		expect(
 			screen.getByLabelText(/Field 10/).closest(".overflow-y-auto"),
-		).not.toBeNull();
+		).not.toBe(descriptionScroller);
 	});
 });

--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
@@ -213,7 +213,7 @@ describe("ResumeFlowRunDialog", () => {
 		});
 	});
 
-	it("renders markdown description alongside many input fields", async () => {
+	it("keeps markdown description outside the scrollable form with many fields", async () => {
 		const manyFieldProperties: Record<
 			string,
 			{ type: string; title: string; default?: number }
@@ -279,10 +279,14 @@ describe("ResumeFlowRunDialog", () => {
 			).toBeInTheDocument();
 		});
 
-		// Verify the description element is visible (not collapsed to 0 height)
+		// Keep validation context visible while the long form itself scrolls.
 		const descriptionElement = screen.getByText(
 			"One or more of your inputs were invalid.",
 		);
 		expect(descriptionElement).toBeVisible();
+		expect(descriptionElement.closest(".overflow-y-auto")).toBeNull();
+		expect(
+			screen.getByLabelText(/Field 10/).closest(".overflow-y-auto"),
+		).not.toBeNull();
 	});
 });

--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
@@ -213,7 +213,7 @@ describe("ResumeFlowRunDialog", () => {
 		});
 	});
 
-	it("bounds the markdown description separately from a scrollable form", async () => {
+	it("bounds the markdown description by the viewport separately from the scrollable form", async () => {
 		const manyFieldProperties: Record<
 			string,
 			{ type: string; title: string; default?: number }
@@ -279,15 +279,15 @@ describe("ResumeFlowRunDialog", () => {
 			).toBeInTheDocument();
 		});
 
-		// Keep validation context visible and independently bounded while the long
-		// form uses the remaining dialog space.
+		// Keep validation context visible and independently bounded relative to the
+		// viewport while the long form uses the remaining dialog space.
 		const descriptionElement = screen.getByText(
 			"One or more of your inputs were invalid.",
 		);
 		expect(descriptionElement).toBeVisible();
 		const descriptionScroller = descriptionElement.closest(".overflow-y-auto");
 		expect(descriptionScroller).not.toBeNull();
-		expect(descriptionScroller).toHaveClass("max-h-48");
+		expect(descriptionScroller).toHaveClass("max-h-[min(12rem,20vh)]");
 		expect(
 			screen.getByLabelText(/Field 10/).closest(".overflow-y-auto"),
 		).not.toBe(descriptionScroller);

--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.test.tsx
@@ -291,5 +291,13 @@ describe("ResumeFlowRunDialog", () => {
 		expect(
 			screen.getByLabelText(/Field 10/).closest(".overflow-y-auto"),
 		).not.toBe(descriptionScroller);
+
+		// The footer sits outside both scroll regions, so neither a long
+		// description nor a long form can push Resume/Cancel off screen.
+		for (const name of [/Resume/, /Cancel/]) {
+			const button = screen.getByRole("button", { name });
+			expect(button).toBeVisible();
+			expect(button.closest(".overflow-y-auto")).toBeNull();
+		}
 	});
 });

--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.tsx
@@ -230,22 +230,20 @@ const ResumeDialogWithInput = ({
 				</DialogDescription>
 			</DialogHeader>
 
-			<div className="overflow-y-auto flex-1 min-h-0">
-				{description && (
-					<div className="prose prose-sm dark:prose-invert max-w-none py-2 px-3 bg-muted/50 rounded-md">
-						<LazyMarkdown>{description}</LazyMarkdown>
-					</div>
-				)}
-
-				<div className="py-4">
-					<LazySchemaForm
-						schema={schema}
-						values={values}
-						onValuesChange={setValues}
-						errors={errors}
-						kinds={["json"]}
-					/>
+			{description && (
+				<div className="prose prose-sm dark:prose-invert max-w-none py-2 px-3 bg-muted/50 rounded-md shrink-0">
+					<LazyMarkdown>{description}</LazyMarkdown>
 				</div>
+			)}
+
+			<div className="overflow-y-auto flex-1 min-h-0 py-4">
+				<LazySchemaForm
+					schema={schema}
+					values={values}
+					onValuesChange={setValues}
+					errors={errors}
+					kinds={["json"]}
+				/>
 			</div>
 
 			<DialogFooter>

--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.tsx
@@ -231,7 +231,7 @@ const ResumeDialogWithInput = ({
 			</DialogHeader>
 
 			{description && (
-				<div className="prose prose-sm dark:prose-invert max-w-none py-2 px-3 bg-muted/50 rounded-md shrink-0">
+				<div className="prose prose-sm dark:prose-invert max-w-none max-h-48 overflow-y-auto py-2 px-3 bg-muted/50 rounded-md shrink-0">
 					<LazyMarkdown>{description}</LazyMarkdown>
 				</div>
 			)}

--- a/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-actions/resume-flow-run-dialog.tsx
@@ -231,7 +231,7 @@ const ResumeDialogWithInput = ({
 			</DialogHeader>
 
 			{description && (
-				<div className="prose prose-sm dark:prose-invert max-w-none max-h-48 overflow-y-auto py-2 px-3 bg-muted/50 rounded-md shrink-0">
+				<div className="prose prose-sm dark:prose-invert max-w-none max-h-[min(12rem,20vh)] overflow-y-auto py-2 px-3 bg-muted/50 rounded-md shrink-0">
 					<LazyMarkdown>{description}</LazyMarkdown>
 				</div>
 			)}


### PR DESCRIPTION
closes #21491

This PR keeps pause/resume input guidance visible while long schema forms scroll.

<details>
<summary>Details</summary>

The markdown description and schema form currently share one `overflow-y-auto` container. With enough fields, scrolling the form also removes validation context such as "One or more of your inputs were invalid" from view.

The description now sits above the form scroller and has its own overflow region capped at `min(12rem, 20vh)`, so it contracts on short viewports without pushing the form or footer off-screen. The schema form scrolls independently, and the footer stays outside both scrolling regions. Dialog headers, schema behavior, and API behavior are unchanged.

The existing ten-field regression asserts both sides of the layout contract: the description is outside the form scroll container, has the responsive height cap, and the final field remains inside the form scroller.

</details>

Verification:
- `npm test -- resume-flow-run-dialog.test.tsx --run` (9 passed)
- Biome check on both touched files
- ESLint on both touched files
- `npm run validate:types`
- `npm run build`
- `git diff --check`
- Browser geometry checks at 800x480 and 800x360 confirmed independent description/form scrolling with the footer remaining accessible

The local Node version was 24.14.0 versus the package's declared Node 22 range; tests, type validation, and the full production build still completed successfully.