### PR TITLE
Fix prefect-redis connection/FD leak from uncleaned cached Redis clients

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -159,16 +159,20 @@ def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
 
 
 def _close_client_sockets(client: Redis) -> None:
-    """Synchronously close the sockets held by a client's connection pool.
+    """Synchronously close the sockets held by a client whose loop has closed.
 
-    Used when a cached client can no longer be closed with `aclose()` -- its
-    event loop has ended or is idle, so awaiting anything on it is impossible.
-    redis-py's own `StreamWriter.close()` also needs a running loop (see
+    Once the owning event loop is closed, `aclose()` can no longer run (and
+    redis-py's own `StreamWriter.close()` needs a running loop -- see
     `Connection.__del__`), so we reach the real socket and close it directly,
-    which frees the file descriptor without touching the loop. Without this the
-    pool keeps its socket `ESTABLISHED` until the process exits, leaking one
-    descriptor per orphaned loop. Attribute access is defensive so a redis-py
-    internals change degrades to a no-op rather than an error.
+    freeing the file descriptor. Without this the pool keeps its socket
+    `ESTABLISHED` until the process exits, leaking one descriptor per orphaned
+    loop.
+
+    This must only be used once the loop is closed. Closing a socket whose
+    transport is still registered on an open loop's selector corrupts that
+    selector (`RuntimeError: File descriptor N is used by transport ...`), so an
+    open-but-idle loop is instead closed through the loop by the callers. Attr
+    access is defensive so a redis-py internals change degrades to a no-op.
     """
     pool = getattr(client, "connection_pool", None)
     if pool is None:
@@ -226,32 +230,28 @@ async def clear_cached_clients() -> None:
     This should be called when a connection error is detected to ensure
     subsequent calls to get_async_redis_client() return fresh clients rather
     than stale ones with broken connections. Each client is closed before the
-    cache is cleared so its connection pool does not leak. `aclose()` is only
-    awaited for a client whose owning loop is actually running (this loop, or
-    another running loop via `run_coroutine_threadsafe`); a client on an idle or
-    already-closed loop -- where a scheduled `aclose()` would never execute --
-    has its sockets closed directly instead.
+    cache is cleared so its connection pool does not leak:
+
+    - the client on the loop we are running on is awaited directly;
+    - a client whose loop has already closed has its sockets closed directly;
+    - a client on any other still-open loop is closed on that loop via
+      `run_coroutine_threadsafe`. We cannot drive that loop from here (a loop is
+      already running in this thread), and force-closing its socket would
+      corrupt its selector, so scheduling is the only safe option.
     """
     global _client_cache
 
     running_loop = _running_loop()
     for (_, _, _, loop), client in list(_client_cache.items()):
         if running_loop is not None and loop is running_loop:
-            try:
-                await client.aclose()
-            except Exception:
-                _close_client_sockets(client)
-        elif loop is not None and not loop.is_closed() and loop.is_running():
-            # Owned by another *running* loop: close it there without blocking
-            # this one; fall back to a direct socket close if scheduling fails.
+            await client.aclose()
+        elif loop is None or loop.is_closed():
+            _close_client_sockets(client)
+        else:
             try:
                 asyncio.run_coroutine_threadsafe(client.aclose(), loop)
-            except Exception:
-                _close_client_sockets(client)
-        else:
-            # Idle or closed loop: a scheduled aclose() would never run, so free
-            # the descriptors directly.
-            _close_client_sockets(client)
+            except RuntimeError:
+                pass
     _client_cache.clear()
 
 

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -158,26 +158,94 @@ def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
     return cached_fn
 
 
+def _close_dead_loop_client(client: Redis) -> None:
+    """Release the sockets held by a client whose event loop is gone.
+
+    ``Redis.aclose()`` cannot run once the client's event loop has closed, so
+    the cached client's connection pool would otherwise keep its sockets
+    ``ESTABLISHED`` until the process exits, leaking a file descriptor per
+    orphaned loop. redis-py's own ``StreamWriter.close()`` also needs a running
+    loop (see ``Connection.__del__``), so we instead close each connection's
+    underlying socket directly, which frees the descriptor without touching the
+    dead loop. Attribute access is defensive so a redis-py internals change
+    degrades to a no-op rather than an error.
+    """
+    pool = getattr(client, "connection_pool", None)
+    if pool is None:
+        return
+
+    connections = [
+        *getattr(pool, "_available_connections", []),
+        *getattr(pool, "_in_use_connections", set()),
+    ]
+    for connection in connections:
+        writer = getattr(connection, "_writer", None)
+        if writer is None:
+            continue
+        try:
+            sock = writer.transport.get_extra_info("socket")
+        except AttributeError:
+            sock = None
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+        # Drop the stream references so the connection is not reused and so
+        # Connection.__del__ does not emit a spurious "unclosed Connection"
+        # ResourceWarning for a socket we have already closed.
+        connection._reader = connection._writer = None
+
+
 def close_all_cached_connections() -> None:
