### PR TITLE
Share orchestration clients across automation actions

### DIFF
--- a/src/prefect/server/api/clients.py
+++ b/src/prefect/server/api/clients.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
+import asyncio
 import base64
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import contextvars
+from contextlib import asynccontextmanager
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    cast,
+)
 from urllib.parse import quote
 from uuid import UUID
 
 import httpx
 import pydantic
-from httpx import Response
+from httpx import Request, Response
 from starlette import status
 from typing_extensions import Self
 
@@ -27,9 +39,105 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class BaseClient:
+# Per-request headers pushed by `scoped_headers()`; the httpx request hook
+# installed in `BaseClient.__init__` merges them into outgoing requests so
+# callers can reuse a single shared client across automation actions while
+# still tagging each request with automation-specific identifiers.
+_request_scoped_headers: contextvars.ContextVar[Optional[Dict[str, str]]] = (
+    contextvars.ContextVar("_request_scoped_headers", default=None)
+)
+
+
+async def _apply_scoped_headers(request: Request) -> None:
+    extras = _request_scoped_headers.get()
+    if not extras:
+        return
+    for name, value in extras.items():
+        request.headers[name] = value
+
+
+@asynccontextmanager
+async def scoped_headers(headers: Dict[str, str]) -> AsyncIterator[None]:
+    """Attach headers to every request sent by a shared client in this scope."""
+    token = _request_scoped_headers.set(headers)
+    try:
+        yield
+    finally:
+        _request_scoped_headers.reset(token)
+
+
+class _SharedClientMixin:
+    """
+    Process-level cache of one open client per `(subclass, settings)`.
+
+    Sharing avoids re-running `create_app()`, `setup_logging()` and
+    `Settings.hash_key()` on every automation action. Headers that vary per
+    call (e.g. automation identifiers) must be applied with `scoped_headers()`
+    rather than baked into the cached client.
+
+    The cache assumes a single, long-lived event loop per process: the cached
+    httpx clients and the lazily-created `asyncio.Lock` are bound to the loop
+    they are first used on. That holds for the Prefect server and for the
+    session-scoped test loop. Test suites that spin up per-test loops (e.g. via
+    `asyncio.run`) must call `_reset_shared()` between tests so a client built
+    on a now-dead loop is never handed back.
+    """
+
+    # Set by each subclass in `__init__`.
     _http_client: PrefectHttpxAsyncClient
 
+    # One registry shared by every subclass, keyed by `(cls, id(settings))`.
+    # The settings object is stored next to the client and held by a strong
+    # reference on purpose: keeping it alive means its `id()` cannot be
+    # recycled for a different `Settings` instance while the entry lives, which
+    # would otherwise hand back a client built for stale settings. Distinct
+    # `temporary_settings()` blocks therefore get distinct entries; tests evict
+    # them via `_reset_shared()`.
+    _shared_instances: ClassVar[
+        Dict[tuple[type, int], tuple[Any, "_SharedClientMixin"]]
+    ] = {}
+    _shared_lock: ClassVar[Optional[asyncio.Lock]] = None
+
+    @classmethod
+    async def shared(cls) -> Self:
+        """
+        Return a process-cached client for the current settings, lazily
+        constructed and left open for the lifetime of the process. Headers that
+        vary per call (e.g. automation identifiers) should be set via
+        `scoped_headers()`, not passed at construction.
+        """
+        settings = get_current_settings()
+        key = (cls, id(settings))
+        cached = _SharedClientMixin._shared_instances.get(key)
+        if cached is not None and cached[0] is settings:
+            return cast(Self, cached[1])
+        # Lazily create the lock. The check-and-set needs no extra guard: there
+        # is no `await` between the `is None` test and the assignment, so no
+        # other coroutine on this loop can interleave here. Do not add one.
+        if _SharedClientMixin._shared_lock is None:
+            _SharedClientMixin._shared_lock = asyncio.Lock()
+        async with _SharedClientMixin._shared_lock:
+            cached = _SharedClientMixin._shared_instances.get(key)
+            if cached is not None and cached[0] is settings:
+                return cast(Self, cached[1])
+            instance = cls()
+            await instance._http_client.__aenter__()
+            _SharedClientMixin._shared_instances[key] = (settings, instance)
+            return instance
+
+    @classmethod
+    async def _reset_shared(cls) -> None:
+        """Test helper: close and discard every cached shared instance."""
+        entries = list(_SharedClientMixin._shared_instances.values())
+        _SharedClientMixin._shared_instances.clear()
+        for _settings, instance in entries:
+            try:
+                await instance._http_client.__aexit__(None, None, None)
+            except Exception:
+                pass
+
+
+class BaseClient(_SharedClientMixin):
     def __init__(self, additional_headers: dict[str, str] | None = None):
         from prefect.server.api.server import create_app
 
