### PR TITLE
fix: use asyncio.TimeoutError as default timeout exception to match asyncpg behavior (closes #16299)

### DIFF
--- a/src/prefect/utilities/timeout.py
+++ b/src/prefect/utilities/timeout.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 from typing import Optional
 
@@ -6,6 +7,11 @@ from prefect._internal.concurrency.cancellation import (
     cancel_async_after,
     cancel_sync_after,
 )
+
+# If Python < 3.11, ensure asyncio.TimeoutError is a subclass of TimeoutError
+# In Python 3.11+, asyncio.TimeoutError is already an alias to TimeoutError
+if not issubclass(asyncio.TimeoutError, TimeoutError):
+    TimeoutError = asyncio.TimeoutError  # type: ignore[misc]
 
 
 def fail_if_not_timeout_error(timeout_exc_type: type[Exception]) -> None:


### PR DESCRIPTION
## What
The `timeout` and `timeout_async` context managers default to raising the built-in `TimeoutError` (which is an alias for `OSError`), but asyncpg raises `asyncio.TimeoutError` which is not a subclass of the built-in `TimeoutError` on Python < 3.11. This mismatch causes the timeout decorators to not catch PostgreSQL timeouts, leading to unhandled exceptions and service loops.

## Fix
- Import `asyncio` and define `TimeoutError` as `asyncio.TimeoutError` for Python < 3.11.
- This ensures the default exception class matches the one raised by asyncpg and other async database drivers.

Closes #16299