### PR TITLE
Add minimal sandbox execution integration

### DIFF
--- a/src/integrations/prefect-sandbox/LICENSE
+++ b/src/integrations/prefect-sandbox/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/integrations/prefect-sandbox/MANIFEST.in
+++ b/src/integrations/prefect-sandbox/MANIFEST.in
@@ -1,0 +1,7 @@
+global-exclude .git*
+global-exclude .ipynb_checkpoints
+global-exclude *.py[co]
+global-exclude __pycache__/**
+
+include LICENSE
+include MANIFEST.in

--- a/src/integrations/prefect-sandbox/README.md
+++ b/src/integrations/prefect-sandbox/README.md
@@ -17,13 +17,14 @@ pip install prefect-sandbox
 brew trust docker/tap
 brew install docker/tap/sbx
 sbx login
-sbx policy init balanced
+sbx policy init deny-all
 ```
 
-`sbx policy init` is a one-time, host-wide choice. `balanced` is Docker's
-recommended development policy; choose `deny-all` or `allow-all` instead when that
-better matches the host's security requirements. Follow Docker's platform-specific
-prerequisites on Windows and Linux.
+`sbx policy init` is a one-time, host-wide choice. `deny-all` is the conservative
+baseline for arbitrary untrusted code. Docker recommends `balanced` for ordinary
+development because it permits common package registries and AI services; choose it
+only when that egress matches the workload's threat model. Follow Docker's
+platform-specific prerequisites on Windows and Linux.
 
 ## Example
 
@@ -60,14 +61,25 @@ await backend.write_file(sandbox, "/tmp/input.bin", b"input")
 
 ## Security boundary
 
-`SandboxHandle` is an opaque, trusted, process-local capability. Do not persist it,
-send it to another worker, or treat it as an authenticated token.
+`SandboxHandle` is an opaque, process-local reference, not an authorization boundary
+or authenticated token. Host-side code that can call the backend is trusted. Pass
+handles only to the backend instance that returned them, use that instance from one
+event loop, and do not persist handles or send them to another worker.
 
-The Docker adapter mounts only a newly created empty temporary directory. It does not
-forward the worker's environment to guest commands; only variables explicitly passed
-to `exec(..., env=...)` are added. The selected image and Docker Sandboxes runtime may
-still provide their own environment or host-configured proxy-backed credentials.
+The only caller-controlled host data directory the adapter asks `sbx` to mount is a
+newly created empty temporary workspace. It does not forward the worker's environment
+to guest commands; only variables explicitly passed to `exec(..., env=...)` are
+added. The selected image and Docker Sandboxes runtime still provide runtime-managed
+configuration and can expose credentials configured separately through `sbx`,
+including proxy-injected secrets or in-VM registry credentials. Audit that host-side
+configuration as part of the deployment boundary.
 
 This package does not configure host or organization network policy. Configure and
 verify egress policy with Docker Sandboxes before running untrusted code. Destroying a
-sandbox removes the microVM and the temporary host directory owned by the adapter.
+sandbox on a normal success, error, timeout, or cancellation path removes the microVM
+and the temporary host directory owned by the adapter.
+
+This first adapter layer has no durable ownership record or orphan sweeper. If the
+worker process or host terminates before cleanup finishes, inspect remaining resources
+with `sbx ls` and remove them with `sbx rm --force <name>`. Durable identity and
+server-driven cleanup belong to the later Prefect execution concept, not this package.

--- a/src/integrations/prefect-sandbox/README.md
+++ b/src/integrations/prefect-sandbox/README.md
@@ -1,0 +1,73 @@
+# prefect-sandbox
+
+`prefect-sandbox` defines a deliberately small adapter boundary for running a
+command in a disposable sandbox without moving the Prefect runtime into the guest.
+The first provider uses [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/)
+through its `sbx` CLI.
+
+This package is experimental. It supplies transport and lifecycle primitives, not a
+Prefect task runner, worker, durable-run API, retry policy, or orchestration layer.
+
+## Installation
+
+Install the Python package, then install and authenticate the host-side `sbx` CLI:
+
+```bash
+pip install prefect-sandbox
+brew trust docker/tap
+brew install docker/tap/sbx
+sbx login
+sbx policy init balanced
+```
+
+`sbx policy init` is a one-time, host-wide choice. `balanced` is Docker's
+recommended development policy; choose `deny-all` or `allow-all` instead when that
+better matches the host's security requirements. Follow Docker's platform-specific
+prerequisites on Windows and Linux.
+
+## Example
+
+```python
+from prefect import flow
+from prefect_sandbox import SbxSandbox, sandbox_session
+
+
+@flow
+async def isolated_python() -> bytes:
+    backend = SbxSandbox(image="python:3.12-slim")
+    async with sandbox_session(backend) as sandbox:
+        result = await backend.exec(
+            sandbox,
+            ["python", "-c", "print('hello from a sandbox')"],
+            timeout=30,
+        )
+    if not result.ok:
+        raise RuntimeError(result.stderr.decode(errors="replace"))
+    return result.stdout
+```
+
+Commands are argv sequences and never interpolated into a shell string. Nonzero
+exit codes are returned on `SandboxResult`; provider failures raise a sandbox
+exception. Captured stdout and stderr are separate byte strings and are bounded while
+being read.
+
+Providers may implement the separate `SandboxFileWriter` capability. Docker
+Sandboxes does so with `sbx cp`:
+
+```python
+await backend.write_file(sandbox, "/tmp/input.bin", b"input")
+```
+
+## Security boundary
+
+`SandboxHandle` is an opaque, trusted, process-local capability. Do not persist it,
+send it to another worker, or treat it as an authenticated token.
+
+The Docker adapter mounts only a newly created empty temporary directory. It does not
+forward the worker's environment to guest commands; only variables explicitly passed
+to `exec(..., env=...)` are added. The selected image and Docker Sandboxes runtime may
+still provide their own environment or host-configured proxy-backed credentials.
+
+This package does not configure host or organization network policy. Configure and
+verify egress policy with Docker Sandboxes before running untrusted code. Destroying a
+sandbox removes the microVM and the temporary host directory owned by the adapter.

--- a/src/integrations/prefect-sandbox/examples/basic.py
+++ b/src/integrations/prefect-sandbox/examples/basic.py
@@ -1,0 +1,20 @@
+"""Run one command in a disposable Docker Sandbox."""
+
+import asyncio
+
+from prefect_sandbox import SbxSandbox, sandbox_session
+
+
+async def main() -> None:
+    backend = SbxSandbox(image="python:3.12-slim")
+    async with sandbox_session(backend) as sandbox:
+        result = await backend.exec(
+            sandbox,
+            ["python", "-c", "print('hello from a sandbox')"],
+            timeout=30,
+        )
+    print(result.stdout.decode(errors="replace"), end="")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/integrations/prefect-sandbox/justfile
+++ b/src/integrations/prefect-sandbox/justfile
@@ -1,0 +1,18 @@
+test:
+    uv run pytest
+
+# Generate API reference documentation for prefect-sandbox
+api-ref:
+    #!/usr/bin/env bash
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    cd "$REPO_ROOT"
+    uvx --with-editable ./src/integrations/prefect-sandbox \
+        --python 3.12 \
+        --isolated \
+        'mdxify>=0.2.45' \
+        --all \
+        --root-module prefect_sandbox \
+        --output-dir docs/integrations/prefect-sandbox/api-ref \
+        --anchor-name "prefect-sandbox-sdk-reference" \
+        --repo-url https://github.com/PrefectHQ/prefect \
+        --include-inheritance

--- a/src/integrations/prefect-sandbox/prefect_sandbox/__init__.py
+++ b/src/integrations/prefect-sandbox/prefect_sandbox/__init__.py
@@ -1,0 +1,35 @@
+"""Prefect primitives for provider-neutral sandbox execution."""
+
+from prefect_sandbox import _version
+from prefect_sandbox.base import (
+    DEFAULT_MAX_OUTPUT_BYTES,
+    SandboxBackend,
+    SandboxCreationError,
+    SandboxError,
+    SandboxExecutionError,
+    SandboxFileWriter,
+    SandboxHandle,
+    SandboxHandleError,
+    SandboxResult,
+    SandboxUnavailableError,
+    sandbox_session,
+)
+from prefect_sandbox.sbx import SbxSandbox
+
+__version__ = _version.__version__
+
+__all__ = [
+    "DEFAULT_MAX_OUTPUT_BYTES",
+    "SandboxBackend",
+    "SandboxCreationError",
+    "SandboxError",
+    "SandboxExecutionError",
+    "SandboxFileWriter",
+    "SandboxHandle",
+    "SandboxHandleError",
+    "SandboxResult",
+    "SandboxUnavailableError",
+    "SbxSandbox",
+    "__version__",
+    "sandbox_session",
+]

--- a/src/integrations/prefect-sandbox/prefect_sandbox/base.py
+++ b/src/integrations/prefect-sandbox/prefect_sandbox/base.py
@@ -1,0 +1,177 @@
+"""Provider-neutral primitives for disposable sandbox execution."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Awaitable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import ClassVar, Protocol, TypeVar, runtime_checkable
+
+from prefect.blocks.core import Block
+
+__all__ = [
+    "DEFAULT_MAX_OUTPUT_BYTES",
+    "SandboxBackend",
+    "SandboxCreationError",
+    "SandboxError",
+    "SandboxExecutionError",
+    "SandboxFileWriter",
+    "SandboxHandle",
+    "SandboxHandleError",
+    "SandboxResult",
+    "SandboxUnavailableError",
+    "sandbox_session",
+]
+
+DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
+
+
+class SandboxError(Exception):
+    """Base class for sandbox infrastructure failures."""
+
+
+class SandboxUnavailableError(SandboxError):
+    """The selected sandbox provider is not available on this host."""
+
+
+class SandboxCreationError(SandboxError):
+    """A sandbox could not be provisioned or safely cleaned up."""
+
+
+class SandboxExecutionError(SandboxError):
+    """Sandbox infrastructure failed while executing a command."""
+
+
+class SandboxHandleError(SandboxError):
+    """A handle is unknown to the backend or no longer usable."""
+
+
+@dataclass(frozen=True)
+class SandboxHandle:
+    """Opaque, process-local capability identifying one sandbox."""
+
+    id: str
+
+
+@dataclass(frozen=True)
+class SandboxResult:
+    """Bounded output and status returned by one sandbox command."""
+
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+    timed_out: bool = False
+    truncated: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """Whether the command completed successfully."""
+        return self.exit_code == 0 and not self.timed_out
+
+
+@runtime_checkable
+class SandboxFileWriter(Protocol):
+    """Optional capability for providers with native file transfer."""
+
+    async def write_file(
+        self,
+        sandbox: SandboxHandle,
+        path: str,
+        content: bytes,
+    ) -> None:
+        """Write bytes to an absolute path inside `sandbox`."""
+
+
+def _validate_exec_request(
+    command: Sequence[str],
+    env: Mapping[str, str] | None,
+    timeout: float | None,
+    max_output_bytes: int,
+) -> None:
+    """Reject request values that no provider can safely honor."""
+    if isinstance(command, (str, bytes)):
+        raise TypeError("command must be an argv sequence, not a string or bytes")
+    if not command:
+        raise ValueError("command must not be empty")
+    for index, value in enumerate(command):
+        if not isinstance(value, str):
+            raise TypeError(f"command[{index}] must be a string")
+        if "\0" in value:
+            raise ValueError(f"command[{index}] must not contain a null byte")
+
+    for key, value in (env or {}).items():
+        if not isinstance(key, str) or not key or "=" in key or "\0" in key:
+            raise ValueError(f"invalid environment variable name: {key!r}")
+        if not isinstance(value, str):
+            raise TypeError(f"environment variable {key!r} must be a string")
+        if "\0" in value:
+            raise ValueError(f"environment variable {key!r} contains a null byte")
+
+    if timeout is not None and (not math.isfinite(timeout) or timeout <= 0):
+        raise ValueError("timeout must be a positive, finite number or None")
+    if not isinstance(max_output_bytes, int) or max_output_bytes <= 0:
+        raise ValueError("max_output_bytes must be a positive integer")
+
+
+T = TypeVar("T")
+
+
+async def _shielded(awaitable: Awaitable[T]) -> T:
+    """Finish an awaitable before re-delivering caller cancellation."""
+    task = asyncio.ensure_future(awaitable)
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    result = task.result()
+    if cancelled:
+        raise asyncio.CancelledError
+    return result
+
+
+class SandboxBackend(Block, ABC):
+    """Minimal lifecycle contract implemented by sandbox providers.
+
+    A handle is trusted only inside the process and backend instance that created it.
+    It is not an authenticated or durable token. Implementations must avoid implicit
+    host-environment forwarding, retain output only up to `max_output_bytes`, return
+    nonzero command exits as data, clean partial creates, and make `destroy`
+    idempotent for handles they created.
+    """
+
+    _block_schema_capabilities: ClassVar[list[str]] = ["run-in-sandbox"]
+
+    @abstractmethod
+    async def create(self) -> SandboxHandle:
+        """Provision a usable sandbox and return its opaque handle."""
+
+    @abstractmethod
+    async def exec(
+        self,
+        sandbox: SandboxHandle,
+        command: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    ) -> SandboxResult:
+        """Execute an argv sequence inside `sandbox`."""
+
+    @abstractmethod
+    async def destroy(self, sandbox: SandboxHandle) -> None:
+        """Destroy a sandbox, succeeding when it was already destroyed."""
+
+
+@asynccontextmanager
+async def sandbox_session(backend: SandboxBackend) -> AsyncIterator[SandboxHandle]:
+    """Create one sandbox and finish its destruction on every exit path."""
+    sandbox = await backend.create()
+    try:
+        yield sandbox
+    finally:
+        await _shielded(backend.destroy(sandbox))

--- a/src/integrations/prefect-sandbox/prefect_sandbox/base.py
+++ b/src/integrations/prefect-sandbox/prefect_sandbox/base.py
@@ -51,7 +51,7 @@ class SandboxHandleError(SandboxError):
 
 @dataclass(frozen=True)
 class SandboxHandle:
-    """Opaque, process-local capability identifying one sandbox."""
+    """Opaque, process-local reference identifying one sandbox."""
 
     id: str
 
@@ -141,7 +141,10 @@ class SandboxBackend(Block, ABC):
     It is not an authenticated or durable token. Implementations must avoid implicit
     host-environment forwarding, retain output only up to `max_output_bytes`, return
     nonzero command exits as data, clean partial creates, and make `destroy`
-    idempotent for handles they created.
+    idempotent for handles they created. A backend instance and its handles belong to
+    one event loop; concurrent tasks on that loop are supported, but sharing them
+    across loops, threads, or processes is outside this contract. Process termination
+    can orphan provider resources because durable identity and sweeping are deferred.
     """
 
     _block_schema_capabilities: ClassVar[list[str]] = ["run-in-sandbox"]

--- a/src/integrations/prefect-sandbox/prefect_sandbox/sbx.py
+++ b/src/integrations/prefect-sandbox/prefect_sandbox/sbx.py
@@ -99,6 +99,34 @@ def _remove_workspace(path: Path) -> None:
         raise SandboxError(f"failed to remove workspace {str(path)!r}: {exc}") from exc
 
 
+async def _make_workspace_cancellation_safe() -> Path:
+    """Finish workspace creation and remove it before delivering cancellation."""
+    task = asyncio.create_task(
+        asyncio.to_thread(tempfile.mkdtemp, prefix=_WORKSPACE_PREFIX)
+    )
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    workspace = _workspace_path(task.result())
+    if cancelled:
+        await _shielded(asyncio.to_thread(_remove_workspace, workspace))
+        raise asyncio.CancelledError
+    return workspace
+
+
+def _remove_staged_file(path: str) -> None:
+    """Remove a staged upload, suppressing only an already-absent path."""
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise SandboxError(f"failed to remove staged file {path!r}: {exc}") from exc
+
+
 def _stage_file(content: bytes) -> str:
     """Write bytes to a restrictive host temporary file."""
     descriptor, path = tempfile.mkstemp(prefix="prefect-sandbox-upload-")
@@ -106,8 +134,7 @@ def _stage_file(content: bytes) -> str:
         with os.fdopen(descriptor, "wb") as file:
             file.write(content)
     except BaseException:
-        with suppress(FileNotFoundError):
-            os.unlink(path)
+        _remove_staged_file(path)
         raise
     return path
 
@@ -123,7 +150,7 @@ async def _stage_file_cancellation_safe(content: bytes) -> str:
             cancelled = True
     path = task.result()
     if cancelled:
-        await _shielded(asyncio.to_thread(os.unlink, path))
+        await _shielded(asyncio.to_thread(_remove_staged_file, path))
         raise asyncio.CancelledError
     return path
 
@@ -305,9 +332,7 @@ class SbxSandbox(SandboxBackend):
         """Create a usable microVM backed by an empty host workspace."""
         self._check_binary()
         sandbox_id = f"prefect-sandbox-{uuid.uuid4().hex[:12]}"
-        workspace = _workspace_path(
-            await asyncio.to_thread(tempfile.mkdtemp, prefix=_WORKSPACE_PREFIX)
-        )
+        workspace = await _make_workspace_cancellation_safe()
         args = [
             "create",
             "--quiet",
@@ -483,4 +508,4 @@ class SbxSandbox(SandboxBackend):
                     f"{detail or '<no output>'}"
                 )
         finally:
-            await _shielded(asyncio.to_thread(os.unlink, staged))
+            await _shielded(asyncio.to_thread(_remove_staged_file, staged))

--- a/src/integrations/prefect-sandbox/prefect_sandbox/sbx.py
+++ b/src/integrations/prefect-sandbox/prefect_sandbox/sbx.py
@@ -1,0 +1,486 @@
+"""Docker Sandboxes backend implemented through the `sbx` CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import signal
+import tempfile
+import uuid
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from pydantic import Field, PrivateAttr
+
+from prefect_sandbox.base import (
+    DEFAULT_MAX_OUTPUT_BYTES,
+    SandboxBackend,
+    SandboxCreationError,
+    SandboxError,
+    SandboxExecutionError,
+    SandboxHandle,
+    SandboxHandleError,
+    SandboxResult,
+    SandboxUnavailableError,
+    _shielded,
+    _validate_exec_request,
+)
+
+__all__ = ["SbxSandbox"]
+
+_UNKNOWN_EXIT_CODE = -1
+_BOOKKEEPING_TIMEOUT = 120.0
+_BOOKKEEPING_OUTPUT_BYTES = 16 * 1024
+_READ_CHUNK_BYTES = 64 * 1024
+_WORKSPACE_PREFIX = "prefect-sandbox-"
+
+
+@dataclass(frozen=True)
+class _CommandResult:
+    """Bounded result of one host-side CLI invocation."""
+
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+    truncated: bool
+
+
+async def _drain_capped(
+    stream: asyncio.StreamReader | None, limit: int
+) -> tuple[bytes, bool]:
+    """Drain a stream to EOF while retaining at most `limit` bytes."""
+    if stream is None:
+        return b"", False
+
+    retained = bytearray()
+    truncated = False
+    while chunk := await stream.read(_READ_CHUNK_BYTES):
+        remaining = limit - len(retained)
+        if remaining > 0:
+            retained.extend(chunk[:remaining])
+        if len(chunk) > remaining:
+            truncated = True
+    return bytes(retained), truncated
+
+
+def _kill_process_tree(process: asyncio.subprocess.Process) -> None:
+    """Kill a CLI subprocess and its POSIX process group."""
+    if os.name == "posix":
+        with suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(process.pid, signal.SIGKILL)
+    with suppress(ProcessLookupError):
+        process.kill()
+
+
+def _workspace_path(path: str | Path) -> Path:
+    """Resolve an adapter-owned workspace or reject an unsafe path."""
+    candidate = Path(path)
+    resolved = candidate.resolve(strict=False)
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    if (
+        not candidate.is_absolute()
+        or resolved.parent != temp_root
+        or not resolved.name.startswith(_WORKSPACE_PREFIX)
+    ):
+        raise SandboxError(f"refusing to remove unowned workspace {str(path)!r}")
+    return resolved
+
+
+def _remove_workspace(path: Path) -> None:
+    """Remove an adapter-owned workspace if it still exists."""
+    try:
+        shutil.rmtree(_workspace_path(path))
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise SandboxError(f"failed to remove workspace {str(path)!r}: {exc}") from exc
+
+
+def _stage_file(content: bytes) -> str:
+    """Write bytes to a restrictive host temporary file."""
+    descriptor, path = tempfile.mkstemp(prefix="prefect-sandbox-upload-")
+    try:
+        with os.fdopen(descriptor, "wb") as file:
+            file.write(content)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(path)
+        raise
+    return path
+
+
+async def _stage_file_cancellation_safe(content: bytes) -> str:
+    """Finish staging and avoid leaking the file if the caller is cancelled."""
+    task = asyncio.create_task(asyncio.to_thread(_stage_file, content))
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    path = task.result()
+    if cancelled:
+        await _shielded(asyncio.to_thread(os.unlink, path))
+        raise asyncio.CancelledError
+    return path
+
+
+def _strip_autostart_notice(stderr: bytes, sandbox_id: str) -> bytes:
+    """Remove the provider's sandbox-start notice from command stderr."""
+    notice = f"Sandbox {sandbox_id} started successfully".encode()
+    return b"".join(
+        line for line in stderr.splitlines(keepends=True) if line.strip() != notice
+    )
+
+
+class SbxSandbox(SandboxBackend):
+    """Run commands in disposable Docker Sandboxes microVMs.
+
+    The backend gives `sbx` an otherwise empty temporary workspace and retains that
+    path only in this backend instance. Host environment variables are available to
+    the host-side CLI, but guest commands receive only the values explicitly passed
+    to `exec` in addition to image/runtime-provided environment variables.
+    """
+
+    _block_type_name = "Docker Sandbox"
+    _documentation_url = "https://docs.docker.com/ai/sandboxes/"
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/14a315b79990200db7341e42553e23650b34bb96-250x250.png"
+
+    image: str = Field(
+        default="python:3.12-slim",
+        min_length=1,
+        description="Container image used as the sandbox template.",
+    )
+    memory: str = Field(
+        default="2g",
+        min_length=1,
+        description="Memory limit accepted by `sbx create`, such as `2g`.",
+    )
+    cpus: int | None = Field(
+        default=None,
+        gt=0,
+        description="CPU count, or the provider default when omitted.",
+    )
+    sbx_path: str = Field(
+        default="sbx",
+        min_length=1,
+        description="Path to the Docker Sandboxes CLI.",
+    )
+    create_timeout: float = Field(
+        default=600.0,
+        gt=0,
+        description="Maximum seconds allowed for sandbox creation.",
+    )
+
+    _sandboxes: dict[str, Path | None] = PrivateAttr(default_factory=dict)
+    _destroy_tasks: dict[str, asyncio.Task[None]] = PrivateAttr(default_factory=dict)
+
+    def _check_binary(self) -> None:
+        """Fail clearly when the Docker Sandboxes CLI is unavailable."""
+        if shutil.which(self.sbx_path) is None:
+            raise SandboxUnavailableError(
+                f"{self.sbx_path!r} was not found on PATH; install Docker Sandboxes "
+                "and run `sbx login`"
+            )
+
+    async def _run_cli(
+        self,
+        args: Sequence[str],
+        *,
+        timeout: float | None,
+        max_output_bytes: int,
+    ) -> _CommandResult:
+        """Run one CLI command with bounded output and process-tree cleanup."""
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self.sbx_path,
+                *args,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=os.name == "posix",
+            )
+        except OSError as exc:
+            raise SandboxUnavailableError(
+                f"could not execute {self.sbx_path!r}: {exc}"
+            ) from exc
+
+        readers = (
+            asyncio.create_task(_drain_capped(process.stdout, max_output_bytes)),
+            asyncio.create_task(_drain_capped(process.stderr, max_output_bytes)),
+        )
+        completed = asyncio.gather(*readers, process.wait())
+        try:
+            (
+                (stdout, out_truncated),
+                (stderr, err_truncated),
+                exit_code,
+            ) = await asyncio.wait_for(completed, timeout)
+        except BaseException:
+            completed.cancel()
+            _kill_process_tree(process)
+            with suppress(BaseException):
+                await process.wait()
+            await asyncio.gather(*readers, return_exceptions=True)
+            raise
+
+        return _CommandResult(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            truncated=out_truncated or err_truncated,
+        )
+
+    def _workspace_for(self, sandbox: SandboxHandle) -> Path:
+        """Resolve a live process-local handle to its host workspace."""
+        if not isinstance(sandbox, SandboxHandle):
+            raise SandboxHandleError("sandbox must be a SandboxHandle")
+        if sandbox.id not in self._sandboxes:
+            raise SandboxHandleError(
+                f"sandbox handle {sandbox.id!r} was not created by this backend"
+            )
+        workspace = self._sandboxes[sandbox.id]
+        if workspace is None:
+            raise SandboxHandleError(f"sandbox {sandbox.id!r} was destroyed")
+        return workspace
+
+    async def _remove_sandbox(self, sandbox_id: str) -> None:
+        """Remove a sandbox or confirm that it is already absent."""
+        try:
+            removed = await self._run_cli(
+                ["rm", "--force", sandbox_id],
+                timeout=_BOOKKEEPING_TIMEOUT,
+                max_output_bytes=_BOOKKEEPING_OUTPUT_BYTES,
+            )
+        except asyncio.TimeoutError as exc:
+            raise SandboxError(
+                f"timed out removing sandbox {sandbox_id!r}; it may still be running"
+            ) from exc
+        if removed.exit_code == 0:
+            return
+
+        try:
+            inventory = await self._run_cli(
+                ["ls", "--quiet"],
+                timeout=_BOOKKEEPING_TIMEOUT,
+                max_output_bytes=_BOOKKEEPING_OUTPUT_BYTES,
+            )
+        except asyncio.TimeoutError as exc:
+            raise SandboxError(
+                f"could not confirm removal of sandbox {sandbox_id!r}"
+            ) from exc
+
+        names = set(inventory.stdout.decode(errors="replace").splitlines())
+        if (
+            inventory.exit_code == 0
+            and not inventory.truncated
+            and sandbox_id not in names
+        ):
+            return
+        detail = removed.stderr.decode(errors="replace").strip()[:1000]
+        raise SandboxError(
+            f"failed to remove sandbox {sandbox_id!r}; it may still be running: "
+            f"{detail or '<no output>'}"
+        )
+
+    async def _discard(self, sandbox_id: str, workspace: Path) -> None:
+        """Attempt provider and host cleanup, reporting every failure."""
+        errors: list[Exception | asyncio.CancelledError] = []
+        try:
+            await self._remove_sandbox(sandbox_id)
+        except (SandboxError, asyncio.CancelledError) as exc:
+            errors.append(exc)
+        try:
+            await asyncio.to_thread(_remove_workspace, workspace)
+        except (SandboxError, asyncio.CancelledError) as exc:
+            errors.append(exc)
+        if errors:
+            detail = "; ".join(str(error) for error in errors)
+            raise SandboxError(detail) from errors[0]
+
+    async def create(self) -> SandboxHandle:
+        """Create a usable microVM backed by an empty host workspace."""
+        self._check_binary()
+        sandbox_id = f"prefect-sandbox-{uuid.uuid4().hex[:12]}"
+        workspace = _workspace_path(
+            await asyncio.to_thread(tempfile.mkdtemp, prefix=_WORKSPACE_PREFIX)
+        )
+        args = [
+            "create",
+            "--quiet",
+            "--name",
+            sandbox_id,
+            "--memory",
+            self.memory,
+        ]
+        if self.cpus is not None:
+            args.extend(["--cpus", str(self.cpus)])
+        args.extend(["--template", self.image, "shell", str(workspace)])
+
+        try:
+            result = await self._run_cli(
+                args,
+                timeout=self.create_timeout,
+                max_output_bytes=_BOOKKEEPING_OUTPUT_BYTES,
+            )
+            if result.exit_code != 0:
+                detail = result.stderr.decode(errors="replace").strip()[:2000]
+                raise SandboxCreationError(
+                    f"`sbx create` exited {result.exit_code}: {detail or '<no output>'}"
+                )
+        except SandboxUnavailableError:
+            await _shielded(asyncio.to_thread(_remove_workspace, workspace))
+            raise
+        except BaseException as create_error:
+            try:
+                await _shielded(self._discard(sandbox_id, workspace))
+            except asyncio.CancelledError:
+                raise
+            except BaseException as cleanup_error:
+                raise SandboxCreationError(
+                    f"sandbox creation failed and cleanup could not be confirmed: "
+                    f"{create_error}"
+                ) from cleanup_error
+            if isinstance(create_error, asyncio.TimeoutError):
+                raise SandboxCreationError(
+                    f"`sbx create` exceeded {self.create_timeout:g} seconds"
+                ) from create_error
+            raise
+
+        self._sandboxes[sandbox_id] = workspace
+        return SandboxHandle(sandbox_id)
+
+    async def exec(
+        self,
+        sandbox: SandboxHandle,
+        command: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    ) -> SandboxResult:
+        """Run an argv sequence without invoking a guest shell."""
+        _validate_exec_request(command, env, timeout, max_output_bytes)
+        self._workspace_for(sandbox)
+
+        args = ["exec"]
+        for key, value in (env or {}).items():
+            args.extend(["--env", f"{key}={value}"])
+        args.append(sandbox.id)
+        args.extend(command)
+
+        try:
+            result = await self._run_cli(
+                args,
+                timeout=timeout,
+                max_output_bytes=max_output_bytes,
+            )
+        except asyncio.TimeoutError:
+            try:
+                await _shielded(self.destroy(sandbox))
+            except BaseException as cleanup_error:
+                raise SandboxExecutionError(
+                    f"command timed out and sandbox {sandbox.id!r} could not be "
+                    "confirmed destroyed"
+                ) from cleanup_error
+            return SandboxResult(
+                exit_code=_UNKNOWN_EXIT_CODE,
+                stdout=b"",
+                stderr=(
+                    f"`sbx exec` exceeded {timeout:g} seconds; sandbox destroyed"
+                ).encode(),
+                timed_out=True,
+            )
+        except asyncio.CancelledError:
+            await _shielded(self.destroy(sandbox))
+            raise
+
+        return SandboxResult(
+            exit_code=result.exit_code,
+            stdout=result.stdout,
+            stderr=_strip_autostart_notice(result.stderr, sandbox.id),
+            truncated=result.truncated,
+        )
+
+    async def _destroy_once(self, sandbox_id: str, workspace: Path) -> None:
+        """Perform the shared cleanup used by concurrent destroy callers."""
+        succeeded = False
+        try:
+            await self._discard(sandbox_id, workspace)
+            succeeded = True
+        finally:
+            if succeeded:
+                self._sandboxes[sandbox_id] = None
+            if self._destroy_tasks.get(sandbox_id) is asyncio.current_task():
+                self._destroy_tasks.pop(sandbox_id, None)
+
+    async def destroy(self, sandbox: SandboxHandle) -> None:
+        """Remove one microVM and its temporary host workspace."""
+        if not isinstance(sandbox, SandboxHandle):
+            raise SandboxHandleError("sandbox must be a SandboxHandle")
+        if sandbox.id not in self._sandboxes:
+            raise SandboxHandleError(
+                f"sandbox handle {sandbox.id!r} was not created by this backend"
+            )
+        workspace = self._sandboxes[sandbox.id]
+        if workspace is None:
+            return
+
+        task = self._destroy_tasks.get(sandbox.id)
+        if task is None:
+            task = asyncio.create_task(self._destroy_once(sandbox.id, workspace))
+            self._destroy_tasks[sandbox.id] = task
+        await _shielded(task)
+
+    async def write_file(
+        self,
+        sandbox: SandboxHandle,
+        path: str,
+        content: bytes,
+    ) -> None:
+        """Copy bytes into a sandbox using the provider's native file transfer."""
+        self._workspace_for(sandbox)
+        if not isinstance(path, str) or "\0" in path or not path.startswith("/"):
+            raise ValueError("path must be an absolute guest path without null bytes")
+        if ".." in PurePosixPath(path).parts:
+            raise ValueError("path must not contain parent traversal")
+        if not isinstance(content, bytes):
+            raise TypeError("content must be bytes")
+
+        parent = str(PurePosixPath(path).parent)
+        if parent != "/":
+            created = await self.exec(
+                sandbox,
+                ["mkdir", "-p", parent],
+                timeout=_BOOKKEEPING_TIMEOUT,
+                max_output_bytes=_BOOKKEEPING_OUTPUT_BYTES,
+            )
+            if not created.ok:
+                raise SandboxExecutionError(
+                    f"could not create parent directory {parent!r}: "
+                    f"{created.stderr.decode(errors='replace')[:1000]}"
+                )
+
+        staged = await _stage_file_cancellation_safe(content)
+        try:
+            try:
+                copied = await self._run_cli(
+                    ["cp", staged, f"{sandbox.id}:{path}"],
+                    timeout=_BOOKKEEPING_TIMEOUT,
+                    max_output_bytes=_BOOKKEEPING_OUTPUT_BYTES,
+                )
+            except asyncio.TimeoutError as exc:
+                raise SandboxExecutionError(
+                    f"timed out copying {path!r} into sandbox {sandbox.id!r}"
+                ) from exc
+            if copied.exit_code != 0:
+                detail = copied.stderr.decode(errors="replace").strip()[:1000]
+                raise SandboxExecutionError(
+                    f"failed to copy {path!r} into sandbox {sandbox.id!r}: "
+                    f"{detail or '<no output>'}"
+                )
+        finally:
+            await _shielded(asyncio.to_thread(os.unlink, staged))

--- a/src/integrations/prefect-sandbox/pyproject.toml
+++ b/src/integrations/prefect-sandbox/pyproject.toml
@@ -1,0 +1,86 @@
+[build-system]
+requires = ["setuptools>=77", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prefect-sandbox"
+description = "Provider-neutral primitives for disposable sandbox execution with Prefect."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+keywords = ["prefect", "sandbox", "microvm", "isolation"]
+authors = [{ name = "Prefect Technologies, Inc.", email = "help@prefect.io" }]
+classifiers = [
+  "Natural Language :: English",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Software Development :: Libraries",
+]
+dependencies = ["prefect>=3.7.8"]
+dynamic = ["version"]
+
+[dependency-groups]
+dev = [
+  "coverage",
+  "interrogate",
+  "mkdocs-gen-files",
+  "mkdocs-material",
+  "mkdocs",
+  "mkdocstrings[python]",
+  "mypy",
+  "pillow; python_version<'3.14'",
+  "pre-commit",
+  "pytest-asyncio",
+  "pytest >= 8.3",
+  "pytest-env",
+  "pytest-xdist",
+]
+
+[project.urls]
+Homepage = "https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-sandbox"
+
+[project.entry-points."prefect.collections"]
+prefect_sandbox = "prefect_sandbox"
+
+[tool.setuptools_scm]
+version_file = "prefect_sandbox/_version.py"
+root = "../../.."
+tag_regex = "^prefect-sandbox-(?P<version>\\d+\\.\\d+\\.\\d+(?:[a-zA-Z0-9]+(?:\\.[a-zA-Z0-9]+)*)?)$"
+fallback_version = "0.1.0"
+git_describe_command = [
+  "git",
+  "describe",
+  "--dirty",
+  "--tags",
+  "--long",
+  "--match",
+  "prefect-sandbox-*[0-9]*",
+]
+
+[tool.interrogate]
+ignore-init-module = true
+ignore_init_method = true
+exclude = ["prefect_sandbox/_version.py", "tests"]
+fail-under = 95
+omit-covered-files = true
+
+[tool.coverage.run]
+omit = ["tests/*", "prefect_sandbox/_version.py"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+env = ["PREFECT_TEST_MODE=1"]
+
+[tool.uv.sources]
+prefect = { path = "../../../" }

--- a/src/integrations/prefect-sandbox/tests/test_block_standards.py
+++ b/src/integrations/prefect-sandbox/tests/test_block_standards.py
@@ -1,0 +1,24 @@
+import prefect_sandbox  # noqa: F401
+import pytest
+
+from prefect.blocks.core import Block
+from prefect.testing.standard_test_suites import BlockStandardTestSuite
+from prefect.utilities.dispatch import get_registry_for_type
+from prefect.utilities.importtools import to_qualified_name
+
+
+def find_module_blocks():
+    blocks = get_registry_for_type(Block)
+    return [
+        block
+        for block in blocks.values()
+        if to_qualified_name(block).startswith("prefect_sandbox")
+        and not getattr(block, "__abstractmethods__", None)
+    ]
+
+
+@pytest.mark.parametrize("block", find_module_blocks())
+class TestAllBlocksAdhereToStandards(BlockStandardTestSuite):
+    @pytest.fixture
+    def block(self, block):
+        return block

--- a/src/integrations/prefect-sandbox/tests/test_contract.py
+++ b/src/integrations/prefect-sandbox/tests/test_contract.py
@@ -1,0 +1,160 @@
+import asyncio
+from collections.abc import Mapping, Sequence
+from dataclasses import FrozenInstanceError
+
+import pytest
+from prefect_sandbox import (
+    SandboxBackend,
+    SandboxFileWriter,
+    SandboxHandle,
+    SandboxResult,
+    sandbox_session,
+)
+from pydantic import PrivateAttr
+
+
+class MemoryBackend(SandboxBackend):
+    _next_id: int = PrivateAttr(default=0)
+    _active: set[str] = PrivateAttr(default_factory=set)
+    _destroyed: list[str] = PrivateAttr(default_factory=list)
+    _destroy_started: asyncio.Event | None = PrivateAttr(default=None)
+    _finish_destroy: asyncio.Event | None = PrivateAttr(default=None)
+    _destroy_error: BaseException | None = PrivateAttr(default=None)
+    _create_error: BaseException | None = PrivateAttr(default=None)
+
+    async def create(self) -> SandboxHandle:
+        if self._create_error is not None:
+            raise self._create_error
+        self._next_id += 1
+        handle = SandboxHandle(f"memory-{self._next_id}")
+        self._active.add(handle.id)
+        return handle
+
+    async def exec(
+        self,
+        sandbox: SandboxHandle,
+        command: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        max_output_bytes: int = 64 * 1024,
+    ) -> SandboxResult:
+        assert sandbox.id in self._active
+        return SandboxResult(0, b"\0".join(value.encode() for value in command), b"")
+
+    async def destroy(self, sandbox: SandboxHandle) -> None:
+        if sandbox.id not in self._active:
+            return
+        if self._destroy_started is not None:
+            self._destroy_started.set()
+        if self._finish_destroy is not None:
+            await self._finish_destroy.wait()
+        if self._destroy_error is not None:
+            raise self._destroy_error
+        self._active.remove(sandbox.id)
+        self._destroyed.append(sandbox.id)
+
+
+class MemoryFileWriter:
+    async def write_file(
+        self, sandbox: SandboxHandle, path: str, content: bytes
+    ) -> None:
+        pass
+
+
+def test_value_types_are_frozen() -> None:
+    handle = SandboxHandle("sandbox")
+    result = SandboxResult(0, b"out", b"err")
+
+    with pytest.raises(FrozenInstanceError):
+        handle.id = "changed"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        result.exit_code = 1  # type: ignore[misc]
+
+
+def test_result_ok_requires_success_without_timeout() -> None:
+    assert SandboxResult(0, b"", b"").ok
+    assert not SandboxResult(1, b"", b"").ok
+    assert not SandboxResult(-1, b"", b"", timed_out=True).ok
+
+
+def test_file_writer_is_a_structural_optional_capability() -> None:
+    assert isinstance(MemoryFileWriter(), SandboxFileWriter)
+    assert not isinstance(MemoryBackend(), SandboxFileWriter)
+
+
+async def test_backend_can_serve_distinct_concurrent_handles() -> None:
+    backend = MemoryBackend()
+
+    first, second = await asyncio.gather(backend.create(), backend.create())
+    results = await asyncio.gather(
+        backend.exec(first, ["one", "argument with spaces"]),
+        backend.exec(second, ["two"]),
+    )
+
+    assert first != second
+    assert results[0].stdout == b"one\0argument with spaces"
+    assert results[1].stdout == b"two"
+
+
+async def test_session_destroys_after_success() -> None:
+    backend = MemoryBackend()
+
+    async with sandbox_session(backend) as sandbox:
+        assert sandbox.id in backend._active
+
+    assert sandbox.id not in backend._active
+    assert backend._destroyed == [sandbox.id]
+
+
+async def test_session_destroys_after_body_failure() -> None:
+    backend = MemoryBackend()
+
+    with pytest.raises(ValueError, match="body failed"):
+        async with sandbox_session(backend) as sandbox:
+            raise ValueError("body failed")
+
+    assert sandbox.id not in backend._active
+
+
+async def test_session_finishes_cleanup_before_redelivering_cancellation() -> None:
+    backend = MemoryBackend()
+    backend._destroy_started = asyncio.Event()
+    backend._finish_destroy = asyncio.Event()
+    body_started = asyncio.Event()
+
+    async def run_session() -> None:
+        async with sandbox_session(backend):
+            body_started.set()
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(run_session())
+    await body_started.wait()
+    task.cancel()
+    await backend._destroy_started.wait()
+
+    assert not task.done()
+    backend._finish_destroy.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not backend._active
+
+
+async def test_session_surfaces_cleanup_failure() -> None:
+    backend = MemoryBackend()
+    backend._destroy_error = RuntimeError("cleanup failed")
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        async with sandbox_session(backend):
+            pass
+
+
+async def test_failed_create_does_not_call_destroy() -> None:
+    backend = MemoryBackend()
+    backend._create_error = RuntimeError("create failed")
+
+    with pytest.raises(RuntimeError, match="create failed"):
+        async with sandbox_session(backend):
+            pass
+
+    assert backend._destroyed == []

--- a/src/integrations/prefect-sandbox/tests/test_sbx.py
+++ b/src/integrations/prefect-sandbox/tests/test_sbx.py
@@ -1,8 +1,11 @@
 import asyncio
+import os
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
+import prefect_sandbox.sbx as sbx_module
 import pytest
 from prefect_sandbox import (
     SandboxCreationError,
@@ -56,6 +59,45 @@ async def test_missing_binary_fails_before_creating_workspace(
         await SbxSandbox().create()
 
     assert list(tmp_path.iterdir()) == []
+
+
+async def test_cancelling_workspace_creation_removes_the_completed_directory(
+    backend: SbxSandbox,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "prefect-sandbox-slow"
+    started = threading.Event()
+    release = threading.Event()
+    cli_calls: list[list[str]] = []
+
+    def slow_mkdtemp(*, prefix: str) -> str:
+        assert prefix == sbx_module._WORKSPACE_PREFIX
+        workspace.mkdir()
+        started.set()
+        if not release.wait(5):
+            raise RuntimeError("test did not release workspace creation")
+        return str(workspace)
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        cli_calls.append(list(args))
+        return command_result()
+
+    monkeypatch.setattr(sbx_module.tempfile, "mkdtemp", slow_mkdtemp)
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    creating = asyncio.create_task(backend.create())
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        creating.cancel()
+        await asyncio.sleep(0)
+        assert not creating.done()
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(creating, 5)
+    assert not workspace.exists()
+    assert cli_calls == []
 
 
 async def test_create_uses_an_empty_workspace_and_provider_options(
@@ -467,6 +509,105 @@ async def test_write_file_uses_native_copy_and_removes_staging_file(
     assert calls[1][0] == "cp"
     assert calls[1][2] == f"{sandbox.id}:/tmp/data/input.bin"
     assert staged_path is not None and not staged_path.exists()
+
+
+def test_failed_file_staging_removes_the_partial_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+
+    class FullDisk:
+        def __init__(self, descriptor: int) -> None:
+            self._descriptor = descriptor
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info: object) -> bool:
+            os.close(self._descriptor)
+            return False
+
+        def write(self, content: bytes) -> int:
+            os.write(self._descriptor, content[:4])
+            raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(
+        sbx_module.os,
+        "fdopen",
+        lambda descriptor, *args, **kwargs: FullDisk(descriptor),
+    )
+
+    with pytest.raises(OSError, match="No space left on device"):
+        sbx_module._stage_file(b"sensitive payload")
+
+    assert list(tmp_path.glob("prefect-sandbox-upload-*")) == []
+
+
+async def test_staged_file_deletion_failure_is_typed(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    staged_path: Path | None = None
+    real_unlink = os.unlink
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        nonlocal staged_path
+        if args[0] == "cp":
+            staged_path = Path(args[1])
+        return command_result()
+
+    def fail_unlink(path: str | os.PathLike[str]) -> None:
+        raise PermissionError(13, "Permission denied", path)
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    monkeypatch.setattr(sbx_module.os, "unlink", fail_unlink)
+
+    with pytest.raises(SandboxError, match="failed to remove staged file"):
+        await backend.write_file(sandbox, "/input.bin", b"sensitive")
+
+    assert staged_path is not None and staged_path.exists()
+    real_unlink(staged_path)
+
+
+async def test_cancelling_file_staging_joins_and_removes_the_file(
+    backend: SbxSandbox,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox = activate(backend)
+    staged = tmp_path / "prefect-sandbox-upload-sensitive"
+    started = threading.Event()
+    release = threading.Event()
+    cli_calls: list[list[str]] = []
+
+    def slow_stage(content: bytes) -> str:
+        staged.write_bytes(content)
+        started.set()
+        if not release.wait(5):
+            raise RuntimeError("test did not release file staging")
+        return str(staged)
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        cli_calls.append(list(args))
+        return command_result()
+
+    monkeypatch.setattr(sbx_module, "_stage_file", slow_stage)
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    writing = asyncio.create_task(
+        backend.write_file(sandbox, "/input.bin", b"sensitive")
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        writing.cancel()
+        await asyncio.sleep(0)
+        assert not writing.done()
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(writing, 5)
+    assert not staged.exists()
+    assert cli_calls == []
 
 
 @pytest.mark.parametrize("path", ["relative", "/tmp/../secret", "/tmp/bad\0path"])

--- a/src/integrations/prefect-sandbox/tests/test_sbx.py
+++ b/src/integrations/prefect-sandbox/tests/test_sbx.py
@@ -1,0 +1,499 @@
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from prefect_sandbox import (
+    SandboxCreationError,
+    SandboxError,
+    SandboxExecutionError,
+    SandboxFileWriter,
+    SandboxHandle,
+    SandboxHandleError,
+    SandboxUnavailableError,
+    SbxSandbox,
+)
+from prefect_sandbox.sbx import _CommandResult
+
+
+@pytest.fixture
+def backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SbxSandbox:
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    monkeypatch.setattr(SbxSandbox, "_check_binary", lambda self: None)
+    return SbxSandbox()
+
+
+def activate(
+    backend: SbxSandbox, sandbox_id: str = "prefect-sandbox-test"
+) -> SandboxHandle:
+    workspace = Path(tempfile.gettempdir()) / f"prefect-sandbox-{sandbox_id}"
+    workspace.mkdir()
+    backend._sandboxes[sandbox_id] = workspace
+    return SandboxHandle(sandbox_id)
+
+
+def command_result(
+    exit_code: int = 0,
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    truncated: bool = False,
+) -> _CommandResult:
+    return _CommandResult(exit_code, stdout, stderr, truncated)
+
+
+def test_sbx_exposes_file_writer_capability() -> None:
+    assert isinstance(SbxSandbox(), SandboxFileWriter)
+
+
+async def test_missing_binary_fails_before_creating_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    monkeypatch.setattr("prefect_sandbox.sbx.shutil.which", lambda _: None)
+
+    with pytest.raises(SandboxUnavailableError, match="not found"):
+        await SbxSandbox().create()
+
+    assert list(tmp_path.iterdir()) == []
+
+
+async def test_create_uses_an_empty_workspace_and_provider_options(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        calls.append(list(args))
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    backend.image = "python:3.13-slim"
+    backend.memory = "4g"
+    backend.cpus = 2
+
+    handle = await backend.create()
+    workspace = backend._sandboxes[handle.id]
+
+    assert workspace is not None
+    assert workspace.is_dir()
+    assert list(workspace.iterdir()) == []
+    assert calls == [
+        [
+            "create",
+            "--quiet",
+            "--name",
+            handle.id,
+            "--memory",
+            "4g",
+            "--cpus",
+            "2",
+            "--template",
+            "python:3.13-slim",
+            "shell",
+            str(workspace),
+        ]
+    ]
+
+
+async def test_failed_create_removes_provider_and_workspace(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+    workspace: Path | None = None
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        nonlocal workspace
+        calls.append(list(args))
+        if args[0] == "create":
+            workspace = Path(args[-1])
+            return command_result(1, stderr=b"provisioning failed")
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    with pytest.raises(SandboxCreationError, match="provisioning failed"):
+        await backend.create()
+
+    assert workspace is not None
+    assert not workspace.exists()
+    assert [call[0] for call in calls] == ["create", "rm"]
+
+
+async def test_create_timeout_is_typed_and_cleaned_up(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace: Path | None = None
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        nonlocal workspace
+        if args[0] == "create":
+            workspace = Path(args[-1])
+            raise asyncio.TimeoutError
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    with pytest.raises(SandboxCreationError, match="exceeded"):
+        await backend.create()
+
+    assert workspace is not None
+    assert not workspace.exists()
+
+
+async def test_create_surfaces_cleanup_failure(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox_id: str | None = None
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        nonlocal sandbox_id
+        if args[0] == "create":
+            sandbox_id = args[3]
+            return command_result(1, stderr=b"create failed")
+        if args[0] == "rm":
+            return command_result(1, stderr=b"remove failed")
+        return command_result(stdout=f"{sandbox_id}\n".encode())
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    with pytest.raises(SandboxCreationError, match="cleanup could not be confirmed"):
+        await backend.create()
+
+
+async def test_exec_preserves_argv_and_forwards_only_explicit_environment(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    calls: list[list[str]] = []
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        calls.append(list(args))
+        return command_result(7, b"out", b"err")
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    monkeypatch.setenv("PREFECT_API_KEY", "host-secret")
+
+    result = await backend.exec(
+        sandbox,
+        ["python", "-c", "print('argument with spaces')"],
+        env={"EXPLICIT": "yes"},
+        timeout=12,
+        max_output_bytes=123,
+    )
+
+    assert calls == [
+        [
+            "exec",
+            "--env",
+            "EXPLICIT=yes",
+            sandbox.id,
+            "python",
+            "-c",
+            "print('argument with spaces')",
+        ]
+    ]
+    assert "host-secret" not in " ".join(calls[0])
+    assert result.exit_code == 7
+    assert result.stdout == b"out"
+    assert result.stderr == b"err"
+
+
+@pytest.mark.parametrize(
+    ("command", "env", "timeout", "max_output_bytes", "error", "message"),
+    [
+        ("echo hi", None, None, 1, TypeError, "argv sequence"),
+        ([], None, None, 1, ValueError, "must not be empty"),
+        (["echo", 1], None, None, 1, TypeError, "must be a string"),
+        (
+            ["echo"],
+            {"BAD=NAME": "value"},
+            None,
+            1,
+            ValueError,
+            "invalid environment",
+        ),
+        (["echo"], {"NAME": 1}, None, 1, TypeError, "must be a string"),
+        (["echo"], None, 0, 1, ValueError, "positive, finite"),
+        (["echo"], None, float("inf"), 1, ValueError, "positive, finite"),
+        (["echo"], None, None, 0, ValueError, "positive integer"),
+    ],
+)
+async def test_exec_validates_portable_arguments(
+    backend: SbxSandbox,
+    command,
+    env,
+    timeout,
+    max_output_bytes,
+    error,
+    message,
+) -> None:
+    sandbox = activate(backend)
+
+    with pytest.raises(error, match=message):
+        await backend.exec(
+            sandbox,
+            command,
+            env=env,
+            timeout=timeout,
+            max_output_bytes=max_output_bytes,
+        )
+
+
+async def test_exec_rejects_unknown_and_destroyed_handles(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    with pytest.raises(SandboxHandleError, match="not created"):
+        await backend.exec(SandboxHandle("forged"), ["true"])
+
+    sandbox = activate(backend)
+    await backend.destroy(sandbox)
+    with pytest.raises(SandboxHandleError, match="destroyed"):
+        await backend.exec(sandbox, ["true"])
+
+
+async def test_exec_timeout_destroys_sandbox_and_returns_distinct_status(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        if args[0] == "exec":
+            raise asyncio.TimeoutError
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    result = await backend.exec(sandbox, ["sleep", "60"], timeout=0.1)
+
+    assert result.timed_out
+    assert result.exit_code == -1
+    assert not result.ok
+    assert backend._sandboxes[sandbox.id] is None
+
+
+async def test_exec_timeout_surfaces_destroy_failure(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        if args[0] == "exec":
+            raise asyncio.TimeoutError
+        if args[0] == "rm":
+            return command_result(1, stderr=b"remove failed")
+        return command_result(stdout=f"{sandbox.id}\n".encode())
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    with pytest.raises(SandboxExecutionError, match="could not be confirmed"):
+        await backend.exec(sandbox, ["sleep", "60"], timeout=0.1)
+
+
+async def test_cancelling_exec_destroys_sandbox(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    started = asyncio.Event()
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        if args[0] == "exec":
+            started.set()
+            await asyncio.Event().wait()
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    task = asyncio.create_task(backend.exec(sandbox, ["sleep", "60"]))
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert backend._sandboxes[sandbox.id] is None
+
+
+async def test_exec_strips_provider_autostart_notice(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        return command_result(
+            stderr=f"Sandbox {sandbox.id} started successfully\ncommand warning\n".encode()
+        )
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    result = await backend.exec(sandbox, ["true"])
+
+    assert result.stderr == b"command warning\n"
+
+
+async def test_destroy_is_idempotent(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    calls: list[list[str]] = []
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        calls.append(list(args))
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    await backend.destroy(sandbox)
+    await backend.destroy(sandbox)
+
+    assert [call[0] for call in calls] == ["rm"]
+    assert backend._sandboxes[sandbox.id] is None
+
+
+async def test_concurrent_destroy_calls_share_cleanup(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    remove_calls = 0
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        nonlocal remove_calls
+        if args[0] == "rm":
+            remove_calls += 1
+            started.set()
+            await finish.wait()
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    first = asyncio.create_task(backend.destroy(sandbox))
+    await started.wait()
+    second = asyncio.create_task(backend.destroy(sandbox))
+    finish.set()
+    await asyncio.gather(first, second)
+
+    assert remove_calls == 1
+
+
+async def test_cancelled_destroy_finishes_cleanup_before_cancellation(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        if args[0] == "rm":
+            started.set()
+            await finish.wait()
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+    task = asyncio.create_task(backend.destroy(sandbox))
+    await started.wait()
+    task.cancel()
+
+    await asyncio.sleep(0)
+    assert not task.done()
+    finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert backend._sandboxes[sandbox.id] is None
+    assert sandbox.id not in backend._destroy_tasks
+
+
+async def test_destroy_accepts_provider_already_absent(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        if args[0] == "rm":
+            return command_result(1, stderr=b"not found")
+        return command_result(stdout=b"another-sandbox\n")
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    await backend.destroy(sandbox)
+
+    assert backend._sandboxes[sandbox.id] is None
+
+
+async def test_destroy_failure_keeps_handle_retryable(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    workspace = backend._sandboxes[sandbox.id]
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        if args[0] == "rm":
+            return command_result(1, stderr=b"remove failed")
+        return command_result(stdout=f"{sandbox.id}\n".encode())
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    with pytest.raises(SandboxError, match="may still be running"):
+        await backend.destroy(sandbox)
+
+    assert backend._sandboxes[sandbox.id] == workspace
+    assert workspace is not None and not workspace.exists()
+
+
+async def test_write_file_uses_native_copy_and_removes_staging_file(
+    backend: SbxSandbox, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sandbox = activate(backend)
+    calls: list[list[str]] = []
+    staged_path: Path | None = None
+
+    async def run_cli(self, args, *, timeout, max_output_bytes):
+        nonlocal staged_path
+        calls.append(list(args))
+        if args[0] == "cp":
+            staged_path = Path(args[1])
+            assert staged_path.read_bytes() == b"binary\0payload"
+        return command_result()
+
+    monkeypatch.setattr(SbxSandbox, "_run_cli", run_cli)
+
+    await backend.write_file(sandbox, "/tmp/data/input.bin", b"binary\0payload")
+
+    assert calls[0] == ["exec", sandbox.id, "mkdir", "-p", "/tmp/data"]
+    assert calls[1][0] == "cp"
+    assert calls[1][2] == f"{sandbox.id}:/tmp/data/input.bin"
+    assert staged_path is not None and not staged_path.exists()
+
+
+@pytest.mark.parametrize("path", ["relative", "/tmp/../secret", "/tmp/bad\0path"])
+async def test_write_file_rejects_unsafe_paths(backend: SbxSandbox, path: str) -> None:
+    sandbox = activate(backend)
+
+    with pytest.raises(ValueError):
+        await backend.write_file(sandbox, path, b"content")
+
+
+async def test_cli_runner_bounds_each_stream_while_draining() -> None:
+    backend = SbxSandbox(sbx_path=sys.executable)
+    script = "import sys; sys.stdout.write('abcdef'); sys.stderr.write('uvwxyz')"
+
+    result = await backend._run_cli(["-c", script], timeout=5, max_output_bytes=4)
+
+    assert result.stdout == b"abcd"
+    assert result.stderr == b"uvwx"
+    assert result.truncated
+
+
+async def test_cli_runner_kills_timed_out_process() -> None:
+    backend = SbxSandbox(sbx_path=sys.executable)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await backend._run_cli(
+            ["-c", "import time; time.sleep(10)"],
+            timeout=0.05,
+            max_output_bytes=100,
+        )

--- a/src/integrations/prefect-sandbox/tests/test_version.py
+++ b/src/integrations/prefect-sandbox/tests/test_version.py
@@ -1,0 +1,9 @@
+from packaging.version import Version
+
+
+def test_version() -> None:
+    from prefect_sandbox import __version__
+
+    assert isinstance(__version__, str)
+    assert Version(__version__)
+    assert __version__.startswith("0.")


### PR DESCRIPTION
## Summary

Add an experimental `prefect-sandbox` integration with a deliberately small,
provider-neutral lifecycle boundary and one initial adapter for Docker Sandboxes
through the `sbx` CLI.

This is the focused replacement for the closed design prototype in #22637. It
does not introduce a Prefect execution concept such as a task runner, worker,
work pool, durable run, or prebuilt task.

Closes #22636.

## What changed

- define async `SandboxBackend.create`, `exec`, and idempotent `destroy` methods;
- add immutable, process-local `SandboxHandle` references and bounded
  `SandboxResult` values;
- expose file writing as the optional `SandboxFileWriter` capability;
- add a cancellation-safe `sandbox_session` lifecycle helper;
- implement `SbxSandbox` using argv-safe `sbx` subprocess calls;
- add contract, provider, block-standard, and package-version tests;
- document installation, host network-policy ownership, credential boundaries,
  process-crash orphan handling, and one end-to-end example.

## Deliberately deferred

- tasks, decorators, workers, work pools, and task runners;
- durable or serialized sandbox handles;
- sync wrappers and cross-event-loop orchestration;
- Islo or any second provider;
- library-managed network policy and provider orphan sweepers.

Those decisions can be evaluated independently after the adapter boundary is
accepted.

## Safety properties and boundaries

- guest commands receive only explicitly supplied environment variables in
  addition to image/runtime defaults;
- the only caller-controlled host data directory given to `sbx` is a newly
  created empty workspace;
- commands are argv sequences and never interpolated through a guest shell;
- stdout and stderr are drained separately with bounded retention;
- timeout and cancellation paths finish sandbox destruction before returning;
- cancellation during host workspace creation or file staging joins the blocking
  operation and removes the resulting temporary data before returning;
- handles are process-local backend references, not authenticated capabilities;
- a backend instance and its handles are supported on one event loop only;
- host-wide Docker Sandboxes network policy and runtime-managed credentials remain
  deployment-owned;
- a process or host crash can still orphan provider resources because durable
  identity and sweeping are intentionally deferred.

## Validation

- Python 3.10: 50 passed;
- Python 3.12: 50 passed;
- Python 3.14: 49 passed, 1 expected Pillow-related skip;
- Ruff formatting and lint checks;
- repository pre-commit checks on all changed files;
- mypy;
- 92% measured source coverage;
- 97.6% documentation coverage;
- wheel and source-distribution builds plus `twine check`;
- wheel import smoke test with published Prefect 3.7.8 on Python 3.10;
- real `sbx` v0.37.1 lifecycle covering create, argv preservation (including
  option-looking values), explicit environment isolation, byte-exact native file
  copy, nonzero exits, timeout destruction, idempotent session cleanup, mount
  inspection, and zero leftover sandboxes or host workspaces.

AI assistance was used to draft and review portions of the implementation. The
contributor reviewed the full diff and ran the checks above locally.

### Checklist

- [x] This pull request references its related issue with `Closes #22636`.
- [ ] A maintainer has confirmed the proposed approach on the linked issue. This
  remains a draft pending that confirmation.
- [x] Functionality includes focused tests.
- [x] User-facing behavior includes installation, example, and security
  documentation.
- [x] New public functions and classes include docstrings.
