### PR TITLE
Gracefully drain active worker runs on termination signals

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -209,11 +209,6 @@ async def start(
             " installed to run your desired worker type."
         )
 
-    worker_process_id = os.getpid()
-    setup_signal_handlers_worker(
-        worker_process_id, f"the {worker_type} worker", _cli.console.print
-    )
-
     template_contents = None
     if base_job_template is not None:
         template_contents = json.loads(base_job_template.read_text())
@@ -227,6 +222,14 @@ async def start(
         heartbeat_interval_seconds=int(PREFECT_WORKER_HEARTBEAT_SECONDS.value()),
         base_job_template=template_contents,
         create_pool_if_not_found=create_pool_if_not_found,
+    )
+
+    worker_process_id = os.getpid()
+    setup_signal_handlers_worker(
+        worker_process_id,
+        f"the {worker_type} worker",
+        _cli.console.print,
+        request_drain=worker._request_drain,
     )
     try:
         await worker.start(

--- a/src/prefect/utilities/processutils/__init__.py
+++ b/src/prefect/utilities/processutils/__init__.py
@@ -577,23 +577,43 @@ def setup_signal_handlers_agent(pid: int, process_name: str, print_fn: PrintFn) 
 
 
 def setup_signal_handlers_worker(
-    pid: int, process_name: str, print_fn: PrintFn
+    pid: int,
+    process_name: str,
+    print_fn: PrintFn,
+    request_drain: Optional[Callable[[], None]] = None,
 ) -> None:
     """Handle interrupts of workers gracefully."""
     setup_handler = partial(
         forward_signal_handler, pid, process_name=process_name, print_fn=print_fn
     )
-    # when agent receives SIGINT, it stops dequeueing new FlowRuns, and runs until the subprocesses finish
+    # when worker receives SIGINT/SIGTERM, it stops dequeueing new FlowRuns,
+    # and runs until the subprocesses finish
     # the signal is not forwarded to subprocesses, so they can continue to run and hopefully still complete
     if sys.platform == "win32":
         # on Windows, use CTRL_BREAK_EVENT as SIGTERM is useless:
         # https://bugs.python.org/issue26350
         setup_handler(signal.SIGINT, signal.CTRL_BREAK_EVENT)
     else:
-        # forward first SIGINT directly, send SIGKILL on subsequent interrupt
-        setup_handler(signal.SIGINT, signal.SIGINT, signal.SIGKILL)
-        # first SIGTERM: send SIGINT, send SIGKILL on subsequent SIGTERM
-        setup_handler(signal.SIGTERM, signal.SIGINT, signal.SIGKILL)
+        if request_drain is None:
+            # forward first SIGINT directly, send SIGKILL on subsequent interrupt
+            setup_handler(signal.SIGINT, signal.SIGINT, signal.SIGKILL)
+            # first SIGTERM: send SIGINT, send SIGKILL on subsequent SIGTERM
+            setup_handler(signal.SIGTERM, signal.SIGINT, signal.SIGKILL)
+        else:
+
+            def drain_then_escalate(signum: signal.Signals) -> None:
+                def handle_signal(*arg: Any) -> None:
+                    print_fn(
+                        f"Received {signum.name}. Draining {process_name} "
+                        f"(PID {pid})..."
+                    )
+                    request_drain()
+                    setup_handler(signum, signal.SIGKILL)
+
+                _register_signal(signum, handle_signal)
+
+            drain_then_escalate(signal.SIGINT)
+            drain_then_escalate(signal.SIGTERM)
 
 
 def get_sys_executable() -> str:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -682,10 +682,14 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         self._work_pool: Optional[WorkPool] = None
         self._exit_stack: AsyncExitStack = AsyncExitStack()
         self._runs_task_group: Optional[anyio.abc.TaskGroup] = None
+        self._loops_task_group: Optional[anyio.abc.TaskGroup] = None
+        self._polling_task_group: Optional[anyio.abc.TaskGroup] = None
+        self._drain_event: Optional[anyio.Event] = None
         self._client: Optional[PrefectClient] = None
         self._last_polled_time: datetime.datetime = prefect.types._datetime.now("UTC")
         self._limit = limit
         self._limiter: Optional[anyio.CapacityLimiter] = None
+        self._draining = False
         self._submitting_flow_run_ids: set[UUID] = set()
         self._scheduled_task_scopes: set[anyio.CancelScope] = set()
         self._worker_channel: Optional[WorkerChannel] = None
@@ -818,6 +822,15 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             extra=extra,
         )
 
