### PR TITLE
Make Redis concurrency leases cluster-slot safe

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/lease_storage.py
+++ b/src/integrations/prefect-redis/prefect_redis/lease_storage.py
@@ -17,7 +17,7 @@ from prefect.server.concurrency.lease_storage import (
     ConcurrencyLeaseStorage as _ConcurrencyLeaseStorage,
 )
 from prefect.server.utilities.leasing import ResourceLease
-from prefect_redis.client import get_async_redis_client
+from prefect_redis.client import cluster_key_prefix, get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
 
     def __init__(self, redis_client: Redis | None = None):
         self.redis_client = redis_client or get_async_redis_client()
-        self.base_prefix = "prefect:concurrency:"
+        self.base_prefix = f"{cluster_key_prefix('prefect:concurrency')}:"
         self.lease_prefix = f"{self.base_prefix}lease:"
         self.expirations_key = f"{self.base_prefix}expirations"
         self.expiration_prefix = f"{self.base_prefix}expiration:"
@@ -45,9 +45,8 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         """Generate Redis key for lease expiration."""
         return f"{self.expiration_prefix}{lease_id}"
 
-    @staticmethod
-    def _limit_holders_key(limit_id: UUID) -> str:
-        return f"prefect:concurrency:limit:{limit_id}:holders"
+    def _limit_holders_key(self, limit_id: UUID) -> str:
+        return f"{self.base_prefix}limit:{limit_id}:holders"
 
     async def _ensure_scripts(self) -> None:
         if self._create_script is None:
@@ -77,6 +76,7 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
             -- KEYS[1] = lease_key
             -- KEYS[2] = expirations_key
             -- ARGV[1] = lease_id
+            -- ARGV[2] = concurrency key prefix
             -- Read the lease in-script to avoid races and compute index keys
             local lease_json = redis.call('GET', KEYS[1])
             if lease_json then
@@ -84,7 +84,7 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
               if ok and lease then
                 if lease['resource_ids'] then
                   for _, rid in ipairs(lease['resource_ids']) do
-                    local holder_index_key = 'prefect:concurrency:limit:' .. tostring(rid) .. ':holders'
+                    local holder_index_key = ARGV[2] .. 'limit:' .. tostring(rid) .. ':holders'
                     redis.call('HDEL', holder_index_key, ARGV[1])
                   end
                 end
@@ -290,6 +290,7 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
             ]
             args: list[str] = [
                 str(lease_id),
+                self.base_prefix,
             ]
             await self._revoke_script(keys=keys, args=args)  # type: ignore[misc]
         except RedisError as e:

--- a/src/integrations/prefect-redis/tests/test_lease_storage.py
+++ b/src/integrations/prefect-redis/tests/test_lease_storage.py
@@ -1,10 +1,12 @@
 import asyncio
+import os
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 import pytest
 from prefect_redis.lease_storage import ConcurrencyLeaseStorage
-from redis.asyncio import Redis
+from redis.asyncio import Redis, RedisCluster
+from redis.cluster import key_slot
 
 from prefect.server.concurrency.lease_storage import ConcurrencyLimitLeaseMetadata
 from prefect.server.utilities.leasing import ResourceLease
@@ -18,6 +20,114 @@ class TestConcurrencyLeaseStorage:
     async def storage(self, redis: Redis) -> ConcurrencyLeaseStorage:
         """Create a ConcurrencyLeaseStorage instance with the test Redis client."""
         return ConcurrencyLeaseStorage(redis_client=redis)