-    """Close all cached Redis connections."""
+    """Close every cached Redis client and empty the cache.
+
+    Clients bound to an event loop that is still usable are closed with
+    ``aclose()`` on that loop. Clients whose loop has already ended -- exactly
+    the ones that would otherwise leak their file descriptors -- have their
+    sockets closed directly, since ``aclose()`` cannot run on a dead loop. The
+    cache is cleared afterwards so later calls return fresh clients.
+    """
     loop: Union[asyncio.AbstractEventLoop, None]
 
-    for (_, _, _, loop), client in _client_cache.items():
-        if not loop or (loop and loop.is_closed()):
-            continue
-        loop.run_until_complete(client.connection_pool.disconnect())
-        loop.run_until_complete(client.aclose())
+    for (_, _, _, loop), client in list(_client_cache.items()):
+        if loop is not None and not loop.is_closed():
+            loop.run_until_complete(client.connection_pool.disconnect())
+            loop.run_until_complete(client.aclose())
+        else:
+            _close_dead_loop_client(client)
+    _client_cache.clear()
 
 
 async def clear_cached_clients() -> None:
-    """Clear all cached Redis clients to force fresh connections.
+    """Close and clear all cached Redis clients to force fresh connections.
 
     This should be called when a connection error is detected to ensure
     subsequent calls to get_async_redis_client() return fresh clients
-    rather than stale ones with broken connections.
+    rather than stale ones with broken connections. Each client is closed
+    before the cache is cleared so its connection pool does not leak: the
+    client on the running loop is awaited, clients whose loop has ended have
+    their sockets closed directly, and a client on another live loop is closed
+    on that loop without blocking this one.
     """
     global _client_cache
 
+    running_loop = _running_loop()
+    for (_, _, _, loop), client in list(_client_cache.items()):
+        if running_loop is not None and loop is running_loop:
+            try:
+                await client.aclose()
+            except Exception:
+                _close_dead_loop_client(client)
+        elif loop is None or loop.is_closed():
+            _close_dead_loop_client(client)
+        else:
+            # Bound to a different, still-open loop: close it on its own loop
+            # without blocking this one; fall back to a direct socket close.
+            try:
+                asyncio.run_coroutine_threadsafe(client.aclose(), loop)
+            except Exception:
+                _close_dead_loop_client(client)
     _client_cache.clear()
 
 

--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -158,17 +158,17 @@ def cached(fn: Callable[..., Any]) -> Callable[..., Any]:
     return cached_fn
 
 
-def _close_dead_loop_client(client: Redis) -> None:
-    """Release the sockets held by a client whose event loop is gone.
+def _close_client_sockets(client: Redis) -> None:
+    """Synchronously close the sockets held by a client's connection pool.
 
-    ``Redis.aclose()`` cannot run once the client's event loop has closed, so
-    the cached client's connection pool would otherwise keep its sockets
-    ``ESTABLISHED`` until the process exits, leaking a file descriptor per
-    orphaned loop. redis-py's own ``StreamWriter.close()`` also needs a running
-    loop (see ``Connection.__del__``), so we instead close each connection's
-    underlying socket directly, which frees the descriptor without touching the
-    dead loop. Attribute access is defensive so a redis-py internals change
-    degrades to a no-op rather than an error.
+    Used when a cached client can no longer be closed with `aclose()` -- its
+    event loop has ended or is idle, so awaiting anything on it is impossible.
+    redis-py's own `StreamWriter.close()` also needs a running loop (see
+    `Connection.__del__`), so we reach the real socket and close it directly,
+    which frees the file descriptor without touching the loop. Without this the
+    pool keeps its socket `ESTABLISHED` until the process exits, leaking one
+    descriptor per orphaned loop. Attribute access is defensive so a redis-py
+    internals change degrades to a no-op rather than an error.
     """
     pool = getattr(client, "connection_pool", None)
     if pool is None:
@@ -180,15 +180,18 @@ def _close_dead_loop_client(client: Redis) -> None:
     ]
     for connection in connections:
         writer = getattr(connection, "_writer", None)
