### PR TITLE
Document how `follows` establishes event ordering for automation triggers

### DIFF
--- a/docs/v3/advanced/use-custom-event-grammar.mdx
+++ b/docs/v3/advanced/use-custom-event-grammar.mdx
@@ -70,24 +70,39 @@ Similarly, the `for_each` field accepts a `set` of resource ids.
 To simulate users causing order status events, run the following in a Python shell or script:
 
 ```python simulate_events.py
-import time
 from prefect.events import emit_event
 
 user_id_1, user_id_2 = "123", "456"
-for event_name, user_id in [
-    ("order.created", user_id_1),
-    ("order.created", user_id_2), # other user
-    ("order.complete", user_id_1),
-]:
-    event = emit_event(
-        event=event_name,
-        resource={"prefect.resource.id": user_id},
-    )
-    time.sleep(1)
-    print(f"{user_id} emitted {event_name}")
+
+order_created_1 = emit_event(
+    event="order.created",
+    resource={"prefect.resource.id": user_id_1},
+)
+emit_event(
+    event="order.created",
+    resource={"prefect.resource.id": user_id_2},  # other user
+)
+emit_event(
+    event="order.complete",
+    resource={"prefect.resource.id": user_id_1},
+    follows=order_created_1,
+)
 ```
 
 In the above example:
 
 - `user_id_1` creates and then completes an order, triggering a run of our deployment.
 - `user_id_2` creates an order, but no completed event is emitted so no deployment is triggered.
+
+<Warning>
+**Declare `follows` for events emitted close together**
+
+Because the trigger uses `order.created` in `after` and `order.complete` in `expect`, it only
+counts an `order.complete` event that arrives *after* an `order.created` event. Events
+emitted within a second or two of each other may arrive at the system in either order unless
+the later event declares [`follows`](/v3/concepts/events#event-ordering)—which is why the
+`order.complete` emission above passes `follows=order_created_1`. In a real system where
+minutes pass between creating and completing an order, `follows` isn't strictly needed,
+though it still documents the relationship between the events (note that `emit_event`
+only sets it when the two events occur within five minutes of each other).
+</Warning>

--- a/docs/v3/concepts/event-triggers.mdx
+++ b/docs/v3/concepts/event-triggers.mdx
@@ -375,6 +375,30 @@ started this trigger with its `prefect.flow-run.Running` event could satisfy the
 }
 ```
 
+### Event ordering and `after`
+
+A trigger with an `after` clause starts watching for its `expect` events only once one of
+its `after` events has arrived. An `expect` event that arrives at the system before the
+trigger's `after` event does not count, even when the two events were emitted in the
+correct order. For a Reactive trigger this can mean a missed firing; for a Proactive
+trigger it can mean a spurious one.
+
+Prefect does not guarantee the order that unrelated events arrive at the system: events
+that occur within a second or two of each other may arrive in either order. When your
+code emits the `expect` event immediately after the `after` event—for example, from a
+[state change hook](/v3/how-to-guides/workflows/state-change-hooks#emit-events-from-state-change-hooks)
+or right after emitting the first event—declare the relationship with
+[`follows`](/v3/concepts/events#event-ordering) on the later event.
+
+Triggers hold an event that declares `follows` until the event it follows has arrived, so
+the pair is always processed in order and the race disappears. If the followed event
+never arrives, the held event is processed on its own after several minutes—a lost
+predecessor delays the follower rather than losing it.
+
+Events that are naturally separated by more time—like an `order.created` and an
+`order.complete` minutes apart—don't strictly need `follows`, but it can still be good
+practice to set it to document the relationship between the events.
+
 ### Metric triggers
 
 Metric triggers (`{"type": "metric"}`) fire when the value of a metric in your workspace crosses a threshold you defined.

--- a/docs/v3/concepts/events.mdx
+++ b/docs/v3/concepts/events.mdx
@@ -29,7 +29,7 @@ Events adhere to a structured [specification](https://app.prefect.cloud/api/docs
 | related  | Array  | no        | List of additional Resources involved in this event                |
 | payload  | Object | no        | Open-ended set of data describing what happened                   |
 | id       | String | yes       | Client-provided identifier of this event                         |
-| follows  | String | no        | ID of an event that is known to have occurred prior to this one |
+| follows  | String | no        | ID of an event that is known to have occurred prior to this one. See [Event ordering](#event-ordering). |
 
 ## Event grammar
 
@@ -88,6 +88,27 @@ Here is an example of a related resource:
   }
 ]
 ```
