### PR TITLE
Fix saved block parameters in deployments

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -424,6 +424,14 @@ class Block(BaseModel, ABC):
     def ser_model(
         self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
     ) -> Any:
+        if info.context and info.context.get("serialize_blocks_as_references"):
+            if self._block_document_id is None:
+                raise BlockNotSavedError(
+                    "Block must be saved with `.save()` before it can be used as a "
+                    "deployment parameter."
+                )
+            return {"$ref": {"block_document_id": str(self._block_document_id)}}
+
         jsonable_self = handler(self)
         if (ctx := info.context) and ctx.get("include_secrets") is True:
             # Add serialization mode to context so handle_secret_render knows how to process nested models

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -125,6 +125,11 @@ if TYPE_CHECKING:
 
 __all__ = ["RunnerDeployment"]
 
+_DEPLOYMENT_PARAMETER_SERIALIZER = TypeAdapter(
+    dict[str, Any],
+    config=ConfigDict(ser_json_timedelta="float"),
+)
+
 
 def _extract_concurrency_options(
     concurrency_limit: Union[int, ConcurrencyLimitConfig, None],
@@ -304,9 +309,9 @@ class RunnerDeployment(BaseModel):
     def full_name(self) -> str:
         return f"{self.flow_name}/{self.name}"
 
-    @field_validator("parameters", mode="before")
+    @field_validator("parameters", "schedules", mode="before")
     @classmethod
-    def validate_block_parameters(cls, parameters: dict[str, Any]) -> dict[str, Any]:
+    def validate_block_parameters(cls, value: Any) -> Any:
         def ensure_block_is_saved(value: Any) -> Any:
             if isinstance(value, Block):
                 if value._block_document_id is None:
@@ -317,16 +322,33 @@ class RunnerDeployment(BaseModel):
                 raise StopVisiting()
             return value
 
-        visit_collection(parameters, ensure_block_is_saved)
-        return parameters
+        visit_collection(value, ensure_block_is_saved)
+        return value
 
     @field_serializer("parameters", when_used="json")
     def serialize_block_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
-        return TypeAdapter(dict[str, Any]).dump_python(
+        return _DEPLOYMENT_PARAMETER_SERIALIZER.dump_python(
             parameters,
             mode="json",
             context={"serialize_blocks_as_references": True},
         )
+
+    def _schedules_with_serialized_block_parameters(
+        self,
+    ) -> Optional[List[Union[DeploymentScheduleCreate, DeploymentScheduleUpdate]]]:
+        if self.schedules is None:
+            return None
+
+        return [
+            schedule.model_copy(
+                update={
+                    "parameters": self.serialize_block_parameters(schedule.parameters)
+                }
+            )
+            if schedule.parameters
+            else schedule
+            for schedule in self.schedules
+        ]
 
     def _get_deployment_version_info(
         self, version_type: Optional[VersionType] = None
@@ -411,6 +433,7 @@ class RunnerDeployment(BaseModel):
             )
 
         parameters = self.model_dump(mode="json", include={"parameters"})["parameters"]
+        schedules = self._schedules_with_serialized_block_parameters()
 
         async with get_client() as client:
             flow_id = await client.create_flow_from_name(self.flow_name)
@@ -423,7 +446,7 @@ class RunnerDeployment(BaseModel):
                 version=self.version,
                 version_info=version_info,
                 paused=self.paused,
-                schedules=self.schedules,
+                schedules=schedules,
                 concurrency_limit=self.concurrency_limit,
                 concurrency_options=self.concurrency_options,
                 parameters=parameters,
@@ -516,6 +539,7 @@ class RunnerDeployment(BaseModel):
             )
 
         parameters = self.model_dump(mode="json", include={"parameters"})["parameters"]
+        schedules = self._schedules_with_serialized_block_parameters()
 
         with get_client(sync_client=True) as client:
             flow_id = client.create_flow_from_name(self.flow_name)
@@ -528,7 +552,7 @@ class RunnerDeployment(BaseModel):
                 version=self.version,
                 version_info=version_info,
                 paused=self.paused,
-                schedules=self.schedules,
+                schedules=schedules,
                 concurrency_limit=self.concurrency_limit,
                 concurrency_options=self.concurrency_options,
                 parameters=parameters,
@@ -615,7 +639,7 @@ class RunnerDeployment(BaseModel):
         if self.schedules:
             update_payload["schedules"] = [
                 schedule.model_dump(mode="json", exclude_unset=True)
-                for schedule in self.schedules
+                for schedule in self._schedules_with_serialized_block_parameters() or []
             ]
 
         await client.update_deployment(
@@ -667,7 +691,7 @@ class RunnerDeployment(BaseModel):
         if self.schedules:
             update_payload["schedules"] = [
                 schedule.model_dump(mode="json", exclude_unset=True)
-                for schedule in self.schedules
+                for schedule in self._schedules_with_serialized_block_parameters() or []
             ]
 
         client.update_deployment(

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -53,6 +53,8 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    TypeAdapter,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -69,6 +71,7 @@ from prefect._internal.schemas.validators import (
     reconcile_schedules_runner,
 )
 from prefect._internal.versioning import VersionType, get_inferred_version_info
+from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.client.base import ServerType
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.actions import (
@@ -106,7 +109,12 @@ from prefect.types.entrypoint import EntrypointType
 from prefect.utilities.annotations import freeze
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.callables import ParameterSchema, parameter_schema
-from prefect.utilities.collections import get_from_dict, isiterable
+from prefect.utilities.collections import (
+    StopVisiting,
+    get_from_dict,
+    isiterable,
+    visit_collection,
+)
 from prefect.utilities.dockerutils import (
     parse_image_tag,
 )
@@ -296,6 +304,30 @@ class RunnerDeployment(BaseModel):
     def full_name(self) -> str:
         return f"{self.flow_name}/{self.name}"
 
+    @field_validator("parameters", mode="before")
+    @classmethod
+    def validate_block_parameters(cls, parameters: dict[str, Any]) -> dict[str, Any]:
+        def ensure_block_is_saved(value: Any) -> Any:
+            if isinstance(value, Block):
+                if value._block_document_id is None:
+                    raise BlockNotSavedError(
+                        "Block must be saved with `.save()` before it can be used as a "
+                        "deployment parameter."
+                    )
+                raise StopVisiting()
+            return value
+
+        visit_collection(parameters, ensure_block_is_saved)
+        return parameters
+
+    @field_serializer("parameters", when_used="json")
+    def serialize_block_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        return TypeAdapter(dict[str, Any]).dump_python(
+            parameters,
+            mode="json",
+            context={"serialize_blocks_as_references": True},
+        )
+
     def _get_deployment_version_info(
         self, version_type: Optional[VersionType] = None
     ) -> VersionInfo:
@@ -378,6 +410,8 @@ class RunnerDeployment(BaseModel):
                 " with a work pool."
             )
 
+        parameters = self.model_dump(mode="json", include={"parameters"})["parameters"]
+
         async with get_client() as client:
             flow_id = await client.create_flow_from_name(self.flow_name)
 
@@ -392,7 +426,7 @@ class RunnerDeployment(BaseModel):
                 schedules=self.schedules,
                 concurrency_limit=self.concurrency_limit,
                 concurrency_options=self.concurrency_options,
-                parameters=self.parameters,
+                parameters=parameters,
                 description=self.description,
                 tags=self.tags,
                 path=self._path,
@@ -481,6 +515,8 @@ class RunnerDeployment(BaseModel):
                 " with a work pool."
             )
 
+        parameters = self.model_dump(mode="json", include={"parameters"})["parameters"]
+
         with get_client(sync_client=True) as client:
             flow_id = client.create_flow_from_name(self.flow_name)
 
@@ -495,7 +531,7 @@ class RunnerDeployment(BaseModel):
                 schedules=self.schedules,
                 concurrency_limit=self.concurrency_limit,
                 concurrency_options=self.concurrency_options,
-                parameters=self.parameters,
+                parameters=parameters,
                 description=self.description,
                 tags=self.tags,
                 path=self._path,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -3442,6 +3442,61 @@ class TestRunnerDeployment:
                 parameters={"block": Secret(value="secret")},
             )
 
+    def test_unsaved_block_schedule_parameters_are_rejected(self):
+        with pytest.raises(
+            BlockNotSavedError,
+            match=re.escape(
+                "Block must be saved with `.save()` before it can be used as a "
+                "deployment parameter."
+            ),
+        ):
+            RunnerDeployment(
+                name="unsaved-block-schedule-parameter",
+                flow_name="flow-with-block",
+                schedules=[
+                    DeploymentScheduleCreate(
+                        schedule=IntervalSchedule(interval=datetime.timedelta(days=1)),
+                        parameters={"block": Secret(value="secret")},
+                    )
+                ],
+            )
+
+    async def test_applied_deployment_preserves_temporal_parameter_encoding(
+        self, prefect_client: PrefectClient
+    ):
+        scheduled_at = datetime.datetime(
+            2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc
+        )
+        delay = datetime.timedelta(seconds=90)
+
+        @flow
+        def flow_with_temporal_parameters(
+            scheduled_at: str | datetime.datetime,
+            delay: datetime.timedelta,
+        ) -> None:
+            pass
+
+        deployment = await flow_with_temporal_parameters.ato_deployment(
+            name="temporal-parameters",
+            parameters={"scheduled_at": scheduled_at, "delay": delay},
+            enforce_parameter_schema=False,
+        )
+
+        deployment_id = await deployment.apply()
+        stored_deployment = await prefect_client.read_deployment(deployment_id)
+
+        assert stored_deployment.parameters == {
+            "scheduled_at": scheduled_at.timestamp(),
+            "delay": delay.total_seconds(),
+        }
+        validated_parameters = flow_with_temporal_parameters.validate_parameters(
+            stored_deployment.parameters
+        )
+        assert validated_parameters == {
+            "scheduled_at": scheduled_at,
+            "delay": delay,
+        }
+
     async def test_applied_deployment_stores_and_resolves_saved_block_parameter(
         self,
         prefect_client: PrefectClient,
@@ -3494,6 +3549,66 @@ class TestRunnerDeployment:
             updated_deployment.parameters
         )
         assert updated_parameters["credentials"].get() == "updated-secret"
+
+    async def test_applied_deployment_stores_saved_block_schedule_parameter(
+        self,
+        prefect_client: PrefectClient,
+        saved_secret_block: tuple[Secret[Any], uuid.UUID],
+    ):
+        block, block_document_id = saved_secret_block
+
+        @flow
+        def flow_with_block(credentials: Secret[Any]) -> str:
+            return str(credentials.get())
+
+        deployment = await flow_with_block.ato_deployment(
+            name="saved-block-schedule-parameter",
+            schedules=[
+                DeploymentScheduleCreate(
+                    schedule=IntervalSchedule(interval=datetime.timedelta(days=1)),
+                    parameters={"credentials": block},
+                    slug="saved-block",
+                )
+            ],
+        )
+
+        deployment_id = await deployment.apply()
+        stored_deployment = await prefect_client.read_deployment(deployment_id)
+
+        assert stored_deployment.schedules[0].parameters == {
+            "credentials": {
+                "$ref": {
+                    "block_document_id": str(block_document_id),
+                }
+            }
+        }
+        validated_parameters = flow_with_block.validate_parameters(
+            stored_deployment.schedules[0].parameters
+        )
+        assert validated_parameters["credentials"].get() == "issue-13122-secret"
+
+        updated_block = Secret(value="updated-schedule-secret")
+        updated_block_document_id = await updated_block.save(
+            f"updated-schedule-parameter-{uuid.uuid4()}"
+        )
+        assert deployment.schedules is not None
+        deployment.schedules[0].parameters = {"credentials": updated_block}
+
+        updated_deployment_id = await deployment.apply()
+        updated_deployment = await prefect_client.read_deployment(updated_deployment_id)
+
+        assert updated_deployment_id == deployment_id
+        assert updated_deployment.schedules[0].parameters == {
+            "credentials": {
+                "$ref": {
+                    "block_document_id": str(updated_block_document_id),
+                }
+            }
+        }
+        updated_parameters = flow_with_block.validate_parameters(
+            updated_deployment.schedules[0].parameters
+        )
+        assert updated_parameters["credentials"].get() == "updated-schedule-secret"
 
     async def test_apply_with_work_pool(
         self, prefect_client: PrefectClient, work_pool, process_work_pool

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -23,12 +23,15 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import anyio
 import pytest
 import uv
+from pydantic import BaseModel
 from starlette import status
 
 import prefect.runner
 from prefect import __version__, aserve, flow, serve, task
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect._internal.versioning import VersionType
+from prefect.blocks.core import BlockNotSavedError
+from prefect.blocks.system import Secret
 from prefect.bundles import create_bundle_for_flow_run
 from prefect.cli.deploy._storage import _PullStepStorage
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient
@@ -2888,6 +2891,12 @@ async def test_run_hooks_with_partial_hooks(
 
 class TestRunnerDeployment:
     @pytest.fixture
+    async def saved_secret_block(self) -> tuple[Secret[Any], uuid.UUID]:
+        block = Secret(value="issue-13122-secret")
+        block_document_id = await block.save(f"deployment-parameter-{uuid.uuid4()}")
+        return block, block_document_id
+
+    @pytest.fixture
     def relative_file_path(self):
         return Path(__file__).relative_to(Path.cwd())
 
@@ -3379,6 +3388,112 @@ class TestRunnerDeployment:
         assert deployment.job_variables == {}
         assert deployment.paused is False
         assert deployment.global_concurrency_limit is None
+
+    async def test_saved_block_parameters_are_converted_to_references(
+        self, saved_secret_block: tuple[Secret[Any], uuid.UUID]
+    ):
+        block, block_document_id = saved_secret_block
+
+        class BlockParameterModel(BaseModel):
+            block: Secret
+
+        deployment = RunnerDeployment(
+            name="saved-block-parameter",
+            flow_name="flow-with-block",
+            parameters={
+                "nested": {
+                    "blocks": [block],
+                    "model": BlockParameterModel(block=block),
+                }
+            },
+        )
+
+        assert deployment.parameters["nested"]["blocks"][0] is block
+        assert deployment.model_dump(mode="json")["parameters"] == {
+            "nested": {
+                "blocks": [
+                    {
+                        "$ref": {
+                            "block_document_id": str(block_document_id),
+                        }
+                    }
+                ],
+                "model": {
+                    "block": {
+                        "$ref": {
+                            "block_document_id": str(block_document_id),
+                        }
+                    }
+                },
+            }
+        }
+
+    def test_unsaved_block_parameters_are_rejected(self):
+        with pytest.raises(
+            BlockNotSavedError,
+            match=re.escape(
+                "Block must be saved with `.save()` before it can be used as a "
+                "deployment parameter."
+            ),
+        ):
+            RunnerDeployment(
+                name="unsaved-block-parameter",
+                flow_name="flow-with-block",
+                parameters={"block": Secret(value="secret")},
+            )
+
+    async def test_applied_deployment_stores_and_resolves_saved_block_parameter(
+        self,
+        prefect_client: PrefectClient,
+        saved_secret_block: tuple[Secret[Any], uuid.UUID],
+    ):
+        block, block_document_id = saved_secret_block
+
+        @flow
+        def flow_with_block(credentials: Secret[Any]) -> str:
+            return str(credentials.get())
+
+        deployment = await flow_with_block.ato_deployment(
+            name="saved-block-parameter",
+            parameters={"credentials": block},
+        )
+
+        deployment_id = await deployment.apply()
+        stored_deployment = await prefect_client.read_deployment(deployment_id)
+
+        assert stored_deployment.parameters == {
+            "credentials": {
+                "$ref": {
+                    "block_document_id": str(block_document_id),
+                }
+            }
+        }
+        validated_parameters = flow_with_block.validate_parameters(
+            stored_deployment.parameters
+        )
+        assert validated_parameters["credentials"].get() == "issue-13122-secret"
+
+        updated_block = Secret(value="updated-secret")
+        updated_block_document_id = await updated_block.save(
+            f"updated-deployment-parameter-{uuid.uuid4()}"
+        )
+        deployment.parameters = {"credentials": updated_block}
+
+        updated_deployment_id = await deployment.apply()
+        updated_deployment = await prefect_client.read_deployment(updated_deployment_id)
+
+        assert updated_deployment_id == deployment_id
+        assert updated_deployment.parameters == {
+            "credentials": {
+                "$ref": {
+                    "block_document_id": str(updated_block_document_id),
+                }
+            }
+        }
+        updated_parameters = flow_with_block.validate_parameters(
+            updated_deployment.parameters
+        )
+        assert updated_parameters["credentials"].get() == "updated-secret"
 
     async def test_apply_with_work_pool(
         self, prefect_client: PrefectClient, work_pool, process_work_pool
@@ -4941,6 +5056,35 @@ class TestAsyncDispatch:
 
         result = sync_prefect_client.read_deployment(deployment_id)
         assert result.name == "test_runner"
+
+    def test_apply_saved_block_parameter_in_sync_context(
+        self, sync_prefect_client: SyncPrefectClient
+    ):
+        block = Secret(value="sync-secret")
+        block_document_id = block.save(
+            f"sync-deployment-parameter-{uuid.uuid4()}",
+            client=sync_prefect_client,
+        )
+
+        @flow
+        def flow_with_block(credentials: Secret[Any]) -> str:
+            return str(credentials.get())
+
+        deployment = flow_with_block.to_deployment(
+            name="sync-saved-block-parameter",
+            parameters={"credentials": block},
+        )
+
+        deployment_id = deployment.apply()
+        stored_deployment = sync_prefect_client.read_deployment(deployment_id)
+
+        assert stored_deployment.parameters == {
+            "credentials": {
+                "$ref": {
+                    "block_document_id": str(block_document_id),
+                }
+            }
+        }
 
     async def test_deploy_in_async_context(
         self,


### PR DESCRIPTION
closes #13122

this PR serializes saved `Block` instances in deployment parameters as block-document references. Deployments now resolve the persisted block instead of storing an inline copy with masked secret values.

<details>
<summary>Details</summary>

The deployment model previously passed arbitrary parameter objects through normal Pydantic JSON serialization. For secret-bearing blocks, that persisted `**********` and block metadata instead of a usable value.

This change:

- adds an opt-in reference mode to `Block` serialization without changing ordinary block dumps;
- uses that mode for `RunnerDeployment` parameters in create and update operations;
- keeps sync and async deployment paths consistent;
- rejects unsaved blocks with actionable `.save()` guidance; and
- covers nested collections and Pydantic models, API round trips, updates, runtime hydration, and sync dispatch.

Checks run:

- `uv run pytest tests/blocks/test_block_reference.py tests/runner/test_runner.py::TestRunnerDeployment tests/runner/test_runner.py::TestAsyncDispatch -q` (`97 passed`)
- focused regression tests (`4 passed`)
- Ruff check and format check for the changed files
- the original `DatabricksCredentials` reproduction against the worktree source

</details>