### PR TITLE
feat(ui-v2): add removable chips for multi-select enum array fields

### DIFF
--- a/ui-v2/src/components/schemas/__snapshots__/schema-form.snapshot.test.tsx.snap
+++ b/ui-v2/src/components/schemas/__snapshots__/schema-form.snapshot.test.tsx.snap
@@ -3488,7 +3488,7 @@ exports[`property.type > string > format:date-time 1`] = `
               data-state="closed"
               type="button"
             >
-              Europe / Berlin
+              UTC
               <svg
                 aria-hidden="true"
                 class="lucide lucide-chevrons-up-down size-4 opacity-50"
@@ -3621,7 +3621,7 @@ exports[`property.type > string > format:date-time with default 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-              01/01/2024 01:00 AM
+              01/01/2024 12:00 AM
             </button>
             <button
               aria-expanded="false"
@@ -3632,7 +3632,7 @@ exports[`property.type > string > format:date-time with default 1`] = `
               data-state="closed"
               type="button"
             >
-              Europe / Berlin
+              UTC
               <svg
                 aria-hidden="true"
                 class="lucide lucide-chevrons-up-down size-4 opacity-50"
@@ -3765,7 +3765,7 @@ exports[`property.type > string > format:date-time with value 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-              01/01/2024 01:00 AM
+              01/01/2024 12:00 AM
             </button>
             <button
               aria-expanded="false"
