### PR TITLE
fix: record state for task runs with no state timestamp

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -378,8 +378,11 @@ async def _record_bulk_task_run_events(events: list[ReceivedEvent]) -> None:
                         if col.name in (update_cols | {"updated"}) - {"id"}
                     },
                 },
-                where=db.TaskRun.state_timestamp
-                < insert_statement.excluded.state_timestamp,
+                where=sa.or_(
+                    db.TaskRun.state_timestamp.is_(None),
+                    db.TaskRun.state_timestamp
+                    < insert_statement.excluded.state_timestamp,
+                ),
             )
             await session.execute(upsert_statement)
 

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -18,8 +18,9 @@ from prefect.server.models.task_run_states import (
     read_task_run_state,
     read_task_run_states,
 )
-from prefect.server.models.task_runs import read_task_run
+from prefect.server.models.task_runs import create_task_run, read_task_run
 from prefect.server.schemas.core import FlowRun, TaskRunPolicy
+from prefect.server.schemas.core import TaskRun as CoreTaskRun
 from prefect.server.schemas.states import StateDetails, StateType
 from prefect.server.services import task_run_recorder
 from prefect.server.utilities.messaging import MessageHandler, create_publisher
@@ -1806,9 +1807,6 @@ async def test_records_state_for_task_run_without_a_state_timestamp(
     `state_timestamp` to compare against, and in SQL that comparison is never
     true, so every state it is subsequently sent would be discarded.
     """
-    from prefect.server.models.task_runs import create_task_run
-    from prefect.server.schemas.core import TaskRun as CoreTaskRun
-
     task_run_id = uuid4()
     await create_task_run(
         session=session,

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1793,3 +1793,52 @@ async def test_bulk_upsert_raises_after_max_retries_on_integrity_error(
         await task_run_recorder.record_bulk_task_run_events([event])
 
     assert call_count == 2
+
+
+async def test_records_state_for_task_run_without_a_state_timestamp(
+    session: AsyncSession,
+    flow_run,
+):
+    """A task run that has no state yet must still accept the one it is sent.
+
+    The upsert only overwrites a task run whose recorded state is older than the
+    incoming one. A task run created before any state was recorded has no
+    `state_timestamp` to compare against, and in SQL that comparison is never
+    true, so every state it is subsequently sent would be discarded.
+    """
+    from prefect.server.models.task_runs import create_task_run
+    from prefect.server.schemas.core import TaskRun as CoreTaskRun
+
+    task_run_id = uuid4()
+    await create_task_run(
+        session=session,
+        task_run=CoreTaskRun(
+            id=task_run_id,
+            flow_run_id=flow_run.id,
+            task_key="task-run-without-a-state",
+            dynamic_key="1",
+        ),
+    )
+    await session.commit()
+
+    task_run = await read_task_run(session=session, task_run_id=str(task_run_id))
+    assert task_run is not None
+    assert task_run.state_timestamp is None
+
+    await task_run_recorder.record_bulk_task_run_events(
+        [
+            make_event_with_flow_run(
+                task_run_id=str(task_run_id),
+                flow_run_id=str(flow_run.id),
+                task_key="task-run-without-a-state",
+                dynamic_key="1",
+                state_ts=datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                state_type=StateType.COMPLETED,
+            )
+        ]
+    )
+
+    session.expire_all()
+    task_run = await read_task_run(session=session, task_run_id=str(task_run_id))
+    assert task_run is not None
+    assert task_run.state_type == StateType.COMPLETED


### PR DESCRIPTION
### Problem

`TaskRunRecorder` only advances a task run when the incoming state is newer than the one already stored:

```python
where=db.TaskRun.state_timestamp < insert_statement.excluded.state_timestamp
```

A task run that has never had a state recorded has a `NULL` `state_timestamp`, and in SQL `NULL < x` evaluates to `NULL` rather than `TRUE`. The `ON CONFLICT ... DO UPDATE` therefore never fires for those rows, so every state the recorder subsequently receives for them is discarded. The task run stays in the database without a state indefinitely — missing from state-filtered queries in the UI and API even though it ran.

This is reachable whenever a task run row is created before any state has been recorded for it, for example through `create_task_run` without a state.

### Fix

Treat an absent `state_timestamp` as older than any incoming state, so the first state a task run receives is recorded while later states still only move it forward.

### Reproduction

Against `main`, a task run created without a state never leaves that condition:

```
>>> existing state_timestamp: None
>>> after COMPLETED event, state_type: None (expected COMPLETED)
```

### Tests

Adds `test_records_state_for_task_run_without_a_state_timestamp`, which fails on `main` and passes with this change.

- `tests/server/services/test_task_run_recorder.py`: 36 passed
- `ruff check`: same 14 pre-existing findings before and after this change
- `ruff format --check`: clean
