### PR TITLE
Fix codspell error on unit test TEST_BLOCK_CODE_BAD_SYNTAX on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,7 +377,7 @@ skip = [
     "pyproject.toml",
 ]
 # from https://github.com/PrefectHQ/prefect/pull/10813#issuecomment-1732676130
-ignore-regex = ".*lazy=\"selectin\"|.*e import Bloc$|America/Nome"
+ignore-regex = ".*lazy=\"selectin\"|.*e import Bloc\\s*$|America/Nome"
 
 ignore-words-list = [
     "selectin",


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/22639

Change the `codespell` ignore-regex to make it compliant with windows CRLF EOL
When executed on MS Windows, `codespell` fails on the unit test `TEST_BLOCK_CODE_BAD_SYNTAX`. This is because the end of line is converted from LF to CRLF during the checkout, therefor the `codespell` `ignore-regex` pattern `.*e import Bloc$` doesn't match. 

This can be fixed by slightly changing the regex to include any whitespace between `Bloc`and the `EOL`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [X] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [X] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [X] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [X] If this pull request adds functions or classes, it includes helpful docstrings.
