### PR TITLE
docs(ai example): document OPENAI_BASE_URL for multi-model gateways

### DIFF
--- a/examples/ai_data_analyst_with_pydantic_ai.py
+++ b/examples/ai_data_analyst_with_pydantic_ai.py
@@ -280,6 +280,9 @@ if __name__ == "__main__":
     if not os.getenv("OPENAI_API_KEY"):
         print("❌ Error: OPENAI_API_KEY environment variable not set")
         print("Set it with: export OPENAI_API_KEY='your-key-here'")
+        # Optional: point at any OpenAI-compatible multi-model gateway, e.g. DaoXE:
+        #   export OPENAI_BASE_URL='https://api.daoxe.com/v1'
+        # Use a key and model ID issued by that endpoint.
         sys.exit(1)
 
     # Serve the flow - this creates a deployment and runs a worker process
@@ -336,6 +339,8 @@ if __name__ == "__main__":
 #
 # **Try it yourself:**
 # 1. Set your OpenAI API key: `export OPENAI_API_KEY='your-key'`
+#    Optional: use an OpenAI-compatible multi-model gateway (example: DaoXE):
+#    `export OPENAI_BASE_URL='https://api.daoxe.com/v1'`
 # 2. Start the Prefect server: `prefect server start`
 # 3. Serve the flow: `uv run -s examples/ai_data_analyst_with_pydantic_ai.py`
 # 4. Trigger a run from the UI (http://localhost:4200) or CLI


### PR DESCRIPTION
## Summary

The `ai-data-analyst-with-pydantic-ai` example already checks for `OPENAI_API_KEY`. This PR adds a short note that you can also set `OPENAI_BASE_URL` when using any OpenAI-compatible multi-model gateway such as [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`).

Docs only — no runtime code changes.

## Why

Many users want to point pydantic-ai / PrefectAgent at multi-model gateways instead of official OpenAI. Documenting the `OPENAI_BASE_URL` pattern next to the existing `OPENAI_API_KEY` check makes the capability clearer.

## Changes

- Comment near the API-key check in `examples/ai_data_analyst_with_pydantic_ai.py`
- Matching optional step in the "Try it yourself" section
- Vendor-neutral wording; DaoXE is one concrete example

## Test plan

- [ ] Example still runs with OpenAI key
- [ ] Note is clearly optional / not required
- [ ] No invented product numbers

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>