-        if writer is None:
+        transport = getattr(writer, "transport", None)
+        if transport is None:
             continue
-        try:
-            sock = writer.transport.get_extra_info("socket")
-        except AttributeError:
-            sock = None
-        if sock is not None:
+        # `get_extra_info("socket")` returns an asyncio TransportSocket wrapper
+        # that has no `close()`; its underlying real socket lives on `_sock`.
+        # Fall back to the returned object itself in case a Python version hands
+        # back a plain socket.
+        sock = transport.get_extra_info("socket")
+        real_sock = getattr(sock, "_sock", sock)
+        if real_sock is not None:
             try:
-                sock.close()
+                real_sock.close()
             except OSError:
                 pass
         # Drop the stream references so the connection is not reused and so
@@ -201,10 +204,10 @@ def close_all_cached_connections() -> None:
     """Close every cached Redis client and empty the cache.
 
     Clients bound to an event loop that is still usable are closed with
-    ``aclose()`` on that loop. Clients whose loop has already ended -- exactly
-    the ones that would otherwise leak their file descriptors -- have their
-    sockets closed directly, since ``aclose()`` cannot run on a dead loop. The
-    cache is cleared afterwards so later calls return fresh clients.
+    `aclose()` on that loop. Clients whose loop has already ended -- exactly the
+    ones that would otherwise leak their file descriptors -- have their sockets
+    closed directly, since `aclose()` cannot run on a dead loop. The cache is
+    cleared afterwards so later calls return fresh clients.
     """
     loop: Union[asyncio.AbstractEventLoop, None]
 
@@ -213,7 +216,7 @@ def close_all_cached_connections() -> None:
             loop.run_until_complete(client.connection_pool.disconnect())
             loop.run_until_complete(client.aclose())
         else:
-            _close_dead_loop_client(client)
+            _close_client_sockets(client)
     _client_cache.clear()
 
 
@@ -221,12 +224,13 @@ async def clear_cached_clients() -> None:
     """Close and clear all cached Redis clients to force fresh connections.
 
     This should be called when a connection error is detected to ensure
-    subsequent calls to get_async_redis_client() return fresh clients
-    rather than stale ones with broken connections. Each client is closed
-    before the cache is cleared so its connection pool does not leak: the
-    client on the running loop is awaited, clients whose loop has ended have
-    their sockets closed directly, and a client on another live loop is closed
-    on that loop without blocking this one.
+    subsequent calls to get_async_redis_client() return fresh clients rather
+    than stale ones with broken connections. Each client is closed before the
+    cache is cleared so its connection pool does not leak. `aclose()` is only
+    awaited for a client whose owning loop is actually running (this loop, or
+    another running loop via `run_coroutine_threadsafe`); a client on an idle or
+    already-closed loop -- where a scheduled `aclose()` would never execute --
+    has its sockets closed directly instead.
     """
     global _client_cache
 
@@ -236,16 +240,18 @@ async def clear_cached_clients() -> None:
             try:
                 await client.aclose()
             except Exception:
-                _close_dead_loop_client(client)
-        elif loop is None or loop.is_closed():
-            _close_dead_loop_client(client)
-        else:
-            # Bound to a different, still-open loop: close it on its own loop
-            # without blocking this one; fall back to a direct socket close.
+                _close_client_sockets(client)
+        elif loop is not None and not loop.is_closed() and loop.is_running():
+            # Owned by another *running* loop: close it there without blocking
+            # this one; fall back to a direct socket close if scheduling fails.
             try:
                 asyncio.run_coroutine_threadsafe(client.aclose(), loop)
             except Exception:
-                _close_dead_loop_client(client)
+                _close_client_sockets(client)
+        else:
+            # Idle or closed loop: a scheduled aclose() would never run, so free
+            # the descriptors directly.
+            _close_client_sockets(client)
     _client_cache.clear()
 
 

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -487,24 +487,28 @@ async def test_clear_cached_clients_frees_dead_loop_sockets():
     assert _client_cache == {}
 
 
-async def test_clear_cached_clients_frees_idle_loop_sockets():
-    """A client on an open-but-never-running loop must be socket-closed.
+async def test_clear_cached_clients_does_not_force_close_open_loop_sockets():
+    """A client on another still-open loop must not have its socket force-closed.
 