+
+    def test_keys_share_cluster_hash_slot(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(
+            "PREFECT_REDIS_MESSAGING_URL",
+            "redis+cluster://redis.example.com:6379",
+        )
+        monkeypatch.setattr(
+            "prefect_redis.lease_storage.get_async_redis_client", lambda: None
+        )
+        storage = ConcurrencyLeaseStorage()
+        lease_id = uuid4()
+        limit_id = uuid4()
+        keys = [
+            storage._lease_key(lease_id),
+            storage.expirations_key,
+            storage._expiration_key(lease_id),
+            storage._limit_holders_key(limit_id),
+        ]
+
+        assert keys == [
+            f"{{prefect:concurrency}}:lease:{lease_id}",
+            "{prefect:concurrency}:expirations",
+            f"{{prefect:concurrency}}:expiration:{lease_id}",
+            f"{{prefect:concurrency}}:limit:{limit_id}:holders",
+        ]
+        assert len({key_slot(key.encode()) for key in keys}) == 1
+
+    def test_keys_preserve_standalone_names(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("PREFECT_REDIS_MESSAGING_URL", raising=False)
+        monkeypatch.setattr(
+            "prefect_redis.lease_storage.get_async_redis_client", lambda: None
+        )
+        storage = ConcurrencyLeaseStorage()
+        lease_id = uuid4()
+        limit_id = uuid4()
+
+        assert storage._lease_key(lease_id) == f"prefect:concurrency:lease:{lease_id}"
+        assert storage.expirations_key == "prefect:concurrency:expirations"
+        assert storage._expiration_key(lease_id) == (
+            f"prefect:concurrency:expiration:{lease_id}"
+        )
+        assert storage._limit_holders_key(limit_id) == (
+            f"prefect:concurrency:limit:{limit_id}:holders"
+        )
+
+    @pytest.mark.skipif(
+        not os.environ.get("PREFECT_REDIS_CLUSTER_TEST_URL"),
+        reason="requires PREFECT_REDIS_CLUSTER_TEST_URL",
+    )
+    async def test_runs_against_real_redis_cluster(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        cluster_url = os.environ["PREFECT_REDIS_CLUSTER_TEST_URL"]
+        client_url = cluster_url.replace("redis+cluster://", "redis://", 1).replace(
+            "rediss+cluster://", "rediss://", 1
+        )
+        settings_url = cluster_url
+        if settings_url.startswith("redis://"):
+            settings_url = settings_url.replace("redis://", "redis+cluster://", 1)
+        elif settings_url.startswith("rediss://"):
+            settings_url = settings_url.replace("rediss://", "rediss+cluster://", 1)
+
+        redis_client = RedisCluster.from_url(client_url, decode_responses=True)
+        await redis_client.flushall()
+        try:
+            monkeypatch.setenv("PREFECT_REDIS_MESSAGING_URL", settings_url)
+            storage = ConcurrencyLeaseStorage(redis_client=redis_client)
+            resource_ids = [uuid4(), uuid4()]
+            holder_id = uuid4()
+            metadata = ConcurrencyLimitLeaseMetadata(slots=2)
+            setattr(
+                metadata,
+                "holder",
+                {"type": "task_run", "id": str(holder_id)},
+            )
+
+            lease = await storage.create_lease(
+                resource_ids, timedelta(minutes=5), metadata
+            )
+
+            read_lease = await storage.read_lease(lease.id)
+            assert read_lease is not None
+            assert read_lease.resource_ids == resource_ids
+            assert lease.id in await storage.read_active_lease_ids()
+            for resource_id in resource_ids:
+                assert await storage.list_holders_for_limit(resource_id) == [
+                    (
+                        lease.id,
+                        ConcurrencyLeaseHolder(type="task_run", id=holder_id),
+                    )
+                ]
+
+            assert await storage.renew_lease(lease.id, timedelta(minutes=10))
+            renewed_lease = await storage.read_lease(lease.id)
+            assert renewed_lease is not None
+            assert renewed_lease.expiration > lease.expiration
+
+            await storage.revoke_lease(lease.id)
+            assert await storage.read_lease(lease.id) is None
+            for resource_id in resource_ids:
+                assert await storage.list_holders_for_limit(resource_id) == []
+
+            expired_lease = await storage.create_lease([uuid4()], timedelta(seconds=-1))
+            assert expired_lease.id in await storage.read_expired_lease_ids()
+            await storage.revoke_lease(expired_lease.id)
+        finally:
+            await redis_client.flushall()
+            await redis_client.aclose()
 
     async def test_create_lease(self, storage: ConcurrencyLeaseStorage):
         """Test creating a new lease."""


### PR DESCRIPTION
this PR makes Redis-backed concurrency lease storage hash-slot safe for Redis Cluster while preserving existing standalone Redis key names.

<details>
<summary>Details</summary>

- hash-tags lease records, expiration indexes, and holder indexes under one `prefect:concurrency` Cluster slot
- makes revoke's Lua-generated holder keys use the same cluster-aware prefix
- adds exact key compatibility coverage for Cluster and standalone configurations
- adds an opt-in real Redis Cluster test covering create, read, renew, active/expired lookup, holder indexing, and revoke cleanup

This is the next incremental Cluster-support slice after #22211, #22448, and #22453. Redis Cluster client activation remains intentionally gated until the cleanup queue's multi-key transactions are made hash-slot safe.

</details>

Tested with:

- `PREFECT_REDIS_CLUSTER_TEST_URL=redis+cluster://192.168.215.2:7000 uv run --project src/integrations/prefect-redis --group dev pytest src/integrations/prefect-redis/tests -qq`
- `uv run pre-commit run ruff-check --files src/integrations/prefect-redis/prefect_redis/lease_storage.py src/integrations/prefect-redis/tests/test_lease_storage.py`
- `uv run pre-commit run ruff-format --files src/integrations/prefect-redis/prefect_redis/lease_storage.py src/integrations/prefect-redis/tests/test_lease_storage.py`
