### PR TITLE
fix(runner): wait for crashed hooks before cleanup

### DIFF
--- a/src/prefect/runner/_flow_run_executor.py
+++ b/src/prefect/runner/_flow_run_executor.py
@@ -61,9 +61,9 @@ class FlowRunExecutor:
     3. start process via starter — `task_status.started(handle)` signals caller early
     4. add handle to `process_manager`
     5. block until process exits (starter.start blocks after signaling started)
-    6. remove handle from `process_manager` (in finally)
-    7. interpret exit code -> propose terminal state (crashed) if non-zero
-    8. run crashed hooks if exit was non-zero
+    6. interpret exit code -> propose terminal state (crashed) if non-zero
+    7. run crashed hooks if exit was non-zero
+    8. remove handle from `process_manager` (in finally)
 
     ASYNCEXITSTACK 6-STEP DEPENDENCY ORDER (for Phase 5 `Runner.__aenter__`):
     Entry order (LIFO teardown is exact reverse):
@@ -160,30 +160,34 @@ class FlowRunExecutor:
                 message=f"Flow run could not start: {exc}",
             )
             return
+        try:
+            # Step 6: interpret exit code and propose terminal state
+            exit_code = handle.returncode if handle else None
+            if exit_code is not None and exit_code != 0:
+                info = get_infrastructure_exit_info(exit_code)
+                msg = (
+                    f"Process exited with status code: {exit_code}. {info.explanation}"
+                )
+                self._logger.log(
+                    info.log_level, msg, extra={"flow_run_id": self._flow_run.id}
+                )
+                if info.resolution:
+                    self._logger.info(
+                        info.resolution,
+                        extra={"flow_run_id": self._flow_run.id},
+                    )
+                crashed_state = await self._state_proposer.propose_crashed(
+                    self._flow_run, message=msg
+                )
+                # Step 7: run crashed hooks
+                if crashed_state is not None:
+                    await self._hook_runner.run_crashed_hooks(
+                        self._flow_run, crashed_state
+                    )
         finally:
-            # Step 6: remove handle from process_manager
+            # Step 8: keep the handle registered until post-process hooks finish.
             if handle is not None:
                 await self._process_manager.remove(self._flow_run.id)
-
-        # Step 7: interpret exit code and propose terminal state
-        exit_code = handle.returncode if handle else None
-        if exit_code is not None and exit_code != 0:
-            info = get_infrastructure_exit_info(exit_code)
-            msg = f"Process exited with status code: {exit_code}. {info.explanation}"
-            self._logger.log(
-                info.log_level, msg, extra={"flow_run_id": self._flow_run.id}
-            )
-            if info.resolution:
-                self._logger.info(
-                    info.resolution,
-                    extra={"flow_run_id": self._flow_run.id},
-                )
-            crashed_state = await self._state_proposer.propose_crashed(
-                self._flow_run, message=msg
-            )
-            # Step 8: run crashed hooks
-            if crashed_state is not None:
-                await self._hook_runner.run_crashed_hooks(self._flow_run, crashed_state)
 
     async def _start_process(
         self,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1422,6 +1422,7 @@ class Runner:
         stream_output: bool = True,
     ) -> Union[Optional[int], Exception]:
         run_logger = self._get_flow_run_logger(flow_run)
