### PR TITLE
Add configurable base directory for included bundle files

### DIFF
--- a/docs/integrations/prefect-aws/api-ref/prefect_aws-decorators.mdx
+++ b/docs/integrations/prefect-aws/api-ref/prefect_aws-decorators.mdx
@@ -7,10 +7,10 @@ sidebarTitle: decorators
 
 ## Functions
 
-### `ecs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-aws/prefect_aws/decorators.py#L53" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `ecs` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-aws/prefect_aws/decorators.py#L54" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-ecs(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
+ecs(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, include_files_base_dir: Path | str | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
 ```
 
 
@@ -19,9 +19,12 @@ Decorator that binds execution of a flow to an ECS work pool
 **Args:**
 - `work_pool`: The name of the ECS work pool to use
 - `include_files`: Optional sequence of file patterns to include in the bundle.
-Patterns are relative to the flow file location. Supports glob patterns
-(e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-be bundled and available in the remote execution environment.
+Patterns are relative to `include_files_base_dir`, which defaults to the
+flow file location. Supports glob patterns (e.g., "*.yaml",
+"data/**/*.csv"). Files matching these patterns will be bundled and
+available in the remote execution environment.
 - `launcher`: Optional upload and execution launcher override.
+- `include_files_base_dir`: Optional base directory for resolving `include_files`.
+Defaults to the directory containing the flow file.
 - `**job_variables`: Additional job variables to use for infrastructure configuration
 

--- a/docs/integrations/prefect-azure/api-ref/prefect_azure-decorators.mdx
+++ b/docs/integrations/prefect-azure/api-ref/prefect_azure-decorators.mdx
@@ -7,10 +7,10 @@ sidebarTitle: decorators
 
 ## Functions
 
-### `azure_container_instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-azure/prefect_azure/decorators.py#L52" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `azure_container_instance` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-azure/prefect_azure/decorators.py#L53" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-azure_container_instance(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
+azure_container_instance(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, include_files_base_dir: Path | str | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
 ```
 
 
@@ -19,9 +19,12 @@ Decorator that binds execution of a flow to an Azure Container Instance work poo
 **Args:**
 - `work_pool`: The name of the Azure Container Instance work pool to use
 - `include_files`: Optional sequence of file patterns to include in the bundle.
-Patterns are relative to the flow file location. Supports glob patterns
-(e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-be bundled and available in the remote execution environment.
+Patterns are relative to `include_files_base_dir`, which defaults to the
+flow file location. Supports glob patterns (e.g., "*.yaml",
+"data/**/*.csv"). Files matching these patterns will be bundled and
+available in the remote execution environment.
 - `launcher`: Optional upload and execution launcher override.
+- `include_files_base_dir`: Optional base directory for resolving `include_files`.
+Defaults to the directory containing the flow file.
 - `**job_variables`: Additional job variables to use for infrastructure configuration
 

--- a/docs/integrations/prefect-docker/api-ref/prefect_docker-decorators.mdx
+++ b/docs/integrations/prefect-docker/api-ref/prefect_docker-decorators.mdx
@@ -7,10 +7,10 @@ sidebarTitle: decorators
 
 ## Functions
 
-### `docker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-docker/prefect_docker/decorators.py#L46" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `docker` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-docker/prefect_docker/decorators.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-docker(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
+docker(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, include_files_base_dir: Path | str | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
 ```
 
 
@@ -19,9 +19,12 @@ Decorator that binds execution of a flow to a Docker work pool
 **Args:**
 - `work_pool`: The name of the Docker work pool to use
 - `include_files`: Optional sequence of file patterns to include in the bundle.
-Patterns are relative to the flow file location. Supports glob patterns
-(e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-be bundled and available in the remote execution environment.
+Patterns are relative to `include_files_base_dir`, which defaults to the
+flow file location. Supports glob patterns (e.g., "*.yaml",
+"data/**/*.csv"). Files matching these patterns will be bundled and
+available in the remote execution environment.
 - `launcher`: Optional upload and execution launcher override.
+- `include_files_base_dir`: Optional base directory for resolving `include_files`.
+Defaults to the directory containing the flow file.
 - `**job_variables`: Additional job variables to use for infrastructure configuration
 

--- a/docs/integrations/prefect-gcp/api-ref/prefect_gcp-decorators.mdx
+++ b/docs/integrations/prefect-gcp/api-ref/prefect_gcp-decorators.mdx
@@ -7,10 +7,10 @@ sidebarTitle: decorators
 
 ## Functions
 
-### `cloud_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-gcp/prefect_gcp/decorators.py#L53" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cloud_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-gcp/prefect_gcp/decorators.py#L54" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-cloud_run(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
+cloud_run(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, include_files_base_dir: Path | str | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
 ```
 
 
@@ -19,17 +19,20 @@ Decorator that binds execution of a flow to a Cloud Run V2 work pool
 **Args:**
 - `work_pool`: The name of the Cloud Run V2 work pool to use
 - `include_files`: Optional sequence of file patterns to include in the bundle.
-Patterns are relative to the flow file location. Supports glob patterns
-(e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-be bundled and available in the remote execution environment.
+Patterns are relative to `include_files_base_dir`, which defaults to the
+flow file location. Supports glob patterns (e.g., "*.yaml",
+"data/**/*.csv"). Files matching these patterns will be bundled and
+available in the remote execution environment.
 - `launcher`: Optional upload and execution launcher override.
+- `include_files_base_dir`: Optional base directory for resolving `include_files`.
+Defaults to the directory containing the flow file.
 - `**job_variables`: Additional job variables to use for infrastructure configuration
 
 
-### `vertex_ai` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-gcp/prefect_gcp/decorators.py#L108" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `vertex_ai` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-gcp/prefect_gcp/decorators.py#L114" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-vertex_ai(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
+vertex_ai(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, include_files_base_dir: Path | str | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
 ```
 
 
@@ -38,9 +41,12 @@ Decorator that binds execution of a flow to a Vertex AI work pool
 **Args:**
 - `work_pool`: The name of the Vertex AI work pool to use
 - `include_files`: Optional sequence of file patterns to include in the bundle.
-Patterns are relative to the flow file location. Supports glob patterns
-(e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-be bundled and available in the remote execution environment.
+Patterns are relative to `include_files_base_dir`, which defaults to the
+flow file location. Supports glob patterns (e.g., "*.yaml",
+"data/**/*.csv"). Files matching these patterns will be bundled and
+available in the remote execution environment.
 - `launcher`: Optional upload and execution launcher override.
+- `include_files_base_dir`: Optional base directory for resolving `include_files`.
+Defaults to the directory containing the flow file.
 - `**job_variables`: Additional job variables to use for infrastructure configuration
 

--- a/docs/integrations/prefect-kubernetes/api-ref/prefect_kubernetes-decorators.mdx
+++ b/docs/integrations/prefect-kubernetes/api-ref/prefect_kubernetes-decorators.mdx
@@ -7,10 +7,10 @@ sidebarTitle: decorators
 
 ## Functions
 
-### `kubernetes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-kubernetes/prefect_kubernetes/decorators.py#L52" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `kubernetes` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-kubernetes/prefect_kubernetes/decorators.py#L53" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-kubernetes(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
+kubernetes(work_pool: str, include_files: Sequence[str] | None = None, launcher: BundleLauncher | None = None, include_files_base_dir: Path | str | None = None, **job_variables: Any) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]
 ```
 
 
@@ -19,9 +19,12 @@ Decorator that binds execution of a flow to a Kubernetes work pool
 **Args:**
 - `work_pool`: The name of the Kubernetes work pool to use
 - `include_files`: Optional sequence of file patterns to include in the bundle.
-Patterns are relative to the flow file location. Supports glob patterns
-(e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-be bundled and available in the remote execution environment.
+Patterns are relative to `include_files_base_dir`, which defaults to the
+flow file location. Supports glob patterns (e.g., "*.yaml",
+"data/**/*.csv"). Files matching these patterns will be bundled and
+available in the remote execution environment.
 - `launcher`: Optional upload and execution launcher override.
+- `include_files_base_dir`: Optional base directory for resolving `include_files`.
+Defaults to the directory containing the flow file.
 - `**job_variables`: Additional job variables to use for infrastructure configuration
 

--- a/docs/v3/advanced/submit-flows-directly-to-dynamic-infrastructure.mdx
+++ b/docs/v3/advanced/submit-flows-directly-to-dynamic-infrastructure.mdx
@@ -314,6 +314,26 @@ def my_flow():
 
 The `include_files` parameter accepts a list of relative paths and glob patterns. Paths are resolved relative to the directory containing the flow file.
 
+To resolve the patterns from another location, set `include_files_base_dir` to a string or [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path). Relative base directories are resolved from the current working directory when the bundle is created. Included files retain their paths relative to this directory when extracted in the remote execution environment.
+
+{/* pmd-metadata: notest */}
+```python
+from pathlib import Path
+
+from prefect import flow
+from prefect_docker.decorators import docker
+
+
+@docker(
+    work_pool="my-pool",
+    include_files=["config.yaml", "data/"],
+    include_files_base_dir=Path("/my/custom/base-dir"),
+)
+@flow
+def my_flow():
+    ...
+```
+
 ### Supported patterns
 
 | Pattern | Description |
@@ -345,7 +365,7 @@ This example includes all JSON files except those in the `fixtures/` directory.
 
 ### Filtering with `.prefectignore`
 
-If a `.prefectignore` file exists in the flow file's directory or at the project root (detected via `pyproject.toml`), its patterns are applied to filter out matching files. The `.prefectignore` file uses gitignore-style syntax:
+If a `.prefectignore` file exists in the base directory used for included files or at that directory's project root (detected via `pyproject.toml`), its patterns are applied to filter out matching files. The `.prefectignore` file uses gitignore-style syntax:
 
 ```text
 # .prefectignore

--- a/docs/v3/api-ref/python/prefect-flows.mdx
+++ b/docs/v3/api-ref/python/prefect-flows.mdx
@@ -12,13 +12,13 @@ Module containing the base workflow class and decorator - for most use cases, us
 
 ## Functions
 
-### `bind_flow_to_infrastructure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2835" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `bind_flow_to_infrastructure` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2846" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-bind_flow_to_infrastructure(flow: Flow[P, R], work_pool: str, worker_cls: type['BaseWorker[Any, Any, Any]'], job_variables: dict[str, Any] | None = None, launcher: BundleLauncher | None = None, include_files: Sequence[str] | None = None) -> InfrastructureBoundFlow[P, R]
+bind_flow_to_infrastructure(flow: Flow[P, R], work_pool: str, worker_cls: type['BaseWorker[Any, Any, Any]'], job_variables: dict[str, Any] | None = None, launcher: BundleLauncher | None = None, include_files: Sequence[str] | None = None, include_files_base_dir: Path | str | None = None) -> InfrastructureBoundFlow[P, R]
 ```
 
-### `select_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2879" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `select_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2895" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 select_flow(flows: Iterable[Flow[P, R]], flow_name: Optional[str] = None, from_message: Optional[str] = None) -> Flow[P, R]
@@ -36,7 +36,7 @@ Returns
 - `UnspecifiedFlowError`: If multiple flows exist but no flow name was provided
 
 
-### `load_flow_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2925" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `load_flow_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2941" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_flow_from_entrypoint(entrypoint: str, use_placeholder_flow: bool = True) -> Flow[P, Any]
@@ -60,7 +60,7 @@ cannot be loaded from the entrypoint (e.g. dependencies are missing)
 - `MissingFlowError`: If the flow function specified in the entrypoint does not exist
 
 
-### `load_function_and_convert_to_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2977" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `load_function_and_convert_to_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2993" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_function_and_convert_to_flow(entrypoint: str) -> Flow[P, Any]
@@ -70,7 +70,7 @@ load_function_and_convert_to_flow(entrypoint: str) -> Flow[P, Any]
 Loads a function from an entrypoint and converts it to a flow if it is not already a flow.
 
 
-### `serve` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3000" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `serve` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3016" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 serve(*args: 'RunnerDeployment', **kwargs: Any) -> None
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 ```
 
 
-### `aserve` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3078" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `aserve` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3094" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 aserve(*args: 'RunnerDeployment', **kwargs: Any) -> None
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 
 
-### `load_flow_from_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3186" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `load_flow_from_flow_run` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3202" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_flow_from_flow_run(client: 'PrefectClient', flow_run: 'FlowRun', ignore_storage: bool = False, storage_base_path: Optional[str] = None, use_placeholder_flow: bool = True) -> Flow[..., Any]
@@ -194,7 +194,7 @@ If `ignore_storage=True` is provided, no pull from remote storage occurs.  This 
 is largely for testing, and assumes the flow is already available locally.
 
 
-### `load_placeholder_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3295" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `load_placeholder_flow` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3311" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_placeholder_flow(entrypoint: str, raises: Exception) -> Flow[P, Any]
@@ -213,7 +213,7 @@ or a module path to a flow function
 - `raises`: an exception to raise when the flow is called
 
 
-### `safe_load_flow_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3330" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `safe_load_flow_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3346" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 safe_load_flow_from_entrypoint(entrypoint: str) -> Optional[Flow[P, Any]]
@@ -233,7 +233,7 @@ Safely load a Prefect flow from an entrypoint string. Returns None if loading fa
 - (e.g. unresolved dependencies, syntax errors, or missing objects).
 
 
-### `load_flow_arguments_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3500" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `load_flow_arguments_from_entrypoint` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3516" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_flow_arguments_from_entrypoint(entrypoint: str, arguments: Optional[Union[list[str], set[str]]] = None) -> dict[str, Any]
@@ -250,7 +250,7 @@ from the `flow` decorator.
 or a module path to a flow function
 
 
-### `is_entrypoint_async` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3580" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `is_entrypoint_async` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L3596" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 is_entrypoint_async(entrypoint: str) -> bool
@@ -1090,13 +1090,16 @@ infrastructure the flow will run on.
 - `job_variables`: Infrastructure configuration that will override the base job
 configuration of the work pool.
 - `launcher`: Optional upload and execution launcher overrides.
+- `include_files`: Optional file patterns to include in the bundle.
+- `include_files_base_dir`: Optional base directory for resolving included file
+patterns. Defaults to the directory containing the flow file.
 - `worker_cls`: The class of the worker to use to spin up infrastructure and submit
 the flow to it.
 
 
 **Methods:**
 
-#### `retry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2553" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `retry` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2560" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 retry(self, flow_run: 'FlowRun') -> R | State[R]
@@ -1114,7 +1117,7 @@ reusing the same flow run ID and incrementing the run_count.
 - The flow result or final state
 
 
-#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2509" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `submit` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2516" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 submit(self, *args: P.args, **kwargs: P.kwargs) -> PrefectFlowRunFuture[R]
@@ -1152,7 +1155,7 @@ print(result)
 ```
 
 
-#### `submit_to_work_pool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2604" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `submit_to_work_pool` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2611" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 submit_to_work_pool(self, *args: P.args, **kwargs: P.kwargs) -> PrefectFlowRunFuture[R]
@@ -1189,7 +1192,7 @@ print(result)
 ```
 
 
-#### `with_options` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2771" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `with_options` <sup><a href="https://github.com/PrefectHQ/prefect/blob/main/src/prefect/flows.py#L2778" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 with_options(self) -> 'InfrastructureBoundFlow[P, R]'

--- a/src/integrations/prefect-aws/prefect_aws/decorators.py
+++ b/src/integrations/prefect-aws/prefect_aws/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -54,6 +55,7 @@ def ecs(
     work_pool: str,
     include_files: Sequence[str] | None = None,
     launcher: BundleLauncher | None = None,
+    include_files_base_dir: Path | str | None = None,
     **job_variables: Any,
 ) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]:
     """
@@ -62,10 +64,13 @@ def ecs(
     Args:
         work_pool: The name of the ECS work pool to use
         include_files: Optional sequence of file patterns to include in the bundle.
-            Patterns are relative to the flow file location. Supports glob patterns
-            (e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-            be bundled and available in the remote execution environment.
+            Patterns are relative to `include_files_base_dir`, which defaults to the
+            flow file location. Supports glob patterns (e.g., "*.yaml",
+            "data/**/*.csv"). Files matching these patterns will be bundled and
+            available in the remote execution environment.
         launcher: Optional upload and execution launcher override.
+        include_files_base_dir: Optional base directory for resolving `include_files`.
+            Defaults to the directory containing the flow file.
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
@@ -100,6 +105,7 @@ def ecs(
             worker_cls=ECSWorker,
             launcher=launcher,
             include_files=list(include_files) if include_files is not None else None,
+            include_files_base_dir=include_files_base_dir,
         )
 
     return decorator

--- a/src/integrations/prefect-aws/tests/experimental/test_decorators.py
+++ b/src/integrations/prefect-aws/tests/experimental/test_decorators.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -223,15 +224,22 @@ class TestEcsDecoratorIncludeFiles:
 
         assert test_flow.include_files == []
 
-    def test_include_files_with_valid_strings(self, mock_submit: AsyncMock) -> None:
+    def test_include_files_with_valid_strings(
+        self, mock_submit: AsyncMock, tmp_path: Path
+    ) -> None:
         """Test that include_files with valid strings is stored correctly"""
 
-        @ecs(work_pool="test-pool", include_files=["config.yaml", "data/"])
+        @ecs(
+            work_pool="test-pool",
+            include_files=["config.yaml", "data/"],
+            include_files_base_dir=tmp_path,
+        )
         @prefect.flow
         def test_flow():
             return "test"
 
         assert test_flow.include_files == ["config.yaml", "data/"]
+        assert test_flow.include_files_base_dir == tmp_path
 
     def test_include_files_tuple_converted_to_list(
         self, mock_submit: AsyncMock

--- a/src/integrations/prefect-azure/prefect_azure/decorators.py
+++ b/src/integrations/prefect-azure/prefect_azure/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -53,6 +54,7 @@ def azure_container_instance(
     work_pool: str,
     include_files: Sequence[str] | None = None,
     launcher: BundleLauncher | None = None,
+    include_files_base_dir: Path | str | None = None,
     **job_variables: Any,
 ) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]:
     """
@@ -61,10 +63,13 @@ def azure_container_instance(
     Args:
         work_pool: The name of the Azure Container Instance work pool to use
         include_files: Optional sequence of file patterns to include in the bundle.
-            Patterns are relative to the flow file location. Supports glob patterns
-            (e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-            be bundled and available in the remote execution environment.
+            Patterns are relative to `include_files_base_dir`, which defaults to the
+            flow file location. Supports glob patterns (e.g., "*.yaml",
+            "data/**/*.csv"). Files matching these patterns will be bundled and
+            available in the remote execution environment.
         launcher: Optional upload and execution launcher override.
+        include_files_base_dir: Optional base directory for resolving `include_files`.
+            Defaults to the directory containing the flow file.
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
@@ -99,6 +104,7 @@ def azure_container_instance(
             worker_cls=AzureContainerWorker,
             launcher=launcher,
             include_files=list(include_files) if include_files is not None else None,
+            include_files_base_dir=include_files_base_dir,
         )
 
     return decorator

--- a/src/integrations/prefect-azure/tests/experimental/tests_decorators.py
+++ b/src/integrations/prefect-azure/tests/experimental/tests_decorators.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -215,17 +216,22 @@ class TestAzureContainerInstanceDecoratorIncludeFiles:
 
         assert test_flow.include_files == []
 
-    def test_include_files_with_valid_strings(self, mock_submit: AsyncMock) -> None:
+    def test_include_files_with_valid_strings(
+        self, mock_submit: AsyncMock, tmp_path: Path
+    ) -> None:
         """Test that include_files with valid strings is stored correctly"""
 
         @azure_container_instance(
-            work_pool="test-pool", include_files=["config.yaml", "data/"]
+            work_pool="test-pool",
+            include_files=["config.yaml", "data/"],
+            include_files_base_dir=tmp_path,
         )
         @prefect.flow
         def test_flow():
             return "test"
 
         assert test_flow.include_files == ["config.yaml", "data/"]
+        assert test_flow.include_files_base_dir == tmp_path
 
     def test_include_files_tuple_converted_to_list(
         self, mock_submit: AsyncMock

--- a/src/integrations/prefect-docker/prefect_docker/decorators.py
+++ b/src/integrations/prefect-docker/prefect_docker/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Sequence, TypeVar
 
 from typing_extensions import ParamSpec
@@ -47,6 +48,7 @@ def docker(
     work_pool: str,
     include_files: Sequence[str] | None = None,
     launcher: BundleLauncher | None = None,
+    include_files_base_dir: Path | str | None = None,
     **job_variables: Any,
 ) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]:
     """
@@ -55,10 +57,13 @@ def docker(
     Args:
         work_pool: The name of the Docker work pool to use
         include_files: Optional sequence of file patterns to include in the bundle.
-            Patterns are relative to the flow file location. Supports glob patterns
-            (e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-            be bundled and available in the remote execution environment.
+            Patterns are relative to `include_files_base_dir`, which defaults to the
+            flow file location. Supports glob patterns (e.g., "*.yaml",
+            "data/**/*.csv"). Files matching these patterns will be bundled and
+            available in the remote execution environment.
         launcher: Optional upload and execution launcher override.
+        include_files_base_dir: Optional base directory for resolving `include_files`.
+            Defaults to the directory containing the flow file.
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
@@ -93,6 +98,7 @@ def docker(
             worker_cls=DockerWorker,
             launcher=launcher,
             include_files=list(include_files) if include_files is not None else None,
+            include_files_base_dir=include_files_base_dir,
         )
 
     return decorator

--- a/src/integrations/prefect-docker/tests/experimental/test_decorators.py
+++ b/src/integrations/prefect-docker/tests/experimental/test_decorators.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import uuid
+from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -209,15 +210,22 @@ class TestDockerDecoratorIncludeFiles:
 
         assert test_flow.include_files == []
 
-    def test_include_files_with_valid_strings(self, mock_submit: AsyncMock) -> None:
+    def test_include_files_with_valid_strings(
+        self, mock_submit: AsyncMock, tmp_path: Path
+    ) -> None:
         """Test that include_files with valid strings is stored correctly"""
 
-        @docker(work_pool="test-pool", include_files=["config.yaml", "data/"])
+        @docker(
+            work_pool="test-pool",
+            include_files=["config.yaml", "data/"],
+            include_files_base_dir=tmp_path,
+        )
         @prefect.flow
         def test_flow():
             return "test"
 
         assert test_flow.include_files == ["config.yaml", "data/"]
+        assert test_flow.include_files_base_dir == tmp_path
 
     def test_include_files_tuple_converted_to_list(
         self, mock_submit: AsyncMock

--- a/src/integrations/prefect-gcp/prefect_gcp/decorators.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -54,6 +55,7 @@ def cloud_run(
     work_pool: str,
     include_files: Sequence[str] | None = None,
     launcher: BundleLauncher | None = None,
+    include_files_base_dir: Path | str | None = None,
     **job_variables: Any,
 ) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]:
     """
@@ -62,10 +64,13 @@ def cloud_run(
     Args:
         work_pool: The name of the Cloud Run V2 work pool to use
         include_files: Optional sequence of file patterns to include in the bundle.
-            Patterns are relative to the flow file location. Supports glob patterns
-            (e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-            be bundled and available in the remote execution environment.
+            Patterns are relative to `include_files_base_dir`, which defaults to the
+            flow file location. Supports glob patterns (e.g., "*.yaml",
+            "data/**/*.csv"). Files matching these patterns will be bundled and
+            available in the remote execution environment.
         launcher: Optional upload and execution launcher override.
+        include_files_base_dir: Optional base directory for resolving `include_files`.
+            Defaults to the directory containing the flow file.
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
@@ -100,6 +105,7 @@ def cloud_run(
             worker_cls=CloudRunWorkerV2,
             launcher=launcher,
             include_files=list(include_files) if include_files is not None else None,
+            include_files_base_dir=include_files_base_dir,
         )
 
     return decorator
@@ -109,6 +115,7 @@ def vertex_ai(
     work_pool: str,
     include_files: Sequence[str] | None = None,
     launcher: BundleLauncher | None = None,
+    include_files_base_dir: Path | str | None = None,
     **job_variables: Any,
 ) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]:
     """
@@ -117,10 +124,13 @@ def vertex_ai(
     Args:
         work_pool: The name of the Vertex AI work pool to use
         include_files: Optional sequence of file patterns to include in the bundle.
-            Patterns are relative to the flow file location. Supports glob patterns
-            (e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-            be bundled and available in the remote execution environment.
+            Patterns are relative to `include_files_base_dir`, which defaults to the
+            flow file location. Supports glob patterns (e.g., "*.yaml",
+            "data/**/*.csv"). Files matching these patterns will be bundled and
+            available in the remote execution environment.
         launcher: Optional upload and execution launcher override.
+        include_files_base_dir: Optional base directory for resolving `include_files`.
+            Defaults to the directory containing the flow file.
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
@@ -155,6 +165,7 @@ def vertex_ai(
             worker_cls=VertexAIWorker,
             launcher=launcher,
             include_files=list(include_files) if include_files is not None else None,
+            include_files_base_dir=include_files_base_dir,
         )
 
     return decorator

--- a/src/integrations/prefect-gcp/tests/experimental/test_decorators.py
+++ b/src/integrations/prefect-gcp/tests/experimental/test_decorators.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -223,13 +224,20 @@ class TestCloudRunDecoratorIncludeFiles:
 
         assert test_flow.include_files == []
 
-    def test_include_files_with_valid_strings(self, mock_submit: AsyncMock) -> None:
-        @cloud_run(work_pool="test-pool", include_files=["config.yaml", "data/"])
+    def test_include_files_with_valid_strings(
+        self, mock_submit: AsyncMock, tmp_path: Path
+    ) -> None:
+        @cloud_run(
+            work_pool="test-pool",
+            include_files=["config.yaml", "data/"],
+            include_files_base_dir=tmp_path,
+        )
         @prefect.flow
         def test_flow():
             return "test"
 
         assert test_flow.include_files == ["config.yaml", "data/"]
+        assert test_flow.include_files_base_dir == tmp_path
 
     def test_include_files_tuple_converted_to_list(
         self, mock_submit: AsyncMock
@@ -493,13 +501,20 @@ class TestVertexAIDecoratorIncludeFiles:
 
         assert test_flow.include_files == []
 
-    def test_include_files_with_valid_strings(self, mock_submit: AsyncMock) -> None:
-        @vertex_ai(work_pool="test-pool", include_files=["config.yaml", "data/"])
+    def test_include_files_with_valid_strings(
+        self, mock_submit: AsyncMock, tmp_path: Path
+    ) -> None:
+        @vertex_ai(
+            work_pool="test-pool",
+            include_files=["config.yaml", "data/"],
+            include_files_base_dir=tmp_path,
+        )
         @prefect.flow
         def test_flow():
             return "test"
 
         assert test_flow.include_files == ["config.yaml", "data/"]
+        assert test_flow.include_files_base_dir == tmp_path
 
     def test_include_files_tuple_converted_to_list(
         self, mock_submit: AsyncMock

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/decorators.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -53,6 +54,7 @@ def kubernetes(
     work_pool: str,
     include_files: Sequence[str] | None = None,
     launcher: BundleLauncher | None = None,
+    include_files_base_dir: Path | str | None = None,
     **job_variables: Any,
 ) -> Callable[[Flow[P, R]], InfrastructureBoundFlow[P, R]]:
     """
@@ -61,10 +63,13 @@ def kubernetes(
     Args:
         work_pool: The name of the Kubernetes work pool to use
         include_files: Optional sequence of file patterns to include in the bundle.
-            Patterns are relative to the flow file location. Supports glob patterns
-            (e.g., "*.yaml", "data/**/*.csv"). Files matching these patterns will
-            be bundled and available in the remote execution environment.
+            Patterns are relative to `include_files_base_dir`, which defaults to the
+            flow file location. Supports glob patterns (e.g., "*.yaml",
+            "data/**/*.csv"). Files matching these patterns will be bundled and
+            available in the remote execution environment.
         launcher: Optional upload and execution launcher override.
+        include_files_base_dir: Optional base directory for resolving `include_files`.
+            Defaults to the directory containing the flow file.
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
@@ -99,6 +104,7 @@ def kubernetes(
             worker_cls=KubernetesWorker,
             launcher=launcher,
             include_files=list(include_files) if include_files is not None else None,
+            include_files_base_dir=include_files_base_dir,
         )
 
     return decorator

--- a/src/integrations/prefect-kubernetes/tests/experimental/test_decorator.py
+++ b/src/integrations/prefect-kubernetes/tests/experimental/test_decorator.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -218,15 +219,22 @@ class TestKubernetesDecoratorIncludeFiles:
 
         assert test_flow.include_files == []
 
-    def test_include_files_with_valid_strings(self, mock_submit: AsyncMock) -> None:
+    def test_include_files_with_valid_strings(
+        self, mock_submit: AsyncMock, tmp_path: Path
+    ) -> None:
         """Test that include_files with valid strings is stored correctly"""
 
-        @kubernetes(work_pool="test-pool", include_files=["config.yaml", "data/"])
+        @kubernetes(
+            work_pool="test-pool",
+            include_files=["config.yaml", "data/"],
+            include_files_base_dir=tmp_path,
+        )
         @prefect.flow
         def test_flow():
             return "test"
 
         assert test_flow.include_files == ["config.yaml", "data/"]
+        assert test_flow.include_files_base_dir == tmp_path
 
     def test_include_files_tuple_converted_to_list(
         self, mock_submit: AsyncMock

--- a/src/prefect/bundles/__init__.py
+++ b/src/prefect/bundles/__init__.py
@@ -466,9 +466,12 @@ def create_bundle_for_flow_run(
 
     if include_files:
         try:
-            # Get base directory from flow file location
-            flow_file = Path(inspect.getfile(flow.fn))
-            base_dir = flow_file.parent.resolve()
+            configured_base_dir = getattr(flow, "include_files_base_dir", None)
+            if configured_base_dir is None:
+                flow_file = Path(inspect.getfile(flow.fn))
+                base_dir = flow_file.parent.resolve()
+            else:
+                base_dir = Path(configured_base_dir).expanduser().resolve()
 
             # Pipeline: collect -> filter -> check -> zip
             collector = FileCollector(base_dir)

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2397,6 +2397,9 @@ class InfrastructureBoundFlow(Flow[P, R]):
         job_variables: Infrastructure configuration that will override the base job
             configuration of the work pool.
         launcher: Optional upload and execution launcher overrides.
+        include_files: Optional file patterns to include in the bundle.
+        include_files_base_dir: Optional base directory for resolving included file
+            patterns. Defaults to the directory containing the flow file.
         worker_cls: The class of the worker to use to spin up infrastructure and submit
             the flow to it.
     """
@@ -2409,6 +2412,7 @@ class InfrastructureBoundFlow(Flow[P, R]):
         worker_cls: type["BaseWorker[Any, Any, Any]"],
         launcher: BundleLauncher | None = None,
         include_files: Sequence[str] | None = None,
+        include_files_base_dir: Path | str | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -2418,6 +2422,9 @@ class InfrastructureBoundFlow(Flow[P, R]):
         self.launcher: BundleLauncherOverride | None = normalize_launcher(launcher)
         self.include_files: list[str] | None = (
             list(include_files) if include_files is not None else None
+        )
+        self.include_files_base_dir: Path | None = (
+            Path(include_files_base_dir) if include_files_base_dir is not None else None
         )
 
     @overload
@@ -2795,6 +2802,7 @@ class InfrastructureBoundFlow(Flow[P, R]):
         job_variables: Optional[dict[str, Any]] = None,
         launcher: BundleLauncher | None = NotSet,  # type: ignore
         include_files: Optional[list[str]] = NotSet,  # type: ignore
+        include_files_base_dir: Path | str | None = NotSet,  # type: ignore
     ) -> "InfrastructureBoundFlow[P, R]":
         new_flow = super().with_options(
             name=name,
@@ -2828,6 +2836,9 @@ class InfrastructureBoundFlow(Flow[P, R]):
             include_files=include_files
             if include_files is not NotSet
             else self.include_files,
+            include_files_base_dir=include_files_base_dir
+            if include_files_base_dir is not NotSet
+            else self.include_files_base_dir,
         )
         return new_infrastructure_bound_flow
 
@@ -2839,6 +2850,7 @@ def bind_flow_to_infrastructure(
     job_variables: dict[str, Any] | None = None,
     launcher: BundleLauncher | None = None,
     include_files: Sequence[str] | None = None,
+    include_files_base_dir: Path | str | None = None,
 ) -> InfrastructureBoundFlow[P, R]:
     new = InfrastructureBoundFlow[P, R](
         flow.fn,
@@ -2847,6 +2859,7 @@ def bind_flow_to_infrastructure(
         worker_cls=worker_cls,
         launcher=launcher,
         include_files=include_files,
+        include_files_base_dir=include_files_base_dir,
     )
     # Copy all attributes from the original flow
     for attr, value in flow.__dict__.items():
@@ -2856,6 +2869,9 @@ def bind_flow_to_infrastructure(
     new.worker_cls = worker_cls
     new.launcher = normalize_launcher(launcher)
     new.include_files = list(include_files) if include_files is not None else None
+    new.include_files_base_dir = (
+        Path(include_files_base_dir) if include_files_base_dir is not None else None
+    )
     return new
 
 

--- a/tests/_experimental/bundles/test_bundles.py
+++ b/tests/_experimental/bundles/test_bundles.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from zipfile import ZipFile
 
 import pytest
 
@@ -321,6 +322,47 @@ def my_flow():
         if result["zip_path"]:
             result["zip_path"].unlink(missing_ok=True)
             result["zip_path"].parent.rmdir()
+
+    def test_include_files_base_dir_overrides_flow_file_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        custom_base_dir = tmp_path / "assets"
+        custom_base_dir.mkdir()
+        (custom_base_dir / "config.yaml").write_text("source: custom")
+
+        flow_dir = tmp_path / "flows"
+        flow_dir.mkdir()
+        flow_file = flow_dir / "my_flow.py"
+        flow_file.write_text("from prefect import flow")
+        (flow_dir / "config.yaml").write_text("source: flow")
+
+        monkeypatch.setattr(
+            bundles_module.subprocess,
+            "check_output",
+            lambda *args, **kwargs: b"prefect>=3.0.0\n",
+        )
+
+        @flow
+        def test_flow():
+            pass
+
+        test_flow.include_files = ["config.yaml"]  # type: ignore[attr-defined]
+        test_flow.include_files_base_dir = custom_base_dir  # type: ignore[attr-defined]
+
+        with patch("prefect.bundles.inspect.getfile", return_value=str(flow_file)):
+            flow_run = MagicMock()
+            flow_run.model_dump.return_value = {"id": "test-123"}
+            result = create_bundle_for_flow_run(test_flow, flow_run)
+
+        zip_path = result["zip_path"]
+        assert zip_path is not None
+
+        try:
+            with ZipFile(zip_path) as archive:
+                assert archive.read("config.yaml") == b"source: custom"
+        finally:
+            zip_path.unlink(missing_ok=True)
+            zip_path.parent.rmdir()
 
     def test_files_key_none_when_no_include_files(self, monkeypatch) -> None:
         """files_key is None when flow has no include_files."""

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -993,6 +993,7 @@ class TestInfrastructureBoundFlow:
         )
 
         assert infrastructure_bound_flow.include_files is None
+        assert infrastructure_bound_flow.include_files_base_dir is None
 
     def test_include_files_with_list(
         self, work_pool: WorkPool, result_storage: LocalFileSystem
@@ -1050,7 +1051,10 @@ class TestInfrastructureBoundFlow:
         assert isinstance(infrastructure_bound_flow.include_files, list)
 
     def test_with_options_preserves_include_files_when_not_provided(
-        self, work_pool: WorkPool, result_storage: LocalFileSystem
+        self,
+        work_pool: WorkPool,
+        result_storage: LocalFileSystem,
+        tmp_path: Path,
     ):
         """with_options() without include_files preserves original include_files."""
 
@@ -1063,12 +1067,41 @@ class TestInfrastructureBoundFlow:
             work_pool=work_pool.name,
             worker_cls=ProcessWorker,
             include_files=["a.txt", "b.yaml"],
+            include_files_base_dir=tmp_path,
         )
 
         new_flow = original_flow.with_options(name="new-name")
 
         assert new_flow.include_files == ["a.txt", "b.yaml"]
+        assert new_flow.include_files_base_dir == tmp_path
         assert new_flow.name == "new-name"
+
+    def test_with_options_replaces_and_clears_include_files_base_dir(
+        self,
+        work_pool: WorkPool,
+        result_storage: LocalFileSystem,
+        tmp_path: Path,
+    ):
+        @flow(result_storage=result_storage)
+        def my_flow():
+            return "Hello"
+
+        original_flow = bind_flow_to_infrastructure(
+            flow=my_flow,
+            work_pool=work_pool.name,
+            worker_cls=ProcessWorker,
+            include_files=["a.txt"],
+            include_files_base_dir=str(tmp_path / "original"),
+        )
+
+        updated_flow = original_flow.with_options(
+            include_files_base_dir=tmp_path / "updated"
+        )
+        cleared_flow = updated_flow.with_options(include_files_base_dir=None)
+
+        assert original_flow.include_files_base_dir == tmp_path / "original"
+        assert updated_flow.include_files_base_dir == tmp_path / "updated"
+        assert cleared_flow.include_files_base_dir is None
 
     def test_with_options_replaces_include_files(
         self, work_pool: WorkPool, result_storage: LocalFileSystem


### PR DESCRIPTION
## Summary

this PR adds an `include_files_base_dir` option to infrastructure decorators so bundle file patterns can be resolved outside the directory containing the flow file.

```python
@docker(
    work_pool="my-pool",
    include_files=["config.yaml", "data/"],
    include_files_base_dir=Path("/my/custom/base-dir"),
)
@flow
def my_flow():
    ...
```

The option accepts a string or `pathlib.Path`. Omitting it preserves the existing behavior of resolving patterns relative to the flow file.

<details>
<summary>Implementation details</summary>

`create_bundle_for_flow_run` previously always derived the collection root from `inspect.getfile(flow.fn)`. It now uses the configured base directory when present, including for archive-relative paths and `.prefectignore` filtering.

The option is propagated through `InfrastructureBoundFlow`, `bind_flow_to_infrastructure`, and `with_options`, and is exposed by the Docker, ECS, Azure Container Instance, Cloud Run, Vertex AI, and Kubernetes decorators.

User documentation and generated API references are updated for the new option.

</details>

## Validation

- `uv run pytest tests/_experimental/bundles/test_bundles.py -q --tb=short` (14 passed)
- `uv run pytest tests/_experimental/bundles/test_include_files_integration.py -q --tb=short` (15 passed, 4 optional-AWS skips)
- `uv run pytest tests/test_infrastructure_bound_flow.py -k 'include_files' -q --tb=short` (10 passed)
- focused decorator tests for Docker, AWS, Azure, GCP, and Kubernetes (6 passed)
- Ruff formatting and import/error checks
- codespell and `git diff --check`
