### PR TITLE
Give TaskRunFilterState.type and .name a default of None

### DIFF
--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -441,8 +441,12 @@ class TaskRunFilterStateName(PrefectBaseModel):
 
 
 class TaskRunFilterState(PrefectBaseModel, OperatorMixin):
-    type: Optional[TaskRunFilterStateType]
-    name: Optional[TaskRunFilterStateName]
+    type: Optional[TaskRunFilterStateType] = Field(
+        default=None, description="Filter criteria for `TaskRun` state type"
+    )
+    name: Optional[TaskRunFilterStateName] = Field(
+        default=None, description="Filter criteria for `TaskRun` state name"
+    )
 
 
 class TaskRunFilterSubFlowRuns(PrefectBaseModel):

--- a/tests/client/schemas/test_filters.py
+++ b/tests/client/schemas/test_filters.py
@@ -1,0 +1,33 @@
+from prefect.client.schemas.filters import (
+    FlowRunFilter,
+    TaskRunFilter,
+    TaskRunFilterState,
+)
+
+
+class TestTaskRunFilterState:
+    def test_can_be_constructed_without_arguments(self):
+        state_filter = TaskRunFilterState()
+        assert state_filter.type is None
+        assert state_filter.name is None
+
+    def test_can_filter_on_state_type_alone(self):
+        task_run_filter = TaskRunFilter.model_validate(
+            {"state": {"type": {"any_": ["COMPLETED"]}}}
+        )
+        assert task_run_filter.state is not None
+        assert task_run_filter.state.name is None
+
+    def test_can_filter_on_state_name_alone(self):
+        task_run_filter = TaskRunFilter.model_validate(
+            {"state": {"name": {"any_": ["Completed"]}}}
+        )
+        assert task_run_filter.state is not None
+        assert task_run_filter.state.type is None
+
+    def test_matches_flow_run_filter_state(self):
+        payload = {"state": {"type": {"any_": ["COMPLETED"]}}}
+        assert (
+            TaskRunFilter.model_validate(payload).state.type.any_
+            == FlowRunFilter.model_validate(payload).state.type.any_
+        )


### PR DESCRIPTION
## The problem

`TaskRunFilterState` declares both of its fields as `Optional[...]` with no default. Under pydantic v2 an `Optional` annotation does not imply a default, so both fields are **required**, and filtering task runs by state type alone fails:

```python
from prefect.client.schemas.filters import TaskRunFilter, FlowRunFilter, TaskRunFilterState, FlowRunFilterState

TaskRunFilterState()   # ValidationError: type Field required, name Field required
FlowRunFilterState()   # OK: operator=and_ type=None name=None

payload = {"state": {"type": {"any_": ["COMPLETED"]}}}
TaskRunFilter.model_validate(payload)   # ValidationError: state.name Field required
FlowRunFilter.model_validate(payload)   # OK
```

So `client.read_task_runs(task_run_filter=...)` cannot filter on state type without also naming a state, and the equivalent flow-run call can. The workaround is passing `name=None` explicitly.

## Why this is an oversight rather than intent

Both neighbours of this class already default these fields to `None`:

- `FlowRunFilterState` — the direct sibling, `client/schemas/filters.py:188`
- `TaskRunFilterState` — the server-side twin, `server/schemas/filters.py:931`

`client/schemas/filters.py:443` is the only one of the three that omits the defaults, and nothing reads these fields in a way that requires them.

## The fix

Add `= Field(default=None, description=...)` to both fields, copying the wording pattern the sibling and the server twin already use. No behaviour changes for callers who pass the fields; callers who omit them stop getting a ValidationError.

**Tradeoffs / compatibility:** this only widens what validates, so no currently-working call can break. It does mean a caller who *relied* on the error to catch a forgotten argument no longer gets it — but that error was inconsistent with every sibling filter, and `FlowRunFilter` has never offered it.

## Testing

`tests/client/schemas/test_filters.py` is new (the client filter schemas had no test module). The tests are behaviour-focused — they construct filters through the public API and assert on results, not on field metadata. All four fail on `main` and pass with the fix.

```
tests/client/ + tests/server/schemas/test_filters.py  ->  536 passed, 2 skipped, 1 xpassed
ruff check / ruff format --check                      ->  clean
```

Documentation: no user-facing doc describes these defaults, so nothing to update.

One note in case it comes up: while running the suite I saw `tests/client/test_prefect_client.py::test_create_flow_run_from_deployment` fail once and then pass on a re-run of the identical command; it also passes in isolation both with and without this change, and the suite is green without my test file present. It looks flaky independently of this PR, but I'd rather flag it than have you wonder.

## AI disclosure

I used an AI agent (Claude Code) to help survey the client schema modules and draft this change. I reproduced the failure myself against a clean `upstream/main` checkout, traced the cause to the missing defaults, verified the sibling/server parity by reading those classes, and ran the tests above locally. Every claim here is from output I ran, not from the model's summary.