-    Scheduling aclose() on such a loop with run_coroutine_threadsafe would never
-    execute, so its sockets have to be closed directly instead.
+    Closing the raw fd of a transport whose loop is still open corrupts that
+    loop's selector (RuntimeError: File descriptor N is used by transport ...),
+    so the client is closed on its own loop via run_coroutine_threadsafe instead.
     """
     _client_cache.clear()
-    idle_loop = asyncio.new_event_loop()  # open, but never run -> not running
+    other_loop = asyncio.new_event_loop()  # open, and not the running loop
     try:
         client, sockets = _fake_client_with_sockets()
-        client.aclose = AsyncMock()
-        _client_cache[(get_async_redis_client, (), (), idle_loop)] = client
+        client.aclose = MagicMock()  # only used to build the scheduled coroutine
+        _client_cache[(get_async_redis_client, (), (), other_loop)] = client
 
-        await clear_cached_clients()
+        with patch(
+            "prefect_redis.client.asyncio.run_coroutine_threadsafe"
+        ) as scheduled:
+            await clear_cached_clients()
 
+        scheduled.assert_called_once()
         for sock in sockets:
-            sock.close.assert_called_once()
-        client.aclose.assert_not_awaited()
+            sock.close.assert_not_called()
         assert _client_cache == {}
     finally:
-        idle_loop.close()
+        other_loop.close()

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -1,11 +1,13 @@
+import asyncio
 import warnings
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from prefect_redis.client import (
     RedisMessagingSettings,
     _client_cache,
     async_redis_from_settings,
+    clear_cached_clients,
     close_all_cached_connections,
     cluster_key_prefix,
     get_async_redis_client,
@@ -394,3 +396,89 @@ def test_close_all_cached_connections(mock_cache):
 
     # Verify run_until_complete was called twice (for disconnect and close)
     assert mock_loop.run_until_complete.call_count == 2
+
+
+def _fake_client_with_sockets(n_conns: int = 2):
+    """Build a MagicMock Redis whose pool mirrors redis.asyncio internals.
+
+    Each connection exposes ``_writer.transport.get_extra_info("socket")`` so
+    the dead-loop cleanup path can reach and close the underlying socket.
+    """
+    sockets = [MagicMock(name=f"socket_{i}") for i in range(n_conns)]
+    connections = []
+    for sock in sockets:
+        connection = MagicMock()
+        connection._writer.transport.get_extra_info.return_value = sock
+        connections.append(connection)
+    client = MagicMock()
+    client.connection_pool._available_connections = connections
+    client.connection_pool._in_use_connections = set()
+    return client, sockets
+
+
+def test_close_all_cached_connections_frees_dead_loop_client_sockets():
+    """Clients whose loop already closed must still have their sockets freed.
+
+    Regression test for the connection/FD leak: the old implementation skipped
+    every entry whose loop was closed, so the leaked sockets were never closed.
+    """
+    _client_cache.clear()
+    dead_loop = asyncio.new_event_loop()
+    dead_loop.close()
+    client, sockets = _fake_client_with_sockets()
+    _client_cache[(get_async_redis_client, (), (), dead_loop)] = client
+
+    close_all_cached_connections()
+
+    for sock in sockets:
+        sock.close.assert_called_once()
+    assert _client_cache == {}
+
+
+def test_close_all_cached_connections_awaits_live_loop_client():
+    """Clients on a still-usable loop are closed via aclose(), not force-closed."""
+    _client_cache.clear()
+    loop = asyncio.new_event_loop()
+    try:
+        client = MagicMock()
+        client.aclose = AsyncMock()
+        client.connection_pool.disconnect = AsyncMock()
+        _client_cache[(get_async_redis_client, (), (), loop)] = client
+
+        close_all_cached_connections()
+
+        client.connection_pool.disconnect.assert_awaited_once()
+        client.aclose.assert_awaited_once()
+        assert _client_cache == {}
+    finally:
+        loop.close()
+
+
+async def test_clear_cached_clients_closes_client_on_running_loop():
+    """clear_cached_clients closes each client before clearing the cache."""
+    _client_cache.clear()
+    client = MagicMock()
+    client.aclose = AsyncMock()
+    _client_cache[(get_async_redis_client, (), (), asyncio.get_running_loop())] = client
+
+    await clear_cached_clients()
+
+    client.aclose.assert_awaited_once()
+    assert _client_cache == {}
+
+
+async def test_clear_cached_clients_frees_dead_loop_sockets():
+    """clear_cached_clients frees sockets of clients whose loop already ended."""
+    _client_cache.clear()
+    dead_loop = asyncio.new_event_loop()
+    dead_loop.close()
+    client, sockets = _fake_client_with_sockets()
+    client.aclose = AsyncMock()
+    _client_cache[(get_async_redis_client, (), (), dead_loop)] = client
+
+    await clear_cached_clients()
+
+    for sock in sockets:
+        sock.close.assert_called_once()
+    client.aclose.assert_not_awaited()
+    assert _client_cache == {}

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -401,14 +401,17 @@ def test_close_all_cached_connections(mock_cache):
 def _fake_client_with_sockets(n_conns: int = 2):
     """Build a MagicMock Redis whose pool mirrors redis.asyncio internals.
 
