### PR TITLE
fix(server): forced transitions cannot undo a flow run cancellation

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -272,6 +272,8 @@ class MinimalFlowPolicy(FlowRunOrchestrationPolicy):
     ]:
         return [
             PreventResultDataLoss,
+            EnforceCancellingToCancelledTransition,  # a forced crash report must not undo an in-progress cancellation
+            PreventCrashedOverCancelledTransition,  # ...nor a completed one
             BypassCancellingFlowRunsWithNoInfra,  # cancel scheduled or suspended runs from the UI
             InstrumentFlowRunStateTransitions,
             ReleaseFlowConcurrencySlots,
@@ -1913,6 +1915,12 @@ class PreventRunningTasksFromStoppedFlows(TaskRunOrchestrationRule):
 class EnforceCancellingToCancelledTransition(TaskRunOrchestrationRule):
     """
     Rejects transitions from Cancelling to any terminal state except for Cancelled.
+
+    Also part of `MinimalFlowPolicy`, so `force=True` transitions cannot undo an
+    in-progress cancellation: a SIGTERM'd flow engine's crash handler reports
+    `Crashed` with `force=True` (see `FlowRunEngine.handle_crash`), which would
+    otherwise overwrite the operator's cancellation and fire crash automations
+    for a run that was cleanly cancelled.
     """
 
     FROM_STATES = {StateType.CANCELLING}
@@ -1932,6 +1940,33 @@ class EnforceCancellingToCancelledTransition(TaskRunOrchestrationRule):
             ),
         )
         return
+
+
+class PreventCrashedOverCancelledTransition(FlowRunOrchestrationRule):
+    """
+    Rejects Cancelled -> Crashed, including under `force=True`.
+
+    A cancelled flow run's process can outlive the cancellation; when it
+    finally dies, the engine's crash handler force-reports `Crashed`
+    (see `FlowRunEngine.handle_crash`), overwriting the operator's clean
+    cancellation and firing crash automations for it. A crash report is the
+    only transition this blocks — Cancelled runs stay retryable
+    (Cancelled -> Scheduled, see #20271).
+    """
+
+    FROM_STATES = {StateType.CANCELLED}
+    TO_STATES = {StateType.CRASHED}
+
+    async def before_transition(
+        self,
+        initial_state: states.State[Any] | None,
+        proposed_state: states.State[Any] | None,
+        context: OrchestrationContext[orm_models.FlowRun, core.FlowRunPolicy],
+    ) -> None:
+        await self.reject_transition(
+            state=None,
+            reason="Cannot mark a cancelled flow run as crashed.",
+        )
 
 
 class BypassCancellingFlowRunsWithNoInfra(FlowRunOrchestrationRule):

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -36,6 +36,7 @@ from prefect.server.orchestration.core_policy import (
     HandleResumingPausedFlows,
     HandleTaskTerminalStateTransitions,
     PreserveDeploymentConcurrencyLeaseId,
+    PreventCrashedOverCancelledTransition,
     PreventDuplicateTransitions,
     PreventPendingTransitions,
     PreventResultDataLoss,
@@ -3531,6 +3532,64 @@ class TestHandleCancellingStateTransitions:
 
         # The rule should NOT reject transitions from CANCELLED state
         # because this rule is specifically for CANCELLING -> CANCELLED enforcement
+        assert ctx.response_status != SetStateStatus.REJECT
+
+
+class TestPreventCrashedOverCancelledTransition:
+    async def test_rejects_cancelled_to_crashed(
+        self,
+        session,
+        initialize_orchestration,
+    ):
+        """
+        A cancelled run's process can outlive the cancellation; its dying crash
+        handler force-reports Crashed, which must not overwrite the cancellation.
+        """
+        intended_transition = (states.StateType.CANCELLED, states.StateType.CRASHED)
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *intended_transition,
+        )
+
+        async with PreventCrashedOverCancelledTransition(
+            ctx, *intended_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.REJECT
+        assert ctx.validated_state_type == states.StateType.CANCELLED
+
+    @pytest.mark.parametrize(
+        "proposed_state_type",
+        sorted(
+            list(
+                set(ALL_ORCHESTRATION_STATES)
+                - {states.StateType.CRASHED, states.StateType.CANCELLED, None}
+            )
+        ),
+    )
+    async def test_does_not_block_other_transitions_from_cancelled(
+        self,
+        session,
+        initialize_orchestration,
+        proposed_state_type,
+    ):
+        """Cancelled runs stay retryable (see #20271) — only Crashed is blocked."""
+        intended_transition = (states.StateType.CANCELLED, proposed_state_type)
+
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *intended_transition,
+        )
+
+        async with PreventCrashedOverCancelledTransition(
+            ctx, *intended_transition
+        ) as ctx:
+            await ctx.validate_proposed_state()
+
         assert ctx.response_status != SetStateStatus.REJECT
 
 


