### PR TITLE
default hide subflows toggled to true on dashboard & run pages

### DIFF
--- a/ui-v2/e2e/dashboard/dashboard.spec.ts
+++ b/ui-v2/e2e/dashboard/dashboard.spec.ts
@@ -166,29 +166,30 @@ test.describe("Dashboard Page", () => {
 			await page.goto("/dashboard");
 			await waitForDashboardReady(page);
 
-			// --- VERIFY: Hide subflows toggle is visible and unchecked by default ---
+			// --- VERIFY: Hide subflows toggle is visible and checked by default ---
 			const hideSubflowsSwitch = page.getByLabel("Hide subflows");
 			await expect(hideSubflowsSwitch).toBeVisible();
-			await expect(hideSubflowsSwitch).not.toBeChecked();
-
-			// --- ACTION: Toggle hide subflows ON ---
-			await hideSubflowsSwitch.click();
-
-			// --- VERIFY: URL updates with hideSubflows parameter ---
-			await expect(page).toHaveURL(/hideSubflows=true/);
-			// Wait for the switch to reflect checked state before toggling again
 			await expect(hideSubflowsSwitch).toBeChecked();
-
-			// The dashboard should refresh and filter out subflows
-			// This is verified by the URL param change and the component re-rendering
 
 			// --- ACTION: Toggle hide subflows OFF ---
 			await hideSubflowsSwitch.click();
 
-			// --- VERIFY: Switch is unchecked and URL no longer has hideSubflows=true ---
+			// --- VERIFY: URL updates with hideSubflows=false parameter ---
+			await expect(page).toHaveURL(/hideSubflows=false/);
+			// Wait for the switch to reflect unchecked state before toggling again
 			await expect(hideSubflowsSwitch).not.toBeChecked();
-			// When false/default, the param should be removed or set to false
-			await expect(page).not.toHaveURL(/hideSubflows=true/, { timeout: 10000 });
+
+			// The dashboard should refresh and show subflows
+			// This is verified by the URL param change and the component re-rendering
+
+			// --- ACTION: Toggle hide subflows ON ---
+			await hideSubflowsSwitch.click();
+
+			// --- VERIFY: Switch is checked and URL no longer has hideSubflows=false ---
+			await expect(hideSubflowsSwitch).toBeChecked();
+			await expect(page).not.toHaveURL(/hideSubflows=false/, {
+				timeout: 10000,
+			});
 		});
 
 		test("should persist date range selection in URL and filter dashboard data", async ({

--- a/ui-v2/e2e/runs/runs-flow-runs.spec.ts
+++ b/ui-v2/e2e/runs/runs-flow-runs.spec.ts
@@ -248,7 +248,7 @@ test.describe("Runs Page - Flow Runs List & Filters", () => {
 
 		await expect(async () => {
 			await page.goto(
-				`/runs?flow-run-search=${encodeURIComponent(`${prefix}pc-`)}`,
+				`/runs?flow-run-search=${encodeURIComponent(`${prefix}pc-`)}&hide-subflows=false`,
 			);
 			await expect(page.getByText(parentName)).toBeVisible({
 				timeout: 2000,
@@ -367,7 +367,7 @@ test.describe("Runs Page - Flow Runs List & Filters", () => {
 
 		await expect(async () => {
 			await page.goto(
-				`/runs?flow-run-search=${encodeURIComponent(`${prefix}pc-`)}`,
+				`/runs?flow-run-search=${encodeURIComponent(`${prefix}pc-`)}&hide-subflows=false`,
 			);
 			await expect(page.getByText(parentName)).toBeVisible({
 				timeout: 2000,

--- a/ui-v2/src/components/runs/runs-page.stories.tsx
+++ b/ui-v2/src/components/runs/runs-page.stories.tsx
@@ -139,7 +139,7 @@ const RunsPageWithState = ({
 		limit: 10,
 	});
 	const [sort, setSort] = useState<SortFilters>("START_TIME_DESC");
-	const [hideSubflows, setHideSubflows] = useState(false);
+	const [hideSubflows, setHideSubflows] = useState(true);
 	const [flowRunSearch, setFlowRunSearch] = useState(initialFlowRunSearch);
 	const [selectedStates, setSelectedStates] = useState<Set<FlowRunState>>(
 		initialSelectedStates,

--- a/ui-v2/src/components/runs/runs-page.test.tsx
+++ b/ui-v2/src/components/runs/runs-page.test.tsx
@@ -462,7 +462,7 @@ describe("Runs page", () => {
 				expect(currentSearch.tags).toBeFalsy();
 				// V1 behavior: also clears flow-run-specific filters
 				expect(currentSearch["flow-run-search"]).toBeFalsy();
-				expect(currentSearch["hide-subflows"]).toBeFalsy();
+				expect(currentSearch["hide-subflows"]).toBe(true);
 			});
 		});
 	});

--- a/ui-v2/src/routes/dashboard.tsx
+++ b/ui-v2/src/routes/dashboard.tsx
@@ -132,7 +132,7 @@ type FlowRunStateTab = (typeof FLOW_RUN_STATE_TABS)[number];
 
 // Search params for dashboard filters (flat structure)
 const searchParams = z.object({
-	hideSubflows: z.boolean().optional().catch(false),
+	hideSubflows: z.boolean().optional().default(true).catch(true),
 	tags: z.array(z.string()).optional().catch(undefined),
 	// Flow run state tab selection (defaults to FAILED-CRASHED)
 	tab: z.enum(FLOW_RUN_STATE_TABS).optional().catch(undefined),
@@ -771,7 +771,7 @@ export function RouteComponent() {
 	const isEmpty = totalFlowRuns === 0;
 
 	// Derive UI states with sensible defaults
-	const hideSubflows = search.hideSubflows ?? false;
+	const hideSubflows = search.hideSubflows ?? true;
 	const tags = search.tags ?? [];
 	const dateRangeValue = useMemo<DateRangeSelectValue>(() => {
 		switch (search.rangeType) {

--- a/ui-v2/src/routes/runs/index.tsx
+++ b/ui-v2/src/routes/runs/index.tsx
@@ -53,7 +53,7 @@ const searchParams = z.object({
 	page: z.number().int().positive().optional().default(1).catch(1),
 	limit: z.number().int().positive().optional().catch(undefined),
 	sort: z.enum(SORT_FILTERS).optional().default("START_TIME_DESC"),
-	"hide-subflows": z.boolean().optional().default(false),
+	"hide-subflows": z.boolean().optional().default(true),
 	"flow-run-search": z.string().optional().default(""),
 	state: z.string().optional().default(""),
 	flows: z.string().optional().default(""),

--- a/ui-v2/tests/dashboard/dashboard.test.tsx
+++ b/ui-v2/tests/dashboard/dashboard.test.tsx
@@ -97,5 +97,20 @@ describe("Dashboard page", () => {
 				expect(screen.getByLabelText("Hide subflows")).toBeVisible();
 			});
 		});
+
+		it("should default hide subflows toggle to checked when flow runs exist", async () => {
+			server.use(
+				http.post(buildApiUrl("/flow_runs/count"), () => {
+					return HttpResponse.json(5);
+				}),
+			);
+
+			await renderDashboardPage();
+
+			await waitFor(() => {
+				const switchEl = screen.getByLabelText("Hide subflows");
+				expect(switchEl).toBeChecked();
+			});
+		});
 	});
 });


### PR DESCRIPTION
This PR changes the default state of the "Hide subflows" filter from `false` to `true` on both the Dashboard and the Runs list pages. This reduces visual noise by default for users with complex workflows containing many nested subflows, while still allowing them to manually toggle the switch when they want to inspect them.

### Checklist
- [x] This pull request references any related issue by including "closes <link to issue>"

  - _Closes #22454_ 
  
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.

  - *This is a minor usability enhancement changing default values.*
  
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.

  - *Added a new unit test in `dashboard.test.tsx` verifying that the toggle is checked by default on dashboard load. Updated existing Playwright E2E tests (`dashboard.spec.ts` and `runs-flow-runs.spec.ts`) to match the new defaults.*
  
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.

  - *This updates UI filter defaults; no documentation changes are required.*
- [ ] If this pull request removes docs files, it includes redirect settings in mint.json.

  - *No documentation files were deleted.*
  
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

  - *No new functions or classes were added.*
