### PR TITLE
(ui-v2): show elapsed time for running flow runs in header

### DIFF
--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.test.tsx
@@ -47,6 +47,7 @@ describe("FlowRunHeader", () => {
 		state_name: "Completed",
 		start_time: "2025-05-15T09:45:46Z",
 		total_run_time: 7,
+		estimated_run_time: 0,
 		state: createFakeState({
 			type: "COMPLETED",
 			name: "Completed",

--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
@@ -206,7 +206,9 @@ export function FlowRunHeader({ flowRun, onDeleteClick }: FlowRunHeaderProps) {
 					<div className="flex items-center gap-1">
 						<Icon id="Clock" className="size-4" />
 						<span>
-							{secondsToApproximateString(flowRun.total_run_time ?? 0)}
+							{secondsToApproximateString(
+							(flowRun.estimated_run_time || flowRun.total_run_time) ?? 0,
+						)}
 						</span>
 					</div>
 					<div

--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
@@ -207,7 +207,9 @@ export function FlowRunHeader({ flowRun, onDeleteClick }: FlowRunHeaderProps) {
 						<Icon id="Clock" className="size-4" />
 						<span>
 							{secondsToApproximateString(
-								(flowRun.total_run_time || flowRun.estimated_run_time) ?? 0,
+								isRunningState(flowRun.state_type)
+									? (flowRun.estimated_run_time ?? 0)
+									: (flowRun.total_run_time ?? 0),
 							)}
 						</span>
 					</div>

--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
@@ -207,8 +207,8 @@ export function FlowRunHeader({ flowRun, onDeleteClick }: FlowRunHeaderProps) {
 						<Icon id="Clock" className="size-4" />
 						<span>
 							{secondsToApproximateString(
-							(flowRun.estimated_run_time || flowRun.total_run_time) ?? 0,
-						)}
+								(flowRun.estimated_run_time || flowRun.total_run_time) ?? 0,
+							)}
 						</span>
 					</div>
 					<div

--- a/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
+++ b/ui-v2/src/components/flow-runs/flow-run-details-page/flow-run-header.tsx
@@ -207,7 +207,7 @@ export function FlowRunHeader({ flowRun, onDeleteClick }: FlowRunHeaderProps) {
 						<Icon id="Clock" className="size-4" />
 						<span>
 							{secondsToApproximateString(
-								(flowRun.estimated_run_time || flowRun.total_run_time) ?? 0,
+								(flowRun.total_run_time || flowRun.estimated_run_time) ?? 0,
 							)}
 						</span>
 					</div>


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

I didn't create an issue, because it is a tiny fix.

The flow run header was showing `0s` for running flows because it only used `total_run_time`, which is `0` until a run completes. Fixed by using `estimated_run_time ||     
  total_run_time`, matching the pattern already used elsewhere in the codebase.                                                                                               
                                                                                                                                                                              
                                                                                                                                                           
  <summary>Before / After</summary>                                                                                                                                           
                                                                                                                                                                              
 
<img width="564" height="64" alt="Screenshot 2026-08-12 at 17 00 23" src="https://github.com/user-attachments/assets/9e1c068a-e7a7-4eab-9ecb-56041e44eced" />
<img width="564" height="64" alt="Screenshot 2026-08-12 at 17 08 59" src="https://github.com/user-attachments/assets/757e0388-3ca0-4d32-8c70-536471210d8b" />
        