+    def _request_drain(self) -> None:
+        self._draining = True
+        if self._drain_event is not None:
+            self._drain_event.set()
+        if self._polling_task_group is not None:
+            self._polling_task_group.cancel_scope.cancel()
+        elif self._drain_event is None and self._loops_task_group is not None:
+            self._loops_task_group.cancel_scope.cancel()
+
     async def start(
         self,
         run_once: bool = False,
@@ -862,43 +875,79 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                     backoff=4,
                 )
 
-                async with anyio.create_task_group() as loops_task_group:
-                    if run_once:
+                async def run_polling_service() -> None:
+                    try:
+                        async with anyio.create_task_group() as polling_task_group:
+                            self._polling_task_group = polling_task_group
+                            if self._draining:
+                                polling_task_group.cancel_scope.cancel()
+                            else:
+                                polling_task_group.start_soon(polling_service)
+                    finally:
+                        self._polling_task_group = None
 
-                        async def run_once_services() -> None:
-                            # A one-shot poll needs the work-pool configuration
-                            # produced by the one-shot synchronization attempt.
-                            await sync_service()
-                            await polling_service()
+                async def wait_for_drain_and_stop() -> None:
+                    if self._drain_event is None:
+                        return
 
-                        loops_task_group.start_soon(run_once_services)
-                    else:
-                        loops_task_group.start_soon(polling_service)
-                        loops_task_group.start_soon(sync_service)
-
-                    self._started_event = await self._emit_worker_started_event()
-
-                    start_client_metrics_server()
-
-                    if with_healthcheck:
-                        from prefect.workers.server import build_healthcheck_server
-
-                        # we'll start the ASGI server in a separate thread so that
-                        # uvicorn does not block the main thread
-                        healthcheck_server = build_healthcheck_server(
-                            worker=worker,
-                            query_interval_seconds=PREFECT_WORKER_QUERY_SECONDS.value(),
+                    await self._drain_event.wait()
+                    while self._has_in_flight_flow_runs():
+                        self._logger.debug(
+                            "Waiting for %s active run(s) to finish before shutdown...",
+                            len(self._submitting_flow_run_ids),
                         )
-                        healthcheck_thread = threading.Thread(
-                            name="healthcheck-server-thread",
-                            target=healthcheck_server.run,
-                            daemon=True,
-                        )
-                        healthcheck_thread.start()
-                    printer(f"Worker {worker.name!r} started!")
+                        await anyio.sleep(0.1)
+
+                    if self._loops_task_group is not None:
+                        self._loops_task_group.cancel_scope.cancel()
+
+                try:
+                    self._drain_event = anyio.Event()
+                    async with anyio.create_task_group() as loops_task_group:
+                        self._loops_task_group = loops_task_group
+                        if self._draining:
+                            self._drain_event.set()
+
+                        if run_once:
+
+                            async def run_once_services() -> None:
+                                # A one-shot poll needs the work-pool configuration
+                                # produced by the one-shot synchronization attempt.
+                                await sync_service()
+                                await run_polling_service()
+
+                            loops_task_group.start_soon(run_once_services)
+                        else:
+                            loops_task_group.start_soon(run_polling_service)
+                            loops_task_group.start_soon(sync_service)
+                            loops_task_group.start_soon(wait_for_drain_and_stop)
+
+                        self._started_event = await self._emit_worker_started_event()
+
+                        start_client_metrics_server()
+
+                        if with_healthcheck:
+                            from prefect.workers.server import build_healthcheck_server
+
+                            # we'll start the ASGI server in a separate thread so that
+                            # uvicorn does not block the main thread
+                            healthcheck_server = build_healthcheck_server(
+                                worker=worker,
+                                query_interval_seconds=PREFECT_WORKER_QUERY_SECONDS.value(),
+                            )
+                            healthcheck_thread = threading.Thread(
+                                name="healthcheck-server-thread",
+                                target=healthcheck_server.run,
+                                daemon=True,
+                            )
+                            healthcheck_thread.start()
+                        printer(f"Worker {worker.name!r} started!")
+                finally:
+                    self._loops_task_group = None
+                    self._drain_event = None
 
                 # If running once, wait for active runs to finish before teardown
-                if run_once and self._limiter:
+                if (run_once or self._draining) and self._limiter:
                     # Use the limiter's borrowed token count as the source of truth
                     while self.limiter.borrowed_tokens > 0:
                         self._logger.debug(
@@ -1292,6 +1341,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         is_still_polling = seconds_since_last_poll <= threshold_seconds
 
+        if not is_still_polling and self._draining and self._has_in_flight_flow_runs():
+            return True
+
         if not is_still_polling:
             self._logger.error(
                 f"Worker has not polled in the last {seconds_since_last_poll} seconds "
@@ -1299,6 +1351,11 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
 
         return is_still_polling
+
+    def _has_in_flight_flow_runs(self) -> bool:
+        return bool(self._submitting_flow_run_ids) or bool(
+            self._limiter and self._limiter.borrowed_tokens > 0
+        )
 
     async def get_and_submit_flow_runs(self) -> list["FlowRun"]:
         if not self._has_successfully_synced:
@@ -1500,6 +1557,11 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         submittable_flow_runs = [entry.flow_run for entry in flow_run_response]
 
         for flow_run in submittable_flow_runs:
+            if self._draining:
+                self._logger.debug(
+                    "Worker is draining; skipping remaining fetched flow runs."
+                )
+                break
             if flow_run.id in self._submitting_flow_run_ids:
                 self._logger.debug(
                     f"Skipping {flow_run.id} because it's already being submitted"
@@ -1629,11 +1691,12 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 worker_name=self.name,
                 worker_id=self.backend_id,
             )
-            submitted_event = self._emit_flow_run_submitted_event(configuration)
+
             await self._give_worker_labels_to_flow_run(flow_run.id)
 
             await self._propose_submitting_state(flow_run)
 
+            submitted_event = self._emit_flow_run_submitted_event(configuration)
             result = await self.run(
                 flow_run=flow_run,
                 task_status=task_status,

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -1020,14 +1020,14 @@ class TestWorkerSignalForwarding:
         sys.platform == "win32",
         reason="SIGTERM is only used in non-Windows environments",
     )
-    async def test_sigint_sends_sigterm(self, worker_process):
+    async def test_sigint_drains_worker(self, worker_process):
         worker_process.send_signal(signal.SIGINT)
         await safe_shutdown(worker_process)
         worker_process.out.seek(0)
         out = worker_process.out.read().decode()
 
-        assert "Sending SIGINT" in out, (
-            "When sending a SIGINT, the main process should receive a SIGINT."
+        assert "Draining the process worker" in out, (
+            "When sending a SIGINT, the worker should drain active runs."
             f" Output:\n{out}"
         )
         assert "Worker 'test-worker' stopped!" in out, (
@@ -1039,14 +1039,14 @@ class TestWorkerSignalForwarding:
         sys.platform == "win32",
         reason="SIGTERM is only used in non-Windows environments",
     )
-    async def test_sigterm_sends_sigterm_directly(self, worker_process):
+    async def test_sigterm_drains_process_worker(self, worker_process):
         worker_process.send_signal(signal.SIGTERM)
         await safe_shutdown(worker_process)
         worker_process.out.seek(0)
         out = worker_process.out.read().decode()
 
-        assert "Sending SIGINT" in out, (
-            "When sending a SIGTERM, the main process should receive a SIGINT."
+        assert "Draining the process worker" in out, (
+            "When sending a SIGTERM, the process worker should drain active runs."
             f" Output:\n{out}"
         )
         assert "Worker 'test-worker' stopped!" in out, (
@@ -1101,5 +1101,5 @@ class TestWorkerSignalForwarding:
             or "Aborted." in out
         ), (
             "When sending two SIGTERM shortly after each other, the main process should"
-            f" first receive a SIGINT and then a SIGKILL. Output:\n{out}"
+            f" drain and then receive a SIGKILL. Output:\n{out}"
         )

--- a/tests/utilities/test_processutils.py
+++ b/tests/utilities/test_processutils.py
@@ -1,6 +1,9 @@
+import signal
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
+from types import FrameType
 from unittest import mock
 
 import pytest
@@ -12,6 +15,7 @@ from prefect.utilities.processutils import (
     open_process,
     run_process,
     sanitize_subprocess_env,
+    setup_signal_handlers_worker,
 )
 
 
@@ -103,6 +107,45 @@ class TestCommandSerialization:
             "-X",
             "utf8",
         ]
+
+
+class TestWorkerSignalHandlers:
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="SIGTERM drain handling is only used in non-Windows environments",
+    )
+    @pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
+    def test_first_signal_requests_drain_then_second_signal_escalates(
+        self, signum: signal.Signals, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registered_handlers: dict[
+            signal.Signals, Callable[[int, FrameType | None], None]
+        ] = {}
+        request_drain = mock.Mock()
+        print_fn = mock.Mock()
+        kill = mock.Mock()
+
+        monkeypatch.setattr(
+            prefect.utilities.processutils,
+            "_register_signal",
+            lambda signum, handler: registered_handlers.__setitem__(
+                signal.Signals(signum), handler
+            ),
+        )
+        monkeypatch.setattr(prefect.utilities.processutils.os, "kill", kill)
+
+        setup_signal_handlers_worker(
+            1234, "the process worker", print_fn, request_drain=request_drain
+        )
+
+        registered_handlers[signum](signum, None)
+
+        request_drain.assert_called_once_with()
+        kill.assert_not_called()
+
+        registered_handlers[signum](signum, None)
+
+        kill.assert_called_once_with(1234, signal.SIGKILL)
 
 
 class TestRunProcess:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -45,6 +45,7 @@ from prefect.client.schemas.objects import (
     WorkPoolStorageConfiguration,
     WorkQueue,
 )
+from prefect.client.schemas.responses import WorkerFlowRunResponse
 from prefect.client.schemas.worker_channel import (
     WORK_POOL_SNAPSHOT_CAPABILITY,
     WORK_POOL_WORKER_CHANNEL_VERSION,
@@ -829,6 +830,267 @@ async def test_worker_with_work_pool_and_limit(
         assert {flow_run.id for flow_run in submitted_flow_runs} == set(
             flow_run_ids[1:4]
         )
+
+
+async def test_base_worker_drain_stops_polling_without_cancelling_active_runs(
+    work_pool: WorkPool,
+):
+    worker = WorkerTestImpl(work_pool_name=work_pool.name)
+    active_run_started = anyio.Event()
+    release_active_run = anyio.Event()
+    active_run_finished = anyio.Event()
+    polling_loop_cancelled = anyio.Event()
+
+    async def active_run():
+        active_run_started.set()
+        await release_active_run.wait()
+        active_run_finished.set()
+
+    async with worker:
+        assert worker._runs_task_group is not None
+        worker._runs_task_group.start_soon(active_run)
+        await active_run_started.wait()
+
+        async with anyio.create_task_group() as loops_task_group:
+            worker._loops_task_group = loops_task_group
+
+            async def polling_loop():
+                try:
+                    await anyio.sleep_forever()
+                finally:
+                    polling_loop_cancelled.set()
+
+            loops_task_group.start_soon(polling_loop)
+            worker._request_drain()
+
+        assert polling_loop_cancelled.is_set()
+
+        assert not active_run_finished.is_set()
+
+        release_active_run.set()
+        await active_run_finished.wait()
+
+
+async def test_base_worker_drain_stops_polling_but_continues_sync_until_active_runs_finish(
+    work_pool: WorkPool,
+):
+    worker = WorkerTestImpl(
+        work_pool_name=work_pool.name,
+        heartbeat_interval_seconds=0.01,
+    )
+    flow_run_id = uuid.uuid4()
+    polled = anyio.Event()
+    synced_while_draining = anyio.Event()
+    release_active_run = anyio.Event()
+    stopped = anyio.Event()
+    poll_count = 0
+
+    async def get_and_submit_flow_runs() -> list[FlowRun]:
+        nonlocal poll_count
+        poll_count += 1
+        worker._submitting_flow_run_ids.add(flow_run_id)
+        polled.set()
+        worker._request_drain()
+        return []
+
+    async def sync_and_initialize() -> None:
+        worker._work_pool = work_pool
+        worker._has_successfully_synced = True
+        if worker._draining and flow_run_id in worker._submitting_flow_run_ids:
+            synced_while_draining.set()
+            await release_active_run.wait()
+            worker._submitting_flow_run_ids.remove(flow_run_id)
+
+    worker.get_and_submit_flow_runs = get_and_submit_flow_runs
+    worker._sync_and_initialize = sync_and_initialize
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(worker.start)
+            await polled.wait()
+            await synced_while_draining.wait()
+
+            assert poll_count == 1
+
+            release_active_run.set()
+
+            async def wait_for_worker_stop() -> None:
+                while worker.is_setup:
+                    await anyio.sleep(0.01)
+                stopped.set()
+
+            task_group.start_soon(wait_for_worker_stop)
+            await stopped.wait()
+
+
+async def test_base_worker_drain_stops_iterating_fetched_batch(
+    prefect_client: PrefectClient,
+    worker_deployment_wq1: WorkQueue,
+    work_pool: WorkPool,
+):
+    flow_runs = [
+        await prefect_client.create_flow_run_from_deployment(
+            worker_deployment_wq1.id,
+            state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+        )
+        for _ in range(2)
+    ]
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+
+        class DrainOnFirstAdd(set[uuid.UUID]):
+            def add(self, flow_run_id: uuid.UUID) -> None:
+                super().add(flow_run_id)
+                worker._request_drain()
+
+        worker._submitting_flow_run_ids = DrainOnFirstAdd()
+        worker._submit_run = AsyncMock()
+        responses = [
+            WorkerFlowRunResponse(
+                work_pool_id=work_pool.id,
+                work_queue_id=worker_deployment_wq1.work_queue_id,
+                flow_run=flow_run,
+            )
+            for flow_run in flow_runs
+        ]
+
+        submitted_flow_runs = await worker._submit_scheduled_flow_runs(responses)
+
+    assert [flow_run.id for flow_run in submitted_flow_runs] == [flow_runs[0].id]
+
+
+async def test_base_worker_drain_after_pending_continues_submission(
+    prefect_client: PrefectClient,
+    worker_deployment_infra_wq1: WorkQueue,
+    work_pool: WorkPool,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_infra_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+    run_mock = AsyncMock(
+        return_value=BaseWorkerResult(status_code=0, identifier="test-run")
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+        worker._work_pool = work_pool
+        worker.run = run_mock
+        worker._submitting_flow_run_ids.add(flow_run.id)
+        worker.limiter.acquire_on_behalf_of_nowait(flow_run.id)
+        propose_pending_state = worker._propose_pending_state
+
+        async def drain_after_pending(flow_run: FlowRun) -> bool:
+            ready_to_submit = await propose_pending_state(flow_run)
+            worker._request_drain()
+            return ready_to_submit
+
+        worker._propose_pending_state = drain_after_pending
+
+        await worker._submit_run(flow_run)
+
+    run_mock.assert_called_once()
+    assert flow_run.id not in worker._submitting_flow_run_ids
+    assert worker.limiter.borrowed_tokens == 0
+    updated_flow_run = await prefect_client.read_flow_run(flow_run.id)
+    assert updated_flow_run.state is not None
+    assert updated_flow_run.state.type == StateType.PENDING
+    assert updated_flow_run.state.name == "Submitting"
+
+
+async def test_base_worker_drain_after_pending_during_configuration_resolution_continues_submission(
+    prefect_client: PrefectClient,
+    worker_deployment_infra_wq1: WorkQueue,
+    work_pool: WorkPool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_infra_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+    resolve_for_flow_run = BaseJobConfiguration.resolve_for_flow_run
+    run_mock = AsyncMock(
+        return_value=BaseWorkerResult(status_code=0, identifier="test-run")
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+
+        async def drain_during_configuration_resolution(
+            *args: Any, **kwargs: Any
+        ) -> BaseJobConfiguration:
+            worker._request_drain()
+            return await resolve_for_flow_run(*args, **kwargs)
+
+        monkeypatch.setattr(
+            BaseJobConfiguration,
+            "resolve_for_flow_run",
+            drain_during_configuration_resolution,
+        )
+        worker._work_pool = work_pool
+        worker.run = run_mock
+        worker._submitting_flow_run_ids.add(flow_run.id)
+        worker.limiter.acquire_on_behalf_of_nowait(flow_run.id)
+
+        await worker._submit_run(flow_run)
+
+    run_mock.assert_called_once()
+    assert flow_run.id not in worker._submitting_flow_run_ids
+    assert worker.limiter.borrowed_tokens == 0
+    updated_flow_run = await prefect_client.read_flow_run(flow_run.id)
+    assert updated_flow_run.state is not None
+    assert updated_flow_run.state.type == StateType.PENDING
+    assert updated_flow_run.state.name == "Submitting"
+
+
+@pytest.mark.parametrize("drain_after", ["labels", "submitting"])
+async def test_base_worker_drain_after_submission_awaits_continues_submission(
+    drain_after: str,
+    prefect_client: PrefectClient,
+    worker_deployment_infra_wq1: WorkQueue,
+    work_pool: WorkPool,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_infra_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+    run_mock = AsyncMock(
+        return_value=BaseWorkerResult(status_code=0, identifier="test-run")
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+        worker._work_pool = work_pool
+        worker.run = run_mock
+        worker._emit_flow_run_submitted_event = Mock()
+        worker._emit_flow_run_executed_event = Mock()
+        worker._submitting_flow_run_ids.add(flow_run.id)
+        worker.limiter.acquire_on_behalf_of_nowait(flow_run.id)
+
+        if drain_after == "labels":
+
+            async def drain_after_labels(flow_run_id: uuid.UUID) -> None:
+                assert flow_run_id == flow_run.id
+                worker._request_drain()
+
+            worker._give_worker_labels_to_flow_run = drain_after_labels
+        else:
+            propose_submitting_state = worker._propose_submitting_state
+
+            async def drain_after_submitting(flow_run: FlowRun) -> None:
+                await propose_submitting_state(flow_run)
+                worker._request_drain()
+
+            worker._propose_submitting_state = drain_after_submitting
+
+        await worker._submit_run(flow_run)
+
+    run_mock.assert_called_once()
+    worker._emit_flow_run_submitted_event.assert_called_once()
+    worker._emit_flow_run_executed_event.assert_called_once()
+    assert flow_run.id not in worker._submitting_flow_run_ids
+    assert worker.limiter.borrowed_tokens == 0
+    updated_flow_run = await prefect_client.read_flow_run(flow_run.id)
+    assert updated_flow_run.state is not None
+    assert updated_flow_run.state.type == StateType.PENDING
+    assert updated_flow_run.state.name == "Submitting"
 
 
 async def test_worker_calls_run_with_expected_arguments(
@@ -2425,6 +2687,41 @@ async def test_worker_last_polled_health_check(work_pool: WorkPool):
                 with travel_to(now + timedelta(minutes=30, seconds=1)):
                     resp = worker.is_worker_still_polling(query_interval_seconds=60)
                     assert resp is False
+    except ExceptionGroup as e:
+        raise e.exceptions[0]
+
+
+async def test_worker_health_check_allows_stale_poll_time_while_draining_active_run(
+    work_pool: WorkPool,
+):
+    now = now_fn("UTC")
+
+    try:
+        with travel_to(now):
+            async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+                worker._last_polled_time = now
+                worker._draining = True
+                worker._submitting_flow_run_ids.add(uuid.uuid4())
+
+                with travel_to(now + timedelta(seconds=301)):
+                    assert worker.is_worker_still_polling(query_interval_seconds=10)
+    except ExceptionGroup as e:
+        raise e.exceptions[0]
+
+
+async def test_worker_health_check_fails_after_drain_has_no_active_runs(
+    work_pool: WorkPool,
+):
+    now = now_fn("UTC")
+
+    try:
+        with travel_to(now):
+            async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+                worker._last_polled_time = now
+                worker._draining = True
+
+                with travel_to(now + timedelta(seconds=301)):
+                    assert not worker.is_worker_still_polling(query_interval_seconds=10)
     except ExceptionGroup as e:
         raise e.exceptions[0]
 

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -607,6 +607,63 @@ async def test_task_status_receives_pid(
         fake_status.started.assert_called_once_with(int(result.identifier))
 
 
+async def test_process_worker_drain_preserves_active_runs(
+    process_work_pool: WorkPool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    worker = ProcessWorker(work_pool_name=process_work_pool.name)
+    active_run_started = anyio.Event()
+    release_active_run = anyio.Event()
+    active_run_finished = anyio.Event()
+    polling_loop_cancelled = anyio.Event()
+
+    async def active_run():
+        active_run_started.set()
+        await release_active_run.wait()
+        active_run_finished.set()
+
+    monkeypatch.setattr(worker, "sync_with_backend", AsyncMock())
+
+    async with worker:
+        assert worker._runs_task_group is not None
+        worker._runs_task_group.start_soon(active_run)
+        await active_run_started.wait()
+
+        async with anyio.create_task_group() as loops_task_group:
+            worker._loops_task_group = loops_task_group
+
+            async def polling_loop():
+                try:
+                    await anyio.sleep_forever()
+                finally:
+                    polling_loop_cancelled.set()
+
+            loops_task_group.start_soon(polling_loop)
+            worker._request_drain()
+
+        assert polling_loop_cancelled.is_set()
+
+        assert not active_run_finished.is_set()
+
+        release_active_run.set()
+        await active_run_finished.wait()
+
+
+@pytest.mark.timeout(15)
+async def test_process_worker_run_once_exits_without_drain():
+    worker = ProcessWorker(work_pool_name="test-pool")
+    worker.setup = AsyncMock()
+    worker.teardown = AsyncMock()
+    worker.sync_with_backend = AsyncMock()
+    worker.get_and_submit_flow_runs = AsyncMock(return_value=[])
+    worker._emit_worker_started_event = AsyncMock(return_value=None)
+
+    await worker.start(run_once=True)
+
+    assert worker.get_and_submit_flow_runs.call_count == 1
+    assert worker.sync_with_backend.call_count == 1
+
+
 async def test_submit_adhoc_run_with_existing_flow_run_reuses_id(
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,


### PR DESCRIPTION
## Summary

- move graceful drain state and polling-loop cancellation into `BaseWorker`, so all CLI-launched worker types stop accepting new work while allowing active runs to finish
- on the first `SIGINT` or `SIGTERM`, stop only polling; keep worker sync and heartbeat running until active/submitting runs drain, while preserving repeated-signal escalation
- stop iterating an already-fetched batch after drain begins, but once the server accepts `SCHEDULED -> PENDING`, continue through configuration, `Submitting`, and `run()` so the authoritative run state and deployment concurrency lease are not stranded
- keep stale-poll health checks healthy only while a drain still has in-flight work; once no run is active or submitting, retain the existing unhealthy boundary

Closes https://github.com/PrefectHQ/prefect/issues/22528

## Validation

- post-claim drain regressions, including the configuration-resolution race: `5 passed`
- focused worker/process drain, health, and `--run-once` lifecycle suite: `13 passed`
- process utility signal/drain suite: `2 passed`
- CLI `SIGINT`/`SIGTERM` suite: `4 passed`
- `uv run ruff check <7 changed files>` — passed
- `git diff --check` — passed

The deterministic regression reproduces the reported race at the prior PR head: after the server accepts `PENDING`, a drain during configuration resolution prevented `run()` and left the authoritative state at default `PENDING`. The corrected implementation continues an already-claimed run to `Submitting`/`run()` while retaining the pre-claim fetched-batch stop boundary. An independent read-only audit returned PASS separately for candidate quality and patch quality.

## Duplicate Check

Checked live `PrefectHQ/prefect` `main` at `b9378c32e42df203e7040a6df7f881a5b3aca174`, issue #22528, linked timeline entries, open PRs, and affected symbols immediately before this update. The issue remains open, the behavior is not fixed on `main`, and the only matching active PR is this PR.

## Browser / Playwright

Not applicable: this change is limited to Python worker signal handling, AnyIO task-group lifecycle, health checks, and CLI subprocess behavior.

### Checklist

- [x] This pull request references the related issue with a `Closes` link.
- [x] Maintainer feedback and the later heartbeat/post-claim lifecycle review are addressed with deterministic regressions.
- [x] This pull request changes functionality and includes focused tests.
- [x] Documentation is not updated because this fixes shutdown behavior to match the documented graceful-drain expectation.
- [x] This pull request does not remove documentation files.
- [x] No new public API surface requiring separate user documentation was added.

