### PR TITLE
fix: raise ValueError for negative timeout in PrefectFutureList.result, as_completed, and wait

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -574,6 +574,10 @@ class PrefectFutureList(list[PrefectFuture[R]], Iterator[PrefectFuture[R]]):
         """
         # Build a mapping from each unique future to every index it occupies
         # so that we can handle duplicates and preserve ordering.
+        if timeout is not None and timeout < 0:
+            raise ValueError(
+                f"'timeout' must be a non-negative number, got {timeout}"
+            )
         future_to_indices: dict[PrefectFuture[R], list[int]] = {}
         for idx, future in enumerate(self):
             future_to_indices.setdefault(future, []).append(idx)
@@ -629,6 +633,10 @@ def _register_prefect_done_callback(
 def as_completed(
     futures: list[PrefectFuture[R]], timeout: float | None = None
 ) -> Generator[PrefectFuture[R], None]:
+    if timeout is not None and timeout < 0:
+        raise ValueError(
+            f"'timeout' must be a non-negative number, got {timeout}"
+        )
     unique_futures: set[PrefectFuture[R]] = set(futures)
     total_futures = len(unique_futures)
     pending = unique_futures
@@ -720,6 +728,10 @@ def wait(
             print(f"Not Done: {len(not_done)}")
         ```
     """
+    if timeout is not None and timeout < 0:
+        raise ValueError(
+            f"'timeout' must be a non-negative number, got {timeout}"
+        )
     _futures = set(futures)
     done = {f for f in _futures if f._final_state}
     not_done = _futures - done

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -575,9 +575,7 @@ class PrefectFutureList(list[PrefectFuture[R]], Iterator[PrefectFuture[R]]):
         # Build a mapping from each unique future to every index it occupies
         # so that we can handle duplicates and preserve ordering.
         if timeout is not None and timeout < 0:
-            raise ValueError(
-                f"'timeout' must be a non-negative number, got {timeout}"
-            )
+            raise ValueError(f"'timeout' must be a non-negative number, got {timeout}")
         future_to_indices: dict[PrefectFuture[R], list[int]] = {}
         for idx, future in enumerate(self):
             future_to_indices.setdefault(future, []).append(idx)
@@ -634,9 +632,7 @@ def as_completed(
     futures: list[PrefectFuture[R]], timeout: float | None = None
 ) -> Generator[PrefectFuture[R], None]:
     if timeout is not None and timeout < 0:
-        raise ValueError(
-            f"'timeout' must be a non-negative number, got {timeout}"
-        )
+        raise ValueError(f"'timeout' must be a non-negative number, got {timeout}")
     unique_futures: set[PrefectFuture[R]] = set(futures)
     total_futures = len(unique_futures)
     pending = unique_futures
@@ -729,9 +725,7 @@ def wait(
         ```
     """
     if timeout is not None and timeout < 0:
-        raise ValueError(
-            f"'timeout' must be a non-negative number, got {timeout}"
-        )
+        raise ValueError(f"'timeout' must be a non-negative number, got {timeout}")
     _futures = set(futures)
     done = {f for f in _futures if f._final_state}
     not_done = _futures - done

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -63,6 +63,16 @@ class TestUtilityFunctions:
         for future in mock_futures:
             assert future.state.is_completed()
 
+    def test_wait_with_negative_timeout_raises_value_error(self):
+        mock_futures = [MockFuture(data=i) for i in range(5)]
+        with pytest.raises(ValueError, match="'timeout' must be a non-negative number"):
+            wait(mock_futures, timeout=-1)
+
+    def test_as_completed_with_negative_timeout_raises_value_error(self):
+        mock_futures = [MockFuture(data=i) for i in range(5)]
+        with pytest.raises(ValueError, match="'timeout' must be a non-negative number"):
+            list(as_completed(mock_futures, timeout=-1))
+
     @pytest.mark.timeout(method="thread")
     def test_wait_with_timeout(self):
         mock_futures = [MockFuture(data=i) for i in range(5)]
@@ -912,6 +922,12 @@ class TestPrefectFutureList:
 
         for future in futures:
             assert future.state.is_completed()
+
+    def test_result_with_negative_timeout_raises_value_error(self):
+        mock_futures = [MockFuture(data=i) for i in range(5)]
+        futures = PrefectFutureList(mock_futures)
+        with pytest.raises(ValueError, match="'timeout' must be a non-negative number"):
+            futures.result(timeout=-1)
 
     @pytest.mark.timeout(method="thread")  # alarm-based pytest-timeout will interfere
     def test_wait_with_timeout(self):


### PR DESCRIPTION
## Summary

`PrefectFutureList.result()`, `as_completed()`, and `wait()` silently 
accepted negative timeout values and raised a confusing `TimeoutError` 
instead of rejecting the invalid input immediately.

## Problem

Passing a negative timeout produced a misleading error message:

```python
futures.result(timeout=-1)
# TimeoutError: Timed out waiting for all futures to complete within -1 seconds
```

`"within -1 seconds"` makes no sense to users and gives no indication 
that the input itself was invalid.

## Fix

Added input validation to all three public timeout entry points:

```python
if timeout is not None and timeout < 0:
    raise ValueError(
        f"'timeout' must be a non-negative number, got {timeout}"
    )
```

## Why ValueError

Python's standard library consistently raises `ValueError` for negative 
timeouts:

```python
import queue
q = queue.Queue()
q.get(timeout=-1)
# ValueError: 'timeout' must be a non-negative number
```

This applies to `queue.Queue`, `threading.Event.wait()`, and 
`asyncio.wait()`. Prefect now follows the same convention.

## Testing

Verified locally that all three functions now raise `ValueError` 
immediately for negative timeout values: