### PR TITLE
fix(ui): persist explicit null when clearing optional string fields

### DIFF
--- a/ui-v2/src/components/schemas/schema-form-input-object.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-object.tsx
@@ -50,6 +50,8 @@ export function SchemaFormInputObject({
 			for (const { key, value } of patches.current) {
 				newValues[key] = value;
 
+				// Only drop keys that were never set. Explicit null must be kept so
+				// optional fields can clear a non-null default on save.
 				if (value === undefined) {
 					delete newValues[key];
 				}

--- a/ui-v2/src/components/schemas/schema-form-input-string.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-string.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { SchemaFormInputString } from "./schema-form-input-string";
+
+describe("SchemaFormInputString", () => {
+	test("clearing the textarea reports null instead of undefined", async () => {
+		const user = userEvent.setup();
+		const onValueChange = vi.fn();
+
+		render(
+			<SchemaFormInputString
+				value="value.split(',')"
+				onValueChange={onValueChange}
+				property={{ type: "string" }}
+				id="format-rule"
+			/>,
+		);
+
+		const input = document.getElementById("format-rule") as HTMLTextAreaElement;
+		expect(input).toBeTruthy();
+		await user.clear(input);
+
+		expect(onValueChange).toHaveBeenCalled();
+		const last = onValueChange.mock.calls.at(-1)?.[0];
+		expect(last).toBeNull();
+	});
+
+	test("typing a non-empty value reports the string", async () => {
+		const user = userEvent.setup();
+		const onValueChange = vi.fn();
+
+		render(
+			<SchemaFormInputString
+				value=""
+				onValueChange={onValueChange}
+				property={{ type: "string" }}
+				id="format-rule"
+			/>,
+		);
+
+		const input = document.getElementById("format-rule") as HTMLTextAreaElement;
+		await user.type(input, "abc");
+
+		const last = onValueChange.mock.calls.at(-1)?.[0];
+		expect(last).toBe("abc");
+	});
+});

--- a/ui-v2/src/components/schemas/schema-form-input-string.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-string.tsx
@@ -9,8 +9,8 @@ import { SchemaFormInputStringFormatTimeDelta } from "./schema-form-input-string
 import { isWithPrimitiveEnum } from "./types/schemas";
 
 export type SchemaFormInputStringProps = {
-	value: string | undefined;
-	onValueChange: (value: string | undefined) => void;
+	value: string | null | undefined;
+	onValueChange: (value: string | null | undefined) => void;
 	property: SchemaObject & StringSubtype;
 	id: string;
 };
@@ -21,8 +21,16 @@ export function SchemaFormInputString({
 	property,
 	id,
 }: SchemaFormInputStringProps) {
-	function handleChange(value: string | undefined) {
-		onValueChange(value || undefined);
+	function handleChange(next: string | undefined) {
+		// Empty input must report explicit null so optional fields can clear a
+		// non-null default. Using `|| undefined` collapses "" to undefined, which
+		// the object form then deletes — and the saved document reverts to the
+		// Pydantic default instead of null.
+		if (next === undefined || next === "") {
+			onValueChange(null);
+			return;
+		}
+		onValueChange(next);
 	}
 
 	if (isWithPrimitiveEnum(property)) {


### PR DESCRIPTION
Clearing an optional `Optional[str]` block field in the block-edit UI did not persist `null`. The string widget used `value || undefined`, and the object form deleted keys whose patch value was `undefined`. Combined with full-replace save (`merge_existing_data: false`), the field silently reverted to its non-null Pydantic default.

### Changes
- `schema-form-input-string.tsx`: empty / cleared input reports `null` instead of `undefined`
- `schema-form-input-object.tsx`: still delete only `undefined` keys; comment clarifies that explicit `null` must be kept
- Unit test: clearing the textarea yields `null`

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - closes https://github.com/PrefectHQ/prefect/issues/22525
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

Local vitest not run if `ui-v2/node_modules` missing; CI should cover.
