### PR TITLE
Emit Kubernetes pod diagnosis as a matchable event label

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/diagnostics.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/diagnostics.py
@@ -20,11 +20,37 @@ class DiagnosisLevel(str, enum.Enum):
     INFO = "info"
 
 
+class DiagnosisCategory(str, enum.Enum):
+    """Category of an infrastructure diagnosis, for matching in automations.
+
+    Values mirror the container-status `reason` strings Kubernetes sets
+    (kubernetes/kubernetes v1.36.2):
+
+    - image pull: https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/kubelet/images/types.go
+    - CrashLoopBackOff: https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/kubelet/container/sync_result.go
+    - OOMKilled: https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/kubelet/kuberuntime/helpers.go
+    - Evicted: https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/kubelet/eviction/helpers.go
+
+    Unschedulable comes from the scheduler; see `_classify_unschedulable`.
+    """
+
+    IMAGE_PULL_BACK_OFF = "image_pull_back_off"
+    CRASH_LOOP_BACK_OFF = "crash_loop_back_off"
+    OOM_KILLED = "oom_killed"
+    EVICTED = "evicted"
+    UNSCHEDULABLE_VOLUME = "unschedulable_volume"
+    UNSCHEDULABLE_INSUFFICIENT_RESOURCES = "unschedulable_insufficient_resources"
+    UNSCHEDULABLE_NODE_AFFINITY = "unschedulable_node_affinity"
+    UNSCHEDULABLE_TAINT = "unschedulable_taint"
+    UNSCHEDULABLE = "unschedulable"
+
+
 @dataclasses.dataclass(frozen=True)
 class InfrastructureDiagnosis:
     """A structured diagnosis of a Kubernetes pod failure."""
 
     level: DiagnosisLevel
+    category: DiagnosisCategory
     summary: str
     detail: str
     resolution: str
