### PR TITLE
fix(ui-v2): preserve empty array when clearing list parameter selections

### DIFF
--- a/ui-v2/src/components/schemas/schema-form-input-array-enum.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-array-enum.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockPointerEvents } from "@tests/utils/browser";
+import type { SchemaObject } from "openapi-typescript";
+import { useState } from "react";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import type { SchemaFormProps } from "./schema-form";
+import { SchemaForm } from "./schema-form";
+
+function TestSchemaForm({
+	schema = { type: "object", properties: {} },
+	kinds = [],
+	errors = [],
+	values = {},
+	onValuesChange = () => {},
+}: Partial<SchemaFormProps>) {
+	return (
+		<SchemaForm
+			schema={schema}
+			kinds={kinds}
+			errors={errors}
+			values={values}
+			onValuesChange={onValuesChange}
+		/>
+	);
+}
+
+describe("SchemaFormInputArray enum", () => {
+	beforeAll(mockPointerEvents);
+
+	test("clearing all selections sends [] instead of omitting the field", async () => {
+		const user = userEvent.setup();
+		const spy = vi.fn();
+
+		function Wrapper() {
+			const [values, setValues] = useState<Record<string, unknown>>({
+				tags: ["foo"],
+			});
+			spy.mockImplementation((value: Record<string, unknown>) =>
+				setValues(value),
+			);
+
+			const schema: SchemaObject = {
+				type: "object",
+				properties: {
+					tags: {
+						type: "array",
+						title: "Tags",
+						items: { type: "string", enum: ["foo", "bar", "baz"] },
+					},
+				},
+			};
+
+			return (
+				<TestSchemaForm schema={schema} values={values} onValuesChange={spy} />
+			);
+		}
+
+		render(<Wrapper />);
+
+		// Open the combobox and deselect the only selected item
+		await user.click(screen.getByRole("button", { name: /select tags/i }));
+		await user.click(screen.getByRole("option", { name: /^foo$/i }));
+
+		// tags key must be [] not omitted — omitting it would cause the server
+		// to fall back to the deployment's stored default instead of empty list
+		await waitFor(() => {
+			expect(spy).toHaveBeenLastCalledWith({ tags: [] });
+		});
+	});
+});

--- a/ui-v2/src/components/schemas/schema-form-input-array.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-array.tsx
@@ -30,11 +30,6 @@ export function SchemaFormInputArray({
 	const { schema } = useSchemaFormContext();
 
 	function handleValuesChange(values: unknown[] | undefined) {
-		if (values === undefined || values.length === 0) {
-			onValuesChange(undefined);
-			return;
-		}
-
 		onValuesChange(values);
 	}
 

--- a/ui-v2/src/components/schemas/schema-form.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form.test.tsx
@@ -1,7 +1,17 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockPointerEvents } from "@tests/utils/browser";
 import type { SchemaObject } from "openapi-typescript";
 import { act, useState } from "react";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import "@/mocks/mock-json-input";
 import type { SchemaFormProps } from "./schema-form";
 import { SchemaForm } from "./schema-form";
@@ -316,6 +326,57 @@ describe("property.type", () => {
 				);
 			});
 			expect(hasJsonKind).toBe(false);
+		});
+	});
+
+	describe("array", () => {
+		beforeAll(mockPointerEvents);
+
+		test("clearing all enum selections sends [] instead of omitting the field", async () => {
+			vi.useRealTimers();
+			const user = userEvent.setup();
+			const spy = vi.fn();
+
+			function Wrapper() {
+				const [values, setValues] = useState<Record<string, unknown>>({
+					tags: ["foo"],
+				});
+				spy.mockImplementation((value: Record<string, unknown>) =>
+					setValues(value),
+				);
+
+				const schema: SchemaObject = {
+					type: "object",
+					properties: {
+						tags: {
+							type: "array",
+							title: "Tags",
+							items: { type: "string", enum: ["foo", "bar", "baz"] },
+						},
+					},
+				};
+
+				return (
+					<TestSchemaForm
+						schema={schema}
+						values={values}
+						onValuesChange={spy}
+					/>
+				);
+			}
+
+			render(<Wrapper />);
+
+			// Open the combobox
+			await user.click(screen.getByRole("button", { name: /select tags/i }));
+
+			// Deselect the currently selected item "foo"
+			await user.click(screen.getByRole("option", { name: /^foo$/i }));
+
+			// tags key must be present with [] — not omitted (which would fall back to deployment default)
+			await waitFor(() => {
+				expect(spy).toHaveBeenLastCalledWith({ tags: [] });
+			});
 		});
 	});
 });

--- a/ui-v2/src/components/schemas/schema-form.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form.test.tsx
@@ -318,5 +318,4 @@ describe("property.type", () => {
 			expect(hasJsonKind).toBe(false);
 		});
 	});
-
 });

--- a/ui-v2/src/components/schemas/schema-form.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form.test.tsx
@@ -1,17 +1,7 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { mockPointerEvents } from "@tests/utils/browser";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { SchemaObject } from "openapi-typescript";
 import { act, useState } from "react";
-import {
-	afterEach,
-	beforeAll,
-	beforeEach,
-	describe,
-	expect,
-	test,
-	vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import "@/mocks/mock-json-input";
 import type { SchemaFormProps } from "./schema-form";
 import { SchemaForm } from "./schema-form";
@@ -329,54 +319,4 @@ describe("property.type", () => {
 		});
 	});
 
-	describe("array", () => {
-		beforeAll(mockPointerEvents);
-
-		test("clearing all enum selections sends [] instead of omitting the field", async () => {
-			vi.useRealTimers();
-			const user = userEvent.setup();
-			const spy = vi.fn();
-
-			function Wrapper() {
-				const [values, setValues] = useState<Record<string, unknown>>({
-					tags: ["foo"],
-				});
-				spy.mockImplementation((value: Record<string, unknown>) =>
-					setValues(value),
-				);
-
-				const schema: SchemaObject = {
-					type: "object",
-					properties: {
-						tags: {
-							type: "array",
-							title: "Tags",
-							items: { type: "string", enum: ["foo", "bar", "baz"] },
-						},
-					},
-				};
-
-				return (
-					<TestSchemaForm
-						schema={schema}
-						values={values}
-						onValuesChange={spy}
-					/>
-				);
-			}
-
-			render(<Wrapper />);
-
-			// Open the combobox
-			await user.click(screen.getByRole("button", { name: /select tags/i }));
-
-			// Deselect the currently selected item "foo"
-			await user.click(screen.getByRole("option", { name: /^foo$/i }));
-
-			// tags key must be present with [] — not omitted (which would fall back to deployment default)
-			await waitFor(() => {
-				expect(spy).toHaveBeenLastCalledWith({ tags: [] });
-			});
-		});
-	});
 });


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

closes #22736
                                                                                                                                                                                                          
  This PR fixes list[Enum] parameters not respecting an explicit empty selection when creating a flow run.                                                                                                
  
  SchemaFormInputArray.handleValuesChange was converting [] → undefined, which caused SchemaFormInputObject to delete the key from the parameters object. The server then fell back to the deployment's   
  stored default instead of the user's intended empty list.
                                                                                                                                                                                                          
  The fix removes the values.length === 0 condition so that an empty array is passed through as-is. undefined (field never touched) is still passed as undefined, preserving existing "use deployment     
  default" behavior for untouched fields.                                                                                                                                                                 
 