### PR TITLE
fix(databricks): conform partner User-Agent to Databricks telemetry f…

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/credentials.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/credentials.py
@@ -10,11 +10,6 @@ from pydantic import Field, PrivateAttr, SecretStr, model_validator
 from prefect.blocks.core import Block
 from prefect_databricks._version import __version__
 
-# Databricks partner telemetry attribution. The format
-# `<isv-name_product-name>/<product-version>` (underscore between company and
-# product) is required so Databricks can attribute API usage to Prefect across
-# all connectors and languages.
-# See https://databrickslabs.github.io/partner-architecture/isv-partners/telemetry-attribution
 _DATABRICKS_PARTNER_USER_AGENT = f"Prefect_PrefectDatabricks/{__version__}"
 
 
@@ -120,7 +115,6 @@ class DatabricksCredentials(Block):
         client_id = values.get("client_id")
         client_secret = values.get("client_secret")
 
-        # Guard against both None and empty strings
         has_token = token is not None and token != ""
         has_client_id = client_id is not None and client_id != ""
         has_client_secret = client_secret is not None and client_secret != ""
@@ -173,14 +167,12 @@ class DatabricksCredentials(Block):
             return self._cached_token
 
         if self.tenant_id is not None:
-            # Azure AD (Microsoft Entra ID) authentication
             token_url = (
                 f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
             )
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded",
             }
-            # Azure Databricks resource ID
             azure_databricks_resource_id = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
             data = {
                 "grant_type": "client_credentials",
@@ -189,7 +181,6 @@ class DatabricksCredentials(Block):
                 "scope": f"{azure_databricks_resource_id}/.default",
             }
         else:
-            # Databricks-managed service principal authentication
             token_url = f"https://{self.databricks_instance}/oidc/v1/token"
             credentials = f"{self.client_id}:{self.client_secret.get_secret_value()}"
             encoded_credentials = base64.b64encode(credentials.encode()).decode()

--- a/src/integrations/prefect-databricks/prefect_databricks/credentials.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/credentials.py
@@ -8,8 +8,14 @@ from httpx import AsyncClient, Client, Headers
 from pydantic import Field, PrivateAttr, SecretStr, model_validator
 
 from prefect.blocks.core import Block
+from prefect_databricks._version import __version__
 
-_DATABRICKS_PARTNER_USER_AGENT = "prefect+prefect-databricks"
+# Databricks partner telemetry attribution. The format
+# `<isv-name_product-name>/<product-version>` (underscore between company and
+# product) is required so Databricks can attribute API usage to Prefect across
+# all connectors and languages.
+# See https://databrickslabs.github.io/partner-architecture/isv-partners/telemetry-attribution
+_DATABRICKS_PARTNER_USER_AGENT = f"Prefect_PrefectDatabricks/{__version__}"
 
 
 class DatabricksCredentials(Block):

--- a/src/integrations/prefect-databricks/tests/test_credentials.py
+++ b/src/integrations/prefect-databricks/tests/test_credentials.py
@@ -15,7 +15,7 @@ class TestDatabricksCredentialsPATAuth:
         ).get_client()
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer token_value"
-        assert client.headers["user-agent"] == "prefect+prefect-databricks"
+        assert client.headers["user-agent"].startswith("Prefect_PrefectDatabricks/")
 
     def test_backward_compatibility_with_token(self):
         """Test backward compatibility - existing PAT-based credentials work unchanged."""
@@ -49,10 +49,24 @@ class TestDatabricksCredentialsPATAuth:
         client = credentials.get_client()
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer token_value"
-        assert (
-            client.headers["user-agent"]
-            == "custom-client/1.0 prefect+prefect-databricks"
-        )
+        user_agent = client.headers["user-agent"]
+        assert user_agent.startswith("custom-client/1.0 Prefect_PrefectDatabricks/")
+
+    def test_partner_user_agent_matches_databricks_format(self):
+        """The partner identifier must follow Databricks' required telemetry
+        attribution format: `<isv-name_product-name>/<product-version>`.
+
+        See https://databrickslabs.github.io/partner-architecture/isv-partners/telemetry-attribution
+        """
+        from prefect_databricks._version import __version__
+        from prefect_databricks.credentials import _DATABRICKS_PARTNER_USER_AGENT
+
+        identifier, _, version = _DATABRICKS_PARTNER_USER_AGENT.partition("/")
+        # underscore separates the (consistent) ISV name from the product name
+        assert identifier == "Prefect_PrefectDatabricks"
+        assert "_" in identifier
+        # version segment is present and tracks the package version
+        assert version == __version__
 
 
 class TestDatabricksCredentialsServicePrincipalAuth:
@@ -145,6 +159,7 @@ class TestDatabricksCredentialsServicePrincipalAuth:
 
         assert isinstance(client, AsyncClient)
         assert client.headers["authorization"] == "Bearer oauth-access-token"
+        assert client.headers["user-agent"].startswith("Prefect_PrefectDatabricks/")
 
         mock_client_instance.post.assert_called_once()
         call_args = mock_client_instance.post.call_args


### PR DESCRIPTION

The Databricks partner telemetry attribution spec requires the User-Agent to follow `<isv-name_product-name>/<product-version>` with an underscore separating the company and product names. The previous identifier `prefect+prefect-databricks` used a `+` separator and carried no version, so it would not attribute correctly in Databricks' telemetry.

Emit `Prefect_PrefectDatabricks/<__version__>` instead, built from the package version so it tracks releases automatically. The existing logic that preserves a user-supplied User-Agent is unchanged.

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
