### PR TITLE
fix(prefect-gcp): mark failed Vertex jobs as crashed

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -514,10 +514,10 @@ class VertexAIWorker(
 
         error_msg = final_job_run.error.message
 
-        # Vertex will include an error message upon valid
-        # flow cancellations, so we'll avoid raising an error in that case
+        # Vertex will include an error message upon valid flow cancellations,
+        # so only report errors for other terminal states.
         if error_msg and "CANCELED" not in error_msg:
-            raise RuntimeError(error_msg)
+            logger.error(f"Vertex AI job {job_name!r} failed: {error_msg}")
 
         status_code = 0 if final_job_run.state == JobState.JOB_STATE_SUCCEEDED else 1
 

--- a/src/integrations/prefect-gcp/tests/test_vertex_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_vertex_worker.py
@@ -224,7 +224,7 @@ class TestVertexAIWorker:
                 status_code=0, identifier="mock_display_name"
             )
 
-    async def test_failed_worker_run(self, flow_run, job_config):
+    async def test_failed_worker_run(self, flow_run, job_config, caplog):
         job_config.prepare_for_flow_run(flow_run, None, None)
         error_msg = "something went kablooey"
         error_job_display_name = "catastrophization"
@@ -237,8 +237,7 @@ class TestVertexAIWorker:
             )
         )
         async with VertexAIWorker("test-pool") as worker:
-            with pytest.raises(RuntimeError, match=error_msg):
-                await worker.run(flow_run=flow_run, configuration=job_config)
+            result = await worker.run(flow_run=flow_run, configuration=job_config)
 
             assert (
                 job_config.credentials.job_service_async_client.create_custom_job.call_count
@@ -248,6 +247,10 @@ class TestVertexAIWorker:
                 job_config.credentials.job_service_async_client.get_custom_job.call_count
                 == 1
             )
+            assert result == VertexAIWorkerResult(
+                status_code=1, identifier=error_job_display_name
+            )
+            assert error_msg in caplog.text
 
     async def test_cancelled_worker_run(self, flow_run, job_config):
         job_config.prepare_for_flow_run(flow_run, None, None)


### PR DESCRIPTION
closes #22727

This PR prevents Vertex AI flow runs from remaining indefinitely in `Pending` when a successfully created CustomJob reaches a terminal failed state before the flow container starts. The worker now logs the Vertex error and returns a nonzero infrastructure result, allowing Prefect's existing worker lifecycle to transition the flow run to `Crashed`.

`Crashed` is preferable to `Failed` here because Prefect reserves `Failed` for errors raised by flow code, while this path represents infrastructure failure before the flow engine begins executing.

<details>
<summary>Implementation details</summary>

Previously, `VertexAIWorker.run` raised `RuntimeError` after calling `task_status.started()`. `BaseWorker` consequently treated the exception as a lost infrastructure connection and expected the execution environment to report the final state. When the Vertex container never started, nothing could update the flow run from `Pending`.

Returning `VertexAIWorkerResult(status_code=1)` uses the existing `BaseWorker` behavior that reports nonzero infrastructure exits as `Crashed`. The original Vertex error remains available in the flow-run logs.

</details>

### Example

Before: `JOB_STATE_FAILED` with an error message raises after infrastructure submission and can leave the flow run `Pending`.

After: the same terminal Vertex state logs its error, returns status code `1`, and is reported by the base worker as `Crashed`.

### Checklist

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references a related issue by including `closes #22727`.
- [x] This pull request includes a regression test covering the changed behavior.
- [x] This pull request does not remove documentation files.
- [x] This pull request does not add functions or classes requiring new docstrings.

### Validation

- `uv run pytest tests/test_vertex_worker.py -q` (`14 passed`)
- Repository pre-commit hooks on both changed files

Generated with Codex
