### PR TITLE
publish prefect docker imgs to aws ecr to public gallery

### DIFF
--- a/.github/workflows/prefect-aws-docker-images.yaml
+++ b/.github/workflows/prefect-aws-docker-images.yaml
@@ -60,11 +60,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.PREFECT_AWS_DOCKERHUB_TOKEN }}
 
+      - name: Login to ECR Public
+        uses: docker/login-action@v4
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.ECR_PUBLIC_AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.ECR_PUBLIC_AWS_SECRET_ACCESS_KEY }}
+
       - name: Generate Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: prefecthq/prefect-aws
+          images: |
+            prefecthq/prefect-aws
+            public.ecr.aws/prefecthq/prefect-aws
           tags: |
             # Full version tag: prefect-aws-version-python-version-prefect-version
             type=raw,value=${{ env.PREFECT_AWS_VERSION }}-python${{ matrix.python-version }}-prefect${{ env.PREFECT_VERSION }}

--- a/src/integrations/prefect-aws/README.md
+++ b/src/integrations/prefect-aws/README.md
@@ -36,6 +36,21 @@ Install `prefect-aws` as a dependency of Prefect. If you don't already have `pre
 pip install "prefect[aws]"
 ```
 
+### Docker images
+
+Pre-built Docker images with `prefect-aws` installed are available from:
+
+- **Docker Hub**: `prefecthq/prefect-aws`
+- **ECR Public Gallery**: `public.ecr.aws/prefecthq/prefect-aws`
+
+```bash
+# Pull from Docker Hub
+docker pull prefecthq/prefect-aws:latest
+
+# Pull from ECR Public Gallery
+docker pull public.ecr.aws/prefecthq/prefect-aws:latest
+```
+
 ## Blocks setup
 
 ### Credentials


### PR DESCRIPTION
- [x] This pull request references any related issue by including "closes <link to issue>"
  
  - *Closes #22251*
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  
  - *The change is a small, additive change to publish to an additional registry.*
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
  
  - *This is a CI/CD workflow update and README change. Tests are not needed because the Docker build process is unchanged, and standard linting/validation of the YAML files remains intact.*
  
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
 
  - *Updated the `prefect-aws` README to document that the Docker images are now available on the ECR Public Gallery and include instructions for pulling from it.*
- [ ] If this pull request removes docs files, it includes redirect settings in mint.json.
  
  - *No documentation files were deleted.*
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
  
  - *No new functions or classes were added.*

***

> [!IMPORTANT]
> **Maintainer Action Required:** Before the ECR Public push step can succeed, the following secrets must be added to this repository:
> - `ECR_PUBLIC_AWS_ACCESS_KEY_ID`
> - `ECR_PUBLIC_AWS_SECRET_ACCESS_KEY`
> 
> Additionally, the `prefecthq/prefect-aws` public repository must be created in AWS ECR Public if it doesn't already exist.