### PR TITLE
fix: honor explicit empty pull step in deployment config

### DIFF
--- a/src/prefect/cli/deploy/_config.py
+++ b/src/prefect/cli/deploy/_config.py
@@ -159,6 +159,10 @@ def _load_deploy_configs_and_actions(
         "build": model.build or [],
         "push": model.push or [],
         "pull": model.pull or [],
+        # Record whether the top-level `pull` was explicitly provided (even as null/empty)
+        # so an explicit empty `pull` can be honored rather than replaced with a default
+        # `set_working_directory` step (see cli/deploy/_core.py).
+        "_pull_explicitly_set": "pull" in model.model_fields_set,
     }
     # Convert Pydantic models to plain dicts for downstream consumption,
     # excluding keys that were not provided by users to preserve legacy semantics

--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -254,19 +254,28 @@ async def _run_single_deploy(
         )
 
     # Prefer the originally captured pull_steps (taken before resolution) to
-    # preserve unresolved block placeholders in the deployment spec. Only fall
-    # back to the config/actions/default if no pull steps were provided.
-    pull_steps = (
-        pull_steps
-        or deploy_config.get("pull")
-        or actions.get("pull")
-        or await _generate_default_pull_action(
-            console,
-            deploy_config=deploy_config,
-            actions=actions,
-            is_interactive=is_interactive,
-        )
+    # preserve unresolved block placeholders in the deployment spec. Fall back to
+    # the config/actions, and only generate a default `set_working_directory` step
+    # when `pull` was not provided at all. An explicit empty `pull` (null/[]) is
+    # honored as "no pull steps" — e.g. for a worker whose command resolves code
+    # itself — rather than defaulting to the deploying machine's working directory.
+    pull_explicitly_provided = "pull" in deploy_config or actions.get(
+        "_pull_explicitly_set", False
     )
+    if not pull_steps:
+        if deploy_config.get("pull"):
+            pull_steps = deploy_config["pull"]
+        elif actions.get("pull"):
+            pull_steps = actions["pull"]
+        elif pull_explicitly_provided:
+            pull_steps = []
+        else:
+            pull_steps = await _generate_default_pull_action(
+                console,
+                deploy_config=deploy_config,
+                actions=actions,
+                is_interactive=is_interactive,
+            )
 
     ## RUN BUILD AND PUSH STEPS
     step_outputs: dict[str, Any] = {}

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -769,6 +769,44 @@ class TestProjectDeploy:
                 }
             ]
 
+        @pytest.mark.parametrize("empty_pull", [None, []], ids=["null", "empty-list"])
+        async def test_explicit_empty_pull_is_honored(
+            self,
+            empty_pull,
+            work_pool: WorkPool,
+            prefect_client: PrefectClient,
+            uninitialized_project_dir: Path,
+        ):
+            """An explicit empty top-level `pull` is honored as no pull steps rather than
+            defaulting to a `set_working_directory` step pointing at the deploying
+            machine's cwd.
+
+            Regression test for https://github.com/PrefectHQ/prefect/issues/22489
+            """
+            prefect_yaml = {
+                "pull": empty_pull,
+                "deployments": [
+                    {
+                        "name": "no-pull",
+                        "entrypoint": "flows/hello.py:my_flow",
+                        "work_pool": {"name": work_pool.name},
+                    }
+                ],
+            }
+            with open("prefect.yaml", "w") as f:
+                yaml.dump(prefect_yaml, f)
+
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command="deploy --all",
+                expected_code=0,
+            )
+
+            deployment = await prefect_client.read_deployment_by_name(
+                "An important name/no-pull"
+            )
+            assert deployment.pull_steps == []
+
         async def test_project_deploy_with_no_prefect_yaml_git_repo_no_remote(
             self,
             work_pool: WorkPool,


### PR DESCRIPTION
closes #22489

> Draft — the underlying behavior is a small design decision (should an explicit empty `pull` be honored, or stay documented-around?). I asked on the issue and am opening this early so the fix is concrete for that discussion. Absent-`pull` behavior is unchanged, so this is backward-compatible either way.

## Problem

Deploying from a `prefect.yaml` with an **explicit empty `pull`** (`pull: null` or `pull: []`) and no image build injects a default `set_working_directory` step pointing at **`Path.cwd()` on the deploying machine**. For a process worker whose custom `command` resolves code itself (e.g. a `uv run` wrapper that clones a branch), that path is meaningless on the worker and crashes the run when it tries to `cd` into it.

## Root cause

`cli/deploy/_core.py` resolved pull steps with an `or` chain:

```python
pull_steps = (
    pull_steps
    or deploy_config.get("pull")
    or actions.get("pull")
    or await _generate_default_pull_action(...)  # -> set_working_directory(Path.cwd())
)
```

An explicit empty `pull` is falsy, so it's treated identically to an **absent** `pull` and falls through to the default. `.get("pull")` can't distinguish the two: `_config.py` collapses `pull: null → []`, and the model field defaults to `None` whether the user wrote `pull: null` or omitted it.

## Fix

Distinguish "explicitly empty" from "absent" and only generate the default when `pull` was not provided at all:

- `_config.py` records `actions["_pull_explicitly_set"] = "pull" in model.model_fields_set` (top-level). Per-deployment configs already carry the signal via `model_dump(exclude_unset=True)` → `"pull" in deploy_config`.
- `_core.py` honors an explicit empty `pull` as **no pull steps**:

```python
pull_explicitly_provided = "pull" in deploy_config or actions.get("_pull_explicitly_set", False)
if not pull_steps:
    if deploy_config.get("pull"):
        pull_steps = deploy_config["pull"]
    elif actions.get("pull"):
        pull_steps = actions["pull"]
    elif pull_explicitly_provided:
        pull_steps = []                      # explicit empty pull -> honor it
    else:
        pull_steps = await _generate_default_pull_action(...)   # unchanged default
```

**Backward compatibility:** the common absent-`pull` path is unchanged — it still generates the default `set_working_directory` step.

## Alternatives considered

- **Docs-only** (document that `pull: null` still uses defaults). Rejected because injecting the *deploying machine's* cwd for a *remote* worker is unsafe/surprising; honoring explicit config is least-surprise and backward-compatible.

## Tests

- `test_explicit_empty_pull_is_honored[null]` / `[empty-list]` — explicit empty `pull` → `deployment.pull_steps == []` (no `set_working_directory`). Fails on `main`.
- Existing `test_project_deploy_generates_pull_action` covers the absent-`pull` regression (default still generated).
- Verified all four resolution cases (explicit-empty top-level / per-deployment, absent, explicit non-empty). `tests/cli/deploy/test_deploy_actions.py` + `TestGeneratedPullAction` pass; ruff clean; no new mypy errors.

*(A short docs note on the honored `pull: null` behavior can be added once the direction is confirmed.)*

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
