### PR TITLE
Confirm suspension events against the flow run instead of state-by-id

### DIFF
--- a/src/prefect/_internal/observers.py
+++ b/src/prefect/_internal/observers.py
@@ -24,8 +24,9 @@ from prefect.exceptions import ObjectNotFound
 from prefect.logging.loggers import get_logger
 from prefect.utilities.services import critical_service_loop
 
-# How long to wait before warning that a suspension state is still unavailable,
-# how often to look initially, and the retry cap after the warning.
+# How long to wait before warning that a suspension transition is still not
+# visible on the flow run, how often to look initially, and the retry cap after
+# the warning.
 SUSPENSION_CONFIRMATION_WARNING_AFTER = 30.0
 SUSPENSION_CONFIRMATION_INTERVAL = 0.5
 SUSPENSION_CONFIRMATION_MAX_INTERVAL = 10.0
@@ -112,29 +113,52 @@ class _SuspensionWatch:
         last_error: Exception | None = None
 
         while not self._closed and not self.is_suspended:
+            # Confirm against the flow run rather than the state-by-id endpoint:
+            # the run is the observer's own resource, and its current state
+            # carries the id and timestamp needed to recognize the reported
+            # transition. Backends that keep in-flight state outside the state
+            # archive (e.g. Prefect Cloud's run-keyed live state) always serve
+            # the run's current state, while an individual superseded state may
+            # never become readable by id.
             try:
-                state = await self._client.read_flow_run_state(state_id)
+                flow_run = await self._client.read_flow_run(self.flow_run_id)
             except ObjectNotFound:
-                pass
+                self._logger.debug(
+                    "Flow run %s no longer exists; abandoning suspension confirmation.",
+                    self.flow_run_id,
+                )
+                return
             except Exception as exc:
                 last_error = exc
             else:
