### PR TITLE
docs: clarify /api/health vs /api/ready for Kubernetes probes

### DIFF
--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -300,9 +300,12 @@ prefect server database upgrade -y
 
 Configure health checks for your load balancer:
 
-- **Health endpoint**: `/api/health`
-- **Expected response**: HTTP 200 with JSON `{"status": "healthy"}`
+- **Health endpoint**: `/api/health` — verifies the HTTP server is running
+- **Readiness endpoint**: `/api/ready` — verifies database connectivity (returns `503` when Postgres is unreachable)
+- **Expected response**: HTTP 200 with JSON `{"status": "healthy"}` from `/api/health`
 - **Check interval**: 5-10 seconds
+
+Use `/api/health` for liveness-style checks where you only need to confirm the process is up. Use `/api/ready` when the check should fail if the database is unavailable—for example, to stop routing traffic during a Postgres outage. See [Kubernetes health and readiness probes](/v3/advanced/server-helm#kubernetes-health-and-readiness-probes) for probe configuration on Kubernetes.
 
 Example NGINX configuration:
 

--- a/docs/v3/advanced/self-hosted.mdx
+++ b/docs/v3/advanced/self-hosted.mdx
@@ -300,9 +300,9 @@ prefect server database upgrade -y
 
 Configure health checks for your load balancer:
 
-- **Health endpoint**: `/api/health` — verifies the HTTP server is running
-- **Readiness endpoint**: `/api/ready` — verifies database connectivity (returns `503` when Postgres is unreachable)
-- **Expected response**: HTTP 200 with JSON `{"status": "healthy"}` from `/api/health`
+- **Health endpoint**: `/api/health` (verifies the HTTP server is running)
+- **Readiness endpoint**: `/api/ready` (verifies database connectivity and returns `503` when Postgres is unreachable)
+- **Expected response**: HTTP 200 with JSON `true` from `/api/health`
 - **Check interval**: 5-10 seconds
 
 Use `/api/health` for liveness-style checks where you only need to confirm the process is up. Use `/api/ready` when the check should fail if the database is unavailable—for example, to stop routing traffic during a Postgres outage. See [Kubernetes health and readiness probes](/v3/advanced/server-helm#kubernetes-health-and-readiness-probes) for probe configuration on Kubernetes.

--- a/docs/v3/advanced/server-helm.mdx
+++ b/docs/v3/advanced/server-helm.mdx
@@ -169,7 +169,35 @@ helm uninstall prefect-worker
 helm uninstall prefect-server
 ```
 
+## Kubernetes health and readiness probes
+
+The Prefect server exposes two HTTP endpoints for monitoring:
+
+| Endpoint | Checks | Typical HTTP status |
+| --- | --- | --- |
+| `/api/health` | HTTP server is running | `200` when the process is up |
+| `/api/ready` | Database connectivity | `200` when Postgres is reachable; `503` when it is not |
+
+The [prefect-server Helm chart](https://github.com/PrefectHQ/prefect-helm/blob/main/charts/prefect-server/values.yaml) uses `/api/health` for the **liveness** probe and `/api/ready` for the **readiness** probe by default. This means Kubernetes stops routing traffic when the database is down, but it does **not** automatically restart the pod after the database recovers—the process may keep running in a broken state until you restart it manually.
+
+If you need the pod to restart after sustained database failure, point the liveness probe at `/api/ready` instead. Be aware that transient database blips can trigger restarts, so tune `periodSeconds` and `failureThreshold` accordingly.
+
+<Note>
+The chart currently exposes probe **timing** settings (for example `periodSeconds`) but not probe **paths**. To customize paths today, patch the generated Deployment manifest or open an issue on [prefect-helm](https://github.com/PrefectHQ/prefect-helm).
+</Note>
+
+For load balancer and reverse-proxy health checks, see [Load balancer configuration](/v3/advanced/self-hosted#load-balancer-configuration) in the self-hosted guide.
+
 ## Troubleshooting
+
+<Expandable title="Server stays unhealthy after database recovery">
+If Postgres recovers but the Prefect server still returns connection errors, check whether the liveness probe is hitting `/api/health` only. That endpoint does not verify database connectivity, so Kubernetes may consider the pod healthy even when API requests fail.
+
+1. Confirm readiness failures with `kubectl describe pod <prefect-server-pod>`.
+2. Test endpoints directly: `kubectl exec -it <pod> -- curl -s -o /dev/null -w "%{http_code}" localhost:4200/api/ready`.
+3. Restart the server pod if it did not recover automatically: `kubectl rollout restart deployment/prefect-server`.
+4. Consider using `/api/ready` for liveness if automatic restart after DB outages is required (see [Kubernetes health and readiness probes](#kubernetes-health-and-readiness-probes)).
+</Expandable>
 
 <Expandable title="Container creation error">
 If you see this error:

--- a/docs/v3/advanced/server-helm.mdx
+++ b/docs/v3/advanced/server-helm.mdx
@@ -178,12 +178,22 @@ The Prefect server exposes two HTTP endpoints for monitoring:
 | `/api/health` | HTTP server is running | `200` when the process is up |
 | `/api/ready` | Database connectivity | `200` when Postgres is reachable; `503` when it is not |
 
-The [prefect-server Helm chart](https://github.com/PrefectHQ/prefect-helm/blob/main/charts/prefect-server/values.yaml) uses `/api/health` for the **liveness** probe and `/api/ready` for the **readiness** probe by default. This means Kubernetes stops routing traffic when the database is down, but it does **not** automatically restart the pod after the database recovers—the process may keep running in a broken state until you restart it manually.
+The [prefect-server Helm chart](https://github.com/PrefectHQ/prefect-helm/blob/main/charts/prefect-server/values.yaml) supports optional liveness and readiness probes, but both are disabled by default. Enable them in your server values:
+
+```yaml
+server:
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
+```
+
+When enabled, the liveness probe uses `/api/health` and the readiness probe uses `/api/ready`. Kubernetes then stops routing traffic when the database is down, but it does **not** restart the pod. If the server does not recover after Postgres becomes available, restart it manually.
 
 If you need the pod to restart after sustained database failure, point the liveness probe at `/api/ready` instead. Be aware that transient database blips can trigger restarts, so tune `periodSeconds` and `failureThreshold` accordingly.
 
 <Note>
-The chart currently exposes probe **timing** settings (for example `periodSeconds`) but not probe **paths**. To customize paths today, patch the generated Deployment manifest or open an issue on [prefect-helm](https://github.com/PrefectHQ/prefect-helm).
+The current chart exposes probe **timing** settings (for example `periodSeconds`) but not probe **paths**. Follow [prefect-helm#635](https://github.com/PrefectHQ/prefect-helm/pull/635) for configurable probe paths. Until that change is available in a released chart, patch the generated Deployment manifest to customize the paths.
 </Note>
 
 For load balancer and reverse-proxy health checks, see [Load balancer configuration](/v3/advanced/self-hosted#load-balancer-configuration) in the self-hosted guide.


### PR DESCRIPTION
## Summary
- Document the difference between `/api/health` (HTTP server up) and `/api/ready` (database connectivity) for self-hosted Prefect server deployments.
- Add Kubernetes probe guidance and a troubleshooting section for pods that stay unhealthy after database recovery.
- Cross-link from the self-hosted load balancer section.

Relates to #22412.

## Test plan
- [x] Verified markdown renders in docs preview locally
- [x] Links between server-helm and self-hosted pages are valid