+        finalize_after_hooks = False
 
         try:
             exit_code = await self._run_process(
@@ -1447,6 +1448,7 @@ class Runner:
                 flow_run_logger.info(
                     f"Process for flow run {flow_run.name!r} exited cleanly."
                 )
+            finalize_after_hooks = True
         except Exception as exc:
             if not task_status._future.done():  # type: ignore
                 # This flow run was being submitted and did not start successfully
@@ -1466,30 +1468,33 @@ class Runner:
             return exc
         finally:
             self._release_limit_slot(flow_run.id)
-
-            await self._remove_flow_run_process_map_entry(flow_run.id)
-
-        if exit_code != 0 and not self._rescheduling:
-            await self._propose_crashed_state(
-                flow_run,
-                f"Flow run process exited with non-zero status code {exit_code}.",
-            )
+            if not finalize_after_hooks:
+                await self._remove_flow_run_process_map_entry(flow_run.id)
 
         try:
-            api_flow_run = await self._client.read_flow_run(flow_run_id=flow_run.id)
-            terminal_state = api_flow_run.state
-            if terminal_state and terminal_state.is_crashed():
-                await self._run_on_crashed_hooks(
-                    flow_run=flow_run, state=terminal_state
+            if exit_code != 0 and not self._rescheduling:
+                await self._propose_crashed_state(
+                    flow_run,
+                    f"Flow run process exited with non-zero status code {exit_code}.",
                 )
-        except ObjectNotFound:
-            # Flow run was deleted - log it but don't crash the runner
-            run_logger = self._get_flow_run_logger(flow_run)
-            run_logger.debug(
-                f"Flow run '{flow_run.id}' was deleted before final state could be checked"
-            )
 
-        return exit_code
+            try:
+                api_flow_run = await self._client.read_flow_run(flow_run_id=flow_run.id)
+                terminal_state = api_flow_run.state
+                if terminal_state and terminal_state.is_crashed():
+                    await self._run_on_crashed_hooks(
+                        flow_run=flow_run, state=terminal_state
+                    )
+            except ObjectNotFound:
+                # Flow run was deleted - log it but don't crash the runner
+                run_logger = self._get_flow_run_logger(flow_run)
+                run_logger.debug(
+                    f"Flow run '{flow_run.id}' was deleted before final state could be checked"
+                )
+
+            return exit_code
+        finally:
+            await self._remove_flow_run_process_map_entry(flow_run.id)
 
     async def _propose_pending_state(self, flow_run: "FlowRun") -> bool:
         return await self._state_proposer.propose_pending(flow_run)

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -302,6 +302,29 @@ class TestFlowRunExecutorSubmit:
             "run_crashed_hooks"
         )
 
+    async def test_submit_keeps_handle_registered_until_crashed_hooks_finish(self):
+        executor, m = _make_executor(handle_returncode=1)
+        crashed_state = MagicMock()
+        hook_started = anyio.Event()
+        hook_can_finish = anyio.Event()
+
+        m["state_proposer"].propose_crashed = AsyncMock(return_value=crashed_state)
+
+        async def run_crashed_hooks(*_args: object, **_kwargs: object) -> None:
+            hook_started.set()
+            await hook_can_finish.wait()
+
+        m["hook_runner"].run_crashed_hooks = AsyncMock(side_effect=run_crashed_hooks)
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(executor.submit)
+            await hook_started.wait()
+
+            m["process_manager"].remove.assert_not_awaited()
+            hook_can_finish.set()
+
+        m["process_manager"].remove.assert_awaited_once_with(m["flow_run"].id)
+
     async def test_submit_signals_task_status_with_handle(self):
         """Outer task_status.started(handle) called with ProcessHandle."""
         executor, m = _make_executor()

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -60,7 +60,7 @@ from prefect.events.schemas.deployment_triggers import DeploymentEventTrigger
 from prefect.exceptions import ScriptError
 from prefect.flows import Flow
 from prefect.logging.loggers import flow_run_logger
-from prefect.runner.runner import Runner
+from prefect.runner.runner import ProcessMapEntry, Runner
 from prefect.runner.server import perform_health_check
 from prefect.schedules import Cron, Interval
 from prefect.settings import (
@@ -1163,6 +1163,48 @@ class TestRunner:
         assert flow_run.state.is_crashed()
         # check to make sure on_cancellation hook was called
         assert "This flow crashed!" in caplog.text
+
+    async def test_process_entry_remains_until_crashed_hooks_finish(self):
+        runner = Runner()
+        flow_run = FlowRun(
+            id=uuid.uuid4(),
+            flow_id=uuid.uuid4(),
+            name="crashed-flow-run",
+        )
+        crashed_flow_run = flow_run.model_copy(update={"state": Crashed()})
+        hook_started = asyncio.Event()
+        hook_can_finish = asyncio.Event()
+
+        async def run_crashed_hooks(*_args: Any, **_kwargs: Any) -> None:
+            hook_started.set()
+            await hook_can_finish.wait()
+
+        runner._client = MagicMock()
+        runner._client.read_flow_run = AsyncMock(return_value=crashed_flow_run)
+        runner._cancelling_observer = MagicMock()
+        runner._control_channel.unregister = MagicMock()
+        runner._release_limit_slot = MagicMock()
+        runner._run_process = AsyncMock(return_value=1)
+        runner._propose_crashed_state = AsyncMock(return_value=Crashed())
+        runner._run_on_crashed_hooks = AsyncMock(side_effect=run_crashed_hooks)
+        runner._flow_run_process_map[flow_run.id] = ProcessMapEntry(
+            pid=1234, flow_run=flow_run
+        )
+
+        finalize_task = asyncio.create_task(
+            runner._submit_run_and_capture_errors(
+                flow_run=flow_run, task_status=MagicMock()
+            )
+        )
+        await hook_started.wait()
+
+        assert flow_run.id in runner._flow_run_process_map
+        assert not finalize_task.done()
+
+        hook_can_finish.set()
+        await finalize_task
+
+        assert flow_run.id not in runner._flow_run_process_map
 
     @pytest.mark.parametrize(
         "exception,hook_type",


### PR DESCRIPTION
closes #22766

this PR keeps the legacy Runner process-map entry alive until crash-state finalization and `on_crashed` hooks complete.

<details>
<summary>Details</summary>

`ProcessWorker` treats `Runner.execute_flow_run()` returning as permission to clean up its temporary working directory. The legacy runner task previously removed the process-map entry immediately after the child process exited, which unblocked `execute_flow_run()` before the crash state and hooks were handled. A hook that needed to reload the flow could therefore race with deletion of its working directory.

Process-map cleanup is now deferred through hook finalization when process monitoring completes normally. Submission and monitoring failures retain the existing immediate cleanup path, and the deferred cleanup is protected by `finally` so state or hook errors cannot leave a stale entry behind.

The regression test pauses crashed-hook execution and verifies that the process entry remains present until the hook finishes.

</details>

### Validation

- `uv run pytest tests/runner/test_runner.py -k 'test_process_entry_remains_until_crashed_hooks_finish or test_runner_handles_exceptions_in_hooks' --no-clear-db -x --tb=short`
- `uv run pytest tests/runner/test_runner.py -k test_runner_runs_on_crashed_hooks_for_remotely_stored_flows --no-clear-db -x --tb=short`
- `uv run ruff check --select F,I src/prefect/runner/runner.py tests/runner/test_runner.py`
- `uv run ruff format --check src/prefect/runner/runner.py tests/runner/test_runner.py`

### Checklist

- [x] The pull request references the related issue.
- [x] The production change includes behavior-focused regression coverage.
- [x] Documentation is not needed because this restores the existing hook lifecycle contract without changing the public API.