-                if state.state_details.flow_run_id not in (None, self.flow_run_id):
-                    self._logger.warning(
-                        "Suspension event for flow run %s referred to state %s owned"
-                        " by flow run %s.",
-                        self.flow_run_id,
-                        state_id,
-                        state.state_details.flow_run_id,
-                    )
-                    return
-                self.notify_if_suspended(state)
-                return
+                state = flow_run.state
+                if state is not None:
+                    if state.id == state_id or is_suspended_flow_run_state(state):
+                        self.notify_if_suspended(state)
+                        return
+                    if state.timestamp >= occurred:
+                        # The run has already moved past the reported suspension
+                        # (e.g. it was resumed before this observer confirmed
+                        # it). The suspension still happened, and a resumed run
+                        # gets a fresh submission — this engine must stop at the
+                        # next boundary so the two cannot double-execute.
+                        self.notify_if_suspended(
+                            State(
+                                id=state_id,
+                                type=StateType.PAUSED,
+                                name="Suspended",
+                                timestamp=occurred,
+                            )
+                        )
+                        return
+                # The current state is missing or older than the reported
+                # transition: the event outran readability; keep retrying.
 
             if not warned and time.monotonic() >= warning_deadline:
                 self._logger.warning(
-                    "Received a suspension event for flow run %s, but state %s has"
-                    " not become readable within %s seconds; continuing to retry.",
+                    "Received a suspension event for flow run %s, but its state %s"
+                    " has not become visible within %s seconds; continuing to"
+                    " retry.",
                     self.flow_run_id,
                     state_id,
                     SUSPENSION_CONFIRMATION_WARNING_AFTER,

--- a/src/prefect/_internal/observers.py
+++ b/src/prefect/_internal/observers.py
@@ -113,13 +113,6 @@ class _SuspensionWatch:
         last_error: Exception | None = None
 
         while not self._closed and not self.is_suspended:
-            # Confirm against the flow run rather than the state-by-id endpoint:
-            # the run is the observer's own resource, and its current state
-            # carries the id and timestamp needed to recognize the reported
-            # transition. Backends that keep in-flight state outside the state
-            # archive (e.g. Prefect Cloud's run-keyed live state) always serve
-            # the run's current state, while an individual superseded state may
-            # never become readable by id.
             try:
                 flow_run = await self._client.read_flow_run(self.flow_run_id)
             except ObjectNotFound:
@@ -137,11 +130,9 @@ class _SuspensionWatch:
                         self.notify_if_suspended(state)
                         return
                     if state.timestamp >= occurred:
-                        # The run has already moved past the reported suspension
-                        # (e.g. it was resumed before this observer confirmed
-                        # it). The suspension still happened, and a resumed run
-                        # gets a fresh submission — this engine must stop at the
-                        # next boundary so the two cannot double-execute.
+                        # Superseded (e.g. resumed) before confirmation: still
+                        # stop, or this engine could double-execute alongside
+                        # the resumed run's fresh submission.
                         self.notify_if_suspended(
                             State(
                                 id=state_id,
@@ -151,8 +142,6 @@ class _SuspensionWatch:
                             )
                         )
                         return
-                # The current state is missing or older than the reported
-                # transition: the event outran readability; keep retrying.
 
             if not warned and time.monotonic() >= warning_deadline:
                 self._logger.warning(

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -12,6 +12,7 @@ import pytest
 from prefect import flow
 from prefect._flow_run_suspension import (
     FlowRunSuspensionRequest,
+    is_suspended_flow_run_state,
     observe_flow_run_suspension,
 )
 from prefect._internal.observers import (
@@ -24,7 +25,7 @@ from prefect.events import Event, Resource
 from prefect.events.filters import EventAnyResourceFilter, EventFilter, EventNameFilter
 from prefect.events.utilities import emit_event
 from prefect.exceptions import ObjectNotFound
-from prefect.states import Running, Suspended
+from prefect.states import Running, Scheduled, Suspended
 from prefect.types._datetime import DateTime, now
 
 
@@ -671,7 +672,7 @@ class TestFlowRunSuspendingObserver:
             callback.assert_called_once_with(flow_run_id, state)
             assert "Failed to check current state" in caplog.text
 
-    async def test_event_confirmation_retries_exact_state_after_warning(
+    async def test_event_confirmation_retries_until_transition_visible(
         self, monkeypatch, caplog
     ):
         callback = MagicMock()
@@ -685,6 +686,9 @@ class TestFlowRunSuspendingObserver:
         observer = FlowRunSuspendingObserver(on_suspended=callback)
 
         flow_run_id = uuid.uuid4()
+        stale_state = Running(
+            timestamp=cast(DateTime, now("UTC") - timedelta(seconds=1))
+        )
         suspended_state = Suspended()
 
         async with observer:
@@ -692,13 +696,13 @@ class TestFlowRunSuspendingObserver:
 
             with patch.object(
                 observer._client,
-                "read_flow_run_state",
+                "read_flow_run",
                 side_effect=[
                     RuntimeError("temporarily unavailable"),
-                    ObjectNotFound(Exception("not committed")),
-                    suspended_state,
+                    MagicMock(state=stale_state),
+                    MagicMock(state=suspended_state),
                 ],
-            ) as read_flow_run_state:
+            ) as read_flow_run:
                 await self.consume(
                     observer, suspension_event(flow_run_id, suspended_state.id)
                 )
@@ -707,8 +711,73 @@ class TestFlowRunSuspendingObserver:
                     with attempt:
                         callback.assert_called_once_with(flow_run_id, suspended_state)
 
-            assert read_flow_run_state.await_count == 3
+            assert read_flow_run.await_count == 3
             assert "continuing to retry" in caplog.text
+
+    async def test_superseded_suspension_still_notifies(self):
+        """A suspension the run has already moved past (e.g. it was resumed
+        before this observer confirmed it) must still stop the engine: the
+        resumed run gets a fresh submission, and this engine continuing would
+        double-execute. The confirmation reconstructs the reported Suspended
+        state from the event's identity."""
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+
+        flow_run_id = uuid.uuid4()
+        state_id = uuid.uuid4()
+        occurred = cast(DateTime, now("UTC") - timedelta(seconds=5))
+        resumed_state = Scheduled()
+
+        async with observer:
+            observer.add_in_flight_flow_run_id(flow_run_id)
+
+            with patch.object(
+                observer._client,
+                "read_flow_run",
+                return_value=MagicMock(state=resumed_state),
+            ):
+                await self.consume(
+                    observer,
+                    suspension_event(flow_run_id, state_id, occurred=occurred),
+                )
+
+                async for attempt in retry_asserts():
+                    with attempt:
+                        callback.assert_called_once()
+
+        notified_flow_run_id, notified_state = callback.call_args[0]
+        assert notified_flow_run_id == flow_run_id
+        assert notified_state.id == state_id
+        assert notified_state.timestamp == occurred
+        assert is_suspended_flow_run_state(notified_state)
+
+    async def test_confirmation_abandoned_when_flow_run_deleted(self):
+        """A deleted flow run has nothing left to suspend: the confirmation
+        stops instead of retrying forever."""
+        callback = MagicMock()
+        observer = FlowRunSuspendingObserver(on_suspended=callback)
+
+        flow_run_id = uuid.uuid4()
+
+        async with observer:
+            observer.add_in_flight_flow_run_id(flow_run_id)
+
+            with patch.object(
+                observer._client,
+                "read_flow_run",
+                side_effect=ObjectNotFound(Exception("deleted")),
+            ) as read_flow_run:
+                await self.consume(
+                    observer, suspension_event(flow_run_id, uuid.uuid4())
+                )
+
+                async for attempt in retry_asserts():
+                    with attempt:
+                        assert read_flow_run.await_count == 1
+
+                await asyncio.sleep(0)
+                assert read_flow_run.await_count == 1
+                callback.assert_not_called()
 
     @pytest.mark.parametrize(
         ("event_offset", "should_suspend"),
@@ -725,21 +794,16 @@ class TestFlowRunSuspendingObserver:
         checkpoint = cast(DateTime, now("UTC") - timedelta(minutes=5))
         current_state = Running(timestamp=checkpoint)
         suspended_state = Suspended()
-        flow_run = MagicMock(state=current_state)
 
         async with observer:
-            with (
-                patch.object(
-                    observer._client,
-                    "read_flow_run",
-                    return_value=flow_run,
-                ),
-                patch.object(
-                    observer._client,
-                    "read_flow_run_state",
-                    return_value=suspended_state,
-                ) as read_flow_run_state,
-            ):
+            with patch.object(
+                observer._client,
+                "read_flow_run",
+                side_effect=[
+                    MagicMock(state=current_state),
+                    MagicMock(state=suspended_state),
+                ],
+            ) as read_flow_run:
                 await observer.watch_flow_run_id(flow_run_id)
                 await self.consume(
                     observer,
@@ -760,7 +824,9 @@ class TestFlowRunSuspendingObserver:
                             )
                 else:
                     await asyncio.sleep(0)
-                    read_flow_run_state.assert_not_awaited()
+                    # Only the initial state check read the flow run; the
+                    # replayed event was filtered before any confirmation read.
+                    assert read_flow_run.await_count == 1
                     callback.assert_not_called()
 
     async def test_event_is_buffered_during_initial_state_check(self):
@@ -773,22 +839,20 @@ class TestFlowRunSuspendingObserver:
         suspended_state = Suspended()
         initial_read_started = asyncio.Event()
         release_initial_read = asyncio.Event()
+        read_count = 0
 
         async def read_flow_run(observed_flow_run_id: uuid.UUID):
             assert observed_flow_run_id == flow_run_id
-            initial_read_started.set()
-            await release_initial_read.wait()
-            return MagicMock(state=current_state)
+            nonlocal read_count
+            read_count += 1
+            if read_count == 1:
+                initial_read_started.set()
+                await release_initial_read.wait()
+                return MagicMock(state=current_state)
+            return MagicMock(state=suspended_state)
 
         async with observer:
-            with (
-                patch.object(observer._client, "read_flow_run", read_flow_run),
-                patch.object(
-                    observer._client,
-                    "read_flow_run_state",
-                    return_value=suspended_state,
-                ) as read_flow_run_state,
-            ):
+            with patch.object(observer._client, "read_flow_run", read_flow_run):
                 watch_task = asyncio.create_task(
                     observer.watch_flow_run_id(flow_run_id)
                 )
@@ -801,7 +865,10 @@ class TestFlowRunSuspendingObserver:
                         occurred=cast(DateTime, checkpoint + timedelta(milliseconds=1)),
                     ),
                 )
-                read_flow_run_state.assert_not_awaited()
+                await asyncio.sleep(0)
+                # Confirmation waits behind the initialization gate: only the
+                # in-flight initial check has read the flow run.
+                assert read_count == 1
                 callback.assert_not_called()
 
                 release_initial_read.set()
@@ -820,19 +887,17 @@ class TestFlowRunSuspendingObserver:
         suspended_state = Suspended()
         blocked = asyncio.Event()
 
-        async def read_flow_run_state(state_id: uuid.UUID):
-            if state_id != suspended_state.id:
+        async def read_flow_run(observed_flow_run_id: uuid.UUID):
+            if observed_flow_run_id == blocked_flow_run_id:
                 await blocked.wait()
-                raise ObjectNotFound(Exception("not committed"))
-            return suspended_state
+                raise ObjectNotFound(Exception("gone"))
+            return MagicMock(state=suspended_state)
 
         async with observer:
             observer.add_in_flight_flow_run_id(blocked_flow_run_id)
             observer.add_in_flight_flow_run_id(flow_run_id)
 
-            with patch.object(
-                observer._client, "read_flow_run_state", read_flow_run_state
-            ):
+            with patch.object(observer._client, "read_flow_run", read_flow_run):
                 await self.consume(
                     observer,
                     suspension_event(blocked_flow_run_id, uuid.uuid4()),
@@ -853,21 +918,19 @@ class TestFlowRunSuspendingObserver:
         started = asyncio.Event()
         cancelled = asyncio.Event()
 
-        async def read_flow_run_state(state_id: uuid.UUID):
+        async def read_flow_run(observed_flow_run_id: uuid.UUID):
             started.set()
             try:
                 await blocked.wait()
             finally:
                 cancelled.set()
-            raise ObjectNotFound(Exception("not committed"))
+            raise ObjectNotFound(Exception("gone"))
 
         async with AsyncExitStack() as stack:
             await stack.enter_async_context(observer)
             observer.add_in_flight_flow_run_id(flow_run_id)
 
-            with patch.object(
-                observer._client, "read_flow_run_state", read_flow_run_state
-            ):
+            with patch.object(observer._client, "read_flow_run", read_flow_run):
                 await self.consume(
                     observer,
                     suspension_event(flow_run_id, uuid.uuid4()),


### PR DESCRIPTION
Reworks the suspension confirmation from #22649 to read the flow run rather than the state-by-id endpoint.

### Problem

`_SuspensionWatch._confirm` polls `GET /flow_run_states/{id}` until the state reported by a `prefect.flow-run.Suspended` event becomes readable, retrying 404s indefinitely (warn at 30s, never give up). That bakes in the assumption that every emitted state id eventually becomes readable at that endpoint. It holds for the OSS server, but not for backends that keep in-flight run state outside the state archive — on Prefect Cloud's run-keyed live state storage, a live run's states are not individually addressable by id, so the poll 404'd forever, the engine never learned it was suspended, and the run continued to completion (this is what broke automation-driven suspension for clients ≥3.8.1 against Cloud).

### Change

Confirm against `GET /flow_runs/{id}` instead — the observer's own resource, served for in-flight runs on every backend. The run's current state carries the id and timestamp needed to recognize the exact reported transition, preserving #22649's semantics:

- **Current state id matches the event id** (or the current state is itself suspended): confirmed — notify with the real server state, as before.
- **Current state older than the event's `occurred`**: the transition isn't visible yet (the exact race #22649 fixed) — keep retrying on the same warn/backoff schedule.
- **Current state newer and not suspended**: the suspension was superseded before confirmation (e.g. a fast resume). The engine is still told to stop — a resumed run gets a fresh submission, and the old engine continuing would double-execute — by reconstructing the reported `Suspended` state from the event's identity. (The previous design got this case implicitly, since the superseded state stayed readable by id.)
- **Flow run deleted** (`ObjectNotFound` on the run): nothing left to suspend — abandon confirmation instead of retrying forever.

The ownership cross-check (`state_details.flow_run_id`) is no longer needed: the read is keyed by the run itself. The `read_flow_run_state` client methods from #22649 are left in place — they're released public API.

The websocket-primary/polling-fallback structure, the initialization gate, the replay checkpoint, and the retry/backoff cadence are all unchanged.

### Tests

Reworked the confirmation tests in `tests/test_observers.py` to mock `read_flow_run`, and added coverage for the two new outcomes (superseded suspension still notifies with a reconstructed state; deleted run abandons confirmation): 39 passed. Ruff and pyright clean on changed files.

Related: the producer-side event-ordering issue remains tracked in #22654. Prefect Cloud is separately fixing `GET /flow_run_states/{id}` to serve live states, which unbreaks already-released 3.8.x clients; this PR removes the SDK's forward dependence on that endpoint's semantics for in-flight runs.

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed. Internal observer behavior only.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)