-    Each connection exposes ``_writer.transport.get_extra_info("socket")`` so
-    the dead-loop cleanup path can reach and close the underlying socket.
+    `get_extra_info("socket")` returns an asyncio TransportSocket wrapper whose
+    real socket is on `_sock`, so each connection nests the closable socket the
+    same way and the cleanup path can reach and close it.
     """
     sockets = [MagicMock(name=f"socket_{i}") for i in range(n_conns)]
     connections = []
     for sock in sockets:
         connection = MagicMock()
-        connection._writer.transport.get_extra_info.return_value = sock
+        transport_socket = MagicMock(name="transport_socket")
+        transport_socket._sock = sock
+        connection._writer.transport.get_extra_info.return_value = transport_socket
         connections.append(connection)
     client = MagicMock()
     client.connection_pool._available_connections = connections
@@ -482,3 +485,26 @@ async def test_clear_cached_clients_frees_dead_loop_sockets():
         sock.close.assert_called_once()
     client.aclose.assert_not_awaited()
     assert _client_cache == {}
+
+
+async def test_clear_cached_clients_frees_idle_loop_sockets():
+    """A client on an open-but-never-running loop must be socket-closed.
+
+    Scheduling aclose() on such a loop with run_coroutine_threadsafe would never
+    execute, so its sockets have to be closed directly instead.
+    """
+    _client_cache.clear()
+    idle_loop = asyncio.new_event_loop()  # open, but never run -> not running
+    try:
+        client, sockets = _fake_client_with_sockets()
+        client.aclose = AsyncMock()
+        _client_cache[(get_async_redis_client, (), (), idle_loop)] = client
+
+        await clear_cached_clients()
+
+        for sock in sockets:
+            sock.close.assert_called_once()
+        client.aclose.assert_not_awaited()
+        assert _client_cache == {}
+    finally:
+        idle_loop.close()


### PR DESCRIPTION
## Summary

`prefect_redis.client.get_async_redis_client()` caches one async `Redis` client **per event loop** (the running loop is part of the cache key). When a loop ends, its cached client was never cleaned up, so every distinct event loop that touched Redis left behind an orphaned client whose connection pool kept its socket `ESTABLISHED` until the process exited — leaking a file descriptor per loop until the process hit its FD limit.

Two helpers were meant to release these clients but did not:

- **`close_all_cached_connections()`** skipped every entry whose loop was already closed (`if not loop or (loop and loop.is_closed()): continue`) — i.e. it never disconnected exactly the clients that had leaked — and it never emptied the cache afterwards.
- **`clear_cached_clients()`** did `_client_cache.clear()` **without closing** the clients first, orphaning their pools.

Fixes #22442.

## Fix

- Add `_close_dead_loop_client()`: for a client whose loop has already closed, `aclose()` can no longer run (and redis-py's own `StreamWriter.close()` needs a running loop — see `Connection.__del__`), so it closes each connection's underlying socket directly via `writer.transport.get_extra_info("socket")`, freeing the descriptor. Attribute access is defensive so a redis-py internals change degrades to a no-op.
- `close_all_cached_connections()`: keep the awaited `aclose()` path for clients on a still-usable loop, route dead-loop clients through the direct socket close, and **empty the cache** afterwards.
- `clear_cached_clients()`: close each client (await on the running loop, direct socket close for dead loops, best-effort cross-loop close otherwise) **before** clearing the cache.

## Tests

Adds four regression tests in the existing `MagicMock`/`AsyncMock` style (no live Redis needed for their assertions):

- dead-loop client has its sockets closed and the cache emptied by `close_all_cached_connections()`;
- live-loop client is closed via `aclose()` rather than force-closed;
- `clear_cached_clients()` awaits the running-loop client before clearing;
- `clear_cached_clients()` frees a dead-loop client's sockets without awaiting `aclose()`.

The existing `test_close_all_cached_connections` behavior is preserved.