### PR TITLE
Fix bundled profile settings resolution

### DIFF
--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -143,17 +143,17 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
 
     def _load_profile_settings(self) -> Dict[str, Any]:
         """Helper method to load the profile settings from the profiles.toml file"""
-        if not self.profiles_path.exists():
-            return self._get_default_profile()
+        all_profile_data: dict[str, Any] = {}
+        if self.profiles_path.exists():
+            try:
+                all_profile_data = _read_toml_file(self.profiles_path)
+            except tomllib.TOMLDecodeError:
+                warnings.warn(
+                    f"Failed to load profiles from {self.profiles_path}. Please ensure the file is valid TOML."
+                )
+                return {}
 
-        try:
-            all_profile_data = _read_toml_file(self.profiles_path)
-        except tomllib.TOMLDecodeError:
-            warnings.warn(
-                f"Failed to load profiles from {self.profiles_path}. Please ensure the file is valid TOML."
-            )
-            return {}
-
+        active_profile: str | None
         if (
             sys.argv[0].endswith("/prefect")
             and len(sys.argv) >= 3
@@ -162,22 +162,29 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
             active_profile = sys.argv[2]
 
         else:
-            active_profile = os.environ.get("PREFECT_PROFILE") or all_profile_data.get(
-                "active"
-            )
+            active_profile = os.environ.get("PREFECT_PROFILE")
+            if not active_profile:
+                configured_profile = all_profile_data.get("active")
+                active_profile = (
+                    configured_profile if isinstance(configured_profile, str) else None
+                )
 
         profiles_data = all_profile_data.get("profiles", {})
 
-        if not active_profile or active_profile not in profiles_data:
-            return self._get_default_profile()
-        return profiles_data[active_profile]
+        if active_profile and active_profile in profiles_data:
+            return profiles_data[active_profile]
+        return self._get_bundled_profile(active_profile)
 
-    def _get_default_profile(self) -> Dict[str, Any]:
-        """Helper method to get the default profile"""
-        default_profile_data = _read_toml_file(DEFAULT_PROFILES_PATH)
-        default_profile = default_profile_data.get("active", "ephemeral")
+    def _get_bundled_profile(self, profile_name: str | None) -> Dict[str, Any]:
+        """Get a named bundled profile, falling back to the bundled default."""
+        bundled_profile_data = _read_toml_file(DEFAULT_PROFILES_PATH)
+        bundled_profiles = bundled_profile_data.get("profiles", {})
+        if profile_name in bundled_profiles:
+            return bundled_profiles[profile_name]
+
+        default_profile = bundled_profile_data.get("active", "ephemeral")
         assert isinstance(default_profile, str)
-        return default_profile_data.get("profiles", {}).get(default_profile, {})
+        return bundled_profiles.get(default_profile, {})
 
     def get_field_value(
         self, field: FieldInfo, field_name: str

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2067,6 +2067,83 @@ class TestSettingsSources:
         # Should default to ephemeral profile
         assert Settings().server.ephemeral.enabled
 
+    def test_loads_bundled_profile_selected_in_user_profiles_file(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        profiles_path = tmp_path / "profiles.toml"
+
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
+
+        profiles_path.write_text('active = "local"\n\n[profiles]\n')
+
+        settings = Settings()
+        assert settings.api.url == "http://127.0.0.1:4200/api"
+        assert not settings.server.ephemeral.enabled
+
+    def test_loads_bundled_profile_selected_by_environment_variable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        profiles_path = tmp_path / "profiles.toml"
+
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
+        monkeypatch.setenv("PREFECT_PROFILE", "local")
+
+        settings = Settings()
+        assert settings.api.url == "http://127.0.0.1:4200/api"
+        assert not settings.server.ephemeral.enabled
+
+    def test_loads_bundled_profile_selected_by_cli(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        profiles_path = tmp_path / "profiles.toml"
+
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
+        monkeypatch.setattr(
+            sys, "argv", ["/usr/local/bin/prefect", "--profile", "local"]
+        )
+
+        settings = Settings()
+        assert settings.api.url == "http://127.0.0.1:4200/api"
+        assert not settings.server.ephemeral.enabled
+
+    def test_user_profile_completely_overrides_bundled_profile(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        profiles_path = tmp_path / "profiles.toml"
+
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
+
+        profiles_path.write_text(
+            textwrap.dedent(
+                """
+                active = "local"
+
+                [profiles.local]
+                PREFECT_LOGGING_LEVEL = "DEBUG"
+                """
+            )
+        )
+
+        settings = Settings()
+        assert settings.api.url is None
+        assert settings.logging.level == "DEBUG"
+
     def test_handle_profile_settings_with_invalid_active_profile(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
addresses https://github.com/PrefectHQ/prefect/discussions/22590

This PR resolves selected bundled profiles by name when they have not been copied into the user's `profiles.toml`.

Previously, `load_profiles()` could select the bundled `local` profile while the runtime settings source fell back to the bundled default (`ephemeral`). As a result, `prefect config view` showed the local API URL but flows silently started an ephemeral server.

The settings source now uses the selected user profile when present, otherwise looks for the selected bundled profile, and only then falls back to the bundled default. User-defined profiles continue to completely override bundled profiles instead of being merged field-by-field.

<details>
<summary>Validation</summary>

- `uv run pytest tests/test_settings.py tests/cli/test_profile.py tests/cli/test_config.py -x -n4 --tb=short`
- `uv run pytest tests/test_context.py -x -n4 --tb=short -q`
- `uv run pre-commit run --files src/prefect/settings/sources.py tests/test_settings.py`
- Started a real local server, selected the unpopulated bundled `local` profile, and confirmed:
  - `Settings().api.url` resolved to `http://127.0.0.1:4200/api`
  - ephemeral mode was disabled
  - the orchestration client reported `ServerType.SERVER`
  - a smoke-test flow completed on the local server with result `42`

</details>