### PR TITLE
Add index on event_resources(event_id) to fix full-scan in retention-override vacuum

### DIFF
--- a/src/prefect/server/database/_migrations/versions/postgresql/2026_06_10_000001_c9f3a5b8d1e2_add_event_resources_event_id_index.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2026_06_10_000001_c9f3a5b8d1e2_add_event_resources_event_id_index.py
@@ -1,0 +1,40 @@
+"""Add index on event_resources(event_id) for vacuum performance
+
+Revision ID: c9f3a5b8d1e2
+Revises: bad1e352c597
+Create Date: 2026-06-10 00:00:00.000000
+
+The db_vacuum `vacuum_events_with_retention_overrides` task deletes
+event_resources rows via `event_id IN (SELECT Event.id WHERE ...)`.
+Without an index on event_resources.event_id this falls back to a
+sequential scan, which times out on large tables and silently breaks
+event retention.
+
+Uses CREATE INDEX CONCURRENTLY so the migration does not hold an
+exclusive lock on the table (which can be very large on affected
+deployments).
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c9f3a5b8d1e2"
+down_revision = "bad1e352c597"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS
+            ix_event_resources__event_id
+            ON event_resources (event_id)
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_event_resources__event_id")

--- a/src/prefect/server/database/_migrations/versions/sqlite/2026_06_10_000001_a1b2c3d4e5f6_add_event_resources_event_id_index.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2026_06_10_000001_a1b2c3d4e5f6_add_event_resources_event_id_index.py
@@ -1,0 +1,34 @@
+"""Add index on event_resources(event_id) for vacuum performance
+
+Revision ID: a1b2c3d4e5f6
+Revises: 79e7a60e43d8
+Create Date: 2026-06-10 00:00:00.000000
+
+The db_vacuum `vacuum_events_with_retention_overrides` task deletes
+event_resources rows via `event_id IN (SELECT Event.id WHERE ...)`.
+Without an index on event_resources.event_id this falls back to a
+sequential scan, which times out on large tables and silently breaks
+event retention.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "79e7a60e43d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+        ix_event_resources__event_id
+        ON event_resources (event_id)
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_event_resources__event_id")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1469,6 +1469,10 @@ class EventResource(Base):
             "ix_event_resources__occurred",
             "occurred",
         ),
+        sa.Index(
+            "ix_event_resources__event_id",
+            "event_id",
+        ),
     )
 
     occurred: Mapped[DateTime]

--- a/src/prefect/server/services/db_vacuum.py
+++ b/src/prefect/server/services/db_vacuum.py
@@ -278,6 +278,10 @@ async def vacuum_events_with_retention_overrides(
         retention_cutoff = now("UTC") - retention
 
         # Delete event resources first (no FK cascade)
+        # The subquery finds event IDs matching the event type and age;
+        # the outer filter uses EventResource.occurred (already indexed)
+        # as a pre-filter and EventResource.event_id (newly indexed) for
+        # the join, avoiding the full table scan described in #22535.
         event_ids = (
             sa.select(db.Event.id)
             .where(
@@ -289,7 +293,10 @@ async def vacuum_events_with_retention_overrides(
         resources_deleted = await _batch_delete(
             db,
             db.EventResource,
-            db.EventResource.event_id.in_(event_ids),
+            sa.and_(
+                db.EventResource.occurred < retention_cutoff,
+                db.EventResource.event_id.in_(event_ids),
+            ),
             batch_size,
         )
 


### PR DESCRIPTION
closes #22535

## Summary

The `vacuum_events_with_retention_overrides` service deletes `event_resources` rows using an `event_id IN (SELECT Event.id WHERE ...)` pattern, but the `EventResource` ORM model had no index on `event_id`. On large tables this causes a full sequential scan of `event_resources` (tens of millions of rows), which consistently times out (default 10s) and silently breaks event retention — no rows are pruned.

Additionally, the default `event_retention_overrides` is `{"prefect.flow-run.heartbeat": timedelta(days=7)}` while `server.events.retention_period` also defaults to 7 days, so the override targets the same rows as `vacuum_old_events` but via the broken unindexed path. Every default deployment with heartbeat volume hits this.

## Changes

1. **ORM model** — Add `ix_event_resources__event_id` index to `EventResource.__table_args__`
2. **PostgreSQL migration** — Uses `CREATE INDEX CONCURRENTLY` for zero-downtime on busy deployments
3. **SQLite migration** — Standard `CREATE INDEX`
4. **Query optimization** — Add `EventResource.occurred < retention_cutoff` as a pre-filter alongside the `event_id` subquery, allowing the query planner to use both the existing `occurred` index and the new `event_id` index

## Testing

- All 37 existing `test_db_vacuum.py` tests pass
- All 4 `test_database.py` event storage tests pass
- No behavioral change — the query logic is identical, just adds an index and an `occurred` pre-filter that is logically redundant but helps the query planner

<details>
<summary>Related context</summary>

The `occurred` column on `EventResource` was added in prior work (PRs #16907, #16921) and an index on it was added in migration `bad1e352c597` — but the `event_id` join path was left unindexed. This PR completes that work by indexing the column used in the retention-override delete path.

Without this fix, the query plan on a busy server shows:
```
Seq Scan on event_resources  (rows=69M+)  <-- full scan every batch
```

With the index, the plan becomes an index scan on `ix_event_resources__event_id`.
</details>