### PR TITLE
Reject option-like Git branch values

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -217,6 +217,9 @@ class GitRepository:
                 "Cannot provide both a branch and a commit SHA. Please provide only one."
             )
 
+        if branch and branch.startswith("-"):
+            raise ValueError("Branch names cannot start with '-'.")
+
         if commit_sha and not re.match(r"^[0-9a-fA-F]{4,64}$", commit_sha):
             raise ValueError(
                 f"Invalid commit SHA: {commit_sha!r}."

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1001,6 +1001,17 @@ class TestSetWorkingDirectory:
 
 
 class TestGitCloneStep:
+    async def test_git_clone_rejects_option_like_branch(self):
+        with pytest.raises(ValueError, match="Branch names cannot start with '-'"):
+            await run_step(
+                {
+                    "prefect.deployments.steps.git_clone": {
+                        "repository": "https://github.com/org/repo.git",
+                        "branch": "--upload-pack=touch /tmp/pwned",
+                    }
+                }
+            )
+
     async def test_git_clone(self, git_repository_mock):
         output = await run_step(
             {

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -193,6 +193,20 @@ class TestGitRepository:
                 branch="main",
             )
 
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "--upload-pack=touch /tmp/pwned",
+            "-u touch /tmp/pwned",
+        ],
+    )
+    def test_init_rejects_option_like_branch(self, branch: str):
+        with pytest.raises(ValueError, match="Branch names cannot start with '-'"):
+            GitRepository(
+                url="https://github.com/org/repo.git",
+                branch=branch,
+            )
+
     def test_init_with_username_no_token(self):
         with pytest.raises(
             ValueError,


### PR DESCRIPTION
this PR adds defense-in-depth validation that rejects Git branch values beginning with `-` before command construction.

Git treats leading-dash branch values as command-line options during an existing repository pull. This could allow values such as `--upload-pack` to change Git's behavior. Validating at `GitRepository` construction covers direct storage use and the `git_clone` deployment pull step while preserving ordinary branch and tag names.

<details>
<summary>Details</summary>

- reject long- and short-option-like branch values
- cover the shared storage boundary and the deployment pull-step entrypoint
- preserve normal and slash-separated branch behavior
- verified with `uv run pytest tests/runner/test_storage.py tests/deployment/test_steps.py -x --tb=short` (213 passed, 1 skipped)
- checked formatting and focused Ruff syntax/import rules

Related: [CVE-2026-72538](https://github.com/advisories/GHSA-42fh-94w4-956q)
</details>
