### PR TITLE
fix(runner): preserve stdlib precedence in flow runs

### DIFF
--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -162,9 +162,11 @@ def _is_interpreter_path(entry: str) -> bool:
     resolved_path = Path(entry).resolve()
     resolved = str(resolved_path)
 
-    for sp in _site_packages_dirs():
-        if resolved == sp or resolved.startswith(sp + os.sep):
-            return True
+    site_packages_dirs = _site_packages_dirs()
+    if resolved in site_packages_dirs:
+        return True
+    if any(resolved.startswith(sp + os.sep) for sp in site_packages_dirs):
+        return False
 
     for root in _stdlib_prefixes():
         if resolved == root or resolved.startswith(root + os.sep):

--- a/src/prefect/runner/_workspace_starter.py
+++ b/src/prefect/runner/_workspace_starter.py
@@ -126,7 +126,7 @@ def _stdlib_prefixes() -> tuple[str, ...]:
 
 @functools.lru_cache(maxsize=1)
 def _site_packages_dirs() -> tuple[str, ...]:
-    """Resolved site-packages directories that should always be kept."""
+    """Resolved site-packages directories that should not be promoted to PYTHONPATH."""
     dirs: set[str] = set()
     paths = sysconfig.get_paths()
     for key in ("purelib", "platlib"):
@@ -147,12 +147,14 @@ def _site_packages_dirs() -> tuple[str, ...]:
     return tuple(sorted(dirs))
 
 
-def _is_stdlib_path(entry: str) -> bool:
-    """True when *entry* is a stdlib, lib-dynload, or stdlib zip path.
+def _is_interpreter_path(entry: str) -> bool:
+    """True when *entry* is managed by the interpreter rather than the workspace.
 
