### PR TITLE
Fix nested deployment parameter rendering

### DIFF
--- a/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.stories.tsx
+++ b/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.stories.tsx
@@ -24,9 +24,16 @@ const meta = {
 						title: "goodbye",
 						type: "boolean",
 					},
+					builder: {
+						default: { day: "today" },
+						position: 2,
+						title: "builder",
+						type: "object",
+					},
 				},
 			},
 			parameters: {
+				builder: { day: "prev_td" },
 				goodbye: false,
 				name: "world",
 			},

--- a/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.test.tsx
+++ b/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.test.tsx
@@ -40,6 +40,46 @@ describe("DeploymentParametersTable", () => {
 		expect(screen.getByRole("cell", { name: /goodbye/i })).toBeVisible();
 	});
 
+	it("renders object-valued parameters as JSON", () => {
+		const deployment = createFakeDeployment({
+			parameter_openapi_schema: {
+				title: "Parameters",
+				type: "object",
+				properties: {
+					builder: {
+						default: { day: "today" },
+						position: 0,
+						title: "builder",
+						type: "object",
+					},
+					days: {
+						default: ["today"],
+						position: 1,
+						title: "days",
+						type: "array",
+					},
+				},
+			},
+			parameters: {
+				builder: { day: "prev_td" },
+				days: ["prev_td", "next_td"],
+			},
+		});
+
+		render(<DeploymentParametersTable deployment={deployment} />);
+
+		expect(
+			screen.getByRole("cell", { name: '{"day":"prev_td"}' }),
+		).toBeVisible();
+		expect(
+			screen.getByRole("cell", { name: '{"day":"today"}' }),
+		).toBeVisible();
+		expect(
+			screen.getByRole("cell", { name: "prev_td,next_td" }),
+		).toBeVisible();
+		expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+	});
+
 	it("filters table rows", async () => {
 		// ------------ Setup
 		const user = userEvent.setup();

--- a/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.test.tsx
+++ b/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.test.tsx
@@ -71,12 +71,8 @@ describe("DeploymentParametersTable", () => {
 		expect(
 			screen.getByRole("cell", { name: '{"day":"prev_td"}' }),
 		).toBeVisible();
-		expect(
-			screen.getByRole("cell", { name: '{"day":"today"}' }),
-		).toBeVisible();
-		expect(
-			screen.getByRole("cell", { name: "prev_td,next_td" }),
-		).toBeVisible();
+		expect(screen.getByRole("cell", { name: '{"day":"today"}' })).toBeVisible();
+		expect(screen.getByRole("cell", { name: "prev_td,next_td" })).toBeVisible();
 		expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
 	});
 

--- a/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.tsx
+++ b/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.tsx
@@ -30,6 +30,10 @@ type ParametersTableColumns = {
 
 const columnHelper = createColumnHelper<ParametersTableColumns>();
 
+/**
+ * Formats object-valued parameters as JSON while preserving existing scalar and
+ * array output.
+ */
 const formatParameterValue = (value: unknown): string => {
 	if (value === null || value === undefined) {
 		return "";

--- a/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.tsx
+++ b/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.tsx
@@ -30,6 +30,27 @@ type ParametersTableColumns = {
 
 const columnHelper = createColumnHelper<ParametersTableColumns>();
 
+const formatParameterValue = (value: unknown): string => {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	if (Array.isArray(value)) {
+		return value.join(",");
+	}
+	if (typeof value === "object") {
+		return JSON.stringify(value);
+	}
+	if (
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean" ||
+		typeof value === "bigint"
+	) {
+		return value.toString();
+	}
+	return JSON.stringify(value) ?? "";
+};
+
 const columns = [
 	columnHelper.accessor("key", {
 		header: "Key",
@@ -46,9 +67,7 @@ const columns = [
 		header: "Override",
 		cell: ({ getValue }) => (
 			<span className="whitespace-normal break-words font-mono text-sm">
-				{getValue() !== null && getValue() !== undefined
-					? String(getValue())
-					: ""}
+				{formatParameterValue(getValue())}
 			</span>
 		),
 	}),
@@ -56,9 +75,7 @@ const columns = [
 		header: "Default",
 		cell: ({ getValue }) => (
 			<span className="whitespace-normal break-words font-mono text-sm">
-				{getValue() !== null && getValue() !== undefined
-					? String(getValue())
-					: ""}
+				{formatParameterValue(getValue())}
 			</span>
 		),
 	}),
@@ -111,12 +128,10 @@ export const DeploymentParametersTable = ({
 		return data.filter(
 			(parameter) =>
 				parameter.key.toLowerCase().includes(deferredSearch.toLowerCase()) ||
-				parameter.value
-					?.toString()
+				formatParameterValue(parameter.value)
 					.toLowerCase()
 					.includes(deferredSearch.toLowerCase()) ||
-				parameter.defaultValue
-					?.toString()
+				formatParameterValue(parameter.defaultValue)
 					.toLowerCase()
 					.includes(deferredSearch.toLowerCase()) ||
 				parameter.type


### PR DESCRIPTION
Fixes #22759

This PR renders object-valued deployment parameter overrides and defaults as compact JSON in the UI v2 Parameters table, restoring readable nested values such as `{"day":"prev_td"}`.

<details>
<summary>Details</summary>

The table previously passed every value through JavaScript's generic string conversion, which turns records into `[object Object]`. The new formatter serializes records as JSON while preserving the existing scalar and array presentation. The same formatter is used by client-side filtering so searches match the text shown in the table.

The regression test covers both object-valued overrides and schema defaults, verifies that arrays keep their current formatting, and the Storybook example now includes a nested object parameter.

</details>

### Validation

- `npm test -- deployment-parameters-table.test.tsx --run` — 8 tests passed
- targeted ESLint for the component, test, and story — passed
- `npm run validate:types` — passed
- `npm run build` — TypeScript completed; the Vite bundle could not complete locally because the Mac environment blocked the native Lightning CSS module while loading. CI can provide the production bundle result.

### Checklist

- [x] This pull request references the related issue.
- [x] This focused UI regression fix includes behavior-level test coverage.
- [x] Documentation is not needed because this restores the intended display behavior without changing an API or workflow.
- [x] The added formatter includes an explanatory doc comment.
