### PR TITLE
fix: cap tag related resources to event maximum

### DIFF
--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -31,14 +31,24 @@ MAX_CACHE_SIZE = 100
 RESOURCE_CACHE: RelatedResourceCache = {}
 
 
-def tags_as_related_resources(tags: Iterable[str]) -> List[RelatedResource]:
+def tags_as_related_resources(
+    tags: Iterable[str], reserved: int = 0
+) -> List[RelatedResource]:
+    """Represent `tags` as related resources, truncated to fit the event limit.
+
+    Events enforce a hard maximum on related resources, so deployments carrying more
+    tags than an event can represent would otherwise fail validation (#19064).
+
+    Args:
+        tags: the tags to represent.
+        reserved: how many related-resource slots the caller has already used for
+            non-tag resources. Tags are truncated to whatever is left, so an event
+            stays under the maximum without discarding tags that would have fit.
+    """
     from prefect.settings.context import get_current_settings
 
-    # Events enforce a hard maximum on related resources; truncate tags so
-    # deployments with many tags do not fail event validation (#19064).
     max_related = get_current_settings().server.events.maximum_related_resources
-    # Leave headroom for non-tag related resources attached by callers.
-    max_tags = max(0, max_related - 10)
+    max_tags = max(0, max_related - reserved)
     tags_to_include = sorted(tags)[:max_tags]
     return [
         RelatedResource(
@@ -191,7 +201,7 @@ async def related_resources_from_run_context(
 
     related += [
         resource
-        for resource in tags_as_related_resources(tags)
+        for resource in tags_as_related_resources(tags, reserved=len(related))
         if resource.id not in exclude
     ]
 

--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -32,6 +32,14 @@ RESOURCE_CACHE: RelatedResourceCache = {}
 
 
 def tags_as_related_resources(tags: Iterable[str]) -> List[RelatedResource]:
+    from prefect.settings.context import get_current_settings
+
+    # Events enforce a hard maximum on related resources; truncate tags so
+    # deployments with many tags do not fail event validation (#19064).
+    max_related = get_current_settings().server.events.maximum_related_resources
+    # Leave headroom for non-tag related resources attached by callers.
+    max_tags = max(0, max_related - 10)
+    tags_to_include = sorted(tags)[:max_tags]
     return [
         RelatedResource(
             {
@@ -39,7 +47,7 @@ def tags_as_related_resources(tags: Iterable[str]) -> List[RelatedResource]:
                 "prefect.resource.role": "tag",
             }
         )
-        for tag in sorted(tags)
+        for tag in tags_to_include
     ]
 
 

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -494,7 +494,7 @@ class BaseFlowRunEngine(Generic[P, R]):
                 )
             )
 
-        related += tags_as_related_resources(set(tags))
+        related += tags_as_related_resources(set(tags), reserved=len(related))
 
         return resource, related
 

--- a/src/prefect/runner/_event_emitter.py
+++ b/src/prefect/runner/_event_emitter.py
@@ -176,7 +176,7 @@ class EventEmitter:
         tags.extend(flow_run.tags)
 
         related = [RelatedResource.model_validate(r) for r in related]
-        related += tags_as_related_resources(set(tags))
+        related += tags_as_related_resources(set(tags), reserved=len(related))
 
         assert self._events_client is not None, (
             "EventEmitter must be used as an async context manager before emitting events"

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -195,6 +195,8 @@ def _resource_data_as_related_resources(
     resource_data: ResourceData,
     excluded_kinds: Optional[List[str]] = None,
 ) -> RelatedResourceList:
+    from prefect.settings.context import get_current_settings
+
     related = []
     tags: Set[str] = set()
 
@@ -218,12 +220,19 @@ def _resource_data_as_related_resources(
 
         related.append(related_resource)
 
+    # Cap tag-related resources so events stay under the maximum related-resource
+    # limit (deployments may carry more tags than events can represent). Reserve
+    # one slot for a provenance resource the caller may append. See #19064.
+    max_related = get_current_settings().server.events.maximum_related_resources
+    max_tags = max(0, max_related - len(related) - 1)
+    tags_to_include = sorted(tags)[:max_tags]
+
     related += [
         {
             "prefect.resource.id": f"prefect.tag.{tag}",
             "prefect.resource.role": "tag",
         }
-        for tag in sorted(tags)
+        for tag in tags_to_include
     ]
 
     return related

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -539,7 +539,7 @@ class BaseJobConfiguration(BaseModel):
                 tags.update(obj.tags)
             related.append(object_as_related_resource(kind=kind, role=kind, object=obj))
 
-        return related + tags_as_related_resources(tags)
+        return related + tags_as_related_resources(tags, reserved=len(related))
 
 
 class BaseVariables(BaseModel):

--- a/tests/events/client/test_events_related_from_context.py
+++ b/tests/events/client/test_events_related_from_context.py
@@ -244,9 +244,7 @@ def test_tags_as_related_resources_keeps_every_tag_that_fits():
     tags; truncating below that silently drops tag relationships, so automations
     matching a dropped tag stop seeing the event.
     """
-    maximum = (
-        get_current_settings().server.events.maximum_related_resources
-    )
+    maximum = get_current_settings().server.events.maximum_related_resources
     tags = [f"tag-{i:04d}" for i in range(maximum + 5)]
 
     resources = tags_as_related_resources(tags)
@@ -257,9 +255,7 @@ def test_tags_as_related_resources_keeps_every_tag_that_fits():
 
 def test_tags_as_related_resources_reserves_for_the_caller():
     """`reserved` accounts for related resources the caller has already composed."""
-    maximum = (
-        get_current_settings().server.events.maximum_related_resources
-    )
+    maximum = get_current_settings().server.events.maximum_related_resources
     tags = [f"tag-{i:04d}" for i in range(maximum + 5)]
 
     resources = tags_as_related_resources(tags, reserved=3)
@@ -268,9 +264,7 @@ def test_tags_as_related_resources_reserves_for_the_caller():
 
 
 def test_tags_as_related_resources_reserved_beyond_maximum_yields_nothing():
-    maximum = (
-        get_current_settings().server.events.maximum_related_resources
-    )
+    maximum = get_current_settings().server.events.maximum_related_resources
 
     assert tags_as_related_resources(["a", "b"], reserved=maximum) == []
     assert tags_as_related_resources(["a", "b"], reserved=maximum + 10) == []

--- a/tests/events/client/test_events_related_from_context.py
+++ b/tests/events/client/test_events_related_from_context.py
@@ -11,7 +11,9 @@ from prefect.events.related import (
     MAX_CACHE_SIZE,
     _get_and_cache_related_object,
     related_resources_from_run_context,
+    tags_as_related_resources,
 )
+from prefect.settings.context import get_current_settings
 from prefect.states import Running
 
 
@@ -233,3 +235,42 @@ async def test_lru_cache_timestamp_updated():
     _, next_timestamp = cache["flow-run.👴"]
 
     assert next_timestamp > timestamp
+
+
+def test_tags_as_related_resources_keeps_every_tag_that_fits():
+    """The public helper must not reserve slots the caller isn't using.
+
+    A caller with no other related resources can carry up to the configured maximum in
+    tags; truncating below that silently drops tag relationships, so automations
+    matching a dropped tag stop seeing the event.
+    """
+    maximum = (
+        get_current_settings().server.events.maximum_related_resources
+    )
+    tags = [f"tag-{i:04d}" for i in range(maximum + 5)]
+
+    resources = tags_as_related_resources(tags)
+
+    assert len(resources) == maximum
+    assert resources[0].id == "prefect.tag.tag-0000"
+
+
+def test_tags_as_related_resources_reserves_for_the_caller():
+    """`reserved` accounts for related resources the caller has already composed."""
+    maximum = (
+        get_current_settings().server.events.maximum_related_resources
+    )
+    tags = [f"tag-{i:04d}" for i in range(maximum + 5)]
+
+    resources = tags_as_related_resources(tags, reserved=3)
+
+    assert len(resources) == maximum - 3
+
+
+def test_tags_as_related_resources_reserved_beyond_maximum_yields_nothing():
+    maximum = (
+        get_current_settings().server.events.maximum_related_resources
+    )
+
+    assert tags_as_related_resources(["a", "b"], reserved=maximum) == []
+    assert tags_as_related_resources(["a", "b"], reserved=maximum + 10) == []

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -1297,6 +1297,38 @@ class TestScheduledRuns:
             assert scheduled_run.auto_scheduled is True
             assert "auto-scheduled" in scheduled_run.tags
 
+    async def test_deployment_with_many_tags_does_not_fail_on_flow_run_creation(
+        self, flow, session
+    ):
+        """Deployments with >100 tags must not blow the event related-resource limit.
+
+        Regression for #19064: each tag becomes a related resource on flow-run
+        state-change events, which cap related resources at 100.
+        """
+        tags = [f"tag-{i:03d}" for i in range(101)]
+        deployment = await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name="deployment-with-many-tags",
+                flow_id=flow.id,
+                tags=tags,
+            ),
+        )
+        await session.commit()
+
+        flow_run = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id,
+                deployment_id=deployment.id,
+                tags=tags,
+            ),
+        )
+        await session.commit()
+
+        assert flow_run.id is not None
+        assert len(flow_run.tags) == 101
+
 
 class TestUpdateDeployment:
     async def test_updating_deployment_creates_associated_work_queue(


### PR DESCRIPTION
## Summary

Fixes #19064

Deployments can store more than 100 tags, but flow-run state-change events
convert each tag into a related resource and enforce
`server.events.maximum_related_resources` (default 100). That caused
runtime validation failures for otherwise-valid deployments.

## Fix

- Truncate tag-related resources in `_resource_data_as_related_resources`,
  reserving one slot for provenance
- Apply the same cap in client-side `tags_as_related_resources`
- Tags remain fully stored on deployments/flow runs; only event embedding
  is capped

## Test plan

- [x] Added regression test creating a deployment/flow run with 101 tags

Made with [Cursor](https://cursor.com)