### PR DESCRIPTION
### Overview

When an operator cancels a flow run whose process outlives the cancellation (slow SIGTERM handling, infra teardown lag), the dying engine's crash handler reports `Crashed` with `force=True` (`FlowRunEngine.handle_crash`). Forced transitions use `MinimalFlowPolicy`, which contains no cancellation guard — so the crash report overwrites the operator's `Cancelling`/`Cancelled` state, publishes `prefect.flow-run.Crashed`, and fires crash automations for a run that was cleanly cancelled.

### Deterministic end-to-end reproduction (stock `main`)

Real `prefect server start`, real engine process, real CLI cancel:

```python
# stubborn_flow.py — a process that outlives cancellation, then dies
import signal, time
from prefect import flow

@flow
def stubborn():
    signal.signal(signal.SIGTERM, signal.SIG_IGN)  # slow teardown
    time.sleep(15)                                 # operator cancels here
    raise KeyboardInterrupt("process finally dying after cancellation")

stubborn()
```

1. `prefect server start` (stock `main`), run the flow against it.
2. While RUNNING: `prefect flow-run cancel <id>` → server records `CANCELLING`.
3. Five seconds later the process dies; the engine force-reports `Crashed`.

State history on stock `main`:

```
16:04:45 PENDING → RUNNING
16:04:55 CANCELLING   ← operator cancel
16:05:00 CRASHED      ← engine's forced crash report overwrites the cancellation
```

Identical scenario against this branch's server:

```
16:05:44 PENDING → RUNNING
16:05:45 CANCELLING   ← operator cancel; the later forced Crashed is rejected
```

(The run remains `Cancelling` in this minimal no-worker harness — moving `Cancelling → Cancelled` is the worker/cancellation-cleanup's job and is unaffected: forced transitions **to** `Cancelled` pass through.)

A models-layer version of the same check: proposing `Crashed` with `force=True` on a `Cancelled` run returns `SetStateStatus.ACCEPT` on stock `main`.

### Design context from history

- `force=True` has never meant "bypass all rules": [`src/prefect/server/AGENTS.md`](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/server/AGENTS.md) documents that it routes through `MinimalFlowPolicy`, "not a true bypass."
- #21956 established the exact pattern this PR follows — adding an integrity guard (`PreventResultDataLoss`) to `MinimalFlowPolicy` so force cannot destroy committed state.
- #20275 removed `CANCELLED` from `EnforceCancellingToCancelledTransition`'s FROM_STATES to keep cancelled runs retryable (#20271); the narrow `Cancelled -> Crashed`-only rule here is designed to preserve that decision rather than re-widen the original rule.

### Changes

- Add `EnforceCancellingToCancelledTransition` to `MinimalFlowPolicy`, so `force=True` cannot move a run out of `Cancelling` to anything but `Cancelled`. (Unchanged in `CoreFlowPolicy`, where it already applies.)
- Add `PreventCrashedOverCancelledTransition` (`Cancelled -> Crashed` only, also in `MinimalFlowPolicy`) for the late-crash-report case. It deliberately blocks **only** `Crashed`, preserving `Cancelled -> Scheduled` retryability per #20271 (the existing regression test `test_does_not_block_cancelled_to_other_states` still passes).
- Cancellation cascades (forced transitions **to** `Cancelled`) are unaffected.

### Tests

- New `TestPreventCrashedOverCancelledTransition`: rejects `Cancelled -> Crashed`; parametrized check that every other from-`Cancelled` transition is untouched.
- `tests/server/orchestration/test_core_policy.py` and `tests/server/models/test_flow_run_states.py`: 544 passed, 1 pre-existing skip, on current `main`.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`" — no existing issue; happy to file one with the reproduction if preferred.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed — behavior change is narrowing an orchestration edge case; docstrings on both rules describe it.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