@@ -53,6 +161,7 @@ class BaseClient:
             base_url=f"http://prefect-in-memory{settings.server.api.base_path or '/api'}",
             enable_csrf_support=settings.server.api.csrf_protection_enabled,
             raise_on_all_errors=False,
+            event_hooks={"request": [_apply_scoped_headers]},
         )
 
     async def __aenter__(self) -> Self:

--- a/src/prefect/server/api/clients.py
+++ b/src/prefect/server/api/clients.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 import contextvars
 from contextlib import asynccontextmanager
@@ -8,11 +7,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
-    ClassVar,
     Dict,
     List,
     Optional,
-    cast,
 )
 from urllib.parse import quote
 from uuid import UUID
@@ -40,9 +37,11 @@ logger: "logging.Logger" = get_logger(__name__)
 
 
 # Per-request headers pushed by `scoped_headers()`; the httpx request hook
-# installed in `BaseClient.__init__` merges them into outgoing requests so
-# callers can reuse a single shared client across automation actions while
-# still tagging each request with automation-specific identifiers.
+# installed on each client merges them into outgoing requests so a single
+# long-lived client (see `prefect.server.events.actions.consumer`) can be reused
+# across automation actions while still tagging each request with
+# automation-specific identifiers. The contextvar makes the headers request-local
+# so concurrent actions sharing a client never clobber each other's headers.
 _request_scoped_headers: contextvars.ContextVar[Optional[Dict[str, str]]] = (
     contextvars.ContextVar("_request_scoped_headers", default=None)
 )
@@ -66,78 +65,9 @@ async def scoped_headers(headers: Dict[str, str]) -> AsyncIterator[None]:
         _request_scoped_headers.reset(token)
 
 
-class _SharedClientMixin:
-    """
-    Process-level cache of one open client per `(subclass, settings)`.
-
-    Sharing avoids re-running `create_app()`, `setup_logging()` and
-    `Settings.hash_key()` on every automation action. Headers that vary per
-    call (e.g. automation identifiers) must be applied with `scoped_headers()`
-    rather than baked into the cached client.
-
-    The cache assumes a single, long-lived event loop per process: the cached
-    httpx clients and the lazily-created `asyncio.Lock` are bound to the loop
-    they are first used on. That holds for the Prefect server and for the
-    session-scoped test loop. Test suites that spin up per-test loops (e.g. via
-    `asyncio.run`) must call `_reset_shared()` between tests so a client built
-    on a now-dead loop is never handed back.
-    """
-
-    # Set by each subclass in `__init__`.
+class BaseClient:
     _http_client: PrefectHttpxAsyncClient
 
