### PR TITLE
test: cover truncated_to in utilities.text

### DIFF
--- a/tests/utilities/test_text.py
+++ b/tests/utilities/test_text.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefect.utilities.text import fuzzy_match_string
+from prefect.utilities.text import fuzzy_match_string, truncated_to
 
 
 @pytest.mark.parametrize(
@@ -24,3 +24,25 @@ from prefect.utilities.text import fuzzy_match_string
 )
 def test_fuzzy_match_string(word, possibilities, expected):
     assert fuzzy_match_string(word, possibilities) == expected
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_truncated_to_empty_values(value):
+    assert truncated_to(10, value) == ""
+
+
+def test_truncated_to_returns_value_when_within_length():
+    assert truncated_to(10, "short") == "short"
+
+
+def test_truncated_to_truncates_long_value():
+    result = truncated_to(10, "x" * 100)
+    assert result == "xxxxx...90 additional characters...xxxxx"
+    assert len(result) < 100
+
+
+def test_truncated_to_keeps_original_when_truncation_would_be_longer():
+    # The placeholder text can be longer than the tiny amount trimmed, in which
+    # case the original value is returned unchanged.
+    value = "x" * 25
+    assert truncated_to(20, value) == value


### PR DESCRIPTION
## Description

`prefect.utilities.text` has two helpers, but the test suite only covered
`fuzzy_match_string`, leaving `truncated_to` untested.

`truncated_to(length, value)` shortens a long string to
`<start>...<N> additional characters...<end>`, but only when that placeholder
form is actually shorter than the original.

This extends `tests/utilities/test_text.py` with coverage for `truncated_to`:

- empty / `None` values returning `""`
- a value within `length` returned unchanged
- a long value being truncated with the "N additional characters" placeholder
- the original value being kept when the placeholder would be longer than the
  small amount trimmed

No source changes.

## Verification

Assertions verified against the real `prefect.utilities.text` module (4/4
pass); `ruff check` / `ruff format --check` clean.
