### PR TITLE
feat(azure): add GPU resources to container instances

### DIFF
--- a/src/integrations/prefect-azure/prefect_azure/workers/container_instance.py
+++ b/src/integrations/prefect-azure/prefect_azure/workers/container_instance.py
@@ -285,6 +285,9 @@ class AzureContainerJobConfiguration(BaseJobConfiguration):
         if self.image_registry:
             self._add_image_registry_credentials(self.image_registry)
 
+        if self.gpu_count is not None or self.gpu_sku is not None:
+            self._add_gpu()
+
         if self.identities:
             self._add_identities(self.identities)
 
@@ -304,6 +307,21 @@ class AzureContainerJobConfiguration(BaseJobConfiguration):
             ]["image"] = self.image
         except KeyError:
             raise ValueError("Unable to add image due to invalid job ARM template.")
+
+    def _add_gpu(self):
+        """Add the requested GPU resources to the container ARM template."""
+        if self.gpu_count is None or self.gpu_sku is None:
+            raise ValueError("gpu_count and gpu_sku must be provided together.")
+
+        try:
+            self.arm_template["resources"][0]["properties"]["containers"][0][
+                "properties"
+            ]["resources"]["requests"]["gpu"] = {
+                "count": self.gpu_count,
+                "sku": self.gpu_sku,
+            }
+        except KeyError:
+            raise ValueError("Unable to add GPU due to invalid job ARM template.")
 
     def _add_image_registry_credentials(self, image_registry: DockerRegistry):
         """

--- a/src/integrations/prefect-azure/tests/test_aci_worker.py
+++ b/src/integrations/prefect-azure/tests/test_aci_worker.py
@@ -1085,6 +1085,32 @@ async def test_add_dns_servers(
         assert dns_server in dns_config["nameServers"]
 
 
+async def test_add_gpu_resources(raw_job_configuration, worker_flow_run):
+    raw_job_configuration.gpu_count = 1
+    raw_job_configuration.gpu_sku = "V100"
+    raw_job_configuration.prepare_for_flow_run(worker_flow_run)
+
+    container = raw_job_configuration.arm_template["resources"][0]["properties"][
+        "containers"
+    ][0]
+    assert container["properties"]["resources"]["requests"]["gpu"] == {
+        "count": 1,
+        "sku": "V100",
+    }
+
+
+@pytest.mark.parametrize("missing_field", ["gpu_count", "gpu_sku"])
+async def test_gpu_resources_require_count_and_sku(
+    raw_job_configuration, worker_flow_run, missing_field
+):
+    raw_job_configuration.gpu_count = 1
+    raw_job_configuration.gpu_sku = "V100"
+    setattr(raw_job_configuration, missing_field, None)
+
+    with pytest.raises(ValueError, match="gpu_count and gpu_sku"):
+        raw_job_configuration.prepare_for_flow_run(worker_flow_run)
+
+
 @pytest.mark.parametrize(
     "flow_name",
     [


### PR DESCRIPTION
## Summary

- apply the existing `gpu_count` and `gpu_sku` options to the Azure Container Instance ARM template
- reject incomplete GPU configuration before sending a malformed request
- add regression coverage for GPU resources and validation

Issue #22674 asked for GPU support, and a maintainer said they would be happy to review a PR. I was thinking of keeping the existing configuration fields and wiring them into the request shape Azure expects, with an explicit error when only one field is supplied. Let me know what you think.

## Validation

- `python -m py_compile` passed for the changed modules
- `git diff --check` passed
- targeted pytest was attempted but could not collect because this environment is missing `azure.storage.blob.aio`