### PR TITLE
Preserve a statement cache size of 0

### DIFF
--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -157,13 +157,19 @@ class BaseDatabaseConfiguration(ABC):
             connection_app_name
             or get_current_settings().server.database.sqlalchemy.connect_args.application_name
         )
+        # `is None`, not `or`: 0 is a meaningful value for both of these. Setting
+        # statement_cache_size to 0 is required behind PgBouncer in transaction mode,
+        # and 0 disables the prepared statement cache, so `or` would discard exactly
+        # the value the settings describe as the reason to set them.
         self.statement_cache_size: Optional[int] = (
             statement_cache_size
-            or get_current_settings().server.database.sqlalchemy.connect_args.statement_cache_size
+            if statement_cache_size is not None
+            else get_current_settings().server.database.sqlalchemy.connect_args.statement_cache_size
         )
         self.prepared_statement_cache_size: Optional[int] = (
             prepared_statement_cache_size
-            or get_current_settings().server.database.sqlalchemy.connect_args.prepared_statement_cache_size
+            if prepared_statement_cache_size is not None
+            else get_current_settings().server.database.sqlalchemy.connect_args.prepared_statement_cache_size
         )
         self.search_path: Optional[str] = (
             search_path

--- a/tests/server/database/test_configurations.py
+++ b/tests/server/database/test_configurations.py
@@ -54,3 +54,35 @@ async def test_postgres_engine_enforces_read_committed(
             assert txn_iso == "read committed"
     finally:
         await engine.dispose()
+
+
+class TestStatementCacheSizeZero:
+    """0 is a meaningful value for both cache-size arguments, not an absent one.
+
+    The settings that back them say so: statement_cache_size is documented as
+    "required when using PgBouncer in transaction mode", and
+    prepared_statement_cache_size as disabling the cache "when set to 0". Resolving
+    either with `or` discards exactly that value.
+    """
+
+    @pytest.mark.parametrize(
+        "field", ["statement_cache_size", "prepared_statement_cache_size"]
+    )
+    def test_zero_is_preserved(self, field: str) -> None:
+        config = AsyncPostgresConfiguration(
+            connection_url="postgresql+asyncpg://u:p@localhost/db", **{field: 0}
+        )
+        assert getattr(config, field) == 0, (
+            f"{field}=0 was discarded; a caller disabling the cache silently gets "
+            f"the default instead"
+        )
+
+    @pytest.mark.parametrize(
+        "field", ["statement_cache_size", "prepared_statement_cache_size"]
+    )
+    def test_nonzero_is_preserved(self, field: str) -> None:
+        config = AsyncPostgresConfiguration(
+            connection_url="postgresql+asyncpg://u:p@localhost/db", **{field: 100}
+        )
+        assert getattr(config, field) == 100
+

--- a/tests/server/database/test_configurations.py
+++ b/tests/server/database/test_configurations.py
@@ -85,4 +85,3 @@ class TestStatementCacheSizeZero:
             connection_url="postgresql+asyncpg://u:p@localhost/db", **{field: 100}
         )
         assert getattr(config, field) == 100
-


### PR DESCRIPTION
`AsyncPostgresConfiguration.__init__` resolves both cache-size arguments with `or`:

```python
self.statement_cache_size = statement_cache_size or <setting>
```

`0` is falsy, so it gets replaced by the setting, which defaults to `None`. The `if ... is not None` further down then skips the key entirely and asyncpg keeps its cache at the default.

Your own settings say `0` is the value that matters. `statement_cache_size` is documented as "Setting this to 0 is required when using PgBouncer in transaction mode", and `prepared_statement_cache_size` as disabling the cache "when set to 0". The `or` discards exactly the value both descriptions name as the reason to reach for the setting.

Switched to `is not None` at both sites. Two lines.

The scope is narrow, and saying so up front seems better than letting it read bigger than it is: passing `0` through settings already worked, because the constructor argument is `None` on that path, and prefect itself only ever builds this class from a connection URL. So the person affected is someone wiring up `AsyncPostgresConfiguration` themselves to sit behind PgBouncer, which is who the docstring is talking to.

Verified with no database and no network, just the constructor. On main, `statement_cache_size=0` comes back as `None` while `statement_cache_size=100` comes back as `100`, and the same split happens for the prepared cache. The same call keeps the non-zero value and drops the zero.

Reverting the two lines with the new tests in place fails them both, and restoring passes all four. `tests/server/database` is 97 passed and 7 skipped with the change, against 93 before it, no regressions either way.

No PgBouncer here. The claim that `0` reaches asyncpg is read off `connect_args`, not observed on a live connection.