@@ -72,6 +98,7 @@ def _check_container_waiting(
         if reason in ("ImagePullBackOff", "ErrImagePull"):
             return InfrastructureDiagnosis(
                 level=DiagnosisLevel.ERROR,
+                category=DiagnosisCategory.IMAGE_PULL_BACK_OFF,
                 summary=f"Image pull failed for container '{container_name}'",
                 detail=(
                     f"Kubernetes cannot pull the container image. "
@@ -88,6 +115,7 @@ def _check_container_waiting(
         if reason == "CrashLoopBackOff":
             return InfrastructureDiagnosis(
                 level=DiagnosisLevel.ERROR,
+                category=DiagnosisCategory.CRASH_LOOP_BACK_OFF,
                 summary=(f"Container '{container_name}' is crash-looping"),
                 detail=(
                     f"The container repeatedly crashes after starting. "
@@ -116,6 +144,7 @@ def _check_container_terminated(
         if reason == "OOMKilled":
             return InfrastructureDiagnosis(
                 level=DiagnosisLevel.ERROR,
+                category=DiagnosisCategory.OOM_KILLED,
                 summary=(
                     f"Container '{container_name}' was killed due to "
                     f"out-of-memory (OOMKilled)"
@@ -135,6 +164,7 @@ def _check_container_terminated(
         if reason == "Evicted":
             return InfrastructureDiagnosis(
                 level=DiagnosisLevel.WARNING,
+                category=DiagnosisCategory.EVICTED,
                 summary=f"Container '{container_name}' was evicted",
                 detail=(
                     "The pod was evicted, likely due to node resource "
@@ -151,6 +181,36 @@ def _check_container_terminated(
     return None
 
 
+def _classify_unschedulable(message: str) -> DiagnosisCategory:
+    """Map an `Unschedulable` message to a cause.
+
+    The cause appears only as free text in the condition message, produced by
+    the scheduler plugins (kubernetes/kubernetes v1.36.2:
+    https://github.com/kubernetes/kubernetes/tree/v1.36.2/pkg/scheduler/framework/plugins),
+    so we match characteristic substrings. A message can list several causes,
+    so checks run in a deliberate order: the plugins that report
+    `UnschedulableAndUnresolvable` (no node will fit without a config change)
+    before the resolvable `Unschedulable` capacity case (which the cluster
+    autoscaler may fix). Volume leads because a "volume node affinity conflict"
+    message also contains "affinity".
+      - "volume"              -> volumebinding    (unresolvable)
+      - "affinity"/"selector" -> nodeaffinity     (unresolvable)
+      - "taint"               -> tainttoleration  (unresolvable)
+      - "insufficient"        -> noderesources    (resolvable capacity)
+    Anything else maps to `UNSCHEDULABLE`.
+    """
+    m = message.lower()
+    if "volume" in m:
+        return DiagnosisCategory.UNSCHEDULABLE_VOLUME
+    if "affinity" in m or "selector" in m:
+        return DiagnosisCategory.UNSCHEDULABLE_NODE_AFFINITY
+    if "taint" in m:
+        return DiagnosisCategory.UNSCHEDULABLE_TAINT
+    if "insufficient" in m:
+        return DiagnosisCategory.UNSCHEDULABLE_INSUFFICIENT_RESOURCES
+    return DiagnosisCategory.UNSCHEDULABLE
+
+
 def _check_unschedulable(
     status: dict[str, Any],
 ) -> InfrastructureDiagnosis | None:
@@ -163,6 +223,7 @@ def _check_unschedulable(
             message = condition.get("message", "")
             return InfrastructureDiagnosis(
                 level=DiagnosisLevel.WARNING,
+                category=_classify_unschedulable(message),
                 summary="Pod is unschedulable",
                 detail=(
                     f"Kubernetes cannot find a suitable node to run "
@@ -187,6 +248,7 @@ def _check_evicted(
         message = status.get("message", "")
         return InfrastructureDiagnosis(
             level=DiagnosisLevel.WARNING,
+            category=DiagnosisCategory.EVICTED,
             summary="Pod was evicted",
             detail=(f"The pod was evicted from its node. {message}".strip()),
             resolution=(

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -172,9 +172,13 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
                     metadata["creationTimestamp"].replace("Z", "+00:00")
                 )
 
+    diagnosis = diagnose_k8s_pod(status)
+
     # Create a deterministic event ID based on the pod's ID, phase, and restart count.
     # This ensures that the event ID is the same for the same pod in the same phase and restart count
     # and Prefect's event system will be able to deduplicate events.
+    # The diagnosis category is included so a condition that appears mid-phase (e.g.
+    # Unschedulable while Pending) is not deduplicated against the earlier event.
     event_id = uuid.uuid5(
         uuid.NAMESPACE_URL,
         json.dumps(
@@ -185,6 +189,7 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
                     cs.get("restartCount", 0)
                     for cs in status.get("containerStatuses", [])
                 ),
+                **({"diagnosis": diagnosis.category.value} if diagnosis else {}),
             },
             sort_keys=True,
         ),
@@ -272,7 +277,6 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
     # Only log when the diagnosis changes to avoid spamming on repeated
     # MODIFIED events for the same failure condition.  Clear the cache
     # entry when the pod recovers so a recurrence is logged again.
-    diagnosis = diagnose_k8s_pod(status)
     if diagnosis and flow_run_id:
         last_diagnosis = _last_diagnosis_cache.get(uid)
         if diagnosis != last_diagnosis:
@@ -293,6 +297,8 @@ async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
         "prefect.resource.name": name,
         "kubernetes.namespace": namespace,
     }
+    if diagnosis is not None:
+        resource["kubernetes.diagnosis"] = diagnosis.category.value
     # Add eviction reason if the pod was evicted for debugging purposes
     if event_type == "MODIFIED" and phase == "Failed":
         for container_status in status.get("containerStatuses", []):

--- a/src/integrations/prefect-kubernetes/tests/test_diagnostics.py
+++ b/src/integrations/prefect-kubernetes/tests/test_diagnostics.py
@@ -2,10 +2,24 @@
 
 import pytest
 from prefect_kubernetes.diagnostics import (
+    DiagnosisCategory,
     DiagnosisLevel,
     InfrastructureDiagnosis,
     diagnose_k8s_pod,
 )
+
+
+def _unschedulable(message: str) -> dict:
+    return {
+        "conditions": [
+            {
+                "type": "PodScheduled",
+                "status": "False",
+                "reason": "Unschedulable",
+                "message": message,
+            }
+        ]
+    }
 
 
 class TestDiagnoseKubernetesPod:
@@ -291,6 +305,7 @@ class TestDiagnoseKubernetesPod:
     def test_diagnosis_is_frozen(self):
         d = InfrastructureDiagnosis(
             level=DiagnosisLevel.ERROR,
+            category=DiagnosisCategory.CRASH_LOOP_BACK_OFF,
             summary="test",
             detail="test",
             resolution="test",
@@ -301,14 +316,87 @@ class TestDiagnoseKubernetesPod:
     def test_diagnosis_equality(self):
         a = InfrastructureDiagnosis(
             level=DiagnosisLevel.ERROR,
+            category=DiagnosisCategory.CRASH_LOOP_BACK_OFF,
             summary="s",
             detail="d",
             resolution="r",
         )
         b = InfrastructureDiagnosis(
             level=DiagnosisLevel.ERROR,
+            category=DiagnosisCategory.CRASH_LOOP_BACK_OFF,
             summary="s",
             detail="d",
             resolution="r",
         )
         assert a == b
+
+    # --- Diagnosis category -----------------------------------------------
+
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            (
+                {
+                    "containerStatuses": [
+                        {"state": {"waiting": {"reason": "ErrImagePull"}}}
+                    ]
+                },
+                DiagnosisCategory.IMAGE_PULL_BACK_OFF,
+            ),
+            (
+                {
+                    "containerStatuses": [
+                        {"state": {"waiting": {"reason": "CrashLoopBackOff"}}}
+                    ]
+                },
+                DiagnosisCategory.CRASH_LOOP_BACK_OFF,
+            ),
+            (
+                {
+                    "containerStatuses": [
+                        {"state": {"terminated": {"reason": "OOMKilled"}}}
+                    ]
+                },
+                DiagnosisCategory.OOM_KILLED,
+            ),
+            ({"reason": "Evicted"}, DiagnosisCategory.EVICTED),
+            (
+                _unschedulable("3 pod has unbound immediate PersistentVolumeClaims."),
+                DiagnosisCategory.UNSCHEDULABLE_VOLUME,
+            ),
+            (
+                _unschedulable("10 Insufficient cpu, 10 Insufficient memory."),
+                DiagnosisCategory.UNSCHEDULABLE_INSUFFICIENT_RESOURCES,
+            ),
+            (
+                _unschedulable("4 node(s) had untolerated taint."),
+                DiagnosisCategory.UNSCHEDULABLE_TAINT,
+            ),
+            (
+                _unschedulable("8 node(s) didn't match Pod's node affinity/selector."),
+                DiagnosisCategory.UNSCHEDULABLE_NODE_AFFINITY,
+            ),
+            (
+                _unschedulable("something unrecognized."),
+                DiagnosisCategory.UNSCHEDULABLE,
+            ),
+            # Several causes at once: volume takes precedence.
+            (
+                _unschedulable(
+                    "4 Insufficient cpu, 2 had volume node affinity conflict."
+                ),
+                DiagnosisCategory.UNSCHEDULABLE_VOLUME,
+            ),
+            # Unresolvable cause (taint) beats resolvable capacity (insufficient).
+            (
+                _unschedulable(
+                    "33 Insufficient memory, 4 node(s) had untolerated taint(s)."
+                ),
+                DiagnosisCategory.UNSCHEDULABLE_TAINT,
+            ),
+        ],
+    )
+    def test_diagnosis_category(self, status: dict, expected: DiagnosisCategory):
+        result = diagnose_k8s_pod(status)
+        assert result is not None
+        assert result.category is expected

--- a/src/integrations/prefect-kubernetes/tests/test_observer.py
+++ b/src/integrations/prefect-kubernetes/tests/test_observer.py
@@ -307,6 +307,7 @@ class TestReplicatePodEvent:
                 "prefect.resource.name": "test",
                 "kubernetes.namespace": "test",
                 "kubernetes.reason": "OOMKilled",
+                "kubernetes.diagnosis": "oom_killed",
             },
         )
 
@@ -648,6 +649,49 @@ class TestReplicatePodEvent:
 
         mock_child.log.assert_called_once()
         assert mock_child.log.call_args[0][0] == logging.WARNING
+
+    async def test_unschedulable_pending_event_is_labeled_and_distinct(
+        self, mock_events_client: AsyncMock
+    ):
+        uid = str(uuid.uuid4())
+
+        # Plain Pending (pod just created, not yet scheduled): no diagnosis.
+        await _replicate_pod_event(
+            event={"type": "ADDED"},
+            uid=uid,
+            name="test",
+            namespace="test",
+            labels={},
+            status={"phase": "Pending"},
+            logger=MagicMock(),
+        )
+        plain_event = mock_events_client.emit.call_args[1]["event"]
+        assert "kubernetes.diagnosis" not in plain_event.resource
+        mock_events_client.emit.reset_mock()
+
+        # Same pod, same phase, now Unschedulable on a volume.
+        await _replicate_pod_event(
+            event={"type": "MODIFIED"},
+            uid=uid,
+            name="test",
+            namespace="test",
+            labels={},
+            status={
+                "phase": "Pending",
+                "conditions": [
+                    {
+                        "type": "PodScheduled",
+                        "status": "False",
+                        "reason": "Unschedulable",
+                        "message": "3 pod has unbound immediate PersistentVolumeClaims.",
+                    }
+                ],
+            },
+            logger=MagicMock(),
+        )
+        event = mock_events_client.emit.call_args[1]["event"]
+        assert event.resource["kubernetes.diagnosis"] == "unschedulable_volume"
+        assert event.id != plain_event.id
 
     async def test_no_diagnosis_for_healthy_pod(
         self,


### PR DESCRIPTION
Closes #22575

The observer already diagnoses pod failures but only writes them to flow-run logs. This puts the diagnosis on the pod events as a `kubernetes.diagnosis` label so automations can match on a specific failure mode.

## Changes
- `diagnostics.py`: add a `DiagnosisCategory` enum and a `category` field on `InfrastructureDiagnosis`; classify `Unschedulable` by cause.
- `observer.py`: set `kubernetes.diagnosis` on the event when a diagnosis is present, and fold the category into the event dedup ID so a pod that becomes e.g. `Unschedulable` while `Pending` emits a distinct event instead of deduplicating against its first `Pending` event.

## Example
```
after {prefect.kubernetes.pod.pending}, expect {prefect.flow-run.Running},
match {kubernetes.diagnosis: [image_pull_back_off]}, Proactive, within=10m
-> change flow run state to CRASHED
```

Event IDs are unchanged when there is no diagnosis; evicted events keep `kubernetes.reason` and additionally get `kubernetes.diagnosis`.
