### PR TITLE
fix: reduce default lease_duration and add timeout to concurrency context manager (closes #16299)

### DIFF
--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -22,9 +22,9 @@ T = TypeVar("T")
 def concurrency(
     names: Union[str, list[str]],
     occupy: int = 1,
-    timeout_seconds: Optional[float] = None,
-    max_retries: Optional[int] = None,
-    lease_duration: float = 300,
+    timeout_seconds: Optional[float] = 30.0,
+    max_retries: Optional[int] = 3,
+    lease_duration: float = 60.0,
     strict: bool = False,
     holder: "Optional[ConcurrencyLeaseHolder]" = None,
     raise_on_lease_renewal_failure: Optional[bool] = None,


### PR DESCRIPTION
## What
Concurrency slots in the sync context manager defaulted to `timeout_seconds=None` (infinite wait) and `lease_duration=300` (5 minutes). In server environments with many concurrent flows or slow database connections (e.g., asyncpg timeouts), this causes long blocking periods, cascading timeouts, and OOMs.

## Fix
- Changed `timeout_seconds` default from `None` to `30.0` seconds so slots are released faster when DB is slow.
- Changed `max_retries` default from `None` to `3` to retry transient failures instead of hanging.
- Reduced `lease_duration` default from `300` to `60.0` seconds to avoid holding slots for extended periods.
- These defaults can still be explicitly overridden by users who need different behavior.

Closes #16299