### PR TITLE
fix(snowflake): close() swallows a failing cursor reset

### DIFF
--- a/src/integrations/prefect-snowflake/prefect_snowflake/database.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/database.py
@@ -794,12 +794,15 @@ class SnowflakeConnector(DatabaseBlock):
         try:
             self.reset_cursors()
         finally:
+            # No `return` in here: returning out of a `finally` block discards
+            # whatever exception `reset_cursors` was raising, so a failed cursor
+            # reset used to look like a clean close to the caller.
             if self._connection is None:
                 self.logger.info("There was no connection open to be closed.")
-                return
-            self._connection.close()
-            self._connection = None
-            self.logger.info("Successfully closed the Snowflake connection.")
+            else:
+                self._connection.close()
+                self._connection = None
+                self.logger.info("Successfully closed the Snowflake connection.")
 
     def __enter__(self):
         """

--- a/src/integrations/prefect-snowflake/tests/test_database.py
+++ b/src/integrations/prefect-snowflake/tests/test_database.py
@@ -399,6 +399,20 @@ class TestSnowflakeConnector:
         assert snowflake_connector._connection is None
         assert snowflake_connector._unique_cursors == {}
 
+    def test_close_propagates_a_failing_cursor_reset(
+        self, snowflake_connector: SnowflakeConnector, monkeypatch
+    ):
+        """A `return` inside the `finally` block used to discard this error."""
+
+        def boom():
+            raise RuntimeError("cursor reset blew up")
+
+        monkeypatch.setattr(snowflake_connector, "reset_cursors", boom)
+
+        assert snowflake_connector._connection is None
+        with pytest.raises(RuntimeError, match="cursor reset blew up"):
+            snowflake_connector.close()
+
     def test_context_management(self, snowflake_connector):
         with snowflake_connector:
             assert snowflake_connector._connection is None


### PR DESCRIPTION
## Problem

`SnowflakeConnector.close()` returns out of its `finally` block:

```python
def close(self):
    try:
        self.reset_cursors()
    finally:
        if self._connection is None:
            self.logger.info("There was no connection open to be closed.")
            return                      # <-- discards the in-flight exception
        self._connection.close()
        ...
```

A `return` inside `finally` discards whatever exception was propagating. So if
`reset_cursors()` raises on a connector that never opened a connection — the
`_connection is None` path — the caller is told the close succeeded and the
original error is gone.

That is the exact shape that hides cursor-cleanup failures during teardown,
including inside `__exit__`, where the connector is closed on the way out of a
`with` block that may itself already be unwinding.

## Fix

Replace the early return with an `if`/`else` so the `finally` block falls off
the end. Logged messages and the connection teardown are byte-for-byte the same;
the only behavioural change is that an exception from `reset_cursors()` now
reaches the caller.

## Test

Added `test_close_propagates_a_failing_cursor_reset` next to the existing
`test_close`. It monkeypatches `reset_cursors` to raise and asserts the error
escapes `close()`.

With the early `return` restored, it fails:

```
E       Failed: DID NOT RAISE RuntimeError
```

`pytest src/integrations/prefect-snowflake/tests/test_database.py -k close`
→ 2 passed. `ruff format --check` clean on both files.