@@ -3776,7 +3776,7 @@ exports[`property.type > string > format:date-time with value 1`] = `
               data-state="closed"
               type="button"
             >
-              Europe / Berlin
+              UTC
               <svg
                 aria-hidden="true"
                 class="lucide lucide-chevrons-up-down size-4 opacity-50"

--- a/ui-v2/src/components/schemas/__snapshots__/schema-form.snapshot.test.tsx.snap
+++ b/ui-v2/src/components/schemas/__snapshots__/schema-form.snapshot.test.tsx.snap
@@ -196,38 +196,120 @@ exports[`property.type > array > with enum items 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            foo, bar
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              Select
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+            <div
+              class="flex flex-wrap gap-1"
+            >
+              <span
+                class="inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90 ml-1 max-w-40"
+                data-slot="badge"
+                title="foo"
+              >
+                <span
+                  class="truncate"
+                >
+                  foo
+                </span>
+                <button
+                  aria-label="Remove foo tag"
+                  class="text-muted-foreground hover:text-foreground rounded-sm focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-x"
+                    fill="none"
+                    height="14"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="14"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 6 6 18"
+                    />
+                    <path
+                      d="m6 6 12 12"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <span
+                class="inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90 ml-1 max-w-40"
+                data-slot="badge"
+                title="bar"
+              >
+                <span
+                  class="truncate"
+                >
+                  bar
+                </span>
+                <button
+                  aria-label="Remove bar tag"
+                  class="text-muted-foreground hover:text-foreground rounded-sm focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-x"
+                    fill="none"
+                    height="14"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="14"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 6 6 18"
+                    />
+                    <path
+                      d="m6 6 12 12"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </div>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -1363,38 +1445,42 @@ exports[`property.type > boolean > enum 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            Select
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              Select
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -1766,38 +1852,42 @@ exports[`property.type > integer > enum 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            Select
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              Select
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -2239,38 +2329,42 @@ exports[`property.type > number > enum 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            Select
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              Select
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -2623,38 +2717,42 @@ exports[`property.type > string > enum 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            Select
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              Select
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -2738,38 +2836,42 @@ exports[`property.type > string > enum with default 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            foo
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              foo
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -2853,38 +2955,42 @@ exports[`property.type > string > enum with value 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            foo
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              foo
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>
@@ -3382,7 +3488,7 @@ exports[`property.type > string > format:date-time 1`] = `
               data-state="closed"
               type="button"
             >
-              UTC
+              Europe / Berlin
               <svg
                 aria-hidden="true"
                 class="lucide lucide-chevrons-up-down size-4 opacity-50"
@@ -3515,7 +3621,7 @@ exports[`property.type > string > format:date-time with default 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-              01/01/2024 12:00 AM
+              01/01/2024 01:00 AM
             </button>
             <button
               aria-expanded="false"
@@ -3526,7 +3632,7 @@ exports[`property.type > string > format:date-time with default 1`] = `
               data-state="closed"
               type="button"
             >
-              UTC
+              Europe / Berlin
               <svg
                 aria-hidden="true"
                 class="lucide lucide-chevrons-up-down size-4 opacity-50"
@@ -3659,7 +3765,7 @@ exports[`property.type > string > format:date-time with value 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-              01/01/2024 12:00 AM
+              01/01/2024 01:00 AM
             </button>
             <button
               aria-expanded="false"
@@ -3670,7 +3776,7 @@ exports[`property.type > string > format:date-time with value 1`] = `
               data-state="closed"
               type="button"
             >
-              UTC
+              Europe / Berlin
               <svg
                 aria-hidden="true"
                 class="lucide lucide-chevrons-up-down size-4 opacity-50"
@@ -4392,38 +4498,42 @@ exports[`property.type > unknown > with value 1`] = `
           </div>
         </div>
         <fieldset>
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Select undefined"
-            class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
-            data-slot="popover-trigger"
-            data-state="closed"
-            id="generated-id-0"
-            type="button"
+          <div
+            class="flex flex-col gap-1"
           >
-            foo
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-chevrons-up-down size-4 opacity-50"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Select undefined"
+              class="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 w-full justify-between bg-card dark:bg-background text-muted-foreground"
+              data-slot="popover-trigger"
+              data-state="closed"
+              id="generated-id-0"
+              type="button"
             >
-              <path
-                d="m7 15 5 5 5-5"
-              />
-              <path
-                d="m7 9 5-5 5 5"
-              />
-            </svg>
-          </button>
+              foo
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevrons-up-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m7 15 5 5 5-5"
+                />
+                <path
+                  d="m7 9 5-5 5 5"
+                />
+              </svg>
+            </button>
+          </div>
         </fieldset>
       </div>
     </div>

--- a/ui-v2/src/components/schemas/schema-form-input-enum.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-enum.test.tsx
@@ -1,0 +1,259 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockPointerEvents } from "@tests/utils/browser";
+import type { SchemaObject } from "openapi-typescript";
+import { useState } from "react";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import type { SchemaFormProps } from "./schema-form";
+import { SchemaForm } from "./schema-form";
+
+function TestSchemaForm({
+	schema = { type: "object", properties: {} },
+	kinds = [],
+	errors = [],
+	values = {},
+	onValuesChange = () => {},
+}: Partial<SchemaFormProps>) {
+	return (
+		<SchemaForm
+			schema={schema}
+			kinds={kinds}
+			errors={errors}
+			values={values}
+			onValuesChange={onValuesChange}
+		/>
+	);
+}
+
+// Array property has a title so the combobox trigger reads "Select Colors"
+const multiEnumSchema: SchemaObject = {
+	type: "object",
+	properties: {
+		colors: {
+			title: "Colors",
+			type: "array",
+			items: { type: "string", enum: ["foo", "bar", "baz"] },
+		},
+	},
+};
+
+const singleEnumSchema: SchemaObject = {
+	type: "object",
+	properties: {
+		name: { type: "string", title: "Name", enum: ["foo", "bar", "baz"] },
+	},
+};
+
+describe("SchemaFormInputEnum", () => {
+	beforeAll(mockPointerEvents);
+
+	describe("multiple select — chips", () => {
+		test("renders chips for each selected value", () => {
+			render(
+				<TestSchemaForm
+					schema={multiEnumSchema}
+					values={{ colors: ["foo", "bar"] }}
+				/>,
+			);
+
+			expect(screen.getByTitle("foo")).toBeInTheDocument();
+			expect(screen.getByTitle("bar")).toBeInTheDocument();
+		});
+
+		test("does not render chips when values array is empty", () => {
+			render(
+				<TestSchemaForm schema={multiEnumSchema} values={{ colors: [] }} />,
+			);
+
+			expect(
+				screen.queryByRole("button", { name: /remove .* tag/i }),
+			).not.toBeInTheDocument();
+		});
+
+		test("does not render chips when values are undefined", () => {
+			render(<TestSchemaForm schema={multiEnumSchema} values={{}} />);
+
+			expect(
+				screen.queryByRole("button", { name: /remove .* tag/i }),
+			).not.toBeInTheDocument();
+		});
+
+		test("clicking remove on a chip removes that value", async () => {
+			const user = userEvent.setup();
+			const spy = vi.fn();
+
+			function Wrapper() {
+				const [values, setValues] = useState<Record<string, unknown>>({
+					colors: ["foo", "bar"],
+				});
+				spy.mockImplementation((v: Record<string, unknown>) => setValues(v));
+
+				return (
+					<TestSchemaForm
+						schema={multiEnumSchema}
+						values={values}
+						onValuesChange={spy}
+					/>
+				);
+			}
+
+			render(<Wrapper />);
+
+			await user.click(screen.getByRole("button", { name: "Remove foo tag" }));
+
+			await waitFor(() => {
+				expect(spy).toHaveBeenLastCalledWith({ colors: ["bar"] });
+			});
+		});
+
+		test("removing the last chip results in an empty array", async () => {
+			const user = userEvent.setup();
+			const spy = vi.fn();
+
+			function Wrapper() {
+				const [values, setValues] = useState<Record<string, unknown>>({
+					colors: ["foo"],
+				});
+				spy.mockImplementation((v: Record<string, unknown>) => setValues(v));
+
+				return (
+					<TestSchemaForm
+						schema={multiEnumSchema}
+						values={values}
+						onValuesChange={spy}
+					/>
+				);
+			}
+
+			render(<Wrapper />);
+
+			await user.click(screen.getByRole("button", { name: "Remove foo tag" }));
+
+			await waitFor(() => {
+				expect(spy).toHaveBeenLastCalledWith({ colors: [] });
+			});
+		});
+
+		test("selecting a value from the combobox adds a chip", async () => {
+			const user = userEvent.setup();
+			const spy = vi.fn();
+
+			function Wrapper() {
+				const [values, setValues] = useState<Record<string, unknown>>({
+					colors: [],
+				});
+				spy.mockImplementation((v: Record<string, unknown>) => setValues(v));
+
+				return (
+					<TestSchemaForm
+						schema={multiEnumSchema}
+						values={values}
+						onValuesChange={spy}
+					/>
+				);
+			}
+
+			render(<Wrapper />);
+
+			await user.click(screen.getByRole("button", { name: /select colors/i }));
+
+			await waitFor(() => {
+				expect(screen.getByRole("option", { name: "foo" })).toBeVisible();
+			});
+
+			await user.click(screen.getByRole("option", { name: "foo" }));
+
+			await waitFor(() => {
+				expect(spy).toHaveBeenLastCalledWith({ colors: ["foo"] });
+			});
+		});
+
+		test("selecting an already-selected value from the combobox removes it", async () => {
+			const user = userEvent.setup();
+			const spy = vi.fn();
+
+			function Wrapper() {
+				const [values, setValues] = useState<Record<string, unknown>>({
+					colors: ["foo", "bar"],
+				});
+				spy.mockImplementation((v: Record<string, unknown>) => setValues(v));
+
+				return (
+					<TestSchemaForm
+						schema={multiEnumSchema}
+						values={values}
+						onValuesChange={spy}
+					/>
+				);
+			}
+
+			render(<Wrapper />);
+
+			await user.click(screen.getByRole("button", { name: /select colors/i }));
+
+			await waitFor(() => {
+				expect(screen.getByRole("option", { name: "foo" })).toBeVisible();
+			});
+
+			await user.click(screen.getByRole("option", { name: "foo" }));
+
+			await waitFor(() => {
+				expect(spy).toHaveBeenLastCalledWith({ colors: ["bar"] });
+			});
+		});
+	});
+
+	describe("single select — no chips", () => {
+		test("does not render chips for single-select enum", () => {
+			render(
+				<TestSchemaForm schema={singleEnumSchema} values={{ name: "foo" }} />,
+			);
+
+			expect(
+				screen.queryByRole("button", { name: /remove .* tag/i }),
+			).not.toBeInTheDocument();
+		});
+
+		test("shows the selected label in the combobox trigger", () => {
+			render(
+				<TestSchemaForm schema={singleEnumSchema} values={{ name: "foo" }} />,
+			);
+
+			expect(
+				screen.getByRole("button", { name: /select name/i }),
+			).toHaveTextContent("foo");
+		});
+
+		test("selecting a value calls onValuesChange with the new value", async () => {
+			const user = userEvent.setup();
+			const spy = vi.fn();
+
+			function Wrapper() {
+				const [values, setValues] = useState<Record<string, unknown>>({});
+				spy.mockImplementation((v: Record<string, unknown>) => setValues(v));
+
+				return (
+					<TestSchemaForm
+						schema={singleEnumSchema}
+						values={values}
+						onValuesChange={spy}
+					/>
+				);
+			}
+
+			render(<Wrapper />);
+
+			await user.click(screen.getByRole("button", { name: /select name/i }));
+
+			await waitFor(() => {
+				expect(screen.getByRole("option", { name: "bar" })).toBeVisible();
+			});
+
+			await user.click(screen.getByRole("option", { name: "bar" }));
+
+			await waitFor(() => {
+				expect(spy).toHaveBeenLastCalledWith({ name: "bar" });
+			});
+		});
+	});
+});

--- a/ui-v2/src/components/schemas/schema-form-input-enum.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-enum.test.tsx
@@ -8,7 +8,7 @@ import { SchemaForm } from "./schema-form";
 import type { PrefectSchemaObject } from "./types/schemas";
 
 function TestSchemaForm({
-	schema = { type: "object", properties: {} } as PrefectSchemaObject,
+	schema = { type: "object", properties: {} },
 	kinds = [],
 	errors = [],
 	values = {},

--- a/ui-v2/src/components/schemas/schema-form-input-enum.test.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-enum.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockPointerEvents } from "@tests/utils/browser";
-import type { SchemaObject } from "openapi-typescript";
 import { useState } from "react";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import type { SchemaFormProps } from "./schema-form";
 import { SchemaForm } from "./schema-form";
+import type { PrefectSchemaObject } from "./types/schemas";
 
 function TestSchemaForm({
-	schema = { type: "object", properties: {} },
+	schema = { type: "object", properties: {} } as PrefectSchemaObject,
 	kinds = [],
 	errors = [],
 	values = {},
@@ -26,7 +26,7 @@ function TestSchemaForm({
 }
 
 // Array property has a title so the combobox trigger reads "Select Colors"
-const multiEnumSchema: SchemaObject = {
+const multiEnumSchema: PrefectSchemaObject = {
 	type: "object",
 	properties: {
 		colors: {
@@ -37,7 +37,7 @@ const multiEnumSchema: SchemaObject = {
 	},
 };
 
-const singleEnumSchema: SchemaObject = {
+const singleEnumSchema: PrefectSchemaObject = {
 	type: "object",
 	properties: {
 		name: { type: "string", title: "Name", enum: ["foo", "bar", "baz"] },

--- a/ui-v2/src/components/schemas/schema-form-input-enum.tsx
+++ b/ui-v2/src/components/schemas/schema-form-input-enum.tsx
@@ -9,6 +9,7 @@ import {
 	ComboboxContent,
 	ComboboxTrigger,
 } from "../ui/combobox";
+import { TagBadge } from "../ui/tag-badge";
 import type { PrimitiveProperty } from "./types/primitives";
 import type { WithPrimitiveEnum } from "./types/schemas";
 
@@ -90,35 +91,48 @@ export function SchemaFormInputEnum<T extends PrimitiveProperty>({
 	}
 
 	return (
-		<Combobox>
-			<ComboboxTrigger
-				selected={selected}
-				aria-label={`Select ${property.title}`}
-				id={id}
-			>
-				{selected ? label : "Select"}
-			</ComboboxTrigger>
-			<ComboboxContent>
-				<ComboboxCommandInput
-					value={search}
-					onValueChange={setSearch}
-					placeholder="Search..."
-				/>
-				<ComboboxCommandEmtpy>No values found</ComboboxCommandEmtpy>
-				<ComboboxCommandList>
-					{Object.entries(options).map(([index, value]) => (
-						<ComboboxCommandItem
-							key={index}
-							value={index}
-							onSelect={onSelect}
-							selected={isSelected(index)}
-							closeOnSelect={!props.multiple}
-						>
-							{String(value)}
-						</ComboboxCommandItem>
+		<div className="flex flex-col gap-1">
+			<Combobox>
+				<ComboboxTrigger
+					selected={selected && !props.multiple}
+					aria-label={`Select ${property.title}`}
+					id={id}
+				>
+					{selected && !props.multiple ? label : "Select"}
+				</ComboboxTrigger>
+				<ComboboxContent>
+					<ComboboxCommandInput
+						value={search}
+						onValueChange={setSearch}
+						placeholder="Search..."
+					/>
+					<ComboboxCommandEmtpy>No values found</ComboboxCommandEmtpy>
+					<ComboboxCommandList>
+						{Object.entries(options).map(([index, value]) => (
+							<ComboboxCommandItem
+								key={index}
+								value={index}
+								onSelect={onSelect}
+								selected={isSelected(index)}
+								closeOnSelect={!props.multiple}
+							>
+								{String(value)}
+							</ComboboxCommandItem>
+						))}
+					</ComboboxCommandList>
+				</ComboboxContent>
+			</Combobox>
+			{props.multiple && props.values && props.values.length > 0 && (
+				<div className="flex flex-wrap gap-1">
+					{props.values.map((value) => (
+						<TagBadge
+							key={String(value)}
+							tag={String(value)}
+							onRemove={() => onSelectMultiple(value)}
+						/>
 					))}
-				</ComboboxCommandList>
-			</ComboboxContent>
-		</Combobox>
+				</div>
+			)}
+		</div>
 	);
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Closes: #22741

This PR adds inline removable chips to multi-select enum array fields (e.g. `list[Enumstr]`) in the schema form.                                                                                           
                                                                                                                                                                                                          
Previously, the only way to deselect a value was to reopen the dropdown and click it again. Now each selected value renders as a badge with an ✕ button directly below the combobox.                    
                                                                                                                
<img width="626" height="136" alt="Screenshot 2026-08-06 at 12 21 39" src="https://github.com/user-attachments/assets/dedc025a-3b13-4157-949c-b937b0083577" />
                                                                                          
  <details>                                                                                                                                                                                               
  <summary>Details</summary>                                                                                                                                                                            
                                                                                                                                                                                                          
  - `SchemaFormInputEnum`: when `multiple=true`, renders selected values as `TagBadge` chips with `onRemove` handlers below the combobox trigger                                                          
  - The trigger no longer shows the comma-separated label for multi-select (redundant with chips) — it always shows "Select"                                                                              
  - Uses the existing `TagBadge` component which already supports `onRemove`                                                                                                                              
  - Updated snapshots with `TZ=UTC` to fix pre-existing datetime snapshot mismatch between local and CI environments                                                                                      
                                                                                                                                                                                                          
  </details>  