-    Site-packages directories that live under the stdlib tree are kept.
-    Only interpreter stdlib zip archives next to stdlib directories are filtered;
-    user archives like `/app/python_deps.zip` are preserved.
+    The interpreter already adds stdlib, lib-dynload, and site-packages directories
+    in the correct order. Adding any of them to PYTHONPATH changes that ordering and
+    can let a site-packages backport shadow a standard-library module. Only
+    interpreter stdlib zip archives next to stdlib directories are filtered; user
+    archives like `/app/python_deps.zip` are preserved.
     """
     if not entry:
         return False
@@ -162,7 +164,7 @@ def _is_stdlib_path(entry: str) -> bool:
 
     for sp in _site_packages_dirs():
         if resolved == sp or resolved.startswith(sp + os.sep):
-            return False
+            return True
 
     for root in _stdlib_prefixes():
         if resolved == root or resolved.startswith(root + os.sep):
@@ -187,7 +189,11 @@ def workspace_environment(workspace: PreparedWorkspace) -> dict[str, str]:
         candidate_entries.extend(existing_pythonpath.split(os.pathsep))
 
     for entry in candidate_entries:
-        if entry and entry not in pythonpath_entries and not _is_stdlib_path(entry):
+        if (
+            entry
+            and entry not in pythonpath_entries
+            and not _is_interpreter_path(entry)
+        ):
             pythonpath_entries.append(entry)
 
     environment["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -476,9 +476,19 @@ class TestWorkspaceEnvironmentPythonpathFiltering:
             / f"python{sys.version_info.major}{sys.version_info.minor}.zip"
         )
         app_zip = tmp_path / "python_deps.zip"
+        site_packages_app = Path(site_packages) / "my_app"
+        site_packages_vendor_zip = Path(site_packages) / "vendor.zip"
         workspace.sys_path = ["/app"]
         workspace.environment["PYTHONPATH"] = os.pathsep.join(
-            [stdlib, site_packages, str(stdlib_zip), str(app_zip), "/extra"]
+            [
+                stdlib,
+                site_packages,
+                str(stdlib_zip),
+                str(app_zip),
+                str(site_packages_app),
+                str(site_packages_vendor_zip),
+                "/extra",
+            ]
         )
 
         env = workspace_environment(workspace)
@@ -486,9 +496,13 @@ class TestWorkspaceEnvironmentPythonpathFiltering:
 
         resolved_stdlib = str(Path(stdlib).resolve())
         resolved_site_packages = str(Path(site_packages).resolve())
+        resolved_site_packages_app = str(site_packages_app.resolve())
+        resolved_site_packages_vendor_zip = str(site_packages_vendor_zip.resolve())
         resolved_stdlib_zip = str(stdlib_zip.resolve())
         assert resolved_stdlib not in pythonpath_entries
         assert resolved_site_packages not in pythonpath_entries
         assert resolved_stdlib_zip not in pythonpath_entries
         assert str(app_zip) in pythonpath_entries
+        assert resolved_site_packages_app in pythonpath_entries
+        assert resolved_site_packages_vendor_zip in pythonpath_entries
         assert "/extra" in pythonpath_entries

--- a/tests/runner/test__workspace_starter.py
+++ b/tests/runner/test__workspace_starter.py
@@ -429,7 +429,7 @@ async def test_load_flow_from_prepared_workspace_preserves_stdlib_imports(
 
 
 class TestWorkspaceEnvironmentPythonpathFiltering:
-    def test_excludes_stdlib_from_pythonpath(self, tmp_path: Path) -> None:
+    def test_excludes_interpreter_paths_from_pythonpath(self, tmp_path: Path) -> None:
         workspace = _prepared_workspace(tmp_path)
         stdlib = sysconfig.get_paths()["stdlib"]
         lib_dynload = os.path.join(stdlib, "lib-dynload")
@@ -463,13 +463,14 @@ class TestWorkspaceEnvironmentPythonpathFiltering:
         assert resolved_stdlib_zip not in pythonpath_entries
 
         resolved_site = str(Path(site_packages).resolve())
-        assert resolved_site in pythonpath_entries
+        assert resolved_site not in pythonpath_entries
         assert str(adjacent_user_zip) in pythonpath_entries
         assert str(app_zip) in pythonpath_entries
 
     def test_filters_stdlib_from_inherited_pythonpath(self, tmp_path: Path) -> None:
         workspace = _prepared_workspace(tmp_path)
         stdlib = sysconfig.get_paths()["stdlib"]
+        site_packages = sysconfig.get_paths()["purelib"]
         stdlib_zip = (
             Path(stdlib).parent
             / f"python{sys.version_info.major}{sys.version_info.minor}.zip"
@@ -477,15 +478,17 @@ class TestWorkspaceEnvironmentPythonpathFiltering:
         app_zip = tmp_path / "python_deps.zip"
         workspace.sys_path = ["/app"]
         workspace.environment["PYTHONPATH"] = os.pathsep.join(
-            [stdlib, str(stdlib_zip), str(app_zip), "/extra"]
+            [stdlib, site_packages, str(stdlib_zip), str(app_zip), "/extra"]
         )
 
         env = workspace_environment(workspace)
         pythonpath_entries = env["PYTHONPATH"].split(os.pathsep)
 
         resolved_stdlib = str(Path(stdlib).resolve())
+        resolved_site_packages = str(Path(site_packages).resolve())
         resolved_stdlib_zip = str(stdlib_zip.resolve())
         assert resolved_stdlib not in pythonpath_entries
+        assert resolved_site_packages not in pythonpath_entries
         assert resolved_stdlib_zip not in pythonpath_entries
         assert str(app_zip) in pythonpath_entries
         assert "/extra" in pythonpath_entries


### PR DESCRIPTION
closes #22527

This PR keeps interpreter-managed directories out of the `PYTHONPATH` assembled for workspace flow-run subprocesses.

## Why

The workspace starter previously preserved site-packages entries alongside workspace paths. `PYTHONPATH` is evaluated before the interpreter's standard library, so a site-packages backport such as `dataclasses` could shadow the matching standard-library module only inside a flow run.

Python already adds its own standard library and site-packages directories in the correct order. The starter now retains workspace and user-provided application paths, while filtering interpreter stdlib, lib-dynload, stdlib zip, and site-packages paths from both captured `sys.path` and inherited `PYTHONPATH`.

## Validation

- `uv run pytest tests/runner/test__workspace_starter.py -q` (16 passed)
- `uv run ruff check src/prefect/runner/_workspace_starter.py tests/runner/test__workspace_starter.py`
- `uv run ruff format --check src/prefect/runner/_workspace_starter.py tests/runner/test__workspace_starter.py`
- `uv run pre-commit run --files src/prefect/runner/_workspace_starter.py tests/runner/test__workspace_starter.py`