+
+## Event ordering
+
+Events arrive from many independent sources—your code, workers, and Prefect itself—so
+Prefect cannot infer the order of two events from their arrival alone. The `follows` field
+declares that order: set it on the later event, referencing the `id` of the earlier one,
+to establish that this event is known to have occurred after the other. The system uses
+this relationship to disambiguate the ordering of events that occur within a second or
+two of each other.
+
+Declare `follows` only between events in the same causal chain, where you know the earlier
+event occurred first—for example, a custom event describing how a flow run state change
+was handled. [`emit_event`](/v3/api-ref/python/prefect-events-utilities) sets the
+relationship when the two events occurred within five minutes of each other.
+
+Ordering matters most to [automation triggers](/v3/concepts/event-triggers/) whose `after`
+and `expect` clauses depend on seeing one event before another. See
+[event ordering and `after`](/v3/concepts/event-triggers#event-ordering-and-after) for how
+triggers use this relationship, and
+[emit events from state change hooks](/v3/how-to-guides/workflows/state-change-hooks#emit-events-from-state-change-hooks)
+for the most common way to declare it.
 
 ## Respond to events
 

--- a/docs/v3/how-to-guides/workflows/state-change-hooks.mdx
+++ b/docs/v3/how-to-guides/workflows/state-change-hooks.mdx
@@ -129,6 +129,54 @@ def failing_flow():
 For more information on logging options, see [How to add logging](/v3/how-to-guides/workflows/add-logging).
 </Tip>
 
+### Emit events from state change hooks
+
+A common use of hooks is to emit a [custom event](/v3/advanced/use-custom-event-grammar)
+when a run reaches a state—for example, a failure event that other automations react to.
+Because the hook runs a fraction of a second after the state change, your custom event and
+Prefect's own state change event (like `prefect.flow-run.Failed`) occur within a second or
+two of each other, and Prefect does not guarantee the
+[order they arrive](/v3/concepts/events#event-ordering) at the automation system. If a
+trigger uses the state change event in `after` and your custom event in `expect`, that
+race can cause missed or spurious firings.
+
+To make the order deterministic, emit your event with `follows` referencing the state
+change event. The `state` argument your hook receives carries what you need: `state.id`
+is the ID of the state change event, and `state.timestamp` is when it occurred.
+
+```python
+from prefect import flow
+from prefect.events import emit_event
+from prefect.events.schemas.events import Event
+
+
+def emit_failure_event(flow, flow_run, state):
+    emit_event(
+        event="my-app.flow-run.failure-handled",
+        resource={"prefect.resource.id": f"prefect.flow-run.{flow_run.id}"},
+        follows=Event(
+            event="prefect.flow-run.Failed",
+            resource={"prefect.resource.id": f"prefect.flow-run.{flow_run.id}"},
+            id=state.id,
+            occurred=state.timestamp,
+        ),
+    )
+
+
+@flow(on_failure=[emit_failure_event])
+def failing_flow():
+    raise ValueError("oops!")
+```
+
+The `Event` passed to `follows` is a stub. `emit_event` reads only its `id` and `occurred`
+fields—to fill in the `follows` field of the emitted event and to check that the two
+events occurred within five minutes of each other. The stub is not emitted: Prefect
+already emitted the real `prefect.flow-run.Failed` event server-side, and the stub only
+identifies it.
+
+With `follows` declared, the automation system always processes your custom event after
+the state change event it follows.
+
 ### Pass `kwargs` to state change hooks
 
 You can compose the `with_options` method to effectively pass arbitrary `**kwargs` to your hooks:

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -53,7 +53,9 @@ def emit_event(
             establishes that this event is known to have occurred after the
             given event, which the system can use to disambiguate the
             ordering of the two events. Only the `id` and `occurred` of the
-            given event are used; it is not emitted again.
+            given event are used; it is not emitted again. If the preceding
+            event happened more than 5 minutes prior to this event the
+            follows relationship will not be set.
 
     Returns:
         The event that was emitted if worker is using a client that emit

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -49,9 +49,11 @@ def emit_event(
         payload: An open-ended set of data describing what happened.
         id: The sender-provided identifier for this event. Defaults to a random
             UUID.
-        follows: The event that preceded this one. If the preceding event
-            happened more than 5 minutes prior to this event the follows
-            relationship will not be set.
+        follows: The event that preceded this one. Setting `follows`
+            establishes that this event is known to have occurred after the
+            given event, which the system can use to disambiguate the
+            ordering of the two events. Only the `id` and `occurred` of the
+            given event are used; it is not emitted again.
 
     Returns:
         The event that was emitted if worker is using a client that emit


### PR DESCRIPTION
Events that occur within a second or two of each other can arrive at the system in either order. A trigger that uses one event in `after` and the other in `expect` can then miss a firing or fire spuriously. The docs described `follows` only as a field, and the custom event grammar guide taught the racy pattern without it. Related to #18838.

This change:

- Adds an "Event ordering" section to the events concept, in a declarative tone: `follows` establishes that one event is known to have occurred after another.
- Adds an "Event ordering and `after`" section to the event triggers concept with the mechanics: a follower is held until its leader arrives, and is processed on its own after several minutes if the leader is lost.
- Adds a state change hooks section showing how to emit an event that follows the state change event, using `state.id` and `state.timestamp` in a stub `Event` that is not emitted again.
- Updates the custom event grammar example to pass `follows`.
- Reframes the `emit_event` docstring for `follows` in the same declarative tone.

Two decisions a reviewer may wonder about: the docs say events "arrive at the system" in either order rather than distinguishing arrival from internal evaluation, and the five minute window stays on the docs pages but left the docstring.

<details>
<summary>Session context</summary>

This came out of a support case where a proactive automation with `after` and `expect` fired even though the expect event was emitted in the correct order; the events were consumed out of order and the cancellation was dropped. The sanctioned resolution is client-side `follows`, which was undocumented beyond a field listing. Doc claims were verified against the server code (state change event id equals state id; `follows` handling in trigger evaluation), and the changed pages' Python blocks pass `pytest --markdown-docs` against a live dev server.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)