### PR TITLE
fix incorrect examples in global-concurrency-limits doc

### DIFF
--- a/docs/v3/how-to-guides/workflows/global-concurrency-limits.mdx
+++ b/docs/v3/how-to-guides/workflows/global-concurrency-limits.mdx
@@ -138,7 +138,7 @@ def my_flow():
 
 
 if __name__ == "__main__":
-    asyncio.run(my_flow())
+    my_flow()
 ```
 
 In both examples, the `concurrency` context manager occupies one slot on the `database` concurrency limit. If no slots are available, execution blocks until a slot becomes available.
@@ -227,7 +227,7 @@ def my_flow():
 
 
 if __name__ == "__main__":
-    asyncio.run(my_flow())
+    my_flow()
 ```
 
 The `rate_limit` function ensures requests are made at a controlled pace based on the concurrency limit's `slot_decay_per_second` setting.


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

both the examples gave the following error before:
```
Traceback (most recent call last):
  File "/Users/instinct/Desktop/working/prefect/temp1/ex1.py", line 20, in <module>
    asyncio.run(my_flow())
    ~~~~~~~~~~~^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/lib/python3.13/asyncio/runners.py", line 89, in run
    raise ValueError("a coroutine was expected, got {!r}".format(coro))
ValueError: a coroutine was expected, got None
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
