### PR TITLE
Fix sync_compatible resolution in synchronous transaction hooks

### DIFF
--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -20,7 +20,6 @@ from typing import (
     Union,
 )
 
-import anyio.to_thread
 from pydantic import Field, PrivateAttr
 from typing_extensions import Self
 
@@ -39,7 +38,11 @@ from prefect.results import (
     get_result_store,
 )
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.asyncutils import (
+    RUNNING_ASYNC_FLAG,
+    run_coro_as_sync,
+    run_sync_in_worker_thread,
+)
 from prefect.utilities.collections import AutoEnum
 
 logger: logging.Logger = get_logger("transactions")
@@ -402,7 +405,11 @@ class Transaction(BaseTransaction):
             if inspect.iscoroutinefunction(hook):
                 run_coro_as_sync(hook(self))
             else:
-                hook(self)
+                token = RUNNING_ASYNC_FLAG.set(False)
+                try:
+                    hook(self)
+                finally:
+                    RUNNING_ASYNC_FLAG.reset(token)
         except Exception as exc:
             if should_log:
                 self.logger.error(
@@ -562,7 +569,7 @@ class AsyncTransaction(BaseTransaction):
             if inspect.iscoroutinefunction(hook):
                 await hook(self)
             else:
-                await anyio.to_thread.run_sync(hook, self)
+                await run_sync_in_worker_thread(hook, self)
         except Exception as exc:
             if should_log:
                 self.logger.error(

--- a/src/prefect/utilities/asyncutils/__init__.py
+++ b/src/prefect/utilities/asyncutils/__init__.py
@@ -53,7 +53,7 @@ EVENT_LOOP_GC_REFS: dict[int, AsyncGenerator[None, Any]] = {}
 
 
 RUNNING_IN_RUN_SYNC_LOOP_FLAG = ContextVar("running_in_run_sync_loop", default=False)
-RUNNING_ASYNC_FLAG = ContextVar("run_async", default=False)
+RUNNING_ASYNC_FLAG: ContextVar[Optional[bool]] = ContextVar("run_async", default=None)
 BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 background_task_lock: threading.Lock = threading.Lock()
 
@@ -317,19 +317,22 @@ def sync_compatible(
         # otherwise, we make some determinations
         if _sync is None:
             try:
-                run_ctx = get_run_context()
-                parent_obj = getattr(run_ctx, "task", None)
-                if not parent_obj:
-                    parent_obj = getattr(run_ctx, "flow", None)
-                is_async = getattr(parent_obj, "isasync", True)
-            except MissingContextError:
-                # not in an execution context, make best effort to
-                # decide whether to syncify
+                asyncio.get_running_loop()
+                has_running_loop = True
+            except RuntimeError:
+                has_running_loop = False
+
+            if not has_running_loop:
+                is_async = False
+            else:
                 try:
-                    asyncio.get_running_loop()
+                    run_ctx = get_run_context()
+                    parent_obj = getattr(run_ctx, "task", None)
+                    if not parent_obj:
+                        parent_obj = getattr(run_ctx, "flow", None)
+                    is_async = getattr(parent_obj, "isasync", True)
+                except MissingContextError:
                     is_async = True
-                except RuntimeError:
-                    is_async = False
 
         async def ctx_call():
             """
@@ -345,7 +348,9 @@ def sync_compatible(
 
         if _sync is True:
             return run_coro_as_sync(ctx_call())
-        elif RUNNING_ASYNC_FLAG.get() or is_async:
+        elif RUNNING_ASYNC_FLAG.get() is False:
+            return run_coro_as_sync(ctx_call())
+        elif RUNNING_ASYNC_FLAG.get() is True or (has_running_loop and is_async):
             return ctx_call()
         else:
             return run_coro_as_sync(ctx_call())

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1226,3 +1226,25 @@ class TestHooks:
 
             assert txn is not None
             spy.assert_called_once_with(txn)
+
+        async def test_sync_on_rollback_hook_calling_sync_compatible(self):
+            from prefect.utilities.asyncutils import sync_compatible
+
+            results = []
+
+            @sync_compatible
+            async def my_sync_compat_func():
+                return "success"
+
+            def sync_hook(txn: AsyncTransaction):
+                res = my_sync_compat_func()
+                results.append(res)
+
+            with pytest.raises(RuntimeError, match="Trigger rollback"):
+                async with atransaction(
+                    key="test_sync_on_rollback_hook_sync_compat"
+                ) as txn:
+                    txn.stage("foo", on_rollback_hooks=[sync_hook])
+                    raise RuntimeError("Trigger rollback")
+
+            assert results == ["success"]

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -614,3 +614,22 @@ class TestRunCoroAsSync:
         assert result["bar"][1] != run_sync_loop._loop
         assert result["foo"][0] == run_sync_loop.thread
         assert result["foo"][1] == run_sync_loop._loop
+
+
+async def test_sync_compatible_call_with_running_async_flag_false():
+    from prefect.utilities.asyncutils import RUNNING_ASYNC_FLAG, sync_compatible
+
+    @sync_compatible
+    async def sample_fn():
+        return 42
+
+    def sync_caller():
+        return sample_fn()
+
+    token = RUNNING_ASYNC_FLAG.set(False)
+    try:
+        res = sync_caller()
+    finally:
+        RUNNING_ASYNC_FLAG.reset(token)
+
+    assert res == 42


### PR DESCRIPTION
## Summary

This PR fixes an issue where `@sync_compatible` functions (such as `Block.load` or `prefect.variables.get`) returned unawaited coroutine objects instead of synchronous values when called inside synchronous transaction hooks (`on_rollback`, `on_commit`, `on_completion`) during an asynchronous flow run.

## Problem

When a synchronous transaction hook (e.g. `@task.on_rollback`) is executed during an `async` flow, the transaction runner executes the hook in a synchronous thread (or directly as a sync function call). However, `@sync_compatible` functions inspect the enclosing run context (`FlowRunContext`), see that the parent flow is asynchronous (`flow.isasync == True`), and assume that the caller will `await` the returned coroutine. Because synchronous hook functions are not `async def` and cannot `await` coroutines, the hook receives a raw unawaited coroutine object (causing `AttributeError` or `TypeError` when accessing properties on the returned value).

## Root cause

1. `sync_compatible` checked `parent_obj.isasync` without checking if the current thread has an active event loop or if `RUNNING_ASYNC_FLAG` was explicitly set to `False`.
2. `RUNNING_ASYNC_FLAG` defaulted to `False`, making `RUNNING_ASYNC_FLAG.get() is False` indistinguishable from the default unset state.
3. Transaction hook handlers did not set `RUNNING_ASYNC_FLAG` to `False` when invoking synchronous hook callables.

## Fix

1. Updated `RUNNING_ASYNC_FLAG` default to `None` so that `RUNNING_ASYNC_FLAG.get() is False` uniquely identifies contexts explicitly marked as synchronous.
2. Updated `sync_compatible` to verify that an active event loop exists in the calling thread and respect `RUNNING_ASYNC_FLAG.get() is False`.
3. Updated `Transaction.run_hook` and `AsyncTransaction.run_hook` to execute synchronous hooks with `RUNNING_ASYNC_FLAG.set(False)` (using `run_sync_in_worker_thread` for async transaction runners).

## Testing

- `uv run pytest tests/test_transactions.py tests/utilities/test_asyncutils.py` — Passed (148 passed, 8 skipped).
- Verified deterministic reproduction script `repros/17656.py` fails before the fix and passes cleanly after the fix.

## Compatibility

Preserves backward compatibility across all client and server APIs.

## Related issue

Closes #17656