### PR TITLE
Don't let a deleted working directory break all imports

### DIFF
--- a/src/prefect/deployments/steps/core.py
+++ b/src/prefect/deployments/steps/core.py
@@ -34,7 +34,10 @@ from prefect.events.clients import get_events_client
 from prefect.events.schemas.events import Event, RelatedResource, Resource
 from prefect.logging.loggers import get_logger
 from prefect.settings import PREFECT_DEBUG_MODE
-from prefect.utilities.importtools import import_object
+from prefect.utilities.importtools import (
+    import_object,
+    safe_current_working_directory,
+)
 from prefect.utilities.templating import (
     apply_values,
     resolve_block_document_references,
@@ -62,13 +65,6 @@ class StepExecutionError(Exception):
     """
     Raised when a step fails to execute.
     """
-
-
-def _safe_current_working_directory() -> Path | None:
-    try:
-        return Path.cwd().resolve()
-    except OSError:
-        return None
 
 
 @contextmanager
@@ -213,7 +209,7 @@ async def run_steps(
         try:
             # catch warnings to ensure deprecation warnings are printed
             step_start_cwd = (
-                _safe_current_working_directory()
+                safe_current_working_directory()
                 if step_completion_observer is not None
                 else None
             )
@@ -246,7 +242,7 @@ async def run_steps(
                     step,
                     step_output,
                     step_start_cwd,
-                    _safe_current_working_directory(),
+                    safe_current_working_directory(),
                 )
 
             if not isinstance(step_output, dict):

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -77,6 +77,21 @@ def from_qualified_name(name: str) -> Any:
     return getattr(module, attr_name)
 
 
+def safe_current_working_directory() -> Path | None:
+    """The current working directory, or `None` if it no longer exists.
+
+    Removing the working directory out from under a process makes `Path.cwd()`
+    raise. The loaders below put the cwd on `sys.path` so relative imports
+    inside a user's module resolve, so reading it unguarded turns that
+    convenience into a hard failure in which nothing can be imported at all —
+    including the machinery that would set a valid working directory again.
+    """
+    try:
+        return Path.cwd().resolve()
+    except OSError:
+        return None
+
+
 def load_script_as_module(path: str) -> ModuleType:
     """Execute a script at the given path.
 
@@ -136,7 +151,11 @@ def load_module(module_name: str) -> ModuleType:
     """
     # Ensure relative imports within the imported module work if the user is in the
     # correct working directory
-    working_directory = os.getcwd()
+    cwd = safe_current_working_directory()
+    if cwd is None:
+        return importlib.import_module(module_name)
+
+    working_directory = str(cwd)
     sys.path.insert(0, working_directory)
 
     try:

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -862,7 +862,7 @@ class TestRunSteps:
             }[fqn],
         )
         monkeypatch.setattr(
-            "prefect.deployments.steps.core._safe_current_working_directory",
+            "prefect.deployments.steps.core.safe_current_working_directory",
             lambda: (_ for _ in ()).throw(
                 AssertionError("cwd should not be probed without a step observer")
             ),

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -1,5 +1,7 @@
 import asyncio
+import importlib
 import importlib.util
+import os
 import runpy
 import sys
 from pathlib import Path
@@ -16,6 +18,7 @@ from prefect.utilities.importtools import (
     from_qualified_name,
     import_object,
     lazy_import,
+    load_module,
     load_script_as_module,
     safe_load_namespace,
     to_qualified_name,
@@ -484,3 +487,55 @@ def hello():
 
     module_names = [m.__name__ for m in loaded_modules]
     assert len(module_names) == len(set(module_names)), "Duplicate module names found"
+
+
+class TestLoadModuleWithMissingWorkingDirectory:
+    """`load_module` inserts the cwd on `sys.path` so relative imports inside a
+    user's module resolve. Reading it with a bare `os.getcwd()` makes importing
+    *any* module fail once the directory has been removed out from under the
+    process.
+
+    That is reachable in normal operation: `Runner._run_on_crashed_hooks` calls
+    `load_flow_from_flow_run`, which re-runs the deployment's pull steps, and
+    running a step imports the step function through `import_object` ->
+    `load_module`. If the run's working directory is already gone by then, the
+    import of `prefect.deployments.steps.set_working_directory` raises
+    FileNotFoundError before that step can correct the cwd — so the recovery
+    path is broken by the thing it exists to recover from, and on_crashed hooks
+    silently never run.
+    """
+
+    @pytest.fixture
+    def deleted_cwd(self, tmp_path: Path):
+        original = os.getcwd()
+        doomed = tmp_path / "doomed"
+        doomed.mkdir()
+        os.chdir(doomed)
+        doomed.rmdir()
+        try:
+            yield
+        finally:
+            os.chdir(original)
+
+    def test_can_import_when_the_working_directory_is_gone(self, deleted_cwd):
+        assert load_module("prefect.deployments.steps") is not None
+
+    def test_import_object_still_resolves(self, deleted_cwd):
+        from prefect.deployments.steps import set_working_directory
+
+        assert (
+            import_object("prefect.deployments.steps.set_working_directory")
+            is set_working_directory
+        )
+
+    def test_cwd_is_still_used_for_imports_when_it_exists(self, tmp_path: Path):
+        """The normal case must keep working: a module that is only importable
+        because it sits in the cwd still resolves, and sys.path is left clean."""
+        (tmp_path / "only_findable_via_cwd.py").write_text("value = 7\n")
+        before = list(sys.path)
+
+        with tmpchdir(str(tmp_path)):
+            module = load_module("only_findable_via_cwd")
+
+        assert module.value == 7
+        assert sys.path == before


### PR DESCRIPTION
Deleting a process's working directory currently breaks *every* import Prefect does, including the machinery that would set a valid working directory again. One consequence: `on_crashed` hooks silently never run for a flow run whose directory is already gone.

`load_module` reads the cwd with a bare `os.getcwd()` so it can put it on `sys.path` for relative imports inside user code. `os.getcwd()` raises `FileNotFoundError` when that directory no longer exists, so the convenience becomes a hard failure.

This reuses the guard that already exists — `_safe_current_working_directory` in `deployments/steps/core.py` — rather than adding a second one.

<details>
<summary>History: this line is a 2022 leftover, and the hazard has been recognized twice since</summary>

The `os.getcwd()` in `load_module` dates to August 2022 (`abd92a2435`, `599a556a52`) and has not been touched since. No commit in the repository has ever mentioned `getcwd`.

Meanwhile the same hazard has been handled twice recently in adjacent code:

- `_safe_current_working_directory` — added May 2026 in #21699 (isolated workspace resolver), guarding `Path.cwd()` with `except OSError` for step-completion observation. This PR moves that helper rather than writing a third variant.
- `_PULL_STEP_SOURCE_CWD` — added June 2026 in #22392, anchoring relative `set_working_directory` paths to the cwd at the start of the pull steps, because re-running the steps otherwise compounds the directory.

Both of those touch the same crashed-hook re-entry; neither reaches the import itself, which is why this one survived.

</details>

<details>
<summary>Note on the legacy path</summary>

`runner/AGENTS.md` lists `_run_on_crashed_hooks()` as legacy — replaced by `HookRunner`, retained "until internal callers (notably ProcessWorker) are migrated." That migration is exactly why this is still worth fixing: process work pools go through `ProcessWorker`, so they still take the legacy path, which is where this was observed on 3.8.2. The modern path injects `resolve_flow` from `WorkspaceResolvingEngineCommandStarter` and loads the flow inside a resolved workspace, so it does not re-run pull steps in-process.

Per that same doc's instruction not to add behavior to the legacy methods, this change does not touch `runner.py` at all — the guard sits in the shared import utility, so it protects any caller of `load_module` regardless of which path reaches it.

</details>

<details>
<summary>How it's reached in normal operation</summary>

`Runner._run_on_crashed_hooks` calls `load_flow_from_flow_run`, which re-runs the deployment's pull steps. Running a step imports the step function through `import_object` → `load_module`. If the run's working directory has already been cleaned up by the time the crashed-hook check runs, the import of `prefect.deployments.steps.set_working_directory` raises before that step can correct the cwd — the recovery path is broken by exactly the condition it exists to recover from.

Observed on 3.8.2 across three unrelated deployments on one worker, always the same trace:

```
Loading flow to check for on_crashed hooks
Running 2 deployment pull step(s)
Executing deployment step: run_shell_script
Runner failed to retrieve flow to execute on_crashed hooks for flow run UUID('...')
Traceback (most recent call last):
  File ".../prefect/deployments/steps/core.py", line 168, in run_step
    step_func = _get_function_for_step(fqn, requires=keywords.get("requires"))
  File ".../prefect/deployments/steps/core.py", line 110, in _get_function_for_step
    step_func = import_object(fully_qualified_name)
  File ".../prefect/utilities/importtools.py", line 174, in import_object
    module = load_module(module_name)
  File ".../prefect/utilities/importtools.py", line 139, in load_module
    working_directory = os.getcwd()
FileNotFoundError: [Errno 2] No such file or directory
```

The run is already `Crashed`, so the only user-visible symptom is a warning — and any `on_crashed` hooks they defined never fire.

</details>

<details>
<summary>The change</summary>

`_safe_current_working_directory` moves from `deployments/steps/core.py` to `utilities/importtools.py` as `safe_current_working_directory`, and `core.py` imports it from there. That direction keeps layering intact (`deployments` already depends on `utilities.importtools` for `import_object`) and avoids pulling `utilities.filesystem` — and with it an eager `fsspec` import — onto the import path.

`load_module` then falls back to importing without the cwd on `sys.path`. Relative imports that genuinely depend on the cwd can't work when the cwd is gone; the point is that importing an installed module still can.

One existing test's monkeypatch target moves with the rename (`tests/deployment/test_steps.py::test_run_steps_does_not_probe_cwd_without_step_observer`). Its contract — don't probe the cwd unless there's a step observer — is unchanged.

`load_script_as_module` has the same unguarded `os.getcwd()`, and I initially guarded it too. It turns out not to fail in this state — it loads fine on `main` with the cwd removed — so I dropped that half rather than ship a change with no failing test behind it. Happy to revisit if someone knows a path that does reach it.

</details>

<details>
<summary>Tests</summary>

`TestLoadModuleWithMissingWorkingDirectory` in `tests/utilities/test_importtools.py`. The fixture chdirs into a directory and then removes it, reproducing the state directly.

- `test_can_import_when_the_working_directory_is_gone`
- `test_import_object_still_resolves` — the exact failing call from the traceback
- `test_cwd_is_still_used_for_imports_when_it_exists` — control: a module importable *only* because it sits in the cwd still resolves, and `sys.path` is left clean

The first two fail on `main` with the `FileNotFoundError` above and pass with this change; the control passes either way. `tests/utilities/` and `tests/deployment/test_steps.py` are green (116 passed, 1 pre-existing skip).

</details>

Draft because I'd like a maintainer's read on whether degrading here is the right call, or whether the runner should chdir somewhere durable before the crashed-hook check — that addresses the ordering rather than the symptom, and the two aren't mutually exclusive.