-    # One registry shared by every subclass, keyed by `(cls, id(settings))`.
-    # The settings object is stored next to the client and held by a strong
-    # reference on purpose: keeping it alive means its `id()` cannot be
-    # recycled for a different `Settings` instance while the entry lives, which
-    # would otherwise hand back a client built for stale settings. Distinct
-    # `temporary_settings()` blocks therefore get distinct entries; tests evict
-    # them via `_reset_shared()`.
-    _shared_instances: ClassVar[
-        Dict[tuple[type, int], tuple[Any, "_SharedClientMixin"]]
-    ] = {}
-    _shared_lock: ClassVar[Optional[asyncio.Lock]] = None
-
-    @classmethod
-    async def shared(cls) -> Self:
-        """
-        Return a process-cached client for the current settings, lazily
-        constructed and left open for the lifetime of the process. Headers that
-        vary per call (e.g. automation identifiers) should be set via
-        `scoped_headers()`, not passed at construction.
-        """
-        settings = get_current_settings()
-        key = (cls, id(settings))
-        cached = _SharedClientMixin._shared_instances.get(key)
-        if cached is not None and cached[0] is settings:
-            return cast(Self, cached[1])
-        # Lazily create the lock. The check-and-set needs no extra guard: there
-        # is no `await` between the `is None` test and the assignment, so no
-        # other coroutine on this loop can interleave here. Do not add one.
-        if _SharedClientMixin._shared_lock is None:
-            _SharedClientMixin._shared_lock = asyncio.Lock()
-        async with _SharedClientMixin._shared_lock:
-            cached = _SharedClientMixin._shared_instances.get(key)
-            if cached is not None and cached[0] is settings:
-                return cast(Self, cached[1])
-            instance = cls()
-            await instance._http_client.__aenter__()
-            _SharedClientMixin._shared_instances[key] = (settings, instance)
-            return instance
-
-    @classmethod
-    async def _reset_shared(cls) -> None:
-        """Test helper: close and discard every cached shared instance."""
-        entries = list(_SharedClientMixin._shared_instances.values())
-        _SharedClientMixin._shared_instances.clear()
-        for _settings, instance in entries:
-            try:
-                await instance._http_client.__aexit__(None, None, None)
-            except Exception:
-                pass
-
-
-class BaseClient(_SharedClientMixin):
     def __init__(self, additional_headers: dict[str, str] | None = None):
         from prefect.server.api.server import create_app
 

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -20,12 +20,14 @@ from typing import (
     ClassVar,
     Coroutine,
     Dict,
+    Generic,
     List,
     Literal,
     MutableMapping,
     Optional,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
 )
@@ -353,34 +355,75 @@ class EmitEventAction(Action):
         """Create an event from the TriggeredAction"""
 
 
+_SharedClient = TypeVar("_SharedClient")
+
+
+class _AutomationScopedClient(Generic[_SharedClient]):
+    """
+    Async context manager returned by `ExternalDataAction.orchestration_client`
+    and `events_api_client`. It acquires the process-shared client, then enters
+    a `scoped_headers()` block that pushes automation-specific headers into the
+    contextvar consumed by the httpx request hook; on exit the headers are
+    popped. The shared client itself is never closed — it lives for the process
+    lifetime.
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[], Awaitable[_SharedClient]],
+        headers: Dict[str, str],
+    ):
+        self._factory = factory
+        self._headers = headers
+        self._scope: Any = None
+
+    async def __aenter__(self) -> _SharedClient:
+        from prefect.server.api.clients import scoped_headers
+
+        # Acquire the client first; `shared()` issues no requests, so the headers
+        # are not needed yet. Entering the scope only after a successful acquire
+        # means a failure in the factory cannot leak a contextvar token.
+        client = await self._factory()
+        self._scope = scoped_headers(self._headers)
+        await self._scope.__aenter__()
+        return client
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._scope is not None:
+            await self._scope.__aexit__(*exc)
+
+
 class ExternalDataAction(Action):
     """Base class for Actions that require data from an external source such as
     the Orchestration API"""
 
+    @staticmethod
+    def _automation_request_headers(
+        triggered_action: "TriggeredAction",
+    ) -> Dict[str, str]:
+        return {
+            "Prefect-Automation-ID": str(triggered_action.automation.id),
+            "Prefect-Automation-Name": (
+                b64encode(triggered_action.automation.name.encode()).decode()
+            ),
+        }
+
     async def orchestration_client(
         self, triggered_action: "TriggeredAction"
-    ) -> "OrchestrationClient":
+    ) -> "_AutomationScopedClient[OrchestrationClient]":
         from prefect.server.api.clients import OrchestrationClient
 
-        return OrchestrationClient(
-            additional_headers={
-                "Prefect-Automation-ID": str(triggered_action.automation.id),
-                "Prefect-Automation-Name": (
-                    b64encode(triggered_action.automation.name.encode()).decode()
-                ),
-            },
+        return _AutomationScopedClient(
+            OrchestrationClient.shared,
+            self._automation_request_headers(triggered_action),
         )
 
     async def events_api_client(
         self, triggered_action: "TriggeredAction"
-    ) -> PrefectServerEventsAPIClient:
-        return PrefectServerEventsAPIClient(
-            additional_headers={
-                "Prefect-Automation-ID": str(triggered_action.automation.id),
-                "Prefect-Automation-Name": (
-                    b64encode(triggered_action.automation.name.encode()).decode()
-                ),
-            },
+    ) -> "_AutomationScopedClient[PrefectServerEventsAPIClient]":
+        return _AutomationScopedClient(
+            PrefectServerEventsAPIClient.shared,
+            self._automation_request_headers(triggered_action),
         )
 
     def reason_from_response(self, response: Response) -> str:

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import contextvars
 import copy
 from base64 import b64encode
-from contextlib import asynccontextmanager
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import (
     TYPE_CHECKING,
@@ -20,7 +21,6 @@ from typing import (
     ClassVar,
     Coroutine,
     Dict,
-    Generic,
     List,
     Literal,
     MutableMapping,
@@ -355,42 +355,46 @@ class EmitEventAction(Action):
         """Create an event from the TriggeredAction"""
 
 
-_SharedClient = TypeVar("_SharedClient")
+_ScopedClient = TypeVar("_ScopedClient")
+
+# The actions consumer (`consumer()` below) opens one OrchestrationClient and one
+# PrefectServerEventsAPIClient for its lifetime and publishes them here, so every
+# action it runs reuses them instead of paying the create_app()/setup_logging()
+# construction cost per action. When no consumer is active — e.g. an action
+# invoked directly in a test — the accessors below fall back to a short-lived
+# client.
+_consumer_orchestration_client: contextvars.ContextVar[
+    Optional["OrchestrationClient"]
+] = contextvars.ContextVar("_consumer_orchestration_client", default=None)
+_consumer_events_api_client: contextvars.ContextVar[
+    Optional["PrefectServerEventsAPIClient"]
+] = contextvars.ContextVar("_consumer_events_api_client", default=None)
 
 
-class _AutomationScopedClient(Generic[_SharedClient]):
+@asynccontextmanager
+async def _scoped_client(
+    shared: Optional[_ScopedClient],
+    build: Callable[[], AbstractAsyncContextManager[_ScopedClient]],
+    headers: Dict[str, str],
+) -> AsyncGenerator[_ScopedClient, None]:
     """
-    Async context manager returned by `ExternalDataAction.orchestration_client`
-    and `events_api_client`. It acquires the process-shared client, then enters
-    a `scoped_headers()` block that pushes automation-specific headers into the
-    contextvar consumed by the httpx request hook; on exit the headers are
-    popped. The shared client itself is never closed — it lives for the process
-    lifetime.
+    Yield a client with the per-action automation `headers` scoped to this block.
+
+    When the actions consumer is running it has already opened a long-lived
+    client (passed as `shared`), which is reused as-is. Otherwise a short-lived
+    client is built and closed when the block exits. Either way the headers are
+    pushed through the `scoped_headers()` contextvar (consumed by the client's
+    httpx request hook) so concurrent actions never clobber each other's headers
+    on a shared client.
     """
+    from prefect.server.api.clients import scoped_headers
 
-    def __init__(
-        self,
-        factory: Callable[[], Awaitable[_SharedClient]],
-        headers: Dict[str, str],
-    ):
-        self._factory = factory
-        self._headers = headers
-        self._scope: Any = None
-
-    async def __aenter__(self) -> _SharedClient:
-        from prefect.server.api.clients import scoped_headers
-
-        # Acquire the client first; `shared()` issues no requests, so the headers
-        # are not needed yet. Entering the scope only after a successful acquire
-        # means a failure in the factory cannot leak a contextvar token.
-        client = await self._factory()
-        self._scope = scoped_headers(self._headers)
-        await self._scope.__aenter__()
-        return client
-
-    async def __aexit__(self, *exc: Any) -> None:
-        if self._scope is not None:
-            await self._scope.__aexit__(*exc)
+    if shared is not None:
+        async with scoped_headers(headers):
+            yield shared
+    else:
+        async with build() as client, scoped_headers(headers):
+            yield client
 
 
 class ExternalDataAction(Action):
@@ -410,19 +414,21 @@ class ExternalDataAction(Action):
 
     async def orchestration_client(
         self, triggered_action: "TriggeredAction"
-    ) -> "_AutomationScopedClient[OrchestrationClient]":
+    ) -> AbstractAsyncContextManager["OrchestrationClient"]:
         from prefect.server.api.clients import OrchestrationClient
 
-        return _AutomationScopedClient(
-            OrchestrationClient.shared,
+        return _scoped_client(
+            _consumer_orchestration_client.get(),
+            OrchestrationClient,
             self._automation_request_headers(triggered_action),
         )
 
     async def events_api_client(
         self, triggered_action: "TriggeredAction"
-    ) -> "_AutomationScopedClient[PrefectServerEventsAPIClient]":
-        return _AutomationScopedClient(
-            PrefectServerEventsAPIClient.shared,
+    ) -> AbstractAsyncContextManager[PrefectServerEventsAPIClient]:
+        return _scoped_client(
+            _consumer_events_api_client.get(),
+            PrefectServerEventsAPIClient,
             self._automation_request_headers(triggered_action),
         )
 
@@ -1899,33 +1905,56 @@ async def action_has_already_happened(id: UUID) -> bool:
 
 @asynccontextmanager
 async def consumer() -> AsyncGenerator[MessageHandler, None]:
+    from prefect.server.api.clients import OrchestrationClient
     from prefect.server.events.schemas.automations import TriggeredAction
 
-    async def message_handler(message: Message):
-        if not message.data:
-            return
+    # Open one orchestration client and one events API client for the lifetime of
+    # the consumer; every action reuses them (via the contextvars read in
+    # `ExternalDataAction.orchestration_client` / `events_api_client`) instead of
+    # constructing a fresh client per action. They are closed when the consumer
+    # shuts down.
+    async with (
+        OrchestrationClient() as orchestration_client,
+        PrefectServerEventsAPIClient() as events_api_client,
+    ):
 
-        triggered_action = TriggeredAction.model_validate_json(message.data)
-        action = triggered_action.action
+        async def message_handler(message: Message):
+            if not message.data:
+                return
 
-        if await action_has_already_happened(triggered_action.id):
-            logger.info(
-                "Action %s has already been executed, skipping",
-                triggered_action.id,
+            triggered_action = TriggeredAction.model_validate_json(message.data)
+            action = triggered_action.action
+
+            if await action_has_already_happened(triggered_action.id):
+                logger.info(
+                    "Action %s has already been executed, skipping",
+                    triggered_action.id,
+                )
+                return
+
+            # Publish the consumer's shared clients for the duration of this
+            # action. Setting and resetting within the same coroutine keeps the
+            # contextvar tokens in a single context, which `ContextVar.reset`
+            # requires (the surrounding `async with` may be entered and exited on
+            # different tasks, e.g. by an async fixture).
+            orchestration_token = _consumer_orchestration_client.set(
+                orchestration_client
             )
-            return
+            events_token = _consumer_events_api_client.set(events_api_client)
+            try:
+                await action.act(triggered_action)
+            except ActionFailed as e:
+                # ActionFailed errors are expected errors and will not be retried
+                await action.fail(triggered_action, e.reason)
+            else:
+                await action.succeed(triggered_action)
+                await record_action_happening(triggered_action.id)
+            finally:
+                _consumer_events_api_client.reset(events_token)
+                _consumer_orchestration_client.reset(orchestration_token)
 
-        try:
-            await action.act(triggered_action)
-        except ActionFailed as e:
-            # ActionFailed errors are expected errors and will not be retried
-            await action.fail(triggered_action, e.reason)
-        else:
-            await action.succeed(triggered_action)
-            await record_action_happening(triggered_action.id)
-
-    logger.info("Starting action message handler")
-    yield message_handler
+        logger.info("Starting action message handler")
+        yield message_handler
 
 
 async def _load_block_from_block_document(

--- a/src/prefect/server/events/clients.py
+++ b/src/prefect/server/events/clients.py
@@ -19,6 +19,7 @@ from typing_extensions import Self, TypeAlias
 
 from prefect.client.base import PrefectHttpxAsyncClient
 from prefect.logging import get_logger
+from prefect.server.api.clients import _SharedClientMixin
 from prefect.server.events import messaging
 from prefect.server.events.schemas.events import (
     Event,
@@ -241,10 +242,11 @@ class PrefectServerEventsClient(EventsClient):
         return received_event
 
 
-class PrefectServerEventsAPIClient:
-    _http_client: PrefectHttpxAsyncClient
+class PrefectServerEventsAPIClient(_SharedClientMixin):
+    # Process-shared client cache; see `_SharedClientMixin` for the rationale.
 
     def __init__(self, additional_headers: dict[str, str] = {}):
+        from prefect.server.api.clients import _apply_scoped_headers
         from prefect.server.api.server import create_app
 
         # create_app caches application instances, and invoking it with no arguments
@@ -257,6 +259,7 @@ class PrefectServerEventsAPIClient:
             base_url="http://prefect-in-memory/api",
             enable_csrf_support=False,
             raise_on_all_errors=False,
+            event_hooks={"request": [_apply_scoped_headers]},
         )
 
     async def __aenter__(self) -> Self:

--- a/src/prefect/server/events/clients.py
+++ b/src/prefect/server/events/clients.py
@@ -19,7 +19,6 @@ from typing_extensions import Self, TypeAlias
 
 from prefect.client.base import PrefectHttpxAsyncClient
 from prefect.logging import get_logger
-from prefect.server.api.clients import _SharedClientMixin
 from prefect.server.events import messaging
 from prefect.server.events.schemas.events import (
     Event,
@@ -242,8 +241,8 @@ class PrefectServerEventsClient(EventsClient):
         return received_event
 
 
-class PrefectServerEventsAPIClient(_SharedClientMixin):
-    # Process-shared client cache; see `_SharedClientMixin` for the rationale.
+class PrefectServerEventsAPIClient:
+    _http_client: PrefectHttpxAsyncClient
 
     def __init__(self, additional_headers: dict[str, str] = {}):
         from prefect.server.api.clients import _apply_scoped_headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,22 +277,6 @@ async def restore_loop_after_each_test():
     asyncio.set_event_loop(loop)
 
 
-@pytest.fixture(autouse=True)
-async def reset_shared_server_clients():
-    """
-    The server-side `OrchestrationClient` / `PrefectServerEventsAPIClient` keep a
-    process-level cache of one open client per settings (see
-    `prefect.server.api.clients._SharedClientMixin`). Close and discard them
-    after each test so a client built under `temporary_settings()`, or on a
-    per-test event loop, is never handed back to a later test.
-    """
-    from prefect.server.api.clients import BaseClient
-
-    yield
-
-    await BaseClient._reset_shared()
-
-
 @pytest.fixture(scope="session")
 def tests_dir() -> pathlib.Path:
     return pathlib.Path(__file__).parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,6 +277,22 @@ async def restore_loop_after_each_test():
     asyncio.set_event_loop(loop)
 
 
+@pytest.fixture(autouse=True)
+async def reset_shared_server_clients():
+    """
+    The server-side `OrchestrationClient` / `PrefectServerEventsAPIClient` keep a
+    process-level cache of one open client per settings (see
+    `prefect.server.api.clients._SharedClientMixin`). Close and discard them
+    after each test so a client built under `temporary_settings()`, or on a
+    per-test event loop, is never handed back to a later test.
+    """
+    from prefect.server.api.clients import BaseClient
+
+    yield
+
+    await BaseClient._reset_shared()
+
+
 @pytest.fixture(scope="session")
 def tests_dir() -> pathlib.Path:
     return pathlib.Path(__file__).parent


### PR DESCRIPTION
Supersedes #22302 — that PR was closed

---

Every triggered automation action constructed a fresh OrchestrationClient (or PrefectServerEventsAPIClient), each of which built a new httpx ASGITransport, called create_app(), and re-ran Settings.hash_key() + setup_logging(). Flamegraphs against a trigger-heavy server show this costing ~7% CPU per action.

Cache one open client per (subclass, settings identity) and inject the per-automation Prefect-Automation-ID / Prefect-Automation-Name headers through a contextvar-driven httpx request hook, so per-call tagging is preserved without paying the construction cost on every action. The existing `async with await self.orchestration_client(...)` callsites are unchanged.

Note: this is when running with separate background services.
Here are flamegraphs showing the impact before and after the patch:

<img width="1200" height="698" alt="2491808-2026-06-16T08:40:17Z" src="https://github.com/user-attachments/assets/3354e8ab-d468-4e37-968a-8940aab70ac2" />
<img width="1200" height="762" alt="1496822-2026-06-15T22:19:21Z" src="https://github.com/user-attachments/assets/55c7464d-e4db-4779-9a3b-99f20339b583" />
