### PR TITLE
Prevent runners from overwriting handled flow-run outcomes

### DIFF
--- a/src/prefect/_internal/attempt_control.py
+++ b/src/prefect/_internal/attempt_control.py
@@ -1,0 +1,158 @@
+"""Shared types and wire framing for the internal Attempt Control Session."""
+
+from __future__ import annotations
+
+import json
+import struct
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, TypeAlias
+from uuid import UUID
+
+Intent = Literal["cancel", "reschedule", "relinquish"]
+
+BYTE_FOR_INTENT: dict[Intent, bytes] = {
+    "cancel": b"c",
+    "reschedule": b"r",
+    "relinquish": b"q",
+}
+INTENT_FOR_BYTE: dict[bytes, Intent] = {
+    value: key for key, value in BYTE_FOR_INTENT.items()
+}
+
+LEGACY_PROTOCOL_VERSION = 1
+CURRENT_PROTOCOL_VERSION = 2
+RECEIPT_CAPABILITY = 1 << 0
+
+# The child-initiated hello deliberately contains no legacy acknowledgement byte
+# (`b"a"`), so a version-one supervisor can safely ignore it.
+NEGOTIATION_PREFIX = b"\x00PF"
+NEGOTIATION_FRAME_SIZE = len(NEGOTIATION_PREFIX) + 2
+RECEIPT_PREFIX = b"\x01"
+RECEIPT_ACK = b"\x02"
+MAX_RECEIPT_SIZE = 4096
+
+
+class EngineDisposition(str, Enum):
+    STATE_REPORTED = "STATE_REPORTED"
+    ORCHESTRATION_ABORTED = "ORCHESTRATION_ABORTED"
+
+
+@dataclass(frozen=True)
+class EngineOutcomeReceipt:
+    """Sanitized evidence that an engine concluded an execution attempt."""
+
+    disposition: EngineDisposition
+    state_id: UUID | None = None
+    state_type: str | None = None
+    state_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.disposition, EngineDisposition):
+            raise TypeError("Receipt disposition must be an EngineDisposition")
+        state_fields = (self.state_id, self.state_type, self.state_name)
+        if self.disposition is EngineDisposition.STATE_REPORTED:
+            if any(value is None for value in state_fields):
+                raise ValueError("STATE_REPORTED receipts require all state fields")
+            if not isinstance(self.state_id, UUID):
+                raise TypeError("Receipt state ID must be a UUID")
+            if not isinstance(self.state_type, str) or not isinstance(
+                self.state_name, str
+            ):
+                raise TypeError("Receipt state type and name must be strings")
+            if not self.state_type or not self.state_name:
+                raise ValueError("Receipt state type and name must not be empty")
+            if len(self.state_type) > 64 or len(self.state_name) > 256:
+                raise ValueError("Receipt state type or name is too long")
+        elif any(value is not None for value in state_fields):
+            raise ValueError(
+                "ORCHESTRATION_ABORTED receipts cannot include state fields"
+            )
+
+    @classmethod
+    def state_reported(
+        cls, *, state_id: UUID, state_type: str, state_name: str
+    ) -> EngineOutcomeReceipt:
+        return cls(
+            disposition=EngineDisposition.STATE_REPORTED,
+            state_id=state_id,
+            state_type=state_type,
+            state_name=state_name,
+        )
+
+    @classmethod
+    def orchestration_aborted(cls) -> EngineOutcomeReceipt:
+        return cls(disposition=EngineDisposition.ORCHESTRATION_ABORTED)
+
+
+@dataclass(frozen=True)
+class StateOwnershipDelegation:
+    """Evidence that the supervisor's acknowledged control intent won."""
+
+    intent: Intent
+
+
+AttemptConclusion: TypeAlias = EngineOutcomeReceipt | StateOwnershipDelegation
+
+
+def encode_negotiation(version: int, capabilities: int) -> bytes:
+    if not 0 <= version <= 255 or not 0 <= capabilities <= 255:
+        raise ValueError("Protocol version and capabilities must fit in one byte")
+    return NEGOTIATION_PREFIX + bytes((version, capabilities))
+
+
+def decode_negotiation(frame: bytes) -> tuple[int, int]:
+    if len(frame) != NEGOTIATION_FRAME_SIZE or not frame.startswith(NEGOTIATION_PREFIX):
+        raise ValueError("Malformed Attempt Control Session negotiation")
+    return frame[-2], frame[-1]
+
+
+def encode_receipt(receipt: EngineOutcomeReceipt) -> bytes:
+    payload: dict[str, str] = {"disposition": receipt.disposition.value}
+    if receipt.disposition is EngineDisposition.STATE_REPORTED:
+        assert receipt.state_id is not None
+        assert receipt.state_type is not None
+        assert receipt.state_name is not None
+        payload.update(
+            {
+                "state_id": str(receipt.state_id),
+                "state_type": receipt.state_type,
+                "state_name": receipt.state_name,
+            }
+        )
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    if len(encoded) > MAX_RECEIPT_SIZE:
+        raise ValueError("Receipt payload is too large")
+    return RECEIPT_PREFIX + struct.pack("!I", len(encoded)) + encoded
+
+
+def decode_receipt(payload: bytes) -> EngineOutcomeReceipt:
+    if len(payload) > MAX_RECEIPT_SIZE:
+        raise ValueError("Receipt payload is too large")
+    try:
+        decoded = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Malformed receipt payload") from exc
+    if not isinstance(decoded, dict):
+        raise TypeError("Receipt payload must be an object")
+
+    try:
+        disposition = EngineDisposition(decoded["disposition"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("Receipt disposition is invalid") from exc
+
+    if disposition is EngineDisposition.ORCHESTRATION_ABORTED:
+        if set(decoded) != {"disposition"}:
+            raise ValueError("Aborted receipt contains unexpected fields")
+        return EngineOutcomeReceipt.orchestration_aborted()
+
+    if set(decoded) != {"disposition", "state_id", "state_type", "state_name"}:
+        raise ValueError("State receipt fields are invalid")
+    try:
+        return EngineOutcomeReceipt.state_reported(
+            state_id=UUID(decoded["state_id"]),
+            state_type=decoded["state_type"],
+            state_name=decoded["state_name"],
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError("State receipt fields are invalid") from exc

--- a/src/prefect/_internal/attempt_control.py
+++ b/src/prefect/_internal/attempt_control.py
@@ -60,10 +60,10 @@ class EngineOutcomeReceipt:
                 self.state_name, str
             ):
                 raise TypeError("Receipt state type and name must be strings")
-            if not self.state_type or not self.state_name:
-                raise ValueError("Receipt state type and name must not be empty")
-            if len(self.state_type) > 64 or len(self.state_name) > 256:
-                raise ValueError("Receipt state type or name is too long")
+            if not self.state_type:
+                raise ValueError("Receipt state type must not be empty")
+            if len(self.state_type) > 64:
+                raise ValueError("Receipt state type is too long")
         elif any(value is not None for value in state_fields):
             raise ValueError(
                 "ORCHESTRATION_ABORTED receipts cannot include state fields"

--- a/src/prefect/_internal/control_listener.py
+++ b/src/prefect/_internal/control_listener.py
@@ -39,6 +39,7 @@ import os
 import signal
 import socket
 import threading
+import time
 
 from prefect._internal.attempt_control import (
     CURRENT_PROTOCOL_VERSION,
@@ -56,7 +57,8 @@ from prefect._internal.attempt_control import (
 from prefect.logging import get_logger
 from prefect.utilities.engine import commit_control_intent_and_ack
 
-_NEGOTIATION_TIMEOUT = 0.25
+_NEGOTIATION_PROBE_TIMEOUT = 0.25
+_NEGOTIATION_RESPONSE_TIMEOUT = 1.0
 _RECEIPT_ACK_TIMEOUT = 1.0
 
 _logger = get_logger(__name__)
@@ -75,6 +77,7 @@ _socket: socket.socket | None = None
 _reader_thread: threading.Thread | None = None
 _send_lock = threading.Lock()
 _negotiation_complete = threading.Event()
+_negotiation_deadline: float | None = None
 _receipt_acked = threading.Event()
 _receipt_capable = False
 _terminal_lock = threading.Lock()
@@ -166,6 +169,23 @@ def _recv_exactly(sock: socket.socket, size: int) -> bytes:
     return bytes(chunks)
 
 
+def _receive_negotiation_response(sock: socket.socket, first: bytes) -> None:
+    """Apply one complete negotiation response from the supervisor."""
+    global _receipt_capable
+
+    response = first + _recv_exactly(sock, NEGOTIATION_FRAME_SIZE - 1)
+    version, capabilities = decode_negotiation(response)
+    _receipt_capable = (
+        version == CURRENT_PROTOCOL_VERSION and capabilities & RECEIPT_CAPABILITY != 0
+    )
+    _negotiation_complete.set()
+    _logger.debug(
+        "Attempt control negotiation selected protocol %d with receipt support %s",
+        version,
+        _receipt_capable,
+    )
+
+
 def _handle_intent_byte(sock: socket.socket, data: bytes) -> bool | None:
     """Handle an intent, returning whether the reader should close the session."""
     global _terminal_claimed
@@ -192,6 +212,7 @@ def _reader_loop(sock: socket.socket) -> None:
     """Negotiate receipt support, then handle session responses and intent."""
     global _receipt_capable
 
+    negotiation_pending = True
     try:
         first = b""
         try:
@@ -199,7 +220,7 @@ def _reader_loop(sock: socket.socket) -> None:
                 sock,
                 encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY),
             )
-            sock.settimeout(_NEGOTIATION_TIMEOUT)
+            sock.settimeout(_NEGOTIATION_PROBE_TIMEOUT)
             first = sock.recv(1)
             if not first:
                 return
@@ -211,21 +232,14 @@ def _reader_loop(sock: socket.socket) -> None:
             if first != NEGOTIATION_PREFIX[:1]:
                 _logger.warning("Attempt control negotiation response was malformed")
                 return
-            response = first + _recv_exactly(sock, NEGOTIATION_FRAME_SIZE - 1)
-            version, capabilities = decode_negotiation(response)
-            _receipt_capable = (
-                version == CURRENT_PROTOCOL_VERSION
-                and capabilities & RECEIPT_CAPABILITY != 0
-            )
-            _logger.debug(
-                "Attempt control negotiation selected protocol %d with receipt support %s",
-                version,
-                _receipt_capable,
-            )
+            _receive_negotiation_response(sock, first)
+            negotiation_pending = False
         except TimeoutError:
             if first:
                 _logger.warning("Attempt control negotiation response was malformed")
             # A version-one supervisor sends no response to the reserved hello.
+            # Keep accepting a late response so scheduler latency does not
+            # permanently downgrade a version-two peer.
             _receipt_capable = False
         except OSError:
             # The owning context may close the socket while negotiation is blocked.
@@ -238,7 +252,6 @@ def _reader_loop(sock: socket.socket) -> None:
                 sock.settimeout(None)
             except OSError:
                 pass
-            _negotiation_complete.set()
 
         while True:
             try:
@@ -251,6 +264,18 @@ def _reader_loop(sock: socket.socket) -> None:
             if intent_handled is not None:
                 if intent_handled:
                     return
+                continue
+            if data == NEGOTIATION_PREFIX[:1] and negotiation_pending:
+                try:
+                    _receive_negotiation_response(sock, data)
+                except OSError:
+                    return
+                except ValueError:
+                    _logger.warning(
+                        "Attempt control negotiation response was malformed"
+                    )
+                    return
+                negotiation_pending = False
                 continue
             if data == RECEIPT_ACK:
                 global _receipt_in_flight, _terminal_claimed
@@ -293,7 +318,9 @@ def report_engine_outcome(receipt: EngineOutcomeReceipt) -> bool:
     if sock is None:
         return False
 
-    _negotiation_complete.wait(_NEGOTIATION_TIMEOUT + 0.1)
+    negotiation_deadline = _negotiation_deadline
+    if negotiation_deadline is not None:
+        _negotiation_complete.wait(max(0.0, negotiation_deadline - time.monotonic()))
     if not _receipt_capable:
         return False
 
@@ -330,6 +357,7 @@ def start() -> None:
     """Connect to the runner's control channel if bootstrap config is present."""
     global _started, _owner_thread_id, _socket, _reader_thread, _receipt_capable
     global _terminal_claimed, _receipt_in_flight, _outcome_report_started
+    global _negotiation_deadline
 
     configure_from_env()
 
@@ -343,6 +371,7 @@ def start() -> None:
         # earlier flow run in the same interpreter.
         _clear_intent()
         _negotiation_complete.clear()
+        _negotiation_deadline = None
         _receipt_acked.clear()
         _receipt_capable = False
         with _terminal_lock:
@@ -370,6 +399,7 @@ def start() -> None:
         _socket = sock
         _reader_thread = thread
         _owner_thread_id = threading.get_ident()
+        _negotiation_deadline = time.monotonic() + _NEGOTIATION_RESPONSE_TIMEOUT
         _started = True
         thread.start()
 
@@ -379,6 +409,7 @@ def stop() -> None:
     global _configured, _configured_port, _configured_token
     global _started, _owner_thread_id, _socket, _reader_thread, _receipt_capable
     global _terminal_claimed, _receipt_in_flight, _outcome_report_started
+    global _negotiation_deadline
 
     with _started_lock:
         sock = _socket
@@ -391,6 +422,7 @@ def stop() -> None:
         _configured_token = None
         _receipt_capable = False
         _negotiation_complete.clear()
+        _negotiation_deadline = None
         _receipt_acked.clear()
         with _terminal_lock:
             _terminal_claimed = False

--- a/src/prefect/_internal/control_listener.py
+++ b/src/prefect/_internal/control_listener.py
@@ -59,7 +59,7 @@ from prefect.utilities.engine import commit_control_intent_and_ack
 _NEGOTIATION_TIMEOUT = 0.25
 _RECEIPT_ACK_TIMEOUT = 1.0
 
-_logger = get_logger("control_listener")
+_logger = get_logger(__name__)
 
 _intent: Intent | None = None
 _intent_lock = threading.Lock()
@@ -80,12 +80,18 @@ _terminal_lock = threading.Lock()
 _terminal_claimed = False
 _receipt_in_flight = False
 _outcome_report_started = False
+_engine_outcome_handled = False
 
 
 def get_intent() -> Intent | None:
     """Return the committed control intent, if any."""
     with _intent_lock:
         return _intent
+
+
+def engine_outcome_is_handled() -> bool:
+    """Return whether the engine concluded the current execution attempt."""
+    return _engine_outcome_handled
 
 
 def _set_intent(value: Intent) -> None:
@@ -107,13 +113,14 @@ def clear_intent() -> None:
 
 def configure_from_env() -> None:
     """Consume one-shot control-channel env vars without connecting yet."""
-    global _configured, _configured_port, _configured_token
+    global _configured, _configured_port, _configured_token, _engine_outcome_handled
 
     with _started_lock:
         if _configured:
             return
 
         _configured = True
+        _engine_outcome_handled = False
         port_str = os.environ.pop("PREFECT__CONTROL_PORT", None)
         token = os.environ.pop("PREFECT__CONTROL_TOKEN", None)
         if not port_str or not token:
@@ -134,7 +141,7 @@ def _acknowledge_intent(sock: socket.socket, intent: Intent) -> bool:
     return commit_control_intent_and_ack(
         commit_intent=lambda: _set_intent(intent),
         clear_intent=_clear_intent,
-        send_ack=lambda: _send(sock, b"a"),
+        send_ack=lambda: sock.sendall(b"a"),
         trigger_cancel=(
             (lambda: _thread.interrupt_main(signal.SIGTERM))
             if os.name == "nt"
@@ -166,7 +173,10 @@ def _handle_intent_byte(sock: socket.socket, data: bytes) -> bool | None:
     if intent is None:
         return None
 
-    with _terminal_lock:
+    # Serialize terminal writes so the wire order matches the local decision:
+    # an intent that claims this lock before receipt transmission wins, while
+    # an already-transmitted receipt remains authoritative.
+    with _send_lock, _terminal_lock:
         if _terminal_claimed or _receipt_in_flight:
             _logger.debug(
                 "Ignoring control intent after a terminal exchange has started"
@@ -259,7 +269,12 @@ def _reader_loop(sock: socket.socket) -> None:
 
 def report_engine_outcome(receipt: EngineOutcomeReceipt) -> bool:
     """Send one negotiated outcome receipt without changing engine semantics."""
-    global _outcome_report_started, _receipt_in_flight
+    global _outcome_report_started, _receipt_in_flight, _engine_outcome_handled
+
+    # The immediate first-party engine process treats a concluded attempt as
+    # successful infrastructure execution even when its supervisor cannot
+    # negotiate or acknowledge the optional receipt transport.
+    _engine_outcome_handled = True
 
     sock = _socket
     if sock is None:
@@ -269,16 +284,21 @@ def report_engine_outcome(receipt: EngineOutcomeReceipt) -> bool:
     if not _receipt_capable:
         return False
 
-    with _terminal_lock:
-        if _terminal_claimed or _outcome_report_started:
-            return False
-        _outcome_report_started = True
-        _receipt_in_flight = True
-        _receipt_acked.clear()
+    try:
+        encoded_receipt = encode_receipt(receipt)
+    except ValueError:
+        _logger.warning("Failed to encode engine outcome receipt")
+        return False
 
     try:
-        _send(sock, encode_receipt(receipt))
-    except (OSError, ValueError):
+        with _send_lock, _terminal_lock:
+            if _terminal_claimed or _outcome_report_started:
+                return False
+            _outcome_report_started = True
+            _receipt_in_flight = True
+            _receipt_acked.clear()
+            sock.sendall(encoded_receipt)
+    except OSError:
         with _terminal_lock:
             _receipt_in_flight = False
         _logger.warning("Failed to send engine outcome receipt")
@@ -376,6 +396,7 @@ def stop() -> None:
 def reset_for_testing() -> None:
     """Reset module state. Tests only."""
     global _intent, _configured, _configured_port, _configured_token
+    global _engine_outcome_handled
 
     with _intent_lock:
         _intent = None
@@ -386,3 +407,4 @@ def reset_for_testing() -> None:
         _configured = False
         _configured_port = None
         _configured_token = None
+        _engine_outcome_handled = False

--- a/src/prefect/_internal/control_listener.py
+++ b/src/prefect/_internal/control_listener.py
@@ -70,6 +70,7 @@ _configured_token: str | None = None
 
 _started = False
 _started_lock = threading.Lock()
+_owner_thread_id: int | None = None
 _socket: socket.socket | None = None
 _reader_thread: threading.Thread | None = None
 _send_lock = threading.Lock()
@@ -230,7 +231,10 @@ def _reader_loop(sock: socket.socket) -> None:
             _logger.warning("Attempt control negotiation response was malformed")
             return
         finally:
-            sock.settimeout(None)
+            try:
+                sock.settimeout(None)
+            except OSError:
+                pass
             _negotiation_complete.set()
 
         while True:
@@ -270,6 +274,12 @@ def _reader_loop(sock: socket.socket) -> None:
 def report_engine_outcome(receipt: EngineOutcomeReceipt) -> bool:
     """Send one negotiated outcome receipt without changing engine semantics."""
     global _outcome_report_started, _receipt_in_flight, _engine_outcome_handled
+
+    if _owner_thread_id is not None and threading.get_ident() != _owner_thread_id:
+        _logger.debug(
+            "Ignoring engine outcome from a thread that does not own the control session"
+        )
+        return False
 
     # The immediate first-party engine process treats a concluded attempt as
     # successful infrastructure execution even when its supervisor cannot
@@ -315,7 +325,7 @@ def report_engine_outcome(receipt: EngineOutcomeReceipt) -> bool:
 
 def start() -> None:
     """Connect to the runner's control channel if bootstrap config is present."""
-    global _started, _socket, _reader_thread, _receipt_capable
+    global _started, _owner_thread_id, _socket, _reader_thread, _receipt_capable
     global _terminal_claimed, _receipt_in_flight, _outcome_report_started
 
     configure_from_env()
@@ -356,6 +366,7 @@ def start() -> None:
         )
         _socket = sock
         _reader_thread = thread
+        _owner_thread_id = threading.get_ident()
         _started = True
         thread.start()
 
@@ -363,13 +374,14 @@ def start() -> None:
 def stop() -> None:
     """Close the active control connection, if any."""
     global _configured, _configured_port, _configured_token
-    global _started, _socket, _reader_thread, _receipt_capable
+    global _started, _owner_thread_id, _socket, _reader_thread, _receipt_capable
     global _terminal_claimed, _receipt_in_flight, _outcome_report_started
 
     with _started_lock:
         sock = _socket
         _socket = None
         _reader_thread = None
+        _owner_thread_id = None
         _started = False
         _configured = False
         _configured_port = None

--- a/src/prefect/_internal/control_listener.py
+++ b/src/prefect/_internal/control_listener.py
@@ -227,6 +227,9 @@ def _reader_loop(sock: socket.socket) -> None:
                 _logger.warning("Attempt control negotiation response was malformed")
             # A version-one supervisor sends no response to the reserved hello.
             _receipt_capable = False
+        except OSError:
+            # The owning context may close the socket while negotiation is blocked.
+            return
         except ValueError:
             _logger.warning("Attempt control negotiation response was malformed")
             return

--- a/src/prefect/_internal/control_listener.py
+++ b/src/prefect/_internal/control_listener.py
@@ -1,11 +1,16 @@
 """
-Child-process runner-control intent listener.
+Child side of the internal Attempt Control Session.
 
 This module is intentionally small. It only supports steady-state graceful
 control delivery after Prefect has already installed its SIGTERM bridge via
 `capture_sigterm()`.
 
-Protocol:
+The version-one protocol remains intact: the supervisor sends one-byte control
+intents and the child acknowledges a committed intent with `b"a"`. Version-two
+peers additionally negotiate outcome receipts over the same authenticated,
+full-duplex loopback connection.
+
+Session outline:
 
 1. The runner injects `PREFECT__CONTROL_PORT` and `PREFECT__CONTROL_TOKEN`
    into the child environment.
@@ -13,12 +18,13 @@ Protocol:
    one-shot env vars without connecting yet.
 3. The outermost `capture_sigterm()` calls `start()`, which connects back to
    the runner and spawns a daemon thread blocked on the socket.
-4. The runner writes a single-byte intent (`b"c"`, `b"r"` or `b"q"`).
-5. If Prefect still owns the live SIGTERM bridge, the child writes `b"a"`,
-   commits the intent for engine dispatch, and on Windows triggers
-   `_thread.interrupt_main(SIGTERM)`.
-6. The runner then sends its normal external termination signal. On POSIX,
-   that real `SIGTERM` is the only trigger that interrupts blocking code.
+4. The child sends a reserved negotiation hello. A version-one supervisor
+   ignores it; a version-two supervisor selects the protocol and capabilities.
+5. The first terminal exchange is either an existing control intent plus
+   `b"a"`, or a structured engine outcome receipt plus a receipt ack.
+6. For control, the runner then sends its normal external termination signal.
+   On POSIX, that real `SIGTERM` remains the only trigger that interrupts
+   blocking code.
 
 If the child is not connected yet, or can no longer safely acknowledge the
 intent, the runner sees no ack and falls back to its existing crash-style
@@ -33,17 +39,27 @@ import os
 import signal
 import socket
 import threading
-from typing import Literal
 
+from prefect._internal.attempt_control import (
+    CURRENT_PROTOCOL_VERSION,
+    INTENT_FOR_BYTE,
+    NEGOTIATION_FRAME_SIZE,
+    NEGOTIATION_PREFIX,
+    RECEIPT_ACK,
+    RECEIPT_CAPABILITY,
+    EngineOutcomeReceipt,
+    Intent,
+    decode_negotiation,
+    encode_negotiation,
+    encode_receipt,
+)
+from prefect.logging import get_logger
 from prefect.utilities.engine import commit_control_intent_and_ack
 
-Intent = Literal["cancel", "reschedule", "relinquish"]
+_NEGOTIATION_TIMEOUT = 0.25
+_RECEIPT_ACK_TIMEOUT = 1.0
 
-_INTENT_FOR_BYTE: dict[bytes, Intent] = {
-    b"c": "cancel",
-    b"r": "reschedule",
-    b"q": "relinquish",
-}
+_logger = get_logger("control_listener")
 
 _intent: Intent | None = None
 _intent_lock = threading.Lock()
@@ -56,6 +72,14 @@ _started = False
 _started_lock = threading.Lock()
 _socket: socket.socket | None = None
 _reader_thread: threading.Thread | None = None
+_send_lock = threading.Lock()
+_negotiation_complete = threading.Event()
+_receipt_acked = threading.Event()
+_receipt_capable = False
+_terminal_lock = threading.Lock()
+_terminal_claimed = False
+_receipt_in_flight = False
+_outcome_report_started = False
 
 
 def get_intent() -> Intent | None:
@@ -107,24 +131,98 @@ def configure_from_env() -> None:
 
 def _acknowledge_intent(sock: socket.socket, intent: Intent) -> bool:
     """Commit intent and acknowledge it to the runner."""
-    if not commit_control_intent_and_ack(
+    return commit_control_intent_and_ack(
         commit_intent=lambda: _set_intent(intent),
         clear_intent=_clear_intent,
-        send_ack=lambda: sock.sendall(b"a"),
+        send_ack=lambda: _send(sock, b"a"),
         trigger_cancel=(
             (lambda: _thread.interrupt_main(signal.SIGTERM))
             if os.name == "nt"
             else None
         ),
-    ):
-        return False
+    )
 
-    return True
+
+def _send(sock: socket.socket, data: bytes) -> None:
+    with _send_lock:
+        sock.sendall(data)
+
+
+def _recv_exactly(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise OSError("Control session closed")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _handle_intent_byte(sock: socket.socket, data: bytes) -> bool | None:
+    """Handle an intent, returning whether the reader should close the session."""
+    global _terminal_claimed
+
+    intent = INTENT_FOR_BYTE.get(data)
+    if intent is None:
+        return None
+
+    with _terminal_lock:
+        if _terminal_claimed or _receipt_in_flight:
+            _logger.debug(
+                "Ignoring control intent after a terminal exchange has started"
+            )
+            return False
+        if _acknowledge_intent(sock, intent):
+            _terminal_claimed = True
+        return True
 
 
 def _reader_loop(sock: socket.socket) -> None:
-    """Block on the runner's control channel and act on a single intent byte."""
+    """Negotiate receipt support, then handle session responses and intent."""
+    global _receipt_capable
+
     try:
+        first = b""
+        try:
+            _send(
+                sock,
+                encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY),
+            )
+            sock.settimeout(_NEGOTIATION_TIMEOUT)
+            first = sock.recv(1)
+            if not first:
+                return
+            intent_handled = _handle_intent_byte(sock, first)
+            if intent_handled is not None:
+                if intent_handled:
+                    return
+                first = b""
+            if first != NEGOTIATION_PREFIX[:1]:
+                _logger.warning("Attempt control negotiation response was malformed")
+                return
+            response = first + _recv_exactly(sock, NEGOTIATION_FRAME_SIZE - 1)
+            version, capabilities = decode_negotiation(response)
+            _receipt_capable = (
+                version == CURRENT_PROTOCOL_VERSION
+                and capabilities & RECEIPT_CAPABILITY != 0
+            )
+            _logger.debug(
+                "Attempt control negotiation selected protocol %d with receipt support %s",
+                version,
+                _receipt_capable,
+            )
+        except TimeoutError:
+            if first:
+                _logger.warning("Attempt control negotiation response was malformed")
+            # A version-one supervisor sends no response to the reserved hello.
+            _receipt_capable = False
+        except ValueError:
+            _logger.warning("Attempt control negotiation response was malformed")
+            return
+        finally:
+            sock.settimeout(None)
+            _negotiation_complete.set()
+
         while True:
             try:
                 data = sock.recv(1)
@@ -132,23 +230,73 @@ def _reader_loop(sock: socket.socket) -> None:
                 return
             if not data:
                 return
-
-            intent = _INTENT_FOR_BYTE.get(data)
-            if intent is None:
+            intent_handled = _handle_intent_byte(sock, data)
+            if intent_handled is not None:
+                if intent_handled:
+                    return
+                continue
+            if data == RECEIPT_ACK:
+                global _receipt_in_flight, _terminal_claimed
+                with _terminal_lock:
+                    if not _receipt_in_flight:
+                        _logger.debug(
+                            "Ignoring receipt acknowledgement after terminal exchange"
+                        )
+                        continue
+                    _receipt_in_flight = False
+                    _terminal_claimed = True
+                    _receipt_acked.set()
                 return
-
-            _acknowledge_intent(sock, intent)
+            _logger.warning("Attempt control session received a malformed message")
             return
     finally:
+        _negotiation_complete.set()
         try:
             sock.close()
         except OSError:
             pass
 
 
+def report_engine_outcome(receipt: EngineOutcomeReceipt) -> bool:
+    """Send one negotiated outcome receipt without changing engine semantics."""
+    global _outcome_report_started, _receipt_in_flight
+
+    sock = _socket
+    if sock is None:
+        return False
+
+    _negotiation_complete.wait(_NEGOTIATION_TIMEOUT + 0.1)
+    if not _receipt_capable:
+        return False
+
+    with _terminal_lock:
+        if _terminal_claimed or _outcome_report_started:
+            return False
+        _outcome_report_started = True
+        _receipt_in_flight = True
+        _receipt_acked.clear()
+
+    try:
+        _send(sock, encode_receipt(receipt))
+    except (OSError, ValueError):
+        with _terminal_lock:
+            _receipt_in_flight = False
+        _logger.warning("Failed to send engine outcome receipt")
+        return False
+
+    if _receipt_acked.wait(_RECEIPT_ACK_TIMEOUT):
+        return True
+
+    with _terminal_lock:
+        _receipt_in_flight = False
+    _logger.warning("Engine outcome receipt was not acknowledged")
+    return False
+
+
 def start() -> None:
     """Connect to the runner's control channel if bootstrap config is present."""
-    global _started, _socket, _reader_thread
+    global _started, _socket, _reader_thread, _receipt_capable
+    global _terminal_claimed, _receipt_in_flight, _outcome_report_started
 
     configure_from_env()
 
@@ -161,6 +309,13 @@ def start() -> None:
         # A new listener session must not inherit a committed intent from an
         # earlier flow run in the same interpreter.
         _clear_intent()
+        _negotiation_complete.clear()
+        _receipt_acked.clear()
+        _receipt_capable = False
+        with _terminal_lock:
+            _terminal_claimed = False
+            _receipt_in_flight = False
+            _outcome_report_started = False
 
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -188,7 +343,8 @@ def start() -> None:
 def stop() -> None:
     """Close the active control connection, if any."""
     global _configured, _configured_port, _configured_token
-    global _started, _socket, _reader_thread
+    global _started, _socket, _reader_thread, _receipt_capable
+    global _terminal_claimed, _receipt_in_flight, _outcome_report_started
 
     with _started_lock:
         sock = _socket
@@ -198,6 +354,13 @@ def stop() -> None:
         _configured = False
         _configured_port = None
         _configured_token = None
+        _receipt_capable = False
+        _negotiation_complete.clear()
+        _receipt_acked.clear()
+        with _terminal_lock:
+            _terminal_claimed = False
+            _receipt_in_flight = False
+            _outcome_report_started = False
 
     if sock is not None:
         try:

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -41,6 +41,7 @@ from prefect.client.schemas.responses import SetStateStatus
 from prefect.client.schemas.sorting import FlowRunSort, LogSort
 from prefect.exceptions import Abort, FlowRunWatchError, ObjectNotFound, Pause
 from prefect.logging import get_logger
+from prefect.runner._control_channel import ControlSignalStatus
 from prefect.runner._flow_run_executor import FlowRunExecutorContext
 from prefect.runner._workspace_starter import WorkspaceResolvingEngineCommandStarter
 from prefect.states import AwaitingRetry, State, exception_to_crashed_state
@@ -791,7 +792,14 @@ async def execute(
                     # The engine must learn the intent before it sees a SIGTERM so it
                     # exits without proposing a state we then override; one that never
                     # acknowledged gets no chance to propose at all.
-                    acknowledged = await ctx.control_channel.signal(id, intent)
+                    signal_status = await ctx.control_channel.signal(id, intent)
+                    if signal_status is ControlSignalStatus.ALREADY_CONCLUDED:
+                        logger.info(
+                            "Engine already reported a final state; leaving it unchanged."
+                        )
+                        return
+
+                    acknowledged = signal_status is ControlSignalStatus.ACKNOWLEDGED
                     if not acknowledged:
                         logger.warning(
                             "Engine did not acknowledge %s intent; stopping it without"

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -13,6 +13,7 @@ from prefect._internal.compatibility.migration import getattr_migration
 from prefect._internal.control_listener import (
     clear_intent,
     configure_from_env,
+    engine_outcome_is_handled,
     get_intent,
 )
 from prefect.exceptions import (
@@ -102,17 +103,22 @@ def handle_engine_signals(flow_run_id: UUID | None = None):
     except TerminationSignal:
         # An intent means the runner or the `prefect flow-run execute` supervisor
         # drove this termination and owns the flow run's next state, so exit cleanly.
-        # A raw external termination has no intent and must keep propagating.
-        if get_intent() is not None:
+        # An engine outcome means orchestration already handled the termination.
+        # A raw external termination with neither form of evidence must propagate.
+        intent = get_intent()
+        if intent is not None or engine_outcome_is_handled():
             if flow_run_id:
                 msg = f"Execution of flow run '{flow_run_id}' was terminated."
             else:
                 msg = "Execution was terminated."
             engine_logger.info(msg)
-            clear_intent()
+            if intent is not None:
+                clear_intent()
             exit(0)
         raise
     except Exception:
+        if engine_outcome_is_handled():
+            exit(0)
         if flow_run_id:
             msg = f"Execution of flow run '{flow_run_id}' exited with unexpected exception"
         else:
@@ -120,6 +126,8 @@ def handle_engine_signals(flow_run_id: UUID | None = None):
         engine_logger.error(msg, exc_info=True)
         exit(1)
     except BaseException:
+        if engine_outcome_is_handled():
+            exit(0)
         if flow_run_id:
             msg = f"Execution of flow run '{flow_run_id}' interrupted by base exception"
         else:

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -583,17 +583,17 @@ class BaseFlowRunEngine(Generic[P, R]):
                         f"Tried to set traceparent {carrier[TRACEPARENT_KEY]} for flow run, but None was found"
                     )
 
-    def _engine_owns_cancellation_and_crash_handling(self) -> bool:
-        """Return whether this engine owns cancel/crash handling.
+    def _engine_owns_cancellation_handling(self) -> bool:
+        """Return whether this engine owns cancellation state and hooks.
 
         Runner-managed subprocesses set `PREFECT__ENABLE_CANCELLATION_AND_CRASHED_HOOKS=false`
-        and execute those hooks plus terminal cancellation state proposals
-        externally after the child exits. Same-process nested subflows are
-        the exception: no external runner fires their hooks or owns their
-        cancellation state, so the engine must ignore the env suppression
-        only when it started inside a non-detached parent `FlowRunContext`.
-        Top-level non-runner flows also fall through to engine ownership
-        because the env defaults to enabled.
+        and retain ownership of acknowledged cancellation state and hooks.
+        Engine-reported Crashed states are different: their hooks remain
+        engine-owned and are not governed by this switch. Same-process nested
+        subflows have no external supervisor, so the engine ignores suppression
+        when it started inside a non-detached parent `FlowRunContext`. Top-level
+        non-runner flows also fall through to engine ownership because the env
+        defaults to enabled.
         """
 
         return self._started_with_in_process_parent_flow_run_context or (
@@ -912,7 +912,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         """
         msg = "Flow run was cancelled."
         self.logger.info(msg)
-        if self._engine_owns_cancellation_and_crash_handling():
+        if self._engine_owns_cancellation_handling():
             self.set_state(Cancelling(message=msg), force=True)
             self.set_state(Cancelled(message=msg), force=True)
         self._raised = exc
@@ -1025,25 +1025,19 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         if not flow_run:
             raise ValueError("Flow run is not set")
 
-        engine_owns_cancellation_and_crash_handling = (
-            self._engine_owns_cancellation_and_crash_handling()
-        )
+        engine_owns_cancellation_handling = self._engine_owns_cancellation_handling()
 
         if state.is_failed() and flow.on_failure_hooks:
             hooks = flow.on_failure_hooks
         elif state.is_completed() and flow.on_completion_hooks:
             hooks = flow.on_completion_hooks
         elif (
-            engine_owns_cancellation_and_crash_handling
+            engine_owns_cancellation_handling
             and state.is_cancelling()
             and flow.on_cancellation_hooks
         ):
             hooks = flow.on_cancellation_hooks
-        elif (
-            engine_owns_cancellation_and_crash_handling
-            and state.is_crashed()
-            and flow.on_crashed_hooks
-        ):
+        elif state.is_crashed() and flow.on_crashed_hooks:
             hooks = flow.on_crashed_hooks
         elif state.is_running() and flow.on_running_hooks:
             hooks = flow.on_running_hooks
@@ -1616,7 +1610,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         with CancelScope(shield=True):
             msg = "Flow run was cancelled."
             self.logger.info(msg)
-            if self._engine_owns_cancellation_and_crash_handling():
+            if self._engine_owns_cancellation_handling():
                 await self.set_state(Cancelling(message=msg), force=True)
                 await self.set_state(Cancelled(message=msg), force=True)
             self._raised = exc
@@ -1727,25 +1721,19 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         if not flow_run:
             raise ValueError("Flow run is not set")
 
-        engine_owns_cancellation_and_crash_handling = (
-            self._engine_owns_cancellation_and_crash_handling()
-        )
+        engine_owns_cancellation_handling = self._engine_owns_cancellation_handling()
 
         if state.is_failed() and flow.on_failure_hooks:
             hooks = flow.on_failure_hooks
         elif state.is_completed() and flow.on_completion_hooks:
             hooks = flow.on_completion_hooks
         elif (
-            engine_owns_cancellation_and_crash_handling
+            engine_owns_cancellation_handling
             and state.is_cancelling()
             and flow.on_cancellation_hooks
         ):
             hooks = flow.on_cancellation_hooks
-        elif (
-            engine_owns_cancellation_and_crash_handling
-            and state.is_crashed()
-            and flow.on_crashed_hooks
-        ):
+        elif state.is_crashed() and flow.on_crashed_hooks:
             hooks = flow.on_crashed_hooks
         elif state.is_running() and flow.on_running_hooks:
             hooks = flow.on_running_hooks

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -51,8 +51,14 @@ from prefect._flow_run_suspension import (
     raise_if_flow_run_suspension_requested,
     register_flow_run_suspension_request,
 )
+from prefect._internal.attempt_control import EngineOutcomeReceipt
 from prefect._internal.compatibility.deprecated import deprecated_callable
-from prefect._internal.control_listener import Intent, configure_from_env, get_intent
+from prefect._internal.control_listener import (
+    Intent,
+    configure_from_env,
+    get_intent,
+    report_engine_outcome,
+)
 from prefect._internal.engine import get_hook_name, resolve_custom_flow_run_name
 from prefect._internal.metrics import RunMetrics
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
@@ -1280,6 +1286,21 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             except Exception as exc:
                 self.logger.exception("Encountered exception during execution: %r", exc)
                 self.handle_exception(exc)
+
+            state = self.state
+            if (
+                not self._started_with_in_process_parent_flow_run_context
+                and state.is_failed()
+                and state.id is not None
+                and state.name is not None
+            ):
+                report_engine_outcome(
+                    EngineOutcomeReceipt.state_reported(
+                        state_id=state.id,
+                        state_type=state.type.value,
+                        state_name=state.name,
+                    )
+                )
 
     def call_flow_fn(self) -> Union[R, Coroutine[Any, Any, R]]:
         """

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -1089,7 +1089,6 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         with ExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
             # wait for futures to complete
-            stack.enter_context(capture_sigterm())
             if log_prints:
                 stack.enter_context(patch_print())
             task_runner = stack.enter_context(self.flow.task_runner.duplicate())
@@ -1209,72 +1208,75 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     parameters=self.parameters,
                 )
 
-                try:
-                    yield self
+                # Keep the control session open until the terminal outcome receipt
+                # has been acknowledged by the supervising process.
+                with capture_sigterm():
+                    try:
+                        yield self
 
-                except TerminationSignal as exc:
-                    self.cancel_all_tasks()
-                    intent = _termination_intent()
-                    if intent == "cancel":
-                        self.handle_cancellation(exc)
-                    elif intent is None:
-                        self.handle_crash(exc)
-                    elif intent not in _SUPERVISOR_OWNED_INTENTS:
-                        # Defensive: an unknown intent means the control
-                        # listener was extended (e.g. "suspend" in a
-                        # follow-up PR) without extending this dispatch.
-                        # Treat as crash so the flow run still reaches a
-                        # terminal state rather than silently hanging.
-                        self.logger.error(
-                            "Unhandled termination intent %r; treating as"
-                            " crash. A follow-up PR needs to add a matching"
-                            " dispatch branch.",
-                            intent,
-                        )
-                        self.handle_crash(exc)
-                    raise
-                except Exception:
-                    # regular exceptions are caught and re-raised to the user
-                    raise
-                except (Abort, Pause) as exc:
-                    if state := getattr(exc, "state", None):
-                        # we set attribute explicitly because
-                        # internals will have already called the state change API
-                        self.flow_run.state = state
-                        self._capture_state_report(state)
-                    elif isinstance(exc, Abort):
-                        self._attempt_conclusion = (
-                            EngineOutcomeReceipt.orchestration_aborted()
-                        )
-                    raise
-                except GeneratorExit:
-                    # Do not capture generator exits as crashes
-                    raise
-                except BaseException as exc:
-                    # We don't want to crash a flow run if the user code finished executing
-                    if self.flow_run.state and not self.flow_run.state.is_final():
-                        # BaseExceptions are caught and handled as crashes
-                        self.handle_crash(exc)
+                    except TerminationSignal as exc:
+                        self.cancel_all_tasks()
+                        intent = _termination_intent()
+                        if intent == "cancel":
+                            self.handle_cancellation(exc)
+                        elif intent is None:
+                            self.handle_crash(exc)
+                        elif intent not in _SUPERVISOR_OWNED_INTENTS:
+                            # Defensive: an unknown intent means the control
+                            # listener was extended (e.g. "suspend" in a
+                            # follow-up PR) without extending this dispatch.
+                            # Treat as crash so the flow run still reaches a
+                            # terminal state rather than silently hanging.
+                            self.logger.error(
+                                "Unhandled termination intent %r; treating as"
+                                " crash. A follow-up PR needs to add a matching"
+                                " dispatch branch.",
+                                intent,
+                            )
+                            self.handle_crash(exc)
                         raise
-                    else:
-                        self.logger.debug(
-                            "BaseException was raised after user code finished executing",
-                            exc_info=exc,
+                    except Exception:
+                        # regular exceptions are caught and re-raised to the user
+                        raise
+                    except (Abort, Pause) as exc:
+                        if state := getattr(exc, "state", None):
+                            # we set attribute explicitly because
+                            # internals will have already called the state change API
+                            self.flow_run.state = state
+                            self._capture_state_report(state)
+                        elif isinstance(exc, Abort):
+                            self._attempt_conclusion = (
+                                EngineOutcomeReceipt.orchestration_aborted()
+                            )
+                        raise
+                    except GeneratorExit:
+                        # Do not capture generator exits as crashes
+                        raise
+                    except BaseException as exc:
+                        # We don't want to crash a flow run if the user code finished executing
+                        if self.flow_run.state and not self.flow_run.state.is_final():
+                            # BaseExceptions are caught and handled as crashes
+                            self.handle_crash(exc)
+                            raise
+                        else:
+                            self.logger.debug(
+                                "BaseException was raised after user code finished executing",
+                                exc_info=exc,
+                            )
+                    finally:
+                        self._report_attempt_conclusion()
+
+                        # If debugging, use the more complete `repr` than the usual `str` description
+                        display_state = (
+                            repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
                         )
-                finally:
-                    self._report_attempt_conclusion()
+                        self.logger.log(
+                            level=logging.INFO,
+                            msg=f"Finished in state {display_state}",
+                        )
 
-                    # If debugging, use the more complete `repr` than the usual `str` description
-                    display_state = (
-                        repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
-                    )
-                    self.logger.log(
-                        level=logging.INFO,
-                        msg=f"Finished in state {display_state}",
-                    )
-
-                    self._is_started = False
-                    self._client = None
+                        self._is_started = False
+                        self._client = None
 
     # --------------------------
     #
@@ -1789,7 +1791,6 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         async with AsyncExitStack() as stack:
             # TODO: Explore closing task runner before completing the flow to
             # wait for futures to complete
-            stack.enter_context(capture_sigterm())
             if log_prints:
                 stack.enter_context(patch_print())
             task_runner = stack.enter_context(self.flow.task_runner.duplicate())
@@ -1913,91 +1914,97 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     parameters=self.parameters,
                 )
 
-                try:
-                    yield self
+                # Keep the control session open until the terminal outcome receipt
+                # has been acknowledged by the supervising process.
+                with capture_sigterm():
+                    try:
+                        yield self
 
-                except TerminationSignal as exc:
-                    self.cancel_all_tasks()
-                    intent = _termination_intent()
-                    if intent == "cancel":
-                        await self.handle_cancellation(exc)
-                    elif intent is None:
-                        await self.handle_crash(exc)
-                    elif intent not in _SUPERVISOR_OWNED_INTENTS:
-                        # Defensive: see sync engine's dispatch for why.
-                        self.logger.error(
-                            "Unhandled termination intent %r; treating as"
-                            " crash. A follow-up PR needs to add a matching"
-                            " dispatch branch.",
-                            intent,
-                        )
-                        await self.handle_crash(exc)
-                    raise
-                except Exception:
-                    # regular exceptions are caught and re-raised to the user
-                    raise
-                except (Abort, Pause) as exc:
-                    if state := getattr(exc, "state", None):
-                        # we set attribute explicitly because
-                        # internals will have already called the state change API
-                        self.flow_run.state = state
-                        self._capture_state_report(state)
-                    elif isinstance(exc, Abort):
-                        self._attempt_conclusion = (
-                            EngineOutcomeReceipt.orchestration_aborted()
-                        )
-                    raise
-                except GeneratorExit:
-                    # Do not capture generator exits as crashes
-                    raise
-                except BaseException as exc:
-                    if (
-                        _is_async_runtime_cancellation(exc)
-                        and _termination_intent() == "cancel"
-                    ):
-                        if self.flow_run.state and not self.flow_run.state.is_final():
+                    except TerminationSignal as exc:
+                        self.cancel_all_tasks()
+                        intent = _termination_intent()
+                        if intent == "cancel":
                             await self.handle_cancellation(exc)
+                        elif intent is None:
+                            await self.handle_crash(exc)
+                        elif intent not in _SUPERVISOR_OWNED_INTENTS:
+                            # Defensive: see sync engine's dispatch for why.
+                            self.logger.error(
+                                "Unhandled termination intent %r; treating as"
+                                " crash. A follow-up PR needs to add a matching"
+                                " dispatch branch.",
+                                intent,
+                            )
+                            await self.handle_crash(exc)
+                        raise
+                    except Exception:
+                        # regular exceptions are caught and re-raised to the user
+                        raise
+                    except (Abort, Pause) as exc:
+                        if state := getattr(exc, "state", None):
+                            # we set attribute explicitly because
+                            # internals will have already called the state change API
+                            self.flow_run.state = state
+                            self._capture_state_report(state)
+                        elif isinstance(exc, Abort):
+                            self._attempt_conclusion = (
+                                EngineOutcomeReceipt.orchestration_aborted()
+                            )
+                        raise
+                    except GeneratorExit:
+                        # Do not capture generator exits as crashes
+                        raise
+                    except BaseException as exc:
+                        if (
+                            _is_async_runtime_cancellation(exc)
+                            and _termination_intent() == "cancel"
+                        ):
+                            if (
+                                self.flow_run.state
+                                and not self.flow_run.state.is_final()
+                            ):
+                                await self.handle_cancellation(exc)
+                                raise TerminationSignal(signal.SIGTERM) from exc
+                            else:
+                                self.logger.debug(
+                                    "Async cancellation was raised after user code"
+                                    " finished executing",
+                                    exc_info=exc,
+                                )
+                                raise
+                        if (
+                            _is_async_runtime_cancellation(exc)
+                            and _termination_intent() in _SUPERVISOR_OWNED_INTENTS
+                        ):
+                            # A supervisor-driven SIGTERM can surface here as a cancellation
+                            # rather than a TerminationSignal.
                             raise TerminationSignal(signal.SIGTERM) from exc
+                        # We don't want to crash a flow run if the user code finished executing
+                        if self.flow_run.state and not self.flow_run.state.is_final():
+                            # BaseExceptions are caught and handled as crashes
+                            await self.handle_crash(exc)
+                            raise
                         else:
                             self.logger.debug(
-                                "Async cancellation was raised after user code"
-                                " finished executing",
+                                "BaseException was raised after user code finished executing",
                                 exc_info=exc,
                             )
-                            raise
-                    if (
-                        _is_async_runtime_cancellation(exc)
-                        and _termination_intent() in _SUPERVISOR_OWNED_INTENTS
-                    ):
-                        # A supervisor-driven SIGTERM can surface here as a cancellation
-                        # rather than a TerminationSignal.
-                        raise TerminationSignal(signal.SIGTERM) from exc
-                    # We don't want to crash a flow run if the user code finished executing
-                    if self.flow_run.state and not self.flow_run.state.is_final():
-                        # BaseExceptions are caught and handled as crashes
-                        await self.handle_crash(exc)
-                        raise
-                    else:
-                        self.logger.debug(
-                            "BaseException was raised after user code finished executing",
-                            exc_info=exc,
+                    finally:
+                        self._report_attempt_conclusion()
+
+                        # If debugging, use the more complete `repr` than the usual `str` description
+                        display_state = (
+                            repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
                         )
-                finally:
-                    self._report_attempt_conclusion()
+                        self.logger.log(
+                            level=logging.INFO
+                            if self.state.is_completed()
+                            else logging.ERROR,
+                            msg=f"Finished in state {display_state}",
+                        )
 
-                    # If debugging, use the more complete `repr` than the usual `str` description
-                    display_state = (
-                        repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
-                    )
-                    self.logger.log(
-                        level=logging.INFO
-                        if self.state.is_completed()
-                        else logging.ERROR,
-                        msg=f"Finished in state {display_state}",
-                    )
-
-                    self._is_started = False
-                    self._client = None
+                        self._is_started = False
+                        self._client = None
 
     # --------------------------
     #

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -903,12 +903,12 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
 
         Used when `capture_sigterm` has determined (via the cancellation
         listener) that the SIGTERM was the runner asking for cancellation,
-        not an unrelated termination. Transitioning through Cancelling first
-        The same ownership rule also governs `on_cancellation` / `on_crashed`
-        hooks: if the engine owns cancellation/crash handling, it must
-        drive the `Cancelling -> Cancelled` transitions locally; if an
-        external runner owns them, the child should avoid duplicating
-        state history.
+        not an unrelated termination. The same ownership rule governs the
+        `on_cancellation` hook: if the engine owns cancellation handling, it
+        must drive `Cancelling -> Cancelled` and run the hook locally; if an
+        external runner owns cancellation, the child avoids duplicating state
+        history and hooks. Engine-reported Crashed states and `on_crashed`
+        hooks always remain engine-owned.
         """
         msg = "Flow run was cancelled."
         self.logger.info(msg)

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -423,6 +423,7 @@ class BaseFlowRunEngine(Generic[P, R]):
     _flow_run_suspension_request: FlowRunSuspensionRequest = field(
         default_factory=FlowRunSuspensionRequest
     )
+    _attempt_conclusion: EngineOutcomeReceipt | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
         if self.flow is None and self.flow_run_id is None:
@@ -456,6 +457,27 @@ class BaseFlowRunEngine(Generic[P, R]):
     def cancel_all_tasks(self) -> None:
         if hasattr(self.flow.task_runner, "cancel_all"):
             self.flow.task_runner.cancel_all()  # type: ignore
+
+    def _capture_state_report(self, state: State) -> None:
+        if (
+            (state.is_final() or state.is_paused())
+            and state.id is not None
+            and state.name is not None
+        ):
+            self._attempt_conclusion = EngineOutcomeReceipt.state_reported(
+                state_id=state.id,
+                state_type=state.type.value,
+                state_name=state.name,
+            )
+        else:
+            self._attempt_conclusion = None
+
+    def _report_attempt_conclusion(self) -> None:
+        if (
+            not self._started_with_in_process_parent_flow_run_context
+            and self._attempt_conclusion is not None
+        ):
+            report_engine_outcome(self._attempt_conclusion)
 
     def _build_heartbeat_event_template(
         self,
@@ -742,6 +764,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         self.flow_run.state_name = state.name  # type: ignore
         self.flow_run.state_type = state.type  # type: ignore
 
+        self._capture_state_report(state)
         self._telemetry.update_state(state)
         self.call_hooks(state)
 
@@ -1214,10 +1237,15 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     # regular exceptions are caught and re-raised to the user
                     raise
                 except (Abort, Pause) as exc:
-                    if getattr(exc, "state", None):
+                    if state := getattr(exc, "state", None):
                         # we set attribute explicitly because
                         # internals will have already called the state change API
-                        self.flow_run.state = exc.state
+                        self.flow_run.state = state
+                        self._capture_state_report(state)
+                    elif isinstance(exc, Abort):
+                        self._attempt_conclusion = (
+                            EngineOutcomeReceipt.orchestration_aborted()
+                        )
                     raise
                 except GeneratorExit:
                     # Do not capture generator exits as crashes
@@ -1234,6 +1262,8 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                             exc_info=exc,
                         )
                 finally:
+                    self._report_attempt_conclusion()
+
                     # If debugging, use the more complete `repr` than the usual `str` description
                     display_state = (
                         repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
@@ -1286,21 +1316,6 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             except Exception as exc:
                 self.logger.exception("Encountered exception during execution: %r", exc)
                 self.handle_exception(exc)
-
-            state = self.state
-            if (
-                not self._started_with_in_process_parent_flow_run_context
-                and state.is_failed()
-                and state.id is not None
-                and state.name is not None
-            ):
-                report_engine_outcome(
-                    EngineOutcomeReceipt.state_reported(
-                        state_id=state.id,
-                        state_type=state.type.value,
-                        state_name=state.name,
-                    )
-                )
 
     def call_flow_fn(self) -> Union[R, Coroutine[Any, Any, R]]:
         """
@@ -1456,6 +1471,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         self.flow_run.state_name = state.name  # type: ignore
         self.flow_run.state_type = state.type  # type: ignore
 
+        self._capture_state_report(state)
         self._telemetry.update_state(state)
         await self.call_hooks(state)
 
@@ -1921,10 +1937,15 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     # regular exceptions are caught and re-raised to the user
                     raise
                 except (Abort, Pause) as exc:
-                    if getattr(exc, "state", None):
+                    if state := getattr(exc, "state", None):
                         # we set attribute explicitly because
                         # internals will have already called the state change API
-                        self.flow_run.state = exc.state
+                        self.flow_run.state = state
+                        self._capture_state_report(state)
+                    elif isinstance(exc, Abort):
+                        self._attempt_conclusion = (
+                            EngineOutcomeReceipt.orchestration_aborted()
+                        )
                     raise
                 except GeneratorExit:
                     # Do not capture generator exits as crashes
@@ -1962,6 +1983,8 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                             exc_info=exc,
                         )
                 finally:
+                    self._report_attempt_conclusion()
+
                     # If debugging, use the more complete `repr` than the usual `str` description
                     display_state = (
                         repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)

--- a/src/prefect/runner/AGENTS.md
+++ b/src/prefect/runner/AGENTS.md
@@ -64,9 +64,11 @@ Services enter in this order during `Runner.__aenter__` (teardown is exact rever
 
 This ordering is a hard constraint. Getting it wrong causes ClosedResourceError during shutdown. Place new services carefully in this sequence.
 
-## ControlChannel: Intent Before Kill
+## Attempt Control Session: Intent or Receipt
 
-`ControlChannel` (`_control_channel.py`) is a TCP loopback socket server that delivers a single-byte *intent* to child processes before the runner sends the actual kill signal. The child-side counterpart lives in `prefect._internal.control_listener`.
+`ControlChannel` (`_control_channel.py`) and the child-side `prefect._internal.control_listener` form an authenticated, attempt-scoped TCP loopback session. Version-one peers retain the single-byte control protocol. Version-two peers negotiate receipt support in-band and may instead conclude the session with one structured Engine Outcome Receipt. The first valid receipt or acknowledged control intent wins; `ControlChannel.get_conclusion()` exposes that immutable evidence, and `unregister()` returns it while cleaning up the registration.
+
+The first authenticated connection consumes its attempt token. Replay and connection replacement are rejected. Wire constants, receipt types, and the shared intent byte map live in `prefect._internal.attempt_control`.
 
 **How cancellation uses it:**
 1. Runner signals `"cancel"` intent over the channel and waits up to 1 s for the child's `b'a'` ack.
@@ -79,7 +81,7 @@ This ordering is a hard constraint. Getting it wrong causes ClosedResourceError 
 
 **Failure modes:** If the child never connects or never acks within 1 s, `signal()` returns `False`. `CancellationManager` falls through to the normal graceful kill and the engine treats the termination as a crash. The `prefect flow-run execute` supervisor instead calls `ProcessManager.kill(force=True)` (SIGKILL, no grace), because an unacked engine would propose `Crashed` and undo a `reschedule`/`relinquish`.
 
-**Extending intents:** The intents today are `"cancel"`, `"reschedule"` and `"relinquish"`. The byte map (`_BYTE_FOR_INTENT` in `_control_channel.py` and `_INTENT_FOR_BYTE` in `_internal/control_listener.py`) must stay in sync when adding new intents.
+**Extending intents:** The intents today are `"cancel"`, `"reschedule"` and `"relinquish"`. Update the single shared map in `prefect._internal.attempt_control` and the engine's `TerminationSignal` dispatch together.
 
 ## ProcessStarter Strategy Pattern
 

--- a/src/prefect/runner/AGENTS.md
+++ b/src/prefect/runner/AGENTS.md
@@ -35,7 +35,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 - Cancellation -> CancellationManager
 - Hooks -> HookRunner
 
-**Legacy methods on Runner exist only for backward compatibility.** Do not add new behavior to:
+**Legacy methods on Runner exist only for backward compatibility.** Except for the narrow ProcessWorker status bridge below, do not add new behavior to:
 - `_submit_run_and_capture_errors()` -- replaced by FlowRunExecutor.submit()
 - `_run_process()` -- replaced by ProcessStarter implementations
 - `_flow_run_process_map` dict -- replaced by ProcessManager
@@ -45,7 +45,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 - `execute_bundle()` -- deprecated (Mar 2026); use `execute_bundle()` from `prefect.bundles.execute`
 - `reschedule_current_flow_runs()` -- deprecated (Mar 2026); SIGTERM rescheduling is now handled inline by the CLI execute path
 
-These will be removed once internal callers are migrated. ProcessWorker uses the same legacy implementation through `_execute_flow_run()` so it can also receive the normalized infrastructure status without changing the deprecated public method's process return type.
+These will be removed once internal callers are migrated. ProcessWorker uses the same legacy implementation through `_execute_flow_run()` so it can also receive the normalized infrastructure status without changing the deprecated public method's process return type. Until ProcessWorker migrates, `_submit_run_and_capture_errors()` may use Attempt Control Session evidence only to suppress its own crash inference and return normalized infrastructure status; keep all other lifecycle changes in the extracted classes.
 
 ## EventEmitter WebSocket Degradation
 

--- a/src/prefect/runner/AGENTS.md
+++ b/src/prefect/runner/AGENTS.md
@@ -20,7 +20,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 | DeploymentRegistry | _deployment_registry.py | Deployment/flow/storage/bundle maps |
 | ScheduledRunPoller | _scheduled_run_poller.py | Poll loop, run discovery, scheduling |
 | ProcessStarter (protocol) | _flow_run_executor.py | Strategy interface for starting processes |
-| FlowRunExecutorContext | _flow_run_executor.py | Async context manager for one-shot execution outside Runner (CLI, bundles) |
+| FlowRunExecutorContext | _flow_run_executor.py | Async context manager for one-shot execution outside Runner (workers, CLI, bundles) |
 | DirectSubprocessStarter | _starter_direct.py | Runs Flow object via run_flow_in_subprocess |
 | EngineCommandStarter | _starter_engine.py | Spawns `python -m prefect.engine` subprocess |
 | WorkspaceResolvingEngineCommandStarter | _workspace_starter.py | Resolves workspace (pull steps) via `_workspace_resolver` subprocess then delegates to EngineCommandStarter; used by `prefect flow-run execute` |
@@ -35,7 +35,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 - Cancellation -> CancellationManager
 - Hooks -> HookRunner
 
-**Legacy methods on Runner exist only for backward compatibility.** Except for the narrow ProcessWorker status bridge below, do not add new behavior to:
+**Legacy methods on Runner exist only for backward compatibility.** Do not add new behavior to:
 - `_submit_run_and_capture_errors()` -- replaced by FlowRunExecutor.submit()
 - `_run_process()` -- replaced by ProcessStarter implementations
 - `_flow_run_process_map` dict -- replaced by ProcessManager
@@ -45,7 +45,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 - `execute_bundle()` -- deprecated (Mar 2026); use `execute_bundle()` from `prefect.bundles.execute`
 - `reschedule_current_flow_runs()` -- deprecated (Mar 2026); SIGTERM rescheduling is now handled inline by the CLI execute path
 
-These will be removed once internal callers are migrated. ProcessWorker uses the same legacy implementation through `_execute_flow_run()` so it can also receive the normalized infrastructure status without changing the deprecated public method's process return type. Until ProcessWorker migrates, `_submit_run_and_capture_errors()` may use Attempt Control Session evidence only to suppress its own crash inference and return normalized infrastructure status; keep all other lifecycle changes in the extracted classes.
+These will be removed once internal callers are migrated. Direct ProcessWorker flow runs already use `FlowRunExecutorContext` with `EngineCommandStarter`; only its ad hoc bundle path still calls deprecated `Runner.execute_bundle()`. Keep lifecycle behavior in the extracted classes and do not route direct worker execution back through Runner.
 
 ## EventEmitter WebSocket Degradation
 
@@ -99,15 +99,16 @@ Each execution mode has a ProcessStarter implementation. To add a new execution 
 
 `ScheduledRunPoller` now calls `propose_pending` (Scheduled → Pending) before handing off to `FlowRunExecutor`. `FlowRunExecutor` then calls `propose_submitting` (Pending → Submitting sub-state) as step 1 of its lifecycle **when `propose_submitting=True` (the default)**. These are two separate transitions — do not collapse them. The split exists so automations listening for the Pending state fire correctly before the executor begins.
 
-**Two callers set `propose_submitting=False`** via `FlowRunExecutorContext.create_executor(propose_submitting=False)` — both have already advanced the flow run past the Pending state, so proposing Submitting again would be wrong:
+**Three callers set `propose_submitting=False`** via `FlowRunExecutorContext.create_executor(propose_submitting=False)` — all have already advanced the flow run past the Pending state, so proposing Submitting again would be wrong:
+- direct `ProcessWorker.run()` execution (`BaseWorker` already proposed Submitting)
 - `prefect flow-run execute` CLI path (invoked by a worker)
 - `execute_bundle()` in `prefect.bundles.execute` (invoked by bundle dispatch)
 
 The cancelling precheck (step 1a) still runs unconditionally even when `propose_submitting=False`.
 
-## ProcessWorker Migration (Known Gap)
+## ProcessWorker Execution Paths
 
-ProcessWorker (src/prefect/workers/process.py) calls the internal legacy `Runner._execute_flow_run()` path and `Runner.execute_bundle()`, suppressing deprecation warnings around the bundle path. It bypasses FlowRunExecutor, ProcessManager, and ProcessStarter entirely. The legacy flow-run path snapshots Attempt Control Session evidence before cleanup and returns a normalized infrastructure status alongside the raw process so BaseWorker cannot reinterpret a handled engine outcome. This remains a migration target.
+Direct ProcessWorker runs use `FlowRunExecutorContext` with `EngineCommandStarter` and `propose_submitting=False`. The executor owns process tracking, cancellation, Attempt Control Session evidence, crash inference, and normalized infrastructure status. Ad hoc ProcessWorker submissions still call deprecated `Runner.execute_bundle()` and remain a migration target.
 
 ## BlockStorageAdapter Pull Behavior
 

--- a/src/prefect/runner/AGENTS.md
+++ b/src/prefect/runner/AGENTS.md
@@ -45,7 +45,7 @@ Thin facade over single-responsibility extracted classes. New behavior belongs i
 - `execute_bundle()` -- deprecated (Mar 2026); use `execute_bundle()` from `prefect.bundles.execute`
 - `reschedule_current_flow_runs()` -- deprecated (Mar 2026); SIGTERM rescheduling is now handled inline by the CLI execute path
 
-These will be removed once internal callers (notably ProcessWorker) are migrated. ProcessWorker currently suppresses the deprecation warnings via `warnings.catch_warnings()`.
+These will be removed once internal callers are migrated. ProcessWorker uses the same legacy implementation through `_execute_flow_run()` so it can also receive the normalized infrastructure status without changing the deprecated public method's process return type.
 
 ## EventEmitter WebSocket Degradation
 
@@ -107,7 +107,7 @@ The cancelling precheck (step 1a) still runs unconditionally even when `propose_
 
 ## ProcessWorker Migration (Known Gap)
 
-ProcessWorker (src/prefect/workers/process.py) calls `Runner.execute_flow_run()` and `Runner.execute_bundle()` via the deprecated path, suppressing `PrefectDeprecationWarning` with `warnings.catch_warnings()`. It bypasses FlowRunExecutor, ProcessManager, and ProcessStarter entirely. This is a known migration target.
+ProcessWorker (src/prefect/workers/process.py) calls the internal legacy `Runner._execute_flow_run()` path and `Runner.execute_bundle()`, suppressing deprecation warnings around the bundle path. It bypasses FlowRunExecutor, ProcessManager, and ProcessStarter entirely. The legacy flow-run path snapshots Attempt Control Session evidence before cleanup and returns a normalized infrastructure status alongside the raw process so BaseWorker cannot reinterpret a handled engine outcome. This remains a migration target.
 
 ## BlockStorageAdapter Pull Behavior
 

--- a/src/prefect/runner/_cancellation_manager.py
+++ b/src/prefect/runner/_cancellation_manager.py
@@ -9,6 +9,7 @@ from prefect.runner._cancel_finalizer import (
     finalize_cancelled_state,
     should_skip_cancel_after_acked_process_exit,
 )
+from prefect.runner._control_channel import ControlSignalStatus
 from prefect.states import Cancelling
 
 if TYPE_CHECKING:
@@ -101,7 +102,17 @@ class CancellationManager:
         grace_seconds = 30.0
         if self._control_channel is not None:
             try:
-                acked = await self._control_channel.signal(flow_run.id, "cancel")
+                signal_status = await self._control_channel.signal(
+                    flow_run.id, "cancel"
+                )
+                if signal_status is ControlSignalStatus.ALREADY_CONCLUDED:
+                    self._logger.debug(
+                        "Skipping cancellation for flow run '%s' because the"
+                        " attempt already concluded.",
+                        flow_run.id,
+                    )
+                    return
+                acked = signal_status is ControlSignalStatus.ACKNOWLEDGED
                 if not acked:
                     self._logger.debug(
                         "Cancel intent for flow run '%s' was not acked on the"

--- a/src/prefect/runner/_control_channel.py
+++ b/src/prefect/runner/_control_channel.py
@@ -41,6 +41,7 @@ import socket
 import time
 import uuid
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from typing_extensions import Self
@@ -69,6 +70,14 @@ if TYPE_CHECKING:
 
 # How long to wait for the child to ack an intent byte once it is connected.
 _DEFAULT_ACK_TIMEOUT = 1.0
+
+
+class ControlSignalStatus(str, Enum):
+    """Result of trying to delegate state ownership to a child process."""
+
+    ACKNOWLEDGED = "acknowledged"
+    ALREADY_CONCLUDED = "already_concluded"
+    NOT_ACKNOWLEDGED = "not_acknowledged"
 
 
 @dataclass
@@ -216,12 +225,14 @@ class ControlChannel:
             reg_writer.close()
         return reg.conclusion
 
-    async def signal(self, flow_run_id: uuid.UUID, intent: Intent) -> bool:
+    async def signal(
+        self, flow_run_id: uuid.UUID, intent: Intent
+    ) -> ControlSignalStatus:
         """Deliver a control intent byte to the child and wait for ack.
 
-        Returns `True` only when the child acknowledges this intent and the
-        corresponding ownership delegation wins the terminal race. A `False`
-        return tells the caller to use its existing fallback path.
+        Returns `ACKNOWLEDGED` when the child accepts ownership,
+        `ALREADY_CONCLUDED` when an engine receipt already won, and
+        `NOT_ACKNOWLEDGED` when the caller should use its fallback path.
 
         If the child has not yet connected, the runner immediately falls
         through to its existing kill/crash path.
@@ -233,7 +244,7 @@ class ControlChannel:
                 intent,
                 flow_run_id,
             )
-            return False
+            return ControlSignalStatus.NOT_ACKNOWLEDGED
 
         if reg.conclusion is not None:
             reg.intent_acked.clear()
@@ -242,7 +253,7 @@ class ControlChannel:
                 intent,
                 flow_run_id,
             )
-            return False
+            return ControlSignalStatus.ALREADY_CONCLUDED
 
         if reg.disconnected.is_set():
             reg.connected.clear()
@@ -255,7 +266,7 @@ class ControlChannel:
                 flow_run_id,
                 intent,
             )
-            return False
+            return ControlSignalStatus.NOT_ACKNOWLEDGED
 
         intent_byte = BYTE_FOR_INTENT.get(intent)
         if intent_byte is None:
@@ -267,11 +278,15 @@ class ControlChannel:
                 intent,
                 flow_run_id,
             )
-            return False
+            return ControlSignalStatus.NOT_ACKNOWLEDGED
 
         try:
             if not await self._deliver_intent(reg, intent, intent_byte):
-                return False
+                return (
+                    ControlSignalStatus.ALREADY_CONCLUDED
+                    if reg.conclusion is not None
+                    else ControlSignalStatus.NOT_ACKNOWLEDGED
+                )
 
             ack_wait_timeout = await self._wait_for_intent_ack(reg)
             if ack_wait_timeout is None:
@@ -285,13 +300,21 @@ class ControlChannel:
                     intent,
                     self._ack_timeout,
                 )
-                return False
-            return True
+                return (
+                    ControlSignalStatus.ALREADY_CONCLUDED
+                    if reg.conclusion is not None
+                    else ControlSignalStatus.NOT_ACKNOWLEDGED
+                )
+            return ControlSignalStatus.ACKNOWLEDGED
         except Exception:
             self._logger.exception(
                 "Error delivering %s intent for flow run '%s'", intent, flow_run_id
             )
-            return False
+            return (
+                ControlSignalStatus.ALREADY_CONCLUDED
+                if reg.conclusion is not None
+                else ControlSignalStatus.NOT_ACKNOWLEDGED
+            )
 
     async def _wait_for_intent_ack(self, reg: _Registration) -> float | None:
         deadline = time.monotonic() + self._ack_timeout

--- a/src/prefect/runner/_control_channel.py
+++ b/src/prefect/runner/_control_channel.py
@@ -1,14 +1,11 @@
-"""
-Runner-side cross-platform control channel for delivering intent into child
-flow run processes.
+"""Runner side of the internal Attempt Control Session.
 
-The runner uses a TCP loopback socket to deliver a single-byte control
-*intent* into child flow run processes before killing them. The child
-connects back to the runner shortly after starting, validates a per-run
-token, and blocks on the socket waiting for an intent byte. When the runner
-wants to act on a run (today: cancel) it writes the intent byte to that
-connection, waits briefly for the child's `b'a'` ack, and only then asks
-the process manager to send the actual kill signal.
+Each child authenticates over a per-attempt TCP loopback connection. The
+version-one protocol delivers a single-byte control intent before the runner
+kills the child. Compatible version-two peers negotiate receipt support and
+may instead complete the session with one structured engine outcome receipt.
+The first valid receipt or acknowledged control intent is recorded as the
+attempt's immutable terminal conclusion.
 
 This separates "intent" from "trigger":
 
@@ -31,16 +28,9 @@ already returns the pre-seeded intent, so the engine's
 `except TerminationSignal` block can dispatch on it (`on_cancellation` vs
 `on_crashed`, or leaving the state alone for `"reschedule"`/`"relinquish"`).
 
-The channel is loopback-only, per-token authenticated, and best-effort: if
-the child never connects or never acks, `signal` returns `False`. Callers
-decide what that means: cancellation falls through to a graceful kill and lets
-the engine crash the run, while `prefect flow-run execute` kills without a
-grace period so an unacked engine cannot crash a run it is about to retry.
-
-This module is deliberately generic. The set of valid intents lives in
-`prefect._internal.control_listener` as `Intent`; the wire
-protocol is a single byte per intent, looked up via `_BYTE_FOR_INTENT`
-below. Adding a new intent is a one-line change on each side.
+The session is best-effort. Without terminal evidence, existing exit-code and
+kill behavior remains the compatibility fallback. Tokens are consumed by the
+first authenticated connection, so replay cannot replace the active child.
 """
 
 from __future__ import annotations
@@ -53,7 +43,25 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from prefect._internal.control_listener import Intent
+from typing_extensions import Self
+
+from prefect._internal.attempt_control import (
+    BYTE_FOR_INTENT,
+    CURRENT_PROTOCOL_VERSION,
+    LEGACY_PROTOCOL_VERSION,
+    MAX_RECEIPT_SIZE,
+    NEGOTIATION_FRAME_SIZE,
+    NEGOTIATION_PREFIX,
+    RECEIPT_ACK,
+    RECEIPT_CAPABILITY,
+    RECEIPT_PREFIX,
+    AttemptConclusion,
+    Intent,
+    StateOwnershipDelegation,
+    decode_negotiation,
+    decode_receipt,
+    encode_negotiation,
+)
 from prefect.logging import get_logger
 
 if TYPE_CHECKING:
@@ -61,16 +69,6 @@ if TYPE_CHECKING:
 
 # How long to wait for the child to ack an intent byte once it is connected.
 _DEFAULT_ACK_TIMEOUT = 1.0
-
-
-# Runner-side wire protocol: intent -> byte. Kept in sync with
-# `_INTENT_FOR_BYTE` in `prefect._internal.control_listener`. Adding a new
-# intent is a matched one-line change on each side.
-_BYTE_FOR_INTENT: dict[Intent, bytes] = {
-    "cancel": b"c",
-    "reschedule": b"r",
-    "relinquish": b"q",
-}
 
 
 @dataclass
@@ -81,10 +79,15 @@ class _Registration:
     intent_acked: asyncio.Event = field(default_factory=asyncio.Event)
     reader: asyncio.StreamReader | None = None
     writer: asyncio.StreamWriter | None = None
+    negotiated_receipts: bool = False
+    pending_intent: Intent | None = None
+    conclusion: AttemptConclusion | None = None
+    conclusion_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    writer_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class ControlChannel:
-    """Cross-platform IPC channel for delivering control intent to child processes.
+    """Attempt-scoped IPC for control intent and negotiated outcome receipts.
 
     The runner owns one instance for its full lifetime. Each flow run subprocess
     spawned by the runner is registered before launch (via `register()`),
@@ -94,8 +97,8 @@ class ControlChannel:
     Use as an async context manager. Inside the context, `port` is the
     listener's bound port (suitable for injecting into child env vars).
 
-    Adding an intent means extending the `Intent` literal, the byte map, and the
-    engine's `except TerminationSignal` dispatch.
+        The shared internal protocol module owns intent bytes, negotiation frames,
+        receipt framing, and terminal conclusion types.
     """
 
     def __init__(
@@ -119,7 +122,7 @@ class ControlChannel:
             )
         return self._port
 
-    async def __aenter__(self) -> ControlChannel:
+    async def __aenter__(self) -> Self:
         try:
             self._server = await asyncio.start_server(
                 self._handle_connection,
@@ -137,8 +140,7 @@ class ControlChannel:
             self._server = None
             self._port = None
             return self
-        sockets = self._server.sockets or []
-        if not sockets:
+        if not self._server.sockets:
             self._logger.warning(
                 "Control channel listener started without a bound socket; "
                 "falling back to kill-only cancellation."
@@ -147,7 +149,7 @@ class ControlChannel:
             self._server = None
             self._port = None
             return self
-        self._port = sockets[0].getsockname()[1]
+        self._port = self._server.sockets[0].getsockname()[1]
         self._logger.debug("Control channel listening on 127.0.0.1:%s", self._port)
         return self
 
@@ -157,10 +159,7 @@ class ControlChannel:
         # until every accepted connection drains.
         for reg in list(self._registrations.values()):
             if reg.writer is not None:
-                try:
-                    reg.writer.close()
-                except Exception:
-                    pass
+                reg.writer.close()
         self._registrations.clear()
         self._tokens_to_id.clear()
 
@@ -168,7 +167,7 @@ class ControlChannel:
             self._server.close()
             try:
                 await asyncio.wait_for(self._server.wait_closed(), timeout=2.0)
-            except (asyncio.TimeoutError, Exception):
+            except (asyncio.TimeoutError, OSError):
                 pass
             self._server = None
         self._port = None
@@ -193,38 +192,36 @@ class ControlChannel:
             prior_writer = prior.writer
             self._reset_connection_state(prior)
             if prior_writer is not None:
-                try:
-                    prior_writer.close()
-                except Exception:
-                    pass
+                prior_writer.close()
 
         token = secrets.token_hex(16)
         self._registrations[flow_run_id] = _Registration(token=token)
         self._tokens_to_id[token] = flow_run_id
         return self._port, token
 
-    def unregister(self, flow_run_id: uuid.UUID) -> None:
-        """Drop a flow run's registration and close any associated connection."""
+    def get_conclusion(self, flow_run_id: uuid.UUID) -> AttemptConclusion | None:
+        """Return the immutable terminal conclusion recorded for an attempt."""
+        reg = self._registrations.get(flow_run_id)
+        return reg.conclusion if reg is not None else None
+
+    def unregister(self, flow_run_id: uuid.UUID) -> AttemptConclusion | None:
+        """Close an attempt registration and return its terminal conclusion."""
         reg = self._registrations.pop(flow_run_id, None)
         if reg is None:
-            return
+            return None
         self._tokens_to_id.pop(reg.token, None)
         reg_writer = reg.writer
         self._reset_connection_state(reg)
         if reg_writer is not None:
-            try:
-                reg_writer.close()
-            except Exception:
-                pass
+            reg_writer.close()
+        return reg.conclusion
 
     async def signal(self, flow_run_id: uuid.UUID, intent: Intent) -> bool:
         """Deliver a control intent byte to the child and wait for ack.
 
-        Returns `True` if the child acknowledged within the timeout, `False`
-        otherwise. A `False` return is a signal to the caller to fall through
-        to its fallback path (for `"cancel"` that means a forced kill) — the
-        engine has not been told to interpret the upcoming termination as
-        anything but a crash.
+        Returns `True` only when the child acknowledges this intent and the
+        corresponding ownership delegation wins the terminal race. A `False`
+        return tells the caller to use its existing fallback path.
 
         If the child has not yet connected, the runner immediately falls
         through to its existing kill/crash path.
@@ -233,6 +230,15 @@ class ControlChannel:
         if reg is None:
             self._logger.debug(
                 "signal(%s) called for unregistered flow run '%s'",
+                intent,
+                flow_run_id,
+            )
+            return False
+
+        if reg.conclusion is not None:
+            reg.intent_acked.clear()
+            self._logger.debug(
+                "Ignoring %s intent for flow run '%s' after terminal conclusion",
                 intent,
                 flow_run_id,
             )
@@ -251,7 +257,7 @@ class ControlChannel:
             )
             return False
 
-        intent_byte = _BYTE_FOR_INTENT.get(intent)
+        intent_byte = BYTE_FOR_INTENT.get(intent)
         if intent_byte is None:
             # Defensive: Intent is a Literal so this should be unreachable,
             # but a runtime-only `Intent.__args__` expansion mistake would
@@ -264,17 +270,15 @@ class ControlChannel:
             return False
 
         try:
-            await self._deliver_intent(reg, intent_byte)
+            if not await self._deliver_intent(reg, intent, intent_byte):
+                return False
 
             ack_wait_timeout = await self._wait_for_intent_ack(reg)
             if ack_wait_timeout is None:
                 reg_writer = reg.writer
                 self._reset_connection_state(reg)
                 if reg_writer is not None:
-                    try:
-                        reg_writer.close()
-                    except Exception:
-                        pass
+                    reg_writer.close()
                 self._logger.debug(
                     "Child for flow run '%s' did not ack %s within %.1fs",
                     flow_run_id,
@@ -309,14 +313,33 @@ class ControlChannel:
             except asyncio.TimeoutError:
                 continue
 
-    async def _deliver_intent(self, reg: _Registration, intent_byte: bytes) -> None:
-        if reg.writer is None:
-            return
-        try:
-            reg.writer.write(intent_byte)
-            await reg.writer.drain()
-        except (ConnectionError, OSError):
-            return
+    async def _deliver_intent(
+        self, reg: _Registration, intent: Intent, intent_byte: bytes
+    ) -> bool:
+        async with reg.writer_lock:
+            if (
+                reg.writer is None
+                or reg.conclusion is not None
+                or reg.pending_intent is not None
+            ):
+                return False
+            reg.pending_intent = intent
+            try:
+                reg.writer.write(intent_byte)
+                await reg.writer.drain()
+            except (ConnectionError, OSError):
+                reg.pending_intent = None
+                return False
+        return True
+
+    async def _record_conclusion(
+        self, reg: _Registration, conclusion: AttemptConclusion
+    ) -> bool:
+        async with reg.conclusion_lock:
+            if reg.conclusion is not None:
+                return False
+            reg.conclusion = conclusion
+            return True
 
     def _reset_connection_state(
         self, reg: _Registration, *, clear_ack: bool = True
@@ -345,9 +368,13 @@ class ControlChannel:
                 writer.close()
                 return
 
-            flow_run_id = self._tokens_to_id.get(token)
+            # Authentication consumes the token before the connection is bound.
+            # Replays and connection replacement therefore cannot find it.
+            flow_run_id = self._tokens_to_id.pop(token, None)
             if flow_run_id is None:
-                self._logger.debug("Control channel: rejected unknown token")
+                self._logger.warning(
+                    "Attempt control session rejected unauthenticated connection"
+                )
                 writer.close()
                 return
 
@@ -361,7 +388,8 @@ class ControlChannel:
             reg.disconnected.clear()
             reg.connected.set()
 
-            # Wait for the child's final ack byte.
+            # Process negotiation, a terminal receipt, or the child's final
+            # acknowledgement of a control intent.
             while True:
                 try:
                     data = await reader.read(1)
@@ -370,20 +398,91 @@ class ControlChannel:
                 if not data:
                     return
                 if data == b"a":
-                    reg.intent_acked.set()
+                    if reg.pending_intent is None:
+                        self._logger.warning(
+                            "Attempt control session received an unexpected intent acknowledgement"
+                        )
+                        return
+                    delegation = StateOwnershipDelegation(reg.pending_intent)
+                    if await self._record_conclusion(reg, delegation):
+                        reg.intent_acked.set()
+                        self._logger.debug(
+                            "Attempt control session recorded acknowledged %s intent",
+                            reg.pending_intent,
+                        )
+                    else:
+                        self._logger.debug(
+                            "Ignoring acknowledged control after terminal conclusion"
+                        )
                     return
+                if data == NEGOTIATION_PREFIX[:1]:
+                    try:
+                        remainder = await reader.readexactly(NEGOTIATION_FRAME_SIZE - 1)
+                        version, capabilities = decode_negotiation(data + remainder)
+                    except (asyncio.IncompleteReadError, TypeError, ValueError):
+                        self._logger.warning(
+                            "Attempt control session received malformed negotiation"
+                        )
+                        return
+                    selected_version = (
+                        CURRENT_PROTOCOL_VERSION
+                        if version >= CURRENT_PROTOCOL_VERSION
+                        and capabilities & RECEIPT_CAPABILITY
+                        else LEGACY_PROTOCOL_VERSION
+                    )
+                    selected_capabilities = (
+                        RECEIPT_CAPABILITY
+                        if selected_version == CURRENT_PROTOCOL_VERSION
+                        else 0
+                    )
+                    reg.negotiated_receipts = bool(selected_capabilities)
+                    async with reg.writer_lock:
+                        writer.write(
+                            encode_negotiation(selected_version, selected_capabilities)
+                        )
+                        await writer.drain()
+                    self._logger.debug(
+                        "Attempt control negotiation selected protocol %d with receipt support %s",
+                        selected_version,
+                        reg.negotiated_receipts,
+                    )
+                    continue
+                if data == RECEIPT_PREFIX:
+                    if not reg.negotiated_receipts:
+                        self._logger.warning(
+                            "Attempt control session received an unnegotiated receipt"
+                        )
+                        return
+                    try:
+                        size = int.from_bytes(await reader.readexactly(4), "big")
+                        if size > MAX_RECEIPT_SIZE:
+                            raise ValueError("Receipt payload is too large")
+                        receipt = decode_receipt(await reader.readexactly(size))
+                    except (asyncio.IncompleteReadError, ValueError):
+                        self._logger.warning(
+                            "Attempt control session received a malformed receipt"
+                        )
+                        return
+                    if await self._record_conclusion(reg, receipt):
+                        self._logger.debug(
+                            "Attempt control session recorded engine outcome receipt"
+                        )
+                        async with reg.writer_lock:
+                            writer.write(RECEIPT_ACK)
+                            await writer.drain()
+                    else:
+                        self._logger.debug("Ignoring receipt after terminal conclusion")
+                    return
+                self._logger.warning(
+                    "Attempt control session received a malformed message"
+                )
+                return
         except Exception:
             self._logger.exception(
                 "Unexpected error handling control channel connection"
             )
-            try:
-                writer.close()
-            except Exception:
-                pass
+            writer.close()
         finally:
             if reg is not None:
-                try:
-                    writer.close()
-                except Exception:
-                    pass
+                writer.close()
                 self._reset_connection_state(reg, clear_ack=False)

--- a/src/prefect/runner/_flow_run_executor.py
+++ b/src/prefect/runner/_flow_run_executor.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import anyio
 import anyio.abc
 
+from prefect._internal.attempt_control import AttemptConclusion, EngineOutcomeReceipt
 from prefect._internal.infrastructure_exit_codes import get_infrastructure_exit_info
 from prefect._internal.observers import FlowRunCancellingObserver
 from prefect.client.orchestration import PrefectClient, get_client
@@ -61,9 +62,9 @@ class FlowRunExecutor:
     3. start process via starter — `task_status.started(handle)` signals caller early
     4. add handle to `process_manager`
     5. block until process exits (starter.start blocks after signaling started)
-    6. remove handle from `process_manager` (in finally)
-    7. interpret exit code -> propose terminal state (crashed) if non-zero
-    8. run crashed hooks if exit was non-zero
+    6. snapshot terminal attempt evidence, then remove the process registration
+    7. treat an engine receipt as handled; otherwise interpret a non-zero exit
+    8. run crashed hooks only when the runner proposes Crashed
 
     ASYNCEXITSTACK 6-STEP DEPENDENCY ORDER (for Phase 5 `Runner.__aenter__`):
     Entry order (LIFO teardown is exact reverse):
@@ -83,6 +84,7 @@ class FlowRunExecutor:
         process_manager: ProcessManager,
         state_proposer: StateProposer,
         hook_runner: HookRunner,
+        get_attempt_conclusion: Callable[[UUID], AttemptConclusion | None],
         propose_submitting: bool = True,
     ) -> None:
         self._flow_run = flow_run
@@ -91,6 +93,7 @@ class FlowRunExecutor:
         self._state_proposer = state_proposer
         self._hook_runner = hook_runner
         self._propose_submitting = propose_submitting
+        self._get_attempt_conclusion = get_attempt_conclusion
         self._logger = get_logger("runner.flow_run_executor")
 
     async def submit(
@@ -109,6 +112,7 @@ class FlowRunExecutor:
         exits.
         """
         handle: ProcessHandle | None = None
+        attempt_conclusion: AttemptConclusion | None = None
         try:
             # Step 1a: already-cancelling precheck (runs regardless of propose_submitting)
             if self._flow_run.state and self._flow_run.state.is_cancelling():
@@ -161,12 +165,17 @@ class FlowRunExecutor:
             )
             return
         finally:
-            # Step 6: remove handle from process_manager
+            # Step 6: snapshot terminal evidence before process cleanup unregisters
+            # the attempt control session, then remove the process handle.
             if handle is not None:
+                attempt_conclusion = self._get_attempt_conclusion(self._flow_run.id)
                 await self._process_manager.remove(self._flow_run.id)
 
-        # Step 7: interpret exit code and propose terminal state
+        # Step 7: a receipt proves the engine handled orchestration regardless of
+        # process status. Without one, preserve the exit-code fallback.
         exit_code = handle.returncode if handle else None
+        if isinstance(attempt_conclusion, EngineOutcomeReceipt):
+            return
         if exit_code is not None and exit_code != 0:
             info = get_infrastructure_exit_info(exit_code)
             msg = f"Process exited with status code: {exit_code}. {info.explanation}"
@@ -349,4 +358,5 @@ class FlowRunExecutorContext:
             state_proposer=self._state_proposer,
             hook_runner=hook_runner,
             propose_submitting=propose_submitting,
+            get_attempt_conclusion=self.control_channel.get_conclusion,
         )

--- a/src/prefect/runner/_flow_run_executor.py
+++ b/src/prefect/runner/_flow_run_executor.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import anyio
 import anyio.abc
 
-from prefect._internal.attempt_control import AttemptConclusion, EngineOutcomeReceipt
+from prefect._internal.attempt_control import AttemptConclusion
 from prefect._internal.infrastructure_exit_codes import get_infrastructure_exit_info
 from prefect._internal.observers import FlowRunCancellingObserver
 from prefect.client.orchestration import PrefectClient, get_client
@@ -171,10 +171,10 @@ class FlowRunExecutor:
                 attempt_conclusion = self._get_attempt_conclusion(self._flow_run.id)
                 await self._process_manager.remove(self._flow_run.id)
 
-        # Step 7: a receipt proves the engine handled orchestration regardless of
-        # process status. Without one, preserve the exit-code fallback.
+        # Step 7: terminal evidence proves the attempt was handled regardless of
+        # process status. Without it, preserve the exit-code fallback.
         exit_code = handle.returncode if handle else None
-        if isinstance(attempt_conclusion, EngineOutcomeReceipt):
+        if attempt_conclusion is not None:
             return
         if exit_code is not None and exit_code != 0:
             info = get_infrastructure_exit_info(exit_code)

--- a/src/prefect/runner/_flow_run_executor.py
+++ b/src/prefect/runner/_flow_run_executor.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Callable, Protocol
+from dataclasses import dataclass
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Protocol
 from uuid import UUID
 
 import anyio
@@ -44,6 +47,14 @@ class ProcessStarter(Protocol):
         flow_run: FlowRun,
         task_status: anyio.abc.TaskStatus[ProcessHandle] = anyio.TASK_STATUS_IGNORED,
     ) -> None: ...
+
+
+@dataclass(frozen=True)
+class FlowRunExecutionResult:
+    """Process handle plus the infrastructure status for a completed attempt."""
+
+    handle: ProcessHandle
+    status_code: int | None
 
 
 class FlowRunExecutor:
@@ -99,8 +110,8 @@ class FlowRunExecutor:
     async def submit(
         self,
         task_status: anyio.abc.TaskStatus[ProcessHandle] = anyio.TASK_STATUS_IGNORED,
-    ) -> None:
-        """Execute the full run lifecycle. Returns None.
+    ) -> FlowRunExecutionResult | None:
+        """Execute the full run lifecycle and return its infrastructure result.
 
         Designed to be called via `runs_task_group.start(executor.submit)` so
         the caller receives the `ProcessHandle` before the process exits.
@@ -173,9 +184,10 @@ class FlowRunExecutor:
 
         # Step 7: terminal evidence proves the attempt was handled regardless of
         # process status. Without it, preserve the exit-code fallback.
-        exit_code = handle.returncode if handle else None
+        assert handle is not None
+        exit_code = handle.returncode
         if attempt_conclusion is not None:
-            return
+            return FlowRunExecutionResult(handle=handle, status_code=0)
         if exit_code is not None and exit_code != 0:
             info = get_infrastructure_exit_info(exit_code)
             msg = f"Process exited with status code: {exit_code}. {info.explanation}"
@@ -193,6 +205,8 @@ class FlowRunExecutor:
             # Step 8: run crashed hooks
             if crashed_state is not None:
                 await self._hook_runner.run_crashed_hooks(self._flow_run, crashed_state)
+
+        return FlowRunExecutionResult(handle=handle, status_code=exit_code)
 
     async def _start_process(
         self,
@@ -219,6 +233,10 @@ class FlowRunExecutor:
         async with anyio.create_task_group() as inner_tg:
             # inner_tg.start() returns when starter calls task_status.started(handle)
             captured_handle = await inner_tg.start(_run_starter)
+            assert captured_handle is not None, (
+                "Starter did not call task_status.started() -- violates"
+                " ProcessStarter contract"
+            )
 
             # Handle is now available; process is still running
             await self._process_manager.add(self._flow_run.id, captured_handle)
@@ -226,9 +244,7 @@ class FlowRunExecutor:
 
             # inner_tg waits for _run_starter to complete (process exits)
 
-        assert captured_handle is not None, (
-            "Starter did not call task_status.started() -- violates ProcessStarter contract"
-        )
+        assert captured_handle is not None
         return captured_handle
 
 
@@ -264,10 +280,13 @@ class FlowRunExecutorContext:
 
         # Create observer object early so we can wire ProcessManager callbacks.
         # on_cancelling lambda captures self._cancellation_manager (assigned in step 4).
+        def _on_cancelling(flow_run_id: UUID) -> None:
+            self._cancellation_task_group.start_soon(
+                self._cancellation_manager.cancel_by_id, flow_run_id
+            )
+
         self._observer = FlowRunCancellingObserver(
-            on_cancelling=lambda frid: self._cancellation_task_group.start_soon(
-                self._cancellation_manager.cancel_by_id, frid
-            ),
+            on_cancelling=_on_cancelling,
             on_failure=lambda flow_run_ids: self._handle_cancellation_observer_failure(
                 flow_run_ids
             ),
@@ -314,8 +333,13 @@ class FlowRunExecutorContext:
 
         return self
 
-    async def __aexit__(self, *exc_info: object) -> bool | None:
-        return await self._stack.__aexit__(*exc_info)
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        return await self._stack.__aexit__(exc_type, exc_value, traceback)
 
     def _handle_cancellation_observer_failure(self, flow_run_ids: set) -> None:
         """Handle failure of both cancellation observer mechanisms.
@@ -345,7 +369,7 @@ class FlowRunExecutorContext:
         self,
         flow_run: FlowRun,
         starter: ProcessStarter,
-        resolve_flow: Callable[[FlowRun], Flow[..., ...]],
+        resolve_flow: Callable[[FlowRun], Awaitable[Flow[Any, Any]]],
         propose_submitting: bool = True,
     ) -> FlowRunExecutor:
         hook_runner = HookRunner(resolve_flow=resolve_flow)

--- a/src/prefect/runner/_scheduled_run_poller.py
+++ b/src/prefect/runner/_scheduled_run_poller.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import datetime
 from functools import partial
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Callable, Protocol
 from uuid import UUID
 
 import anyio
 import anyio.abc
 
+from prefect._internal.attempt_control import AttemptConclusion
 from prefect.logging import get_logger
 from prefect.runner._flow_run_executor import FlowRunExecutor, ProcessStarter
 from prefect.types._datetime import now
@@ -59,6 +60,7 @@ class ScheduledRunPoller:
         state_proposer: StateProposer,
         hook_runner: HookRunner,
         cancellation_manager: CancellationManager,
+        get_attempt_conclusion: Callable[[UUID], AttemptConclusion | None],
     ) -> None:
         self._query_seconds = query_seconds
         self._prefetch_seconds = prefetch_seconds
@@ -72,6 +74,7 @@ class ScheduledRunPoller:
         self._state_proposer = state_proposer
         self._hook_runner = hook_runner
         self._cancellation_manager = cancellation_manager
+        self._get_attempt_conclusion = get_attempt_conclusion
 
         self._submitting_flow_run_ids: set[UUID] = set()
         self.last_polled: datetime.datetime | None = None
@@ -196,6 +199,7 @@ class ScheduledRunPoller:
                 process_manager=self._process_manager,
                 state_proposer=self._state_proposer,
                 hook_runner=self._hook_runner,
+                get_attempt_conclusion=self._get_attempt_conclusion,
             )
             await executor.submit()
         except Exception:

--- a/src/prefect/runner/_starter_bundle.py
+++ b/src/prefect/runner/_starter_bundle.py
@@ -31,7 +31,7 @@ class BundleExecutionStarter:
         self,
         *,
         bundle: SerializedBundle,
-        cwd: Path | None = None,
+        cwd: Path | str | None = None,
         env: dict[str, str | None] | None = None,
         control_channel: ControlChannel | None = None,
     ) -> None:
@@ -71,5 +71,6 @@ class BundleExecutionStarter:
             await anyio.to_thread.run_sync(process.join)  # SpawnProcess.join is sync
         except BaseException:
             if control_registered and not handed_off:
+                assert self._control_channel is not None
                 self._control_channel.unregister(flow_run.id)
             raise

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -912,13 +912,19 @@ class Runner:
 
             await anyio.to_thread.run_sync(process.join)
 
-            await self._remove_flow_run_process_map_entry(flow_run.id)
+            attempt_conclusion = await self._remove_flow_run_process_map_entry(
+                flow_run.id
+            )
 
             flow_run_logger = self._get_flow_run_logger(flow_run)
             if process.exitcode is None:
                 raise RuntimeError("Process has no exit code")
 
-            if process.exitcode:
+            if attempt_conclusion is not None:
+                flow_run_logger.info(
+                    f"Process for flow run {flow_run.name!r} reported a handled outcome."
+                )
+            elif process.exitcode:
                 info = get_infrastructure_exit_info(process.exitcode)
                 flow_run_logger.log(
                     info.log_level,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -50,6 +50,7 @@ import uuid
 import warnings
 from contextlib import AsyncExitStack
 from copy import deepcopy
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from typing import (
@@ -70,6 +71,7 @@ import anyio.abc
 import anyio.to_thread
 from typing_extensions import Self
 
+from prefect._internal.attempt_control import AttemptConclusion
 from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.compatibility.deprecated import (
     PrefectDeprecationWarning,
@@ -99,7 +101,7 @@ from prefect.events.clients import (  # noqa: F401 (patch target)
     EventsClient,
     get_events_client,
 )
-from prefect.exceptions import Abort, ObjectNotFound
+from prefect.exceptions import Abort
 from prefect.flow_engine import run_flow_in_subprocess
 from prefect.flows import Flow, FlowStateHook, load_flow_from_flow_run
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logger
@@ -169,6 +171,12 @@ __all__ = ["Runner"]
 class ProcessMapEntry(TypedDict):
     flow_run: "FlowRun"
     pid: int
+
+
+@dataclass(frozen=True)
+class _FlowRunProcessResult:
+    process: anyio.abc.Process | multiprocessing.context.SpawnProcess
+    status_code: int | None
 
 
 class Runner:
@@ -329,7 +337,9 @@ class Runner:
                 assert self._cancelling_observer is not None
             self._cancelling_observer.add_in_flight_flow_run_id(flow_run_id)
 
-    async def _remove_flow_run_process_map_entry(self, flow_run_id: UUID):
+    async def _remove_flow_run_process_map_entry(
+        self, flow_run_id: UUID
+    ) -> AttemptConclusion | None:
         async with self._flow_run_process_map_lock:
             self._flow_run_process_map.pop(flow_run_id, None)
 
@@ -339,7 +349,7 @@ class Runner:
 
         # Drop the control channel registration so the per-run token,
         # connection, and pending state are released.
-        self._control_channel.unregister(flow_run_id)
+        return self._control_channel.unregister(flow_run_id)
 
     async def aadd_deployment(
         self,
@@ -729,12 +739,33 @@ class Runner:
             PrefectDeprecationWarning,
             stacklevel=2,
         )
+        result = await self._execute_flow_run(
+            flow_run_id=flow_run_id,
+            entrypoint=entrypoint,
+            command=command,
+            cwd=cwd,
+            env=env,
+            task_status=task_status,
+            stream_output=stream_output,
+        )
+        return result.process if result is not None else None
+
+    async def _execute_flow_run(
+        self,
+        flow_run_id: UUID,
+        entrypoint: str | None = None,
+        command: str | None = None,
+        cwd: Path | str | None = None,
+        env: dict[str, str | None] | None = None,
+        task_status: anyio.abc.TaskStatus[int] = anyio.TASK_STATUS_IGNORED,
+        stream_output: bool = True,
+    ) -> _FlowRunProcessResult | None:
         self.pause_on_shutdown = False
         context = self if not self.started else asyncnullcontext()
 
         async with context:
             if not self._acquire_limit_slot(flow_run_id):
-                return
+                return None
 
             self._submitting_flow_run_ids.add(flow_run_id)
             flow_run = await self._client.read_flow_run(flow_run_id)
@@ -749,13 +780,16 @@ class Runner:
                 )
                 self._release_limit_slot(flow_run_id)
                 self._submitting_flow_run_ids.discard(flow_run_id)
-                return
+                return None
 
             if flow_run.state and flow_run.state.is_cancelled():
                 self._release_limit_slot(flow_run_id)
                 self._submitting_flow_run_ids.discard(flow_run_id)
-                return
+                return None
 
+            completion_status: asyncio.Future[int | None] = (
+                asyncio.get_running_loop().create_future()
+            )
             process: (
                 anyio.abc.Process | multiprocessing.context.SpawnProcess | Exception
             ) = await self._runs_task_group.start(
@@ -767,10 +801,11 @@ class Runner:
                     cwd=cwd,
                     env=env,
                     stream_output=stream_output,
+                    completion_status=completion_status,
                 ),
             )
             if isinstance(process, Exception):
-                return
+                return None
 
             if process.pid is None:
                 raise RuntimeError("Process has no PID")
@@ -794,7 +829,10 @@ class Runner:
                 if self._flow_run_process_map.get(flow_run.id) is None:
                     break
 
-            return process
+            return _FlowRunProcessResult(
+                process=process,
+                status_code=await completion_status,
+            )
 
     async def execute_bundle(
         self,
@@ -1420,8 +1458,10 @@ class Runner:
         cwd: Path | str | None = None,
         env: dict[str, str | None] | None = None,
         stream_output: bool = True,
+        completion_status: asyncio.Future[int | None] | None = None,
     ) -> Union[Optional[int], Exception]:
         run_logger = self._get_flow_run_logger(flow_run)
+        attempt_conclusion: AttemptConclusion | None = None
 
         try:
             exit_code = await self._run_process(
@@ -1433,20 +1473,6 @@ class Runner:
                 env=env,
                 stream_output=stream_output,
             )
-            flow_run_logger = self._get_flow_run_logger(flow_run)
-            if exit_code:
-                info = get_infrastructure_exit_info(exit_code)
-                flow_run_logger.log(
-                    info.log_level,
-                    f"Process for flow run {flow_run.name!r} exited with status code:"
-                    f" {exit_code}; {info.explanation}",
-                )
-                if info.resolution:
-                    flow_run_logger.info(info.resolution)
-            else:
-                flow_run_logger.info(
-                    f"Process for flow run {flow_run.name!r} exited cleanly."
-                )
         except Exception as exc:
             if not task_status._future.done():  # type: ignore
                 # This flow run was being submitted and did not start successfully
@@ -1463,33 +1489,54 @@ class Runner:
                     "The flow run will not be marked as failed, but an issue may have "
                     "occurred."
                 )
+            if completion_status is not None and not completion_status.done():
+                completion_status.set_result(None)
             return exc
         finally:
             self._release_limit_slot(flow_run.id)
 
-            await self._remove_flow_run_process_map_entry(flow_run.id)
-
-        if exit_code != 0 and not self._rescheduling:
-            await self._propose_crashed_state(
-                flow_run,
-                f"Flow run process exited with non-zero status code {exit_code}.",
+            attempt_conclusion = await self._remove_flow_run_process_map_entry(
+                flow_run.id
             )
 
+        status_code = 0 if attempt_conclusion is not None else exit_code
+        flow_run_logger = self._get_flow_run_logger(flow_run)
         try:
-            api_flow_run = await self._client.read_flow_run(flow_run_id=flow_run.id)
-            terminal_state = api_flow_run.state
-            if terminal_state and terminal_state.is_crashed():
+            if attempt_conclusion is not None:
+                flow_run_logger.info(
+                    f"Process for flow run {flow_run.name!r} reported a handled outcome."
+                )
+            elif exit_code:
+                info = get_infrastructure_exit_info(exit_code)
+                flow_run_logger.log(
+                    info.log_level,
+                    f"Process for flow run {flow_run.name!r} exited with status code:"
+                    f" {exit_code}; {info.explanation}",
+                )
+                if info.resolution:
+                    flow_run_logger.info(info.resolution)
+            else:
+                flow_run_logger.info(
+                    f"Process for flow run {flow_run.name!r} exited cleanly."
+                )
+
+            if exit_code != 0 and attempt_conclusion is None and not self._rescheduling:
+                terminal_state = await self._propose_crashed_state(
+                    flow_run,
+                    f"Flow run process exited with non-zero status code {exit_code}.",
+                )
+            else:
+                terminal_state = None
+
+            if terminal_state is not None:
                 await self._run_on_crashed_hooks(
                     flow_run=flow_run, state=terminal_state
                 )
-        except ObjectNotFound:
-            # Flow run was deleted - log it but don't crash the runner
-            run_logger = self._get_flow_run_logger(flow_run)
-            run_logger.debug(
-                f"Flow run '{flow_run.id}' was deleted before final state could be checked"
-            )
+        finally:
+            if completion_status is not None and not completion_status.done():
+                completion_status.set_result(status_code)
 
-        return exit_code
+        return status_code
 
     async def _propose_pending_state(self, flow_run: "FlowRun") -> bool:
         return await self._state_proposer.propose_pending(flow_run)

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1792,6 +1792,7 @@ class Runner:
             state_proposer=self._state_proposer,
             hook_runner=self._hook_runner,
             cancellation_manager=self._cancellation_manager,
+            get_attempt_conclusion=self._control_channel.get_conclusion,
         )
 
         # Step 6: Enter observer context manager last

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -109,7 +109,7 @@ from prefect.runner._cancel_finalizer import (
     should_skip_cancel_after_acked_process_exit,
 )
 from prefect.runner._cancellation_manager import CancellationManager
-from prefect.runner._control_channel import ControlChannel
+from prefect.runner._control_channel import ControlChannel, ControlSignalStatus
 from prefect.runner._deployment_registry import DeploymentRegistry
 from prefect.runner._event_emitter import EventEmitter
 from prefect.runner._flow_run_executor import FlowRunExecutor, ProcessStarter
@@ -1267,7 +1267,16 @@ class Runner:
         acked = False
         grace_seconds = 30.0
         try:
-            acked = await self._control_channel.signal(flow_run.id, "cancel")
+            signal_status = await self._control_channel.signal(flow_run.id, "cancel")
+            if signal_status is ControlSignalStatus.ALREADY_CONCLUDED:
+                self._logger.debug(
+                    "Skipping cancellation for flow run '%s' because the"
+                    " attempt already concluded.",
+                    flow_run.id,
+                )
+                self._cancelling_flow_run_ids.discard(flow_run.id)
+                return
+            acked = signal_status is ControlSignalStatus.ACKNOWLEDGED
             if not acked:
                 self._logger.debug(
                     "Cancel intent for flow run '%s' was not acked on the"

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -87,7 +87,6 @@ from prefect._internal.infrastructure_exit_codes import get_infrastructure_exit_
 from prefect._internal.observers import FlowRunCancellingObserver
 from prefect.bundles import (
     SerializedBundle,
-    execute_bundle_in_subprocess,
     extract_flow_from_bundle,
 )
 from prefect.client.orchestration import get_client
@@ -113,11 +112,12 @@ from prefect.runner._cancellation_manager import CancellationManager
 from prefect.runner._control_channel import ControlChannel
 from prefect.runner._deployment_registry import DeploymentRegistry
 from prefect.runner._event_emitter import EventEmitter
-from prefect.runner._flow_run_executor import ProcessStarter
+from prefect.runner._flow_run_executor import FlowRunExecutor, ProcessStarter
 from prefect.runner._hook_runner import HookRunner
 from prefect.runner._limit_manager import LimitManager
 from prefect.runner._process_manager import ProcessManager, _pid_is_alive
 from prefect.runner._scheduled_run_poller import ScheduledRunPoller
+from prefect.runner._starter_bundle import BundleExecutionStarter
 from prefect.runner._starter_direct import DirectSubprocessStarter
 from prefect.runner._starter_engine import EngineCommandStarter
 from prefect.runner._state_proposer import StateProposer
@@ -278,6 +278,7 @@ class Runner:
         # HookRunner is constructed in __aenter__ once the client is available,
         # so we can build a storage-aware flow resolver closure.
         self._hook_runner: HookRunner | None = None
+        self._state_proposer: StateProposer
         # Cross-platform IPC channel for delivering control intent (cancel
         # today; suspend in a follow-up) into child subprocesses; see
         # prefect.runner._control_channel.
@@ -871,79 +872,26 @@ class Runner:
             if not self._acquire_limit_slot(flow_run.id):
                 return
 
-            # Register the flow run with the control channel before spawning
-            # so the child can connect back as soon as it starts.
-            control_env: dict[str, str] = {}
-            control_registered = False
             try:
-                port, token = self._control_channel.register(flow_run.id)
-                control_env["PREFECT__CONTROL_PORT"] = str(port)
-                control_env["PREFECT__CONTROL_TOKEN"] = token
-                control_registered = True
-            except RuntimeError:
-                # Channel not entered (e.g. tests using the legacy facade
-                # without __aenter__); silently skip.
-                pass
-
-            if control_env:
-                env = dict(env or {})
-                env.update(control_env)
-
-            try:
-                process = execute_bundle_in_subprocess(bundle, cwd=cwd, env=env)
-            except BaseException:
-                if control_registered:
-                    self._control_channel.unregister(flow_run.id)
-                raise
-
-            if process.pid is None:
-                if control_registered:
-                    self._control_channel.unregister(flow_run.id)
-                # This shouldn't happen because `execute_bundle_in_subprocess` starts the process
-                # but we'll handle it gracefully anyway
-                msg = "Failed to start process for flow execution. No PID returned."
-                await self._propose_crashed_state(flow_run, msg)
-                raise RuntimeError(msg)
-
-            await self._add_flow_run_process_map_entry(
-                flow_run.id, ProcessMapEntry(pid=process.pid, flow_run=flow_run)
-            )
-            self._flow_run_bundle_map[flow_run.id] = bundle
-
-            await anyio.to_thread.run_sync(process.join)
-
-            attempt_conclusion = await self._remove_flow_run_process_map_entry(
-                flow_run.id
-            )
-
-            flow_run_logger = self._get_flow_run_logger(flow_run)
-            if process.exitcode is None:
-                raise RuntimeError("Process has no exit code")
-
-            if attempt_conclusion is not None:
-                flow_run_logger.info(
-                    f"Process for flow run {flow_run.name!r} reported a handled outcome."
+                self._flow_run_bundle_map[flow_run.id] = bundle
+                assert self._hook_runner is not None
+                executor = FlowRunExecutor(
+                    flow_run=flow_run,
+                    starter=BundleExecutionStarter(
+                        bundle=bundle,
+                        cwd=cwd,
+                        env=env,
+                        control_channel=self._control_channel,
+                    ),
+                    process_manager=self._process_manager,
+                    state_proposer=self._state_proposer,
+                    hook_runner=self._hook_runner,
+                    propose_submitting=False,
+                    get_attempt_conclusion=self._control_channel.get_conclusion,
                 )
-            elif process.exitcode:
-                info = get_infrastructure_exit_info(process.exitcode)
-                flow_run_logger.log(
-                    info.log_level,
-                    f"Process for flow run {flow_run.name!r} exited with status code:"
-                    f" {process.exitcode}; {info.explanation}",
-                )
-                if info.resolution:
-                    flow_run_logger.info(info.resolution)
-                terminal_state = await self._propose_crashed_state(
-                    flow_run, info.explanation
-                )
-                if terminal_state:
-                    await self._run_on_crashed_hooks(
-                        flow_run=flow_run, state=terminal_state
-                    )
-            else:
-                flow_run_logger.info(
-                    f"Process for flow run {flow_run.name!r} exited cleanly."
-                )
+                await executor.submit()
+            finally:
+                self._release_limit_slot(flow_run.id)
 
     def _get_flow_run_logger(self, flow_run: "FlowRun") -> PrefectLogAdapter:
         return flow_run_logger(

--- a/src/prefect/workers/AGENTS.md
+++ b/src/prefect/workers/AGENTS.md
@@ -12,7 +12,7 @@ This module does NOT manage the Runner execution model (no work pool) — see `r
 
 - `BaseWorker` — abstract base; handles heartbeating, polling, cancellation, and attribution env vars
 - `BaseJobConfiguration` — Pydantic model for per-run infrastructure config; `prepare_for_flow_run()` stamps attribution variables into `env`
-- `ProcessWorker` (`process.py`) — runs flow runs as local subprocesses via `Runner.execute_bundle()`
+- `ProcessWorker` (`process.py`) — runs direct flow runs through `FlowRunExecutor` with `EngineCommandStarter`; ad hoc bundles still use `Runner.execute_bundle()`
 - `BaseWorkerResult` — result returned by `run()`; wraps infrastructure status codes
 
 ## Worker Channel
@@ -48,7 +48,7 @@ Work-pool-level launchers are configured via `prefect work-pool storage configur
 ## Pitfalls
 
 - `backend_id` is `None` until the first heartbeat succeeds; `PREFECT__WORKER_ID` is not set until then. Code that reads `self.backend_id` early in the lifecycle may get `None`.
-- `ProcessWorker` calls the internal legacy `Runner._execute_flow_run()` path and deprecated `Runner.execute_bundle()` path. It bypasses `FlowRunExecutor` and `ProcessStarter` — this is a known migration gap (see `runner/AGENTS.md`). The flow-run path returns the raw process plus a normalized infrastructure status derived from Attempt Control Session evidence; BaseWorker must consume the normalized status, not the raw child exit code.
+- Direct `ProcessWorker.run()` execution uses `FlowRunExecutorContext` with `EngineCommandStarter` and `propose_submitting=False` because `BaseWorker` already proposed Submitting. Consume the executor's normalized infrastructure status, not the raw child exit code. The ad hoc bundle path still uses deprecated `Runner.execute_bundle()` and remains a migration gap (see `runner/AGENTS.md`).
 
 ## Related
 

--- a/src/prefect/workers/AGENTS.md
+++ b/src/prefect/workers/AGENTS.md
@@ -48,7 +48,7 @@ Work-pool-level launchers are configured via `prefect work-pool storage configur
 ## Pitfalls
 
 - `backend_id` is `None` until the first heartbeat succeeds; `PREFECT__WORKER_ID` is not set until then. Code that reads `self.backend_id` early in the lifecycle may get `None`.
-- `ProcessWorker` calls the deprecated `Runner.execute_flow_run()` / `Runner.execute_bundle()` paths (suppressing `PrefectDeprecationWarning` with `warnings.catch_warnings()`). It bypasses `FlowRunExecutor` and `ProcessStarter` — this is a known migration gap (see `runner/AGENTS.md`).
+- `ProcessWorker` calls the internal legacy `Runner._execute_flow_run()` path and deprecated `Runner.execute_bundle()` path. It bypasses `FlowRunExecutor` and `ProcessStarter` — this is a known migration gap (see `runner/AGENTS.md`). The flow-run path returns the raw process plus a normalized infrastructure status derived from Attempt Control Session evidence; BaseWorker must consume the normalized status, not the raw child exit code.
 
 ## Related
 

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -188,7 +188,7 @@ class ProcessWorker(
         )
         with working_dir_ctx as working_dir, warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            process = await self._runner.execute_flow_run(
+            execution = await self._runner._execute_flow_run(
                 flow_run_id=flow_run.id,
                 command=configuration._resolve_command(working_dir),
                 cwd=working_dir,
@@ -197,16 +197,13 @@ class ProcessWorker(
                 task_status=task_status,
             )
 
-        status_code = (
-            getattr(process, "returncode", None)
-            if getattr(process, "returncode", None) is not None
-            else getattr(process, "exitcode", None)
-        )
-
-        if process is None or status_code is None:
+        if execution is None or execution.status_code is None:
             raise RuntimeError("Failed to start flow run process.")
 
-        return ProcessWorkerResult(status_code=status_code, identifier=str(process.pid))
+        return ProcessWorkerResult(
+            status_code=execution.status_code,
+            identifier=str(execution.process.pid),
+        )
 
     async def _submit_adhoc_run(
         self,

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -270,11 +270,19 @@ class ProcessWorker(
             logger.debug("Flow run bundle execution complete")
 
     async def __aenter__(self) -> ProcessWorker:
-        await super().__aenter__()
-        self._runner = await self._exit_stack.enter_async_context(
-            Runner(pause_on_shutdown=False, limit=None)
-        )
+        runner = Runner(pause_on_shutdown=False, limit=None)
+        self._runner = await runner.__aenter__()
+        try:
+            await super().__aenter__()
+        except BaseException as exc:
+            await runner.__aexit__(type(exc), exc, exc.__traceback__)
+            raise
         return self
 
     async def __aexit__(self, *exc_info: Any) -> None:
-        await super().__aexit__(*exc_info)
+        try:
+            # The worker task group owns ad-hoc submissions. Let those finish
+            # while the runner is still available to supervise their children.
+            await super().__aexit__(*exc_info)
+        finally:
+            await self._runner.__aexit__(*exc_info)

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -29,6 +29,13 @@ from pydantic import Field, PrivateAttr, TypeAdapter, ValidationError, field_val
 
 from prefect._internal.schemas.validators import validate_working_dir
 from prefect.client.schemas.objects import Flow as APIFlow
+from prefect.flows import load_flow_from_flow_run
+from prefect.runner._flow_run_executor import (
+    FlowRunExecutionResult,
+    FlowRunExecutorContext,
+)
+from prefect.runner._process_manager import ProcessHandle
+from prefect.runner._starter_engine import EngineCommandStarter
 from prefect.runner._uv_command import uv_project_command
 from prefect.runner.runner import Runner
 from prefect.states import Pending
@@ -188,21 +195,42 @@ class ProcessWorker(
         )
         with working_dir_ctx as working_dir, warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            execution = await self._runner._execute_flow_run(
-                flow_run_id=flow_run.id,
-                command=configuration._resolve_command(working_dir),
-                cwd=working_dir,
-                env=configuration.env,
-                stream_output=configuration.stream_output,
-                task_status=task_status,
-            )
+            async with FlowRunExecutorContext() as ctx:
+                executor = ctx.create_executor(
+                    flow_run,
+                    EngineCommandStarter(
+                        command=configuration._resolve_command(working_dir),
+                        cwd=working_dir,
+                        env=configuration.env,
+                        stream_output=configuration.stream_output,
+                        control_channel=ctx.control_channel,
+                    ),
+                    resolve_flow=load_flow_from_flow_run,
+                    propose_submitting=False,
+                )
+                execution: FlowRunExecutionResult | None = None
+
+                async def execute(
+                    *,
+                    task_status: anyio.abc.TaskStatus[
+                        ProcessHandle
+                    ] = anyio.TASK_STATUS_IGNORED,
+                ) -> None:
+                    nonlocal execution
+                    execution = await executor.submit(task_status=task_status)
+
+                async with anyio.create_task_group() as task_group:
+                    handle = await task_group.start(execute)
+                    if handle.pid is None:
+                        raise RuntimeError("Flow run process has no PID")
+                    task_status.started(handle.pid)
 
         if execution is None or execution.status_code is None:
             raise RuntimeError("Failed to start flow run process.")
 
         return ProcessWorkerResult(
             status_code=execution.status_code,
-            identifier=str(execution.process.pid),
+            identifier=str(execution.handle.pid),
         )
 
     async def _submit_adhoc_run(

--- a/tests/_experimental/bundles/test_execute.py
+++ b/tests/_experimental/bundles/test_execute.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import os
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+import prefect.bundles as bundles_module
 from prefect import flow
+from prefect.bundles import create_bundle_for_flow_run
 from prefect.bundles.execute import execute_bundle
 from prefect.client.orchestration import PrefectClient
+from prefect.logging.loggers import flow_run_logger
+
+
+def _log_bundle_crashed_hook(flow: Any, flow_run: Any, state: Any) -> None:
+    flow_run_logger(flow_run, flow).error("bundle crash hook ran")
 
 
 async def test_execute_bundle_creates_executor_with_propose_submitting_false(
@@ -44,3 +54,88 @@ async def test_execute_bundle_creates_executor_with_propose_submitting_false(
         await execute_bundle(bundle)
 
     assert captured_kwargs.get("propose_submitting") is False
+
+
+@pytest.mark.usefixtures("use_hosted_api_server")
+async def test_execute_bundle_preserves_failed_outcome(
+    prefect_client: PrefectClient,
+    caplog: pytest.LogCaptureFixture,
+):
+    import prefect.runner._starter_bundle as starter_module
+
+    @flow(on_crashed=[_log_bundle_crashed_hook])
+    def failed_flow() -> None:
+        raise ValueError("application failure")
+
+    flow_run = await prefect_client.create_flow_run(failed_flow)
+    with patch.object(
+        bundles_module.subprocess,
+        "check_output",
+        MagicMock(return_value=b""),
+    ):
+        bundle = create_bundle_for_flow_run(failed_flow, flow_run)["bundle"]
+
+    processes: list[Any] = []
+    original_execute_bundle_in_subprocess = starter_module.execute_bundle_in_subprocess
+
+    def tracking_execute_bundle(*args: Any, **kwargs: Any):
+        process = original_execute_bundle_in_subprocess(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    with patch.object(
+        starter_module,
+        "execute_bundle_in_subprocess",
+        side_effect=tracking_execute_bundle,
+    ):
+        infrastructure_result = await execute_bundle(bundle)
+
+    flow_run = await prefect_client.read_flow_run(flow_run.id)
+    assert processes[0].exitcode == 1
+    assert infrastructure_result is None
+    assert flow_run.state is not None
+    assert flow_run.state.is_failed()
+    assert "bundle crash hook ran" not in caplog.text
+    assert "Process exited with status code: 1" not in caplog.text
+
+
+@pytest.mark.usefixtures("use_hosted_api_server")
+async def test_execute_bundle_preserves_crash_fallback(
+    prefect_client: PrefectClient,
+    caplog: pytest.LogCaptureFixture,
+):
+    import prefect.runner._starter_bundle as starter_module
+
+    @flow(on_crashed=[_log_bundle_crashed_hook])
+    def crashed_flow() -> None:
+        os._exit(7)
+
+    flow_run = await prefect_client.create_flow_run(crashed_flow)
+    with patch.object(
+        bundles_module.subprocess,
+        "check_output",
+        MagicMock(return_value=b""),
+    ):
+        bundle = create_bundle_for_flow_run(crashed_flow, flow_run)["bundle"]
+
+    processes: list[Any] = []
+    original_execute_bundle_in_subprocess = starter_module.execute_bundle_in_subprocess
+
+    def tracking_execute_bundle(*args: Any, **kwargs: Any):
+        process = original_execute_bundle_in_subprocess(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    with patch.object(
+        starter_module,
+        "execute_bundle_in_subprocess",
+        side_effect=tracking_execute_bundle,
+    ):
+        await execute_bundle(bundle)
+
+    flow_run = await prefect_client.read_flow_run(flow_run.id)
+    assert processes[0].exitcode == 7
+    assert flow_run.state is not None
+    assert flow_run.state.is_crashed()
+    assert "bundle crash hook ran" in caplog.text
+    assert "Process exited with status code: 7" in caplog.text

--- a/tests/_experimental/bundles/test_execute.py
+++ b/tests/_experimental/bundles/test_execute.py
@@ -90,7 +90,7 @@ async def test_execute_bundle_preserves_failed_outcome(
         infrastructure_result = await execute_bundle(bundle)
 
     flow_run = await prefect_client.read_flow_run(flow_run.id)
-    assert processes[0].exitcode == 1
+    assert processes[0].exitcode == 0
     assert infrastructure_result is None
     assert flow_run.state is not None
     assert flow_run.state.is_failed()

--- a/tests/_experimental/bundles/test_execute.py
+++ b/tests/_experimental/bundles/test_execute.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import prefect.bundles as bundles_module
+import prefect.runner._starter_bundle as starter_module
 from prefect import flow
 from prefect.bundles import create_bundle_for_flow_run
 from prefect.bundles.execute import execute_bundle
@@ -61,8 +62,6 @@ async def test_execute_bundle_preserves_failed_outcome(
     prefect_client: PrefectClient,
     caplog: pytest.LogCaptureFixture,
 ):
-    import prefect.runner._starter_bundle as starter_module
-
     @flow(on_crashed=[_log_bundle_crashed_hook])
     def failed_flow() -> None:
         raise ValueError("application failure")
@@ -104,8 +103,6 @@ async def test_execute_bundle_preserves_crash_fallback(
     prefect_client: PrefectClient,
     caplog: pytest.LogCaptureFixture,
 ):
-    import prefect.runner._starter_bundle as starter_module
-
     @flow(on_crashed=[_log_bundle_crashed_hook])
     def crashed_flow() -> None:
         os._exit(7)

--- a/tests/_internal/test_control_listener.py
+++ b/tests/_internal/test_control_listener.py
@@ -6,12 +6,17 @@ import asyncio
 import os
 import signal
 import threading
-import time
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 import pytest
 
 from prefect._internal import control_listener
+from prefect._internal.attempt_control import (
+    CURRENT_PROTOCOL_VERSION,
+    NEGOTIATION_FRAME_SIZE,
+    RECEIPT_CAPABILITY,
+    encode_negotiation,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -29,7 +34,7 @@ def reset_listener_state():
 async def fake_runner_server() -> AsyncIterator[
     tuple[
         int,
-        "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+        asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
     ]
 ]:
     accepted: asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]] = (
@@ -43,7 +48,7 @@ async def fake_runner_server() -> AsyncIterator[
     ) -> None:
         try:
             await reader.readline()
-        except Exception:
+        except (ConnectionError, OSError):
             writer.close()
             return
         held_writers.append(writer)
@@ -61,14 +66,11 @@ async def fake_runner_server() -> AsyncIterator[
         for done in done_events:
             done.set()
         for writer in held_writers:
-            try:
-                writer.close()
-            except Exception:
-                pass
+            writer.close()
         server.close()
         try:
             await asyncio.wait_for(server.wait_closed(), timeout=1.0)
-        except (asyncio.TimeoutError, Exception):
+        except (asyncio.TimeoutError, OSError):
             pass
 
 
@@ -81,7 +83,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
     ) -> None:
         port, accepted = fake_runner_server
@@ -105,7 +107,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
     ) -> None:
         port, accepted = fake_runner_server
@@ -123,7 +125,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
     ) -> None:
         port, accepted = fake_runner_server
@@ -140,7 +142,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -170,6 +172,12 @@ class TestControlListener:
             control_listener.start()
 
             reader, writer = await asyncio.wait_for(accepted.get(), timeout=2.0)
+            hello = await asyncio.wait_for(
+                reader.readexactly(NEGOTIATION_FRAME_SIZE), timeout=2.0
+            )
+            assert hello == encode_negotiation(
+                CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY
+            )
             writer.write(b"c")
             await writer.drain()
 
@@ -180,7 +188,7 @@ class TestControlListener:
             for _ in range(50):
                 if signal_received.is_set():
                     break
-                time.sleep(0.01)
+                await asyncio.sleep(0.01)
             if os.name == "nt":
                 assert signal_received.is_set()
             else:
@@ -253,7 +261,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -269,6 +277,10 @@ class TestControlListener:
         control_listener.start()
 
         reader, writer = await asyncio.wait_for(accepted.get(), timeout=2.0)
+        hello = await asyncio.wait_for(
+            reader.readexactly(NEGOTIATION_FRAME_SIZE), timeout=2.0
+        )
+        assert hello == encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY)
         writer.write(b"c")
         await writer.drain()
 
@@ -308,7 +320,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
     ) -> None:
         port, accepted = fake_runner_server
@@ -325,7 +337,7 @@ class TestControlListener:
         self,
         fake_runner_server: tuple[
             int,
-            "asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]]",
+            asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
         ],
     ) -> None:
         port, accepted = fake_runner_server
@@ -335,6 +347,10 @@ class TestControlListener:
         control_listener.start()
 
         reader, writer = await asyncio.wait_for(accepted.get(), timeout=2.0)
+        hello = await asyncio.wait_for(
+            reader.readexactly(NEGOTIATION_FRAME_SIZE), timeout=2.0
+        )
+        assert hello == encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY)
         writer.write(b"x")
         await writer.drain()
 
@@ -353,6 +369,7 @@ class TestControlListener:
                 self.closed = False
                 self.recv_started = threading.Event()
                 self.release_recv = threading.Event()
+                self.timeout: float | None = None
 
             def connect(self, address: tuple[str, int]) -> None:
                 self.connected_to = address
@@ -364,6 +381,9 @@ class TestControlListener:
                 self.recv_started.set()
                 self.release_recv.wait(timeout=1.0)
                 return b""
+
+            def settimeout(self, value: float | None) -> None:
+                self.timeout = value
 
             def shutdown(self, how: int) -> None:
                 self.shutdown_how = how
@@ -389,7 +409,10 @@ class TestControlListener:
         assert first is not None
         assert first.recv_started.wait(timeout=1.0) is True
         assert first.connected_to == ("127.0.0.1", 4201)
-        assert first.sent == [b"test-token-restart\n"]
+        assert first.sent == [
+            b"test-token-restart\n",
+            encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY),
+        ]
 
         control_listener.stop()
 
@@ -404,7 +427,10 @@ class TestControlListener:
         assert second is not None
         assert second.recv_started.wait(timeout=1.0) is True
         assert second.connected_to == ("127.0.0.1", 4202)
-        assert second.sent == [b"test-token-restart-second\n"]
+        assert second.sent == [
+            b"test-token-restart-second\n",
+            encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY),
+        ]
 
     def test_start_handles_connect_failure_gracefully(self) -> None:
         os.environ["PREFECT__CONTROL_PORT"] = "1"

--- a/tests/_internal/test_control_listener.py
+++ b/tests/_internal/test_control_listener.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import signal
 import threading
+import uuid
 from collections.abc import AsyncIterator
 
 import pytest
@@ -15,6 +16,7 @@ from prefect._internal.attempt_control import (
     CURRENT_PROTOCOL_VERSION,
     NEGOTIATION_FRAME_SIZE,
     RECEIPT_CAPABILITY,
+    EngineOutcomeReceipt,
     encode_negotiation,
 )
 
@@ -78,6 +80,43 @@ class TestControlListener:
     def test_start_is_noop_without_env_vars(self) -> None:
         control_listener.start()
         assert control_listener.get_intent() is None
+
+    def test_non_owner_thread_cannot_report_engine_outcome(self) -> None:
+        control_listener._owner_thread_id = threading.get_ident()
+        result: list[bool] = []
+        receipt = EngineOutcomeReceipt.state_reported(
+            state_id=uuid.uuid4(),
+            state_type="COMPLETED",
+            state_name="Completed",
+        )
+
+        thread = threading.Thread(
+            target=lambda: result.append(
+                control_listener.report_engine_outcome(receipt)
+            )
+        )
+        thread.start()
+        thread.join()
+
+        assert result == [False]
+        assert control_listener.engine_outcome_is_handled() is False
+
+    def test_reader_tolerates_socket_close_during_negotiation_cleanup(self) -> None:
+        class ClosingSocket:
+            def sendall(self, data: bytes) -> None:
+                pass
+
+            def settimeout(self, timeout: float | None) -> None:
+                if timeout is None:
+                    raise OSError("socket closed")
+
+            def recv(self, size: int) -> bytes:
+                return b""
+
+            def close(self) -> None:
+                pass
+
+        control_listener._reader_loop(ClosingSocket())  # type: ignore[arg-type]
 
     async def test_configure_from_env_consumes_env_and_defers_connection(
         self,

--- a/tests/_internal/test_control_listener.py
+++ b/tests/_internal/test_control_listener.py
@@ -15,9 +15,12 @@ from prefect._internal import control_listener
 from prefect._internal.attempt_control import (
     CURRENT_PROTOCOL_VERSION,
     NEGOTIATION_FRAME_SIZE,
+    RECEIPT_ACK,
     RECEIPT_CAPABILITY,
+    RECEIPT_PREFIX,
     EngineOutcomeReceipt,
     encode_negotiation,
+    encode_receipt,
 )
 
 
@@ -117,6 +120,77 @@ class TestControlListener:
                 pass
 
         control_listener._reader_loop(ClosingSocket())  # type: ignore[arg-type]
+
+    def test_late_negotiation_response_remains_receipt_capable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receipt = EngineOutcomeReceipt.state_reported(
+            state_id=uuid.uuid4(),
+            state_type="COMPLETED",
+            state_name="Completed",
+        )
+        response = encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY)
+
+        class LateNegotiationSocket:
+            def __init__(self) -> None:
+                self.sent: list[bytes] = []
+                self.recv_count = 0
+                self.ready_for_receipt = threading.Event()
+                self.receipt_sent = threading.Event()
+
+            def connect(self, address: tuple[str, int]) -> None:
+                pass
+
+            def sendall(self, data: bytes) -> None:
+                self.sent.append(data)
+                if data.startswith(RECEIPT_PREFIX):
+                    self.receipt_sent.set()
+
+            def recv(self, size: int) -> bytes:
+                self.recv_count += 1
+                if self.recv_count == 1:
+                    raise TimeoutError
+                if self.recv_count == 2:
+                    return response[:1]
+                if self.recv_count == 3:
+                    return response[1:]
+                if self.recv_count == 4:
+                    self.ready_for_receipt.set()
+                    assert self.receipt_sent.wait(timeout=1.0) is True
+                    return RECEIPT_ACK
+                return b""
+
+            def settimeout(self, value: float | None) -> None:
+                pass
+
+            def shutdown(self, how: int) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        sock = LateNegotiationSocket()
+        monkeypatch.setattr(
+            control_listener.socket,
+            "socket",
+            lambda *args, **kwargs: sock,
+        )
+        os.environ["PREFECT__CONTROL_PORT"] = "4201"
+        os.environ["PREFECT__CONTROL_TOKEN"] = "late-negotiation-token"
+
+        control_listener.start()
+
+        assert sock.ready_for_receipt.wait(timeout=1.0) is True
+        assert control_listener.report_engine_outcome(receipt) is True
+        reader_thread = control_listener._reader_thread
+        assert reader_thread is not None
+        reader_thread.join(timeout=1.0)
+        assert reader_thread.is_alive() is False
+        assert sock.sent == [
+            b"late-negotiation-token\n",
+            encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY),
+            encode_receipt(receipt),
+        ]
 
     async def test_configure_from_env_consumes_env_and_defers_connection(
         self,

--- a/tests/_internal/test_control_listener.py
+++ b/tests/_internal/test_control_listener.py
@@ -471,6 +471,60 @@ class TestControlListener:
             encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY),
         ]
 
+    def test_stop_during_negotiation_does_not_crash_reader(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _BlockingSocket:
+            def __init__(self) -> None:
+                self.recv_started = threading.Event()
+                self.closed = threading.Event()
+
+            def connect(self, address: tuple[str, int]) -> None:
+                pass
+
+            def sendall(self, data: bytes) -> None:
+                pass
+
+            def recv(self, size: int) -> bytes:
+                self.recv_started.set()
+                self.closed.wait(timeout=1.0)
+                raise OSError("socket closed")
+
+            def settimeout(self, value: float | None) -> None:
+                pass
+
+            def shutdown(self, how: int) -> None:
+                self.closed.set()
+
+            def close(self) -> None:
+                self.closed.set()
+
+        sock = _BlockingSocket()
+        thread_errors: list[BaseException] = []
+        monkeypatch.setattr(
+            control_listener.socket,
+            "socket",
+            lambda *args, **kwargs: sock,
+        )
+        monkeypatch.setattr(
+            control_listener.threading,
+            "excepthook",
+            lambda args: thread_errors.append(args.exc_value),
+        )
+        os.environ["PREFECT__CONTROL_PORT"] = "4201"
+        os.environ["PREFECT__CONTROL_TOKEN"] = "test-token-stop-negotiation"
+
+        control_listener.start()
+        reader_thread = control_listener._reader_thread
+        assert reader_thread is not None
+        assert sock.recv_started.wait(timeout=1.0) is True
+
+        control_listener.stop()
+        reader_thread.join(timeout=1.0)
+
+        assert reader_thread.is_alive() is False
+        assert thread_errors == []
+
     def test_start_handles_connect_failure_gracefully(self) -> None:
         os.environ["PREFECT__CONTROL_PORT"] = "1"
         os.environ["PREFECT__CONTROL_TOKEN"] = "anything"

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -20,7 +20,7 @@ from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import LogCreate
 from prefect.client.schemas.objects import FlowRun
 from prefect.deployments.runner import RunnerDeployment
-from prefect.runner._control_channel import ControlChannel
+from prefect.runner._control_channel import ControlChannel, ControlSignalStatus
 from prefect.runner._flow_run_executor import FlowRunExecutorContext
 from prefect.runner._process_manager import ProcessManager
 from prefect.runner._workspace_starter import WorkspaceResolvingEngineCommandStarter
@@ -2011,7 +2011,11 @@ class TestSignalHandling:
                 "prefect.cli.flow_run._install_termination_handler",
                 side_effect=capture_install,
             ),
-            patch.object(ControlChannel, "signal", AsyncMock(return_value=False)),
+            patch.object(
+                ControlChannel,
+                "signal",
+                AsyncMock(return_value=ControlSignalStatus.NOT_ACKNOWLEDGED),
+            ),
             patch.object(ProcessManager, "kill", fake_kill),
             patch(
                 "prefect.runner._flow_run_executor.FlowRunExecutor.submit", fake_submit
@@ -2025,6 +2029,51 @@ class TestSignalHandling:
         assert run.state and not run.state.is_final(), (
             "the run must stay nonterminal so the infrastructure retry can resume it"
         )
+
+    async def test_engine_receipt_wins_over_late_termination_signal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        prefect_client: PrefectClient,
+    ):
+        monkeypatch.setenv("PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR", "reschedule")
+
+        deployment_id = await (await hello_flow.to_deployment(__file__)).apply()
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        handlers: list[Callable[[], None]] = []
+        kill = AsyncMock()
+        propose = AsyncMock()
+
+        def capture_install(handler: Callable[[], None]) -> bool:
+            handlers.append(handler)
+            return True
+
+        async def fake_submit(*_: Any, **__: Any) -> None:
+            handlers[0]()
+            await anyio.sleep(0)
+
+        with (
+            patch(
+                "prefect.cli.flow_run._install_termination_handler",
+                side_effect=capture_install,
+            ),
+            patch.object(
+                ControlChannel,
+                "signal",
+                AsyncMock(return_value=ControlSignalStatus.ALREADY_CONCLUDED),
+            ),
+            patch.object(ProcessManager, "kill", kill),
+            patch("prefect.cli.flow_run.propose_state", propose),
+            patch(
+                "prefect.runner._flow_run_executor.FlowRunExecutor.submit", fake_submit
+            ),
+        ):
+            await execute(id=flow_run.id)
+
+        kill.assert_not_awaited()
+        propose.assert_not_awaited()
 
     async def test_termination_handler_installed_even_when_submit_exits_early(
         self,

--- a/tests/cli/test_prompts.py
+++ b/tests/cli/test_prompts.py
@@ -30,7 +30,7 @@ def project_dir(tmp_path: Path):
 class TestDiscoverFlows:
     async def test_find_all_flows_in_dir_tree(self, project_dir: Path):
         flows = await search_for_flow_functions(str(project_dir))
-        assert len(flows) == 7, f"Expected 7 flows, found {len(flows)}"
+        assert len(flows) == 8, f"Expected 8 flows, found {len(flows)}"
 
         expected_flows = [
             {
@@ -56,6 +56,13 @@ class TestDiscoverFlows:
                 "flow_name": "Second important name",
                 "function_name": "my_flow2",
                 "filepath": str(project_dir / "flows" / "hello.py"),
+            },
+            {
+                "flow_name": "failed",
+                "function_name": "failed_flow",
+                "filepath": str(
+                    project_dir / "import-project" / "my_module" / "flow.py"
+                ),
             },
             {
                 "flow_name": "test",

--- a/tests/experimental/test_bundles.py
+++ b/tests/experimental/test_bundles.py
@@ -131,7 +131,7 @@ class TestExecuteBundleInSubprocess:
         process = execute_bundle_in_subprocess(bundle)
 
         process.join()
-        assert process.exitcode == 1
+        assert process.exitcode == 0
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state is not None
@@ -412,7 +412,7 @@ class TestExecuteBundleInSubprocess:
         bundle = result["bundle"]
         process = execute_bundle_in_subprocess(bundle)
         process.join()
-        assert process.exitcode == 1
+        assert process.exitcode == 0
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state is not None

--- a/tests/runner/test__cancellation_manager.py
+++ b/tests/runner/test__cancellation_manager.py
@@ -7,6 +7,7 @@ import pytest
 
 from prefect.client.schemas.objects import StateType
 from prefect.runner._cancellation_manager import CancellationManager
+from prefect.runner._control_channel import ControlSignalStatus
 
 pytestmark = pytest.mark.clear_db
 
@@ -245,7 +246,9 @@ class TestCancellationManagerCancel:
         event_emitter.emit_flow_run_cancelled = AsyncMock()
 
         control_channel = MagicMock()
-        control_channel.signal = AsyncMock(return_value=True)
+        control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
 
         mgr = _make_manager(
             process_manager=process_manager,
@@ -530,7 +533,7 @@ class TestCancellationManagerCancel:
 
         async def _signal(_id, _intent):
             call_order.append("signal")
-            return True
+            return ControlSignalStatus.ACKNOWLEDGED
 
         control_channel.signal = AsyncMock(side_effect=_signal)
 
@@ -569,7 +572,9 @@ class TestCancellationManagerCancel:
         process_manager.kill = AsyncMock()
 
         control_channel = MagicMock()
-        control_channel.signal = AsyncMock(return_value=True)
+        control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
 
         mgr = _make_manager(
             process_manager=process_manager,
@@ -617,7 +622,9 @@ class TestCancellationManagerCancel:
             process_manager=process_manager,
             hook_runner=hook_runner,
             event_emitter=event_emitter,
-            control_channel=MagicMock(signal=AsyncMock(return_value=True)),
+            control_channel=MagicMock(
+                signal=AsyncMock(return_value=ControlSignalStatus.ACKNOWLEDGED)
+            ),
         )
         mgr._finalize_cancelled_state = AsyncMock(return_value=True)
 
@@ -662,7 +669,9 @@ class TestCancellationManagerCancel:
             process_manager=process_manager,
             hook_runner=hook_runner,
             event_emitter=event_emitter,
-            control_channel=MagicMock(signal=AsyncMock(return_value=True)),
+            control_channel=MagicMock(
+                signal=AsyncMock(return_value=ControlSignalStatus.ACKNOWLEDGED)
+            ),
         )
         mgr._finalize_cancelled_state = AsyncMock(return_value=True)
 
@@ -688,7 +697,9 @@ class TestCancellationManagerCancel:
         process_manager.kill = AsyncMock()
 
         control_channel = MagicMock()
-        control_channel.signal = AsyncMock(return_value=True)
+        control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
 
         mgr = _make_manager(
             process_manager=process_manager,
@@ -710,7 +721,9 @@ class TestCancellationManagerCancel:
         process_manager.kill = AsyncMock()
 
         control_channel = MagicMock()
-        control_channel.signal = AsyncMock(return_value=False)
+        control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.NOT_ACKNOWLEDGED
+        )
 
         mgr = _make_manager(
             process_manager=process_manager,
@@ -722,6 +735,36 @@ class TestCancellationManagerCancel:
         control_channel.signal.assert_awaited_once_with(flow_run.id, "cancel")
         process_manager.wait_for_exit.assert_not_awaited()
         process_manager.kill.assert_awaited_once_with(flow_run.id, grace_seconds=30.0)
+
+    async def test_cancel_stops_when_engine_receipt_already_concluded_attempt(self):
+        flow_run = _make_flow_run()
+
+        process_manager = MagicMock()
+        process_manager.get.return_value = _make_process_handle()
+        process_manager.wait_for_exit = AsyncMock()
+        process_manager.kill = AsyncMock()
+
+        hook_runner = MagicMock()
+        hook_runner.run_cancellation_hooks = AsyncMock()
+
+        control_channel = MagicMock()
+        control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ALREADY_CONCLUDED
+        )
+
+        mgr = _make_manager(
+            process_manager=process_manager,
+            hook_runner=hook_runner,
+            control_channel=control_channel,
+        )
+        mgr._finalize_cancelled_state = AsyncMock(return_value=True)
+
+        await mgr.cancel(flow_run)
+
+        process_manager.wait_for_exit.assert_not_awaited()
+        process_manager.kill.assert_not_awaited()
+        hook_runner.run_cancellation_hooks.assert_not_awaited()
+        mgr._finalize_cancelled_state.assert_not_awaited()
 
     async def test_cancel_falls_through_when_channel_raises(self):
         """If the channel raises, kill still proceeds — channel is best-effort."""

--- a/tests/runner/test__control_channel.py
+++ b/tests/runner/test__control_channel.py
@@ -8,7 +8,8 @@ from uuid import uuid4
 
 import pytest
 
-from prefect.runner._control_channel import ControlChannel
+from prefect._internal.attempt_control import EngineOutcomeReceipt
+from prefect.runner._control_channel import ControlChannel, ControlSignalStatus
 
 pytestmark = pytest.mark.clear_db
 
@@ -58,17 +59,41 @@ class TestControlChannel:
         assert flow_run_id not in channel._registrations
         assert token not in channel._tokens_to_id
 
-    async def test_signal_unregistered_returns_false(
+    async def test_signal_unregistered_is_not_acknowledged(
         self, channel: ControlChannel
     ) -> None:
-        assert await channel.signal(uuid4(), "cancel") is False
+        assert (
+            await channel.signal(uuid4(), "cancel")
+            is ControlSignalStatus.NOT_ACKNOWLEDGED
+        )
 
-    async def test_signal_with_no_connection_returns_false_immediately(
+    async def test_signal_with_no_connection_is_not_acknowledged_immediately(
         self, channel: ControlChannel
     ) -> None:
         flow_run_id = uuid4()
         channel.register(flow_run_id)
-        assert await channel.signal(flow_run_id, "cancel") is False
+        assert (
+            await channel.signal(flow_run_id, "cancel")
+            is ControlSignalStatus.NOT_ACKNOWLEDGED
+        )
+
+    async def test_signal_reports_when_an_engine_receipt_already_concluded_attempt(
+        self, channel: ControlChannel
+    ) -> None:
+        flow_run_id = uuid4()
+        channel.register(flow_run_id)
+        channel._registrations[
+            flow_run_id
+        ].conclusion = EngineOutcomeReceipt.state_reported(
+            state_id=uuid4(),
+            state_type="COMPLETED",
+            state_name="Completed",
+        )
+
+        assert (
+            await channel.signal(flow_run_id, "cancel")
+            is ControlSignalStatus.ALREADY_CONCLUDED
+        )
 
     async def test_signal_does_not_wait_for_not_yet_connected_child(
         self,
@@ -77,7 +102,7 @@ class TestControlChannel:
             flow_run_id = uuid4()
             channel.register(flow_run_id)
             result = await asyncio.wait_for(channel.signal(flow_run_id, "cancel"), 0.1)
-            assert result is False
+            assert result is ControlSignalStatus.NOT_ACKNOWLEDGED
 
     async def test_signal_returns_false_quickly_when_connected_child_disconnects_before_ack(
         self,
@@ -102,7 +127,7 @@ class TestControlChannel:
             result = await asyncio.wait_for(channel.signal(flow_run_id, "cancel"), 0.5)
             await child_task
 
-            assert result is False
+            assert result is ControlSignalStatus.NOT_ACKNOWLEDGED
 
     async def test_disconnect_clears_stale_acked_state_for_repeat_signal(self) -> None:
         async with ControlChannel(ack_timeout=0.05) as channel:
@@ -123,7 +148,10 @@ class TestControlChannel:
                 sock.close()
 
             child_task = asyncio.create_task(ack_then_disconnect())
-            assert await channel.signal(flow_run_id, "cancel") is True
+            assert (
+                await channel.signal(flow_run_id, "cancel")
+                is ControlSignalStatus.ACKNOWLEDGED
+            )
             await child_task
 
             reg = channel._registrations[flow_run_id]
@@ -136,7 +164,7 @@ class TestControlChannel:
             assert not reg.connected.is_set()
 
             result = await asyncio.wait_for(channel.signal(flow_run_id, "cancel"), 0.2)
-            assert result is False
+            assert result is ControlSignalStatus.ALREADY_CONCLUDED
             assert not reg.intent_acked.is_set()
 
     async def test_full_handshake_after_connection(
@@ -157,7 +185,7 @@ class TestControlChannel:
         result = await channel.signal(flow_run_id, "cancel")
         await child_task
         sock.close()
-        assert result is True
+        assert result is ControlSignalStatus.ACKNOWLEDGED
 
     async def test_late_connection_after_fallback_receives_no_intent(
         self, channel: ControlChannel
@@ -165,7 +193,10 @@ class TestControlChannel:
         flow_run_id = uuid4()
         port, token = channel.register(flow_run_id)
 
-        assert await channel.signal(flow_run_id, "cancel") is False
+        assert (
+            await channel.signal(flow_run_id, "cancel")
+            is ControlSignalStatus.NOT_ACKNOWLEDGED
+        )
 
         sock = await _connect_client(port, token)
         sock.settimeout(0.1)
@@ -183,7 +214,7 @@ class TestControlChannel:
         await asyncio.sleep(0.05)
         result = await channel.signal(flow_run_id, "cancel")
         sock.close()
-        assert result is False
+        assert result is ControlSignalStatus.NOT_ACKNOWLEDGED
 
     async def test_disabled_channel_raises_on_register(self) -> None:
         ch = ControlChannel()
@@ -204,6 +235,6 @@ class TestControlChannel:
         async with ControlChannel() as channel:
             result = await channel.signal(uuid4(), "cancel")
 
-        assert result is False
+        assert result is ControlSignalStatus.NOT_ACKNOWLEDGED
         with pytest.raises(RuntimeError):
             channel.register(uuid4())

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import inspect
 import logging
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import anyio
 import anyio.abc
 import pytest
 
+from prefect._internal.attempt_control import EngineOutcomeReceipt
 from prefect._internal.infrastructure_exit_codes import get_infrastructure_exit_info
 from prefect.runner._flow_run_executor import FlowRunExecutor, ProcessStarter
 from prefect.runner._process_manager import ProcessHandle
@@ -39,6 +40,8 @@ def _make_executor(
     cancelled: bool = False,
     cancelling: bool = False,
     propose_submitting: bool = True,
+    attempt_conclusion=None,
+    get_attempt_conclusion=None,
 ):
     """Build a `FlowRunExecutor` with all-mock dependencies.
 
@@ -79,6 +82,9 @@ def _make_executor(
     process_manager.remove = AsyncMock()
     process_manager.get = MagicMock(return_value=None)
 
+    if get_attempt_conclusion is None:
+        get_attempt_conclusion = MagicMock(return_value=attempt_conclusion)
+
     executor = FlowRunExecutor(
         flow_run=flow_run,
         starter=mock_starter,
@@ -86,6 +92,7 @@ def _make_executor(
         state_proposer=state_proposer,
         hook_runner=hook_runner,
         propose_submitting=propose_submitting,
+        get_attempt_conclusion=get_attempt_conclusion,
     )
 
     mocks = dict(
@@ -95,6 +102,7 @@ def _make_executor(
         state_proposer=state_proposer,
         hook_runner=hook_runner,
         process_manager=process_manager,
+        get_attempt_conclusion=get_attempt_conclusion,
     )
     return executor, mocks
 
@@ -228,6 +236,57 @@ class TestFlowRunExecutorSubmit:
         call_args = m["state_proposer"].propose_crashed.call_args
         assert m["flow_run"] == call_args[0][0]
         assert "1" in call_args[1]["message"]
+
+    async def test_submit_treats_engine_receipt_as_handled_despite_nonzero_exit(self):
+        receipt = EngineOutcomeReceipt.state_reported(
+            state_id=uuid4(),
+            state_type="FAILED",
+            state_name="Failed",
+        )
+        executor, m = _make_executor(
+            handle_returncode=1,
+            attempt_conclusion=receipt,
+        )
+
+        await executor.submit()
+
+        m["get_attempt_conclusion"].assert_called_once_with(m["flow_run"].id)
+        m["state_proposer"].propose_crashed.assert_not_awaited()
+        m["hook_runner"].run_crashed_hooks.assert_not_awaited()
+
+    async def test_submit_snapshots_engine_receipt_before_process_cleanup(self):
+        receipt = EngineOutcomeReceipt.state_reported(
+            state_id=uuid4(),
+            state_type="FAILED",
+            state_name="Failed",
+        )
+        flow_run = _make_flow_run()
+        process_removed = False
+
+        def get_attempt_conclusion(
+            flow_run_id: UUID,
+        ) -> EngineOutcomeReceipt | None:
+            assert flow_run_id == flow_run.id
+            return None if process_removed else receipt
+
+        executor, m = _make_executor(
+            flow_run=flow_run,
+            handle_returncode=1,
+            get_attempt_conclusion=get_attempt_conclusion,
+        )
+
+        async def remove_process(flow_run_id: UUID) -> None:
+            nonlocal process_removed
+            assert flow_run_id == flow_run.id
+            process_removed = True
+
+        m["process_manager"].remove = AsyncMock(side_effect=remove_process)
+
+        await executor.submit()
+
+        assert process_removed
+        m["state_proposer"].propose_crashed.assert_not_awaited()
+        m["hook_runner"].run_crashed_hooks.assert_not_awaited()
 
     async def test_submit_crashed_message_includes_registry_explanation(self):
         """The crashed state message should include the explanation from

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -9,7 +9,12 @@ import anyio
 import anyio.abc
 import pytest
 
-from prefect._internal.attempt_control import EngineOutcomeReceipt
+from prefect._internal.attempt_control import (
+    AttemptConclusion,
+    EngineOutcomeReceipt,
+    Intent,
+    StateOwnershipDelegation,
+)
 from prefect._internal.infrastructure_exit_codes import get_infrastructure_exit_info
 from prefect.runner._flow_run_executor import FlowRunExecutor, ProcessStarter
 from prefect.runner._process_manager import ProcessHandle
@@ -254,20 +259,43 @@ class TestFlowRunExecutorSubmit:
         m["state_proposer"].propose_crashed.assert_not_awaited()
         m["hook_runner"].run_crashed_hooks.assert_not_awaited()
 
-    async def test_submit_snapshots_engine_receipt_before_process_cleanup(self):
-        receipt = EngineOutcomeReceipt.state_reported(
-            state_id=uuid4(),
-            state_type="FAILED",
-            state_name="Failed",
+    @pytest.mark.parametrize("intent", ["cancel", "reschedule", "relinquish"])
+    async def test_submit_treats_acknowledged_control_as_handled_despite_nonzero_exit(
+        self, intent: Intent
+    ):
+        executor, m = _make_executor(
+            handle_returncode=1,
+            attempt_conclusion=StateOwnershipDelegation(intent),
         )
+
+        await executor.submit()
+
+        m["get_attempt_conclusion"].assert_called_once_with(m["flow_run"].id)
+        m["state_proposer"].propose_crashed.assert_not_awaited()
+        m["hook_runner"].run_crashed_hooks.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "attempt_conclusion",
+        [
+            EngineOutcomeReceipt.state_reported(
+                state_id=uuid4(),
+                state_type="FAILED",
+                state_name="Failed",
+            ),
+            StateOwnershipDelegation("cancel"),
+        ],
+    )
+    async def test_submit_snapshots_terminal_conclusion_before_process_cleanup(
+        self, attempt_conclusion: AttemptConclusion
+    ):
         flow_run = _make_flow_run()
         process_removed = False
 
         def get_attempt_conclusion(
             flow_run_id: UUID,
-        ) -> EngineOutcomeReceipt | None:
+        ) -> AttemptConclusion | None:
             assert flow_run_id == flow_run.id
-            return None if process_removed else receipt
+            return None if process_removed else attempt_conclusion
 
         executor, m = _make_executor(
             flow_run=flow_run,

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -259,6 +259,31 @@ class TestFlowRunExecutorSubmit:
         m["state_proposer"].propose_crashed.assert_not_awaited()
         m["hook_runner"].run_crashed_hooks.assert_not_awaited()
 
+    @pytest.mark.parametrize(
+        "attempt_conclusion",
+        [
+            EngineOutcomeReceipt.state_reported(
+                state_id=uuid4(),
+                state_type="COMPLETED",
+                state_name="Completed",
+            ),
+            StateOwnershipDelegation("cancel"),
+        ],
+    )
+    async def test_submit_treats_terminal_evidence_as_handled_with_zero_exit(
+        self, attempt_conclusion: AttemptConclusion
+    ):
+        executor, m = _make_executor(
+            handle_returncode=0,
+            attempt_conclusion=attempt_conclusion,
+        )
+
+        await executor.submit()
+
+        m["get_attempt_conclusion"].assert_called_once_with(m["flow_run"].id)
+        m["state_proposer"].propose_crashed.assert_not_awaited()
+        m["hook_runner"].run_crashed_hooks.assert_not_awaited()
+
     @pytest.mark.parametrize("intent", ["cancel", "reschedule", "relinquish"])
     async def test_submit_treats_acknowledged_control_as_handled_despite_nonzero_exit(
         self, intent: Intent

--- a/tests/runner/test__flow_run_executor.py
+++ b/tests/runner/test__flow_run_executor.py
@@ -253,8 +253,11 @@ class TestFlowRunExecutorSubmit:
             attempt_conclusion=receipt,
         )
 
-        await executor.submit()
+        result = await executor.submit()
 
+        assert result is not None
+        assert result.handle is m["handle"]
+        assert result.status_code == 0
         m["get_attempt_conclusion"].assert_called_once_with(m["flow_run"].id)
         m["state_proposer"].propose_crashed.assert_not_awaited()
         m["hook_runner"].run_crashed_hooks.assert_not_awaited()
@@ -353,6 +356,15 @@ class TestFlowRunExecutorSubmit:
         info = get_infrastructure_exit_info(-9)
         assert str(-9) in msg
         assert info.explanation in msg
+
+    async def test_submit_returns_raw_unhandled_exit_status(self):
+        executor, m = _make_executor(handle_returncode=7)
+
+        result = await executor.submit()
+
+        assert result is not None
+        assert result.handle is m["handle"]
+        assert result.status_code == 7
 
     async def test_submit_logs_resolution_separately(
         self, caplog: "pytest.LogCaptureFixture"

--- a/tests/runner/test__scheduled_run_poller.py
+++ b/tests/runner/test__scheduled_run_poller.py
@@ -54,6 +54,7 @@ def _make_poller(**overrides):
     state_proposer.propose_pending = AsyncMock(return_value=True)
     hook_runner = MagicMock()
     cancellation_manager = MagicMock()
+    get_attempt_conclusion = MagicMock(return_value=None)
 
     kwargs = dict(
         query_seconds=10.0,
@@ -68,6 +69,7 @@ def _make_poller(**overrides):
         state_proposer=state_proposer,
         hook_runner=hook_runner,
         cancellation_manager=cancellation_manager,
+        get_attempt_conclusion=get_attempt_conclusion,
     )
     kwargs.update(overrides)
 
@@ -85,6 +87,7 @@ def _make_poller(**overrides):
         state_proposer=state_proposer,
         hook_runner=hook_runner,
         cancellation_manager=cancellation_manager,
+        get_attempt_conclusion=get_attempt_conclusion,
     )
     return poller, mocks
 

--- a/tests/runner/test__starter_bundle.py
+++ b/tests/runner/test__starter_bundle.py
@@ -165,6 +165,38 @@ class TestBundleExecutionStarter:
 
         control_channel.unregister.assert_called_once_with(mock_flow_run.id)
 
+    async def test_start_passes_control_session_env_to_subprocess(self):
+        mock_bundle = MagicMock()
+        mock_flow_run = MagicMock()
+        mock_flow_run.id = "flow-run-id"
+        mock_process = MagicMock()
+        mock_process.join = MagicMock()
+
+        control_channel = MagicMock()
+        control_channel.register.return_value = (54321, "deadbeef" * 4)
+        starter = BundleExecutionStarter(
+            bundle=mock_bundle,
+            env={"EXISTING_VAR": "present"},
+            control_channel=control_channel,
+        )
+
+        with patch(
+            "prefect.runner._starter_bundle.execute_bundle_in_subprocess",
+            return_value=mock_process,
+        ) as mock_exec:
+            await starter.start(mock_flow_run)
+
+        control_channel.register.assert_called_once_with(mock_flow_run.id)
+        mock_exec.assert_called_once_with(
+            mock_bundle,
+            cwd=None,
+            env={
+                "EXISTING_VAR": "present",
+                "PREFECT__CONTROL_PORT": "54321",
+                "PREFECT__CONTROL_TOKEN": "deadbeef" * 4,
+            },
+        )
+
     async def test_start_omits_control_env_when_channel_is_disabled(self):
         mock_bundle = MagicMock()
         mock_flow_run = MagicMock()

--- a/tests/runner/test__starter_direct.py
+++ b/tests/runner/test__starter_direct.py
@@ -184,6 +184,37 @@ class TestDirectSubprocessStarter:
 
         control_channel.unregister.assert_called_once_with(mock_flow_run.id)
 
+    async def test_start_passes_control_session_env_to_subprocess(self):
+        mock_flow = MagicMock()
+        mock_flow_run = MagicMock()
+        mock_flow_run.id = "flow-run-id"
+        mock_process = MagicMock()
+        mock_process.join = MagicMock()
+
+        control_channel = MagicMock()
+        control_channel.register.return_value = (54321, "deadbeef" * 4)
+        starter = DirectSubprocessStarter(
+            flow=mock_flow,
+            control_channel=control_channel,
+        )
+
+        with patch(
+            "prefect.runner._starter_direct.run_flow_in_subprocess",
+            return_value=mock_process,
+        ) as mock_run:
+            await starter.start(mock_flow_run)
+
+        control_channel.register.assert_called_once_with(mock_flow_run.id)
+        mock_run.assert_called_once_with(
+            mock_flow,
+            flow_run=mock_flow_run,
+            env={
+                "PREFECT__DEPLOYMENT_NAME": None,
+                "PREFECT__CONTROL_PORT": "54321",
+                "PREFECT__CONTROL_TOKEN": "deadbeef" * 4,
+            },
+        )
+
     async def test_start_omits_control_env_when_channel_is_disabled(self):
         mock_flow = MagicMock()
         mock_flow_run = MagicMock()

--- a/tests/runner/test_control_channel_e2e.py
+++ b/tests/runner/test_control_channel_e2e.py
@@ -43,7 +43,7 @@ from prefect._internal.attempt_control import (
     decode_receipt,
     encode_negotiation,
 )
-from prefect.runner._control_channel import ControlChannel
+from prefect.runner._control_channel import ControlChannel, ControlSignalStatus
 
 pytestmark = pytest.mark.clear_db
 
@@ -377,7 +377,9 @@ async def test_acknowledged_intent_records_delegation_before_real_process_termin
                 await asyncio.sleep(0.1)
 
             acked = await channel.signal(flow_run_id, intent)
-            assert acked, f"child failed to ack {intent} intent over loopback"
+            assert acked is ControlSignalStatus.ACKNOWLEDGED, (
+                f"child failed to ack {intent} intent over loopback"
+            )
             assert channel.get_conclusion(flow_run_id) == StateOwnershipDelegation(
                 intent
             )
@@ -487,7 +489,10 @@ async def test_old_engine_retains_control_protocol_with_new_supervisor():
                     break
                 await asyncio.sleep(0.05)
 
-            assert await channel.signal(flow_run_id, "cancel") is True
+            assert (
+                await channel.signal(flow_run_id, "cancel")
+                is ControlSignalStatus.ACKNOWLEDGED
+            )
             _stdout, stderr = await _wait_for_child(proc)
             assert proc.returncode == 0, stderr.decode(errors="replace")
             assert channel.get_conclusion(flow_run_id) == StateOwnershipDelegation(
@@ -537,7 +542,10 @@ async def test_first_terminal_message_wins_real_process_race(
                     await asyncio.to_thread(proc.stdout.readline)
                     == b"receipt-recorded\n"
                 )
-                assert await channel.signal(flow_run_id, intent) is False
+                assert (
+                    await channel.signal(flow_run_id, intent)
+                    is ControlSignalStatus.ALREADY_CONCLUDED
+                )
                 await asyncio.to_thread(proc.stdin.write, b"continue\n")
                 await asyncio.to_thread(proc.stdin.flush)
             else:
@@ -547,7 +555,7 @@ async def test_first_terminal_message_wins_real_process_race(
                 signal_task = asyncio.create_task(channel.signal(flow_run_id, intent))
                 while channel._registrations[flow_run_id].pending_intent is None:
                     await asyncio.sleep(0)
-                assert await signal_task is True
+                assert await signal_task is ControlSignalStatus.ACKNOWLEDGED
                 await asyncio.to_thread(proc.stdin.write, b"continue\n")
                 await asyncio.to_thread(proc.stdin.flush)
             expected = (
@@ -656,7 +664,10 @@ async def test_first_authenticated_connection_consumes_token():
             assert proc.stdout is not None
             assert await asyncio.to_thread(proc.stdout.readline) == b"replay-rejected\n"
 
-            assert await channel.signal(flow_run_id, "cancel") is True
+            assert (
+                await channel.signal(flow_run_id, "cancel")
+                is ControlSignalStatus.ACKNOWLEDGED
+            )
             assert channel.get_conclusion(flow_run_id) == StateOwnershipDelegation(
                 "cancel"
             )

--- a/tests/runner/test_control_channel_e2e.py
+++ b/tests/runner/test_control_channel_e2e.py
@@ -38,6 +38,7 @@ from prefect._internal.attempt_control import (
     RECEIPT_CAPABILITY,
     RECEIPT_PREFIX,
     EngineOutcomeReceipt,
+    Intent,
     StateOwnershipDelegation,
     decode_receipt,
     encode_negotiation,
@@ -64,7 +65,7 @@ CHILD_PROGRAM = textwrap.dedent(
             while time.monotonic() < deadline:
                 time.sleep(0.05)
     except TerminationSignal:
-        if control_listener.get_intent() == "cancel":
+        if control_listener.get_intent() == os.environ["EXPECTED_INTENT"]:
             sys.exit(7)
         sys.exit(8)
 
@@ -192,7 +193,8 @@ RACING_ENGINE_PROGRAM = textwrap.dedent(
         sys.exit(0 if acknowledged and control_listener.get_intent() is None else 14)
     sys.exit(
         0
-        if not acknowledged and control_listener.get_intent() == "cancel"
+        if not acknowledged
+        and control_listener.get_intent() == os.environ["EXPECTED_INTENT"]
         else 15
     )
     """
@@ -356,12 +358,20 @@ def _ensure_child_stopped(proc: subprocess.Popen[bytes]) -> None:
 
 
 @pytest.mark.timeout(60)
-async def test_cancel_intent_reaches_real_subprocess():
+@pytest.mark.parametrize("intent", ["cancel", "reschedule", "relinquish"])
+async def test_acknowledged_intent_records_delegation_before_real_process_termination(
+    intent: Intent,
+):
     async with ControlChannel(ack_timeout=5.0) as channel:
         flow_run_id = uuid4()
         port, token = channel.register(flow_run_id)
 
-        proc = _start_child(CHILD_PROGRAM, port=port, token=token)
+        proc = _start_child(
+            CHILD_PROGRAM,
+            port=port,
+            token=token,
+            env_overrides={"EXPECTED_INTENT": intent},
+        )
 
         try:
             # Give the child time to connect back to the channel before we
@@ -374,16 +384,19 @@ async def test_cancel_intent_reaches_real_subprocess():
                         break
                 await asyncio.sleep(0.1)
 
-            acked = await channel.signal(flow_run_id, "cancel")
-            assert acked, "child failed to ack cancel intent over loopback"
+            acked = await channel.signal(flow_run_id, intent)
+            assert acked, f"child failed to ack {intent} intent over loopback"
+            assert channel.get_conclusion(flow_run_id) == StateOwnershipDelegation(
+                intent
+            )
 
             if os.name != "nt":
                 proc.send_signal(signal.SIGTERM)
 
-            # The handler exits 7 on cancel intent.
+            # The handler exits 7 when the acknowledged intent is visible.
             _stdout, stderr = await _wait_for_child(proc)
             assert proc.returncode == 7, (
-                f"expected exit code 7 (cancel intent visible), got "
+                f"expected exit code 7 ({intent} intent visible), got "
                 f"{proc.returncode}; stderr: {stderr.decode(errors='replace')}"
             )
         finally:
@@ -494,12 +507,13 @@ async def test_old_engine_retains_control_protocol_with_new_supervisor():
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.parametrize("intent", ["cancel", "reschedule", "relinquish"])
 @pytest.mark.parametrize(
     ("order", "intent_acknowledged"),
     [("receipt-first", False), ("intent-first", True)],
 )
 async def test_first_terminal_message_wins_real_process_race(
-    order: str, intent_acknowledged: bool
+    intent: Intent, order: str, intent_acknowledged: bool
 ):
     receipt = EngineOutcomeReceipt.state_reported(
         state_id=UUID("33333333-3333-3333-3333-333333333333"),
@@ -514,7 +528,7 @@ async def test_first_terminal_message_wins_real_process_race(
             RACING_ENGINE_PROGRAM,
             port=port,
             token=token,
-            env_overrides={"RACE_ORDER": order},
+            env_overrides={"EXPECTED_INTENT": intent, "RACE_ORDER": order},
         )
 
         try:
@@ -530,14 +544,14 @@ async def test_first_terminal_message_wins_real_process_race(
                 assert (
                     await asyncio.to_thread(proc.stdout.readline) == b"receipt-ready\n"
                 )
-                signal_task = asyncio.create_task(channel.signal(flow_run_id, "cancel"))
+                signal_task = asyncio.create_task(channel.signal(flow_run_id, intent))
                 while channel._registrations[flow_run_id].pending_intent is None:
                     await asyncio.sleep(0)
                 await asyncio.to_thread(proc.stdin.write, b"continue\n")
                 await asyncio.to_thread(proc.stdin.flush)
                 assert await signal_task is False
             else:
-                signal_task = asyncio.create_task(channel.signal(flow_run_id, "cancel"))
+                signal_task = asyncio.create_task(channel.signal(flow_run_id, intent))
                 assert (
                     await asyncio.to_thread(proc.stdout.readline)
                     == b"intent-committed\n"
@@ -550,7 +564,7 @@ async def test_first_terminal_message_wins_real_process_race(
                 await asyncio.to_thread(proc.stdin.flush)
                 assert await signal_task is True
             expected = (
-                StateOwnershipDelegation("cancel") if intent_acknowledged else receipt
+                StateOwnershipDelegation(intent) if intent_acknowledged else receipt
             )
             assert channel.get_conclusion(flow_run_id) == expected
 

--- a/tests/runner/test_control_channel_e2e.py
+++ b/tests/runner/test_control_channel_e2e.py
@@ -16,18 +16,32 @@ this test guarantees they connect across a process boundary on the host's
 actual Python.
 """
 
+# Real `subprocess.Popen` is the seam under test; the event loop remains live
+# because every blocking wait is replaced by async polling.
+
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import signal
 import subprocess
 import sys
 import textwrap
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
+from prefect._internal.attempt_control import (
+    CURRENT_PROTOCOL_VERSION,
+    NEGOTIATION_FRAME_SIZE,
+    RECEIPT_CAPABILITY,
+    RECEIPT_PREFIX,
+    EngineOutcomeReceipt,
+    StateOwnershipDelegation,
+    decode_receipt,
+    encode_negotiation,
+)
 from prefect.runner._control_channel import ControlChannel
 
 pytestmark = pytest.mark.clear_db
@@ -58,25 +72,296 @@ CHILD_PROGRAM = textwrap.dedent(
     """
 )
 
+RECEIPT_CHILD_PROGRAM = textwrap.dedent(
+    """
+    import sys
+    from uuid import UUID
+
+    from prefect._internal import control_listener
+    from prefect._internal.attempt_control import EngineOutcomeReceipt
+
+    control_listener.configure_from_env()
+    control_listener.start()
+
+    acknowledged = control_listener.report_engine_outcome(
+        EngineOutcomeReceipt.state_reported(
+            state_id=UUID("11111111-1111-1111-1111-111111111111"),
+            state_type="FAILED",
+            state_name="Failed",
+        )
+    )
+    sys.exit(0 if acknowledged else 10)
+    """
+)
+
+NEW_ENGINE_OLD_SUPERVISOR_PROGRAM = textwrap.dedent(
+    """
+    import os
+    import sys
+    import time
+    from uuid import UUID
+
+    from prefect._internal import control_listener
+    from prefect._internal.attempt_control import EngineOutcomeReceipt
+    from prefect.utilities.engine import capture_sigterm
+
+    control_listener.configure_from_env()
+    with capture_sigterm():
+        acknowledged = control_listener.report_engine_outcome(
+            EngineOutcomeReceipt.state_reported(
+                state_id=UUID("22222222-2222-2222-2222-222222222222"),
+                state_type="FAILED",
+                state_name="Failed",
+            )
+        )
+
+        deadline = time.monotonic() + 5
+        while control_listener.get_intent() is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    if acknowledged:
+        sys.exit(11)
+    sys.exit(
+        0
+        if control_listener.get_intent() == os.environ["EXPECTED_INTENT"]
+        else 12
+    )
+    """
+)
+
+OLD_ENGINE_PROGRAM = textwrap.dedent(
+    """
+    import os
+    import socket
+    import sys
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5)
+    sock.connect(("127.0.0.1", int(os.environ["PREFECT__CONTROL_PORT"])))
+    sock.sendall(os.environ["PREFECT__CONTROL_TOKEN"].encode("ascii") + b"\\n")
+    intent = sock.recv(1)
+    if intent == b"c":
+        sock.sendall(b"a")
+        sys.exit(0)
+    sys.exit(13)
+    """
+)
+
+RACING_ENGINE_PROGRAM = textwrap.dedent(
+    """
+    import os
+    import sys
+    import time
+    from uuid import UUID
+
+    from prefect._internal import control_listener
+    from prefect._internal.attempt_control import RECEIPT_PREFIX, EngineOutcomeReceipt
+    from prefect.utilities.engine import capture_sigterm
+
+    control_listener.configure_from_env()
+    original_send = control_listener._send
+
+    def coordinated_send(sock, data):
+        if os.environ["RACE_ORDER"] == "receipt-first" and data.startswith(
+            RECEIPT_PREFIX
+        ):
+            print("receipt-ready", flush=True)
+            sys.stdin.readline()
+        elif os.environ["RACE_ORDER"] == "intent-first" and data == b"a":
+            print("intent-committed", flush=True)
+            sys.stdin.readline()
+        original_send(sock, data)
+
+    control_listener._send = coordinated_send
+    receipt = (
+        EngineOutcomeReceipt.state_reported(
+            state_id=UUID("33333333-3333-3333-3333-333333333333"),
+            state_type="FAILED",
+            state_name="Failed",
+        )
+    )
+    with capture_sigterm():
+        if os.environ["RACE_ORDER"] == "intent-first":
+            deadline = time.monotonic() + 5
+            while control_listener.get_intent() is None and time.monotonic() < deadline:
+                time.sleep(0.01)
+            print("receipt-attempting", flush=True)
+        acknowledged = control_listener.report_engine_outcome(receipt)
+
+    if os.environ["RACE_ORDER"] == "receipt-first":
+        sys.exit(0 if acknowledged and control_listener.get_intent() is None else 14)
+    sys.exit(
+        0
+        if not acknowledged and control_listener.get_intent() == "cancel"
+        else 15
+    )
+    """
+)
+
+ACK_LOSS_CHILD_PROGRAM = textwrap.dedent(
+    """
+    import sys
+    from uuid import UUID
+
+    from prefect._internal import control_listener
+    from prefect._internal.attempt_control import EngineOutcomeReceipt
+
+    control_listener.configure_from_env()
+    control_listener.start()
+    acknowledged = control_listener.report_engine_outcome(
+        EngineOutcomeReceipt.state_reported(
+            state_id=UUID("44444444-4444-4444-4444-444444444444"),
+            state_type="FAILED",
+            state_name="Failed",
+        )
+    )
+    sys.exit(16 if acknowledged else 0)
+    """
+)
+
+MALFORMED_ENGINE_PROGRAM = textwrap.dedent(
+    """
+    import os
+    import socket
+    import sys
+
+    from prefect._internal.attempt_control import (
+        CURRENT_PROTOCOL_VERSION,
+        NEGOTIATION_FRAME_SIZE,
+        RECEIPT_CAPABILITY,
+        RECEIPT_PREFIX,
+        encode_negotiation,
+    )
+
+    port = int(os.environ["PREFECT__CONTROL_PORT"])
+    token = os.environ["PREFECT__CONTROL_TOKEN"]
+    hello = encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY)
+
+    unauthenticated = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    unauthenticated.settimeout(5)
+    unauthenticated.connect(("127.0.0.1", port))
+    unauthenticated.sendall(b"not-the-attempt-token\\n" + hello)
+    if unauthenticated.recv(1) != b"":
+        sys.exit(17)
+
+    malformed = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    malformed.settimeout(5)
+    malformed.connect(("127.0.0.1", port))
+    malformed.sendall(token.encode("ascii") + b"\\n" + hello)
+    response = b""
+    while len(response) < NEGOTIATION_FRAME_SIZE:
+        response += malformed.recv(NEGOTIATION_FRAME_SIZE - len(response))
+    malformed.sendall(RECEIPT_PREFIX + (3).to_bytes(4, "big") + b"bad")
+    if malformed.recv(1) != b"":
+        sys.exit(18)
+    sys.exit(0)
+    """
+)
+
+REPLAYING_ENGINE_PROGRAM = textwrap.dedent(
+    """
+    import os
+    import socket
+    import sys
+    import time
+
+    port = int(os.environ["PREFECT__CONTROL_PORT"])
+    token_line = os.environ["PREFECT__CONTROL_TOKEN"].encode("ascii") + b"\\n"
+
+    first = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    first.settimeout(5)
+    first.connect(("127.0.0.1", port))
+    first.sendall(token_line)
+
+    replay = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    replay.settimeout(5)
+    replay.connect(("127.0.0.1", port))
+    replay.sendall(token_line)
+    if replay.recv(1) != b"":
+        sys.exit(19)
+    print("replay-rejected", flush=True)
+
+    if first.recv(1) != b"c":
+        sys.exit(20)
+    first.sendall(b"a")
+    time.sleep(0.1)
+    sys.exit(0)
+    """
+)
+
+UNNEGOTIATED_ENGINE_PROGRAM = textwrap.dedent(
+    """
+    import os
+    import socket
+    import sys
+    from uuid import UUID
+
+    from prefect._internal.attempt_control import EngineOutcomeReceipt, encode_receipt
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5)
+    sock.connect(("127.0.0.1", int(os.environ["PREFECT__CONTROL_PORT"])))
+    receipt = encode_receipt(
+        EngineOutcomeReceipt.state_reported(
+            state_id=UUID("55555555-5555-5555-5555-555555555555"),
+            state_type="FAILED",
+            state_name="Failed",
+        )
+    )
+    sock.sendall(
+        os.environ["PREFECT__CONTROL_TOKEN"].encode("ascii") + b"\\n" + receipt
+    )
+    sys.exit(0 if sock.recv(1) == b"" else 21)
+    """
+)
+
+
+def _start_child(
+    program: str,
+    *,
+    port: int,
+    token: str,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.Popen[bytes]:
+    env = {
+        **dict(os.environ),
+        "PREFECT__CONTROL_PORT": str(port),
+        "PREFECT__CONTROL_TOKEN": token,
+        **(env_overrides or {}),
+    }
+    return subprocess.Popen(
+        [sys.executable, "-c", program],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+async def _wait_for_child(
+    proc: subprocess.Popen[bytes],
+) -> tuple[bytes, bytes]:
+    for _ in range(100):
+        if proc.poll() is not None:
+            break
+        await asyncio.sleep(0.05)
+    assert proc.returncode is not None, "child did not exit in time"
+    return proc.communicate(timeout=5)
+
+
+def _ensure_child_stopped(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is None:
+        proc.kill()
+        proc.wait(timeout=5)
+
 
 @pytest.mark.timeout(60)
-async def test_cancel_intent_reaches_real_subprocess() -> None:
+async def test_cancel_intent_reaches_real_subprocess():
     async with ControlChannel(ack_timeout=5.0) as channel:
         flow_run_id = uuid4()
         port, token = channel.register(flow_run_id)
 
-        env = {
-            **dict(__import__("os").environ),
-            "PREFECT__CONTROL_PORT": str(port),
-            "PREFECT__CONTROL_TOKEN": token,
-        }
-
-        proc = subprocess.Popen(
-            [sys.executable, "-c", CHILD_PROGRAM],
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        proc = _start_child(CHILD_PROGRAM, port=port, token=token)
 
         try:
             # Give the child time to connect back to the channel before we
@@ -95,20 +380,309 @@ async def test_cancel_intent_reaches_real_subprocess() -> None:
             if os.name != "nt":
                 proc.send_signal(signal.SIGTERM)
 
-            # Wait for the child to exit. The handler exits 7 on cancel intent.
-            for _ in range(100):
-                if proc.poll() is not None:
-                    break
-                await asyncio.sleep(0.05)
-
-            assert proc.returncode is not None, "child did not exit in time"
-            stdout, stderr = proc.communicate(timeout=5)
+            # The handler exits 7 on cancel intent.
+            _stdout, stderr = await _wait_for_child(proc)
             assert proc.returncode == 7, (
                 f"expected exit code 7 (cancel intent visible), got "
                 f"{proc.returncode}; stderr: {stderr.decode(errors='replace')}"
             )
         finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=5)
+            _ensure_child_stopped(proc)
+            channel.unregister(flow_run_id)
+
+
+@pytest.mark.timeout(60)
+async def test_negotiates_and_acknowledges_receipt_from_real_subprocess():
+    expected = EngineOutcomeReceipt.state_reported(
+        state_id=UUID("11111111-1111-1111-1111-111111111111"),
+        state_type="FAILED",
+        state_name="Failed",
+    )
+
+    async with ControlChannel(ack_timeout=5.0) as channel:
+        flow_run_id = uuid4()
+        port, token = channel.register(flow_run_id)
+        proc = _start_child(RECEIPT_CHILD_PROGRAM, port=port, token=token)
+
+        try:
+            stdout, stderr = await _wait_for_child(proc)
+            assert proc.returncode == 0, (
+                f"receipt was not acknowledged; stderr: "
+                f"{stderr.decode(errors='replace')}"
+            )
+            assert stdout == b""
+            assert channel.get_conclusion(flow_run_id) == expected
+        finally:
+            _ensure_child_stopped(proc)
+            channel.unregister(flow_run_id)
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    ("intent", "wire_byte"),
+    [("cancel", b"c"), ("reschedule", b"r"), ("relinquish", b"q")],
+)
+async def test_new_engine_falls_back_to_old_supervisor_without_delaying_intent(
+    intent: str, wire_byte: bytes
+):
+    accepted: asyncio.Future[tuple[asyncio.StreamReader, asyncio.StreamWriter]] = (
+        asyncio.Future()
+    )
+
+    async def handle_old_supervisor(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        await reader.readline()
+        accepted.set_result((reader, writer))
+
+    server = await asyncio.start_server(handle_old_supervisor, host="127.0.0.1", port=0)
+    port = (server.sockets or [])[0].getsockname()[1]
+    proc = _start_child(
+        NEW_ENGINE_OLD_SUPERVISOR_PROGRAM,
+        port=port,
+        token="mixed-version-token",
+        env_overrides={"EXPECTED_INTENT": intent},
+    )
+
+    try:
+        reader, writer = await asyncio.wait_for(accepted, timeout=5)
+        hello = await asyncio.wait_for(
+            reader.readexactly(NEGOTIATION_FRAME_SIZE), timeout=2
+        )
+        assert hello == encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY)
+
+        # A version-one supervisor ignores the reserved hello and may deliver
+        # control immediately, including while the child awaits negotiation.
+        writer.write(wire_byte)
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(1), timeout=2) == b"a"
+
+        _stdout, stderr = await _wait_for_child(proc)
+        assert proc.returncode == 0, stderr.decode(errors="replace")
+        assert stderr == b""
+    finally:
+        _ensure_child_stopped(proc)
+        if "writer" in locals():
+            writer.close()
+            await writer.wait_closed()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.timeout(60)
+async def test_old_engine_retains_control_protocol_with_new_supervisor():
+    async with ControlChannel(ack_timeout=5.0) as channel:
+        flow_run_id = uuid4()
+        port, token = channel.register(flow_run_id)
+        proc = _start_child(OLD_ENGINE_PROGRAM, port=port, token=token)
+
+        try:
+            for _ in range(50):
+                if channel._registrations[flow_run_id].connected.is_set():
+                    break
+                await asyncio.sleep(0.05)
+
+            assert await channel.signal(flow_run_id, "cancel") is True
+            _stdout, stderr = await _wait_for_child(proc)
+            assert proc.returncode == 0, stderr.decode(errors="replace")
+            assert channel.get_conclusion(flow_run_id) == StateOwnershipDelegation(
+                "cancel"
+            )
+        finally:
+            _ensure_child_stopped(proc)
+            channel.unregister(flow_run_id)
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    ("order", "intent_acknowledged"),
+    [("receipt-first", False), ("intent-first", True)],
+)
+async def test_first_terminal_message_wins_real_process_race(
+    order: str, intent_acknowledged: bool
+):
+    receipt = EngineOutcomeReceipt.state_reported(
+        state_id=UUID("33333333-3333-3333-3333-333333333333"),
+        state_type="FAILED",
+        state_name="Failed",
+    )
+
+    async with ControlChannel(ack_timeout=5.0) as channel:
+        flow_run_id = uuid4()
+        port, token = channel.register(flow_run_id)
+        proc = _start_child(
+            RACING_ENGINE_PROGRAM,
+            port=port,
+            token=token,
+            env_overrides={"RACE_ORDER": order},
+        )
+
+        try:
+            for _ in range(100):
+                if channel._registrations[flow_run_id].negotiated_receipts:
+                    break
+                await asyncio.sleep(0.05)
+            assert channel._registrations[flow_run_id].negotiated_receipts
+
+            assert proc.stdout is not None
+            assert proc.stdin is not None
+            if order == "receipt-first":
+                assert (
+                    await asyncio.to_thread(proc.stdout.readline) == b"receipt-ready\n"
+                )
+                signal_task = asyncio.create_task(channel.signal(flow_run_id, "cancel"))
+                while channel._registrations[flow_run_id].pending_intent is None:
+                    await asyncio.sleep(0)
+                await asyncio.to_thread(proc.stdin.write, b"continue\n")
+                await asyncio.to_thread(proc.stdin.flush)
+                assert await signal_task is False
+            else:
+                signal_task = asyncio.create_task(channel.signal(flow_run_id, "cancel"))
+                assert (
+                    await asyncio.to_thread(proc.stdout.readline)
+                    == b"intent-committed\n"
+                )
+                assert (
+                    await asyncio.to_thread(proc.stdout.readline)
+                    == b"receipt-attempting\n"
+                )
+                await asyncio.to_thread(proc.stdin.write, b"continue\n")
+                await asyncio.to_thread(proc.stdin.flush)
+                assert await signal_task is True
+            expected = (
+                StateOwnershipDelegation("cancel") if intent_acknowledged else receipt
+            )
+            assert channel.get_conclusion(flow_run_id) == expected
+
+            _stdout, stderr = await _wait_for_child(proc)
+            assert proc.returncode == 0, stderr.decode(errors="replace")
+        finally:
+            _ensure_child_stopped(proc)
+            channel.unregister(flow_run_id)
+
+
+@pytest.mark.timeout(60)
+async def test_acknowledgement_loss_does_not_create_engine_failure():
+    expected = EngineOutcomeReceipt.state_reported(
+        state_id=UUID("44444444-4444-4444-4444-444444444444"),
+        state_type="FAILED",
+        state_name="Failed",
+    )
+    recorded: asyncio.Future[EngineOutcomeReceipt] = asyncio.Future()
+
+    async def drop_ack_after_recording(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            await reader.readline()
+            await reader.readexactly(NEGOTIATION_FRAME_SIZE)
+            writer.write(
+                encode_negotiation(CURRENT_PROTOCOL_VERSION, RECEIPT_CAPABILITY)
+            )
+            await writer.drain()
+            assert await reader.readexactly(1) == RECEIPT_PREFIX
+            size = int.from_bytes(await reader.readexactly(4), "big")
+            recorded.set_result(decode_receipt(await reader.readexactly(size)))
+        except (
+            AssertionError,
+            asyncio.IncompleteReadError,
+            ConnectionError,
+            OSError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            if not recorded.done():
+                recorded.set_exception(exc)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(
+        drop_ack_after_recording, host="127.0.0.1", port=0
+    )
+    port = (server.sockets or [])[0].getsockname()[1]
+    proc = _start_child(ACK_LOSS_CHILD_PROGRAM, port=port, token="ack-loss-token")
+
+    try:
+        assert await asyncio.wait_for(recorded, timeout=5) == expected
+        _stdout, stderr = await _wait_for_child(proc)
+        assert proc.returncode == 0, stderr.decode(errors="replace")
+        assert b"Engine outcome receipt was not acknowledged" in stderr
+        assert b"ack-loss-token" not in stderr
+        assert b"44444444-4444-4444-4444-444444444444" not in stderr
+    finally:
+        _ensure_child_stopped(proc)
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.timeout(60)
+async def test_unauthenticated_and_malformed_messages_are_not_evidence(
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(logging.DEBUG, logger="prefect.runner.control_channel")
+    async with ControlChannel(ack_timeout=5.0) as channel:
+        flow_run_id = uuid4()
+        port, token = channel.register(flow_run_id)
+        proc = _start_child(MALFORMED_ENGINE_PROGRAM, port=port, token=token)
+
+        try:
+            _stdout, stderr = await _wait_for_child(proc)
+            assert proc.returncode == 0, stderr.decode(errors="replace")
+            assert channel.get_conclusion(flow_run_id) is None
+            assert "rejected unauthenticated connection" in caplog.text
+            assert "malformed receipt" in caplog.text
+            assert token not in caplog.text
+            assert "not-the-attempt-token" not in caplog.text
+        finally:
+            _ensure_child_stopped(proc)
+            channel.unregister(flow_run_id)
+
+
+@pytest.mark.timeout(60)
+async def test_first_authenticated_connection_consumes_token():
+    async with ControlChannel(ack_timeout=5.0) as channel:
+        flow_run_id = uuid4()
+        port, token = channel.register(flow_run_id)
+        proc = _start_child(REPLAYING_ENGINE_PROGRAM, port=port, token=token)
+
+        try:
+            for _ in range(100):
+                if channel._registrations[flow_run_id].connected.is_set():
+                    break
+                await asyncio.sleep(0.05)
+            assert channel._registrations[flow_run_id].connected.is_set()
+            assert proc.stdout is not None
+            assert await asyncio.to_thread(proc.stdout.readline) == b"replay-rejected\n"
+
+            assert await channel.signal(flow_run_id, "cancel") is True
+            assert channel.get_conclusion(flow_run_id) == StateOwnershipDelegation(
+                "cancel"
+            )
+            _stdout, stderr = await _wait_for_child(proc)
+            assert proc.returncode == 0, stderr.decode(errors="replace")
+        finally:
+            _ensure_child_stopped(proc)
+            channel.unregister(flow_run_id)
+
+
+@pytest.mark.timeout(60)
+async def test_unnegotiated_receipt_is_not_terminal_evidence(
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(logging.DEBUG, logger="prefect.runner.control_channel")
+    async with ControlChannel(ack_timeout=5.0) as channel:
+        flow_run_id = uuid4()
+        port, token = channel.register(flow_run_id)
+        proc = _start_child(UNNEGOTIATED_ENGINE_PROGRAM, port=port, token=token)
+
+        try:
+            _stdout, stderr = await _wait_for_child(proc)
+            assert proc.returncode == 0, stderr.decode(errors="replace")
+            assert channel.get_conclusion(flow_run_id) is None
+            assert "unnegotiated receipt" in caplog.text
+            assert token not in caplog.text
+            assert "55555555-5555-5555-5555-555555555555" not in caplog.text
+        finally:
+            _ensure_child_stopped(proc)
             channel.unregister(flow_run_id)

--- a/tests/runner/test_control_channel_e2e.py
+++ b/tests/runner/test_control_channel_e2e.py
@@ -160,20 +160,15 @@ RACING_ENGINE_PROGRAM = textwrap.dedent(
     from prefect.utilities.engine import capture_sigterm
 
     control_listener.configure_from_env()
-    original_send = control_listener._send
+    original_encode_receipt = control_listener.encode_receipt
 
-    def coordinated_send(sock, data):
-        if os.environ["RACE_ORDER"] == "receipt-first" and data.startswith(
-            RECEIPT_PREFIX
-        ):
+    def coordinated_encode_receipt(receipt):
+        if os.environ["RACE_ORDER"] == "intent-before-receipt-send":
             print("receipt-ready", flush=True)
             sys.stdin.readline()
-        elif os.environ["RACE_ORDER"] == "intent-first" and data == b"a":
-            print("intent-committed", flush=True)
-            sys.stdin.readline()
-        original_send(sock, data)
+        return original_encode_receipt(receipt)
 
-    control_listener._send = coordinated_send
+    control_listener.encode_receipt = coordinated_encode_receipt
     receipt = (
         EngineOutcomeReceipt.state_reported(
             state_id=UUID("33333333-3333-3333-3333-333333333333"),
@@ -182,14 +177,11 @@ RACING_ENGINE_PROGRAM = textwrap.dedent(
         )
     )
     with capture_sigterm():
-        if os.environ["RACE_ORDER"] == "intent-first":
-            deadline = time.monotonic() + 5
-            while control_listener.get_intent() is None and time.monotonic() < deadline:
-                time.sleep(0.01)
-            print("receipt-attempting", flush=True)
         acknowledged = control_listener.report_engine_outcome(receipt)
 
-    if os.environ["RACE_ORDER"] == "receipt-first":
+    if os.environ["RACE_ORDER"] == "receipt-recorded-first":
+        print("receipt-recorded", flush=True)
+        sys.stdin.readline()
         sys.exit(0 if acknowledged and control_listener.get_intent() is None else 14)
     sys.exit(
         0
@@ -510,7 +502,7 @@ async def test_old_engine_retains_control_protocol_with_new_supervisor():
 @pytest.mark.parametrize("intent", ["cancel", "reschedule", "relinquish"])
 @pytest.mark.parametrize(
     ("order", "intent_acknowledged"),
-    [("receipt-first", False), ("intent-first", True)],
+    [("receipt-recorded-first", False), ("intent-before-receipt-send", True)],
 )
 async def test_first_terminal_message_wins_real_process_race(
     intent: Intent, order: str, intent_acknowledged: bool
@@ -540,29 +532,24 @@ async def test_first_terminal_message_wins_real_process_race(
 
             assert proc.stdout is not None
             assert proc.stdin is not None
-            if order == "receipt-first":
+            if order == "receipt-recorded-first":
+                assert (
+                    await asyncio.to_thread(proc.stdout.readline)
+                    == b"receipt-recorded\n"
+                )
+                assert await channel.signal(flow_run_id, intent) is False
+                await asyncio.to_thread(proc.stdin.write, b"continue\n")
+                await asyncio.to_thread(proc.stdin.flush)
+            else:
                 assert (
                     await asyncio.to_thread(proc.stdout.readline) == b"receipt-ready\n"
                 )
                 signal_task = asyncio.create_task(channel.signal(flow_run_id, intent))
                 while channel._registrations[flow_run_id].pending_intent is None:
                     await asyncio.sleep(0)
-                await asyncio.to_thread(proc.stdin.write, b"continue\n")
-                await asyncio.to_thread(proc.stdin.flush)
-                assert await signal_task is False
-            else:
-                signal_task = asyncio.create_task(channel.signal(flow_run_id, intent))
-                assert (
-                    await asyncio.to_thread(proc.stdout.readline)
-                    == b"intent-committed\n"
-                )
-                assert (
-                    await asyncio.to_thread(proc.stdout.readline)
-                    == b"receipt-attempting\n"
-                )
-                await asyncio.to_thread(proc.stdin.write, b"continue\n")
-                await asyncio.to_thread(proc.stdin.flush)
                 assert await signal_task is True
+                await asyncio.to_thread(proc.stdin.write, b"continue\n")
+                await asyncio.to_thread(proc.stdin.flush)
             expected = (
                 StateOwnershipDelegation(intent) if intent_acknowledged else receipt
             )

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -5479,11 +5479,6 @@ class TestResolveStarter:
         prefect_client: PrefectClient,
         caplog: pytest.LogCaptureFixture,
     ):
-        import prefect.runner._starter_direct as starter_mod
-        from prefect.flow_engine import (
-            run_flow_in_subprocess as original_run_flow_in_subprocess,
-        )
-
         @flow(on_crashed=[on_crashed])
         def crashed_flow():
             os._exit(7)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 from starlette import status
 
 import prefect.runner
+import prefect.runner._starter_bundle as bundle_starter_mod
 import prefect.runner._starter_direct as starter_mod
 from prefect import __version__, aserve, flow, serve, task
 from prefect._internal.attempt_control import (
@@ -2737,7 +2738,7 @@ class TestRunner:
 
             execute_bundle_in_subprocess = MagicMock(return_value=process)
             monkeypatch.setattr(
-                prefect.runner.runner,
+                bundle_starter_mod,
                 "execute_bundle_in_subprocess",
                 execute_bundle_in_subprocess,
             )
@@ -2777,13 +2778,13 @@ class TestRunner:
             )
             process = MagicMock(pid=12345, exitcode=1, join=MagicMock())
             monkeypatch.setattr(
-                prefect.runner.runner,
+                bundle_starter_mod,
                 "execute_bundle_in_subprocess",
                 MagicMock(return_value=process),
             )
 
             async with Runner() as runner:
-                runner._control_channel.unregister = MagicMock(return_value=receipt)
+                runner._control_channel.get_conclusion = MagicMock(return_value=receipt)
                 runner._state_proposer.propose_crashed = AsyncMock()
                 runner._hook_runner.run_crashed_hooks = AsyncMock()
 
@@ -2792,10 +2793,11 @@ class TestRunner:
             runner._state_proposer.propose_crashed.assert_not_awaited()
             runner._hook_runner.run_crashed_hooks.assert_not_awaited()
 
-        async def test_handled_crashed_bundle_execution_does_not_repeat_hook(
-            self, prefect_client: PrefectClient, caplog: pytest.LogCaptureFixture
+        async def test_handled_crashed_bundle_execution_runs_engine_hook_once(
+            self, prefect_client: PrefectClient, tmp_path: Path
         ):
             runner = Runner()
+            hook_marker = tmp_path / "crashed-hook.txt"
 
             @flow
             def crashed_flow():
@@ -2805,7 +2807,8 @@ class TestRunner:
             def da_hook(
                 flow: "Flow[Any, Any]", flow_run: "FlowRun", state: "State[Any]"
             ):
-                flow_run_logger(flow_run, flow).info("This flow crashed!")
+                with hook_marker.open("a") as marker:
+                    marker.write("ran\n")
 
             flow_run = await prefect_client.create_flow_run(crashed_flow)
 
@@ -2817,7 +2820,7 @@ class TestRunner:
             assert flow_run.state
             assert flow_run.state.is_crashed()
 
-            assert "This flow crashed!" not in caplog.text
+            assert hook_marker.read_text().splitlines() == ["ran"]
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -2230,19 +2230,28 @@ class TestRunner:
             assert record.levelname == "ERROR"
 
     @pytest.mark.parametrize(
-        "attempt_conclusion",
+        "attempt_conclusion,exit_code,expected_status_code,expects_crash",
         [
-            EngineOutcomeReceipt.state_reported(
-                state_id=uuid.uuid4(),
-                state_type="FAILED",
-                state_name="Failed",
+            (
+                EngineOutcomeReceipt.state_reported(
+                    state_id=uuid.uuid4(),
+                    state_type="FAILED",
+                    state_name="Failed",
+                ),
+                1,
+                0,
+                False,
             ),
-            StateOwnershipDelegation("cancel"),
+            (StateOwnershipDelegation("cancel"), 1, 0, False),
+            (None, 7, 7, True),
         ],
     )
-    async def test_legacy_execution_normalizes_handled_outcomes(
+    async def test_legacy_execution_interprets_terminal_evidence(
         self,
-        attempt_conclusion: AttemptConclusion,
+        attempt_conclusion: AttemptConclusion | None,
+        exit_code: int,
+        expected_status_code: int,
+        expects_crash: bool,
         monkeypatch: pytest.MonkeyPatch,
     ):
         runner = Runner()
@@ -2251,12 +2260,13 @@ class TestRunner:
         completion_status: asyncio.Future[int | None] = (
             asyncio.get_running_loop().create_future()
         )
-        propose_crashed = AsyncMock()
+        crashed_state = Crashed(message="Process crashed")
+        propose_crashed = AsyncMock(return_value=crashed_state)
         run_crashed_hooks = AsyncMock()
         client = MagicMock()
         client.read_flow_run = AsyncMock()
 
-        monkeypatch.setattr(runner, "_run_process", AsyncMock(return_value=1))
+        monkeypatch.setattr(runner, "_run_process", AsyncMock(return_value=exit_code))
         monkeypatch.setattr(runner, "_release_limit_slot", MagicMock())
         monkeypatch.setattr(
             runner,
@@ -2274,53 +2284,17 @@ class TestRunner:
             completion_status=completion_status,
         )
 
-        assert status_code == 0
-        assert completion_status.result() == 0
-        propose_crashed.assert_not_awaited()
-        run_crashed_hooks.assert_not_awaited()
-        client.read_flow_run.assert_not_awaited()
-
-    async def test_legacy_execution_preserves_nonzero_exit_fallback(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ):
-        runner = Runner()
-        flow_run = MagicMock(id=uuid.uuid4(), name="test-flow-run")
-        task_status = MagicMock(spec=anyio.abc.TaskStatus)
-        completion_status: asyncio.Future[int | None] = (
-            asyncio.get_running_loop().create_future()
-        )
-        crashed_state = Crashed(message="Process crashed")
-        propose_crashed = AsyncMock(return_value=crashed_state)
-        run_crashed_hooks = AsyncMock()
-        client = MagicMock()
-        client.read_flow_run = AsyncMock()
-
-        monkeypatch.setattr(runner, "_run_process", AsyncMock(return_value=7))
-        monkeypatch.setattr(runner, "_release_limit_slot", MagicMock())
-        monkeypatch.setattr(
-            runner,
-            "_remove_flow_run_process_map_entry",
-            AsyncMock(return_value=None),
-        )
-        monkeypatch.setattr(runner, "_get_flow_run_logger", MagicMock())
-        monkeypatch.setattr(runner, "_propose_crashed_state", propose_crashed)
-        monkeypatch.setattr(runner, "_run_on_crashed_hooks", run_crashed_hooks)
-        runner._client = client
-
-        status_code = await runner._submit_run_and_capture_errors(
-            flow_run,
-            task_status,
-            completion_status=completion_status,
-        )
-
-        assert status_code == 7
-        assert completion_status.result() == 7
-        propose_crashed.assert_awaited_once()
-        run_crashed_hooks.assert_awaited_once_with(
-            flow_run=flow_run,
-            state=crashed_state,
-        )
+        assert status_code == expected_status_code
+        assert completion_status.result() == expected_status_code
+        if expects_crash:
+            propose_crashed.assert_awaited_once()
+            run_crashed_hooks.assert_awaited_once_with(
+                flow_run=flow_run,
+                state=crashed_state,
+            )
+        else:
+            propose_crashed.assert_not_awaited()
+            run_crashed_hooks.assert_not_awaited()
         client.read_flow_run.assert_not_awaited()
 
     @pytest.mark.skipif(

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -29,6 +29,11 @@ from starlette import status
 import prefect.runner
 import prefect.runner._starter_direct as starter_mod
 from prefect import __version__, aserve, flow, serve, task
+from prefect._internal.attempt_control import (
+    AttemptConclusion,
+    EngineOutcomeReceipt,
+    StateOwnershipDelegation,
+)
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect._internal.versioning import VersionType
 from prefect.blocks.core import BlockNotSavedError
@@ -1134,7 +1139,6 @@ class TestRunner:
         temp_storage.code = dedent(
             """\
         import os
-        import signal
 
         from prefect import flow
         from prefect.logging.loggers import flow_run_logger
@@ -1146,7 +1150,7 @@ class TestRunner:
         @flow(on_crashed=[on_crashed], log_prints=True)
         def crashing_flow():
             print("Oh boy, here I go crashing again...")
-            os.kill(os.getpid(), signal.SIGTERM)
+            os._exit(7)
         """
         )
 
@@ -2224,6 +2228,100 @@ class TestRunner:
             assert record.levelname == "INFO"
         else:
             assert record.levelname == "ERROR"
+
+    @pytest.mark.parametrize(
+        "attempt_conclusion",
+        [
+            EngineOutcomeReceipt.state_reported(
+                state_id=uuid.uuid4(),
+                state_type="FAILED",
+                state_name="Failed",
+            ),
+            StateOwnershipDelegation("cancel"),
+        ],
+    )
+    async def test_legacy_execution_normalizes_handled_outcomes(
+        self,
+        attempt_conclusion: AttemptConclusion,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        runner = Runner()
+        flow_run = MagicMock(id=uuid.uuid4(), name="test-flow-run")
+        task_status = MagicMock(spec=anyio.abc.TaskStatus)
+        completion_status: asyncio.Future[int | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+        propose_crashed = AsyncMock()
+        run_crashed_hooks = AsyncMock()
+        client = MagicMock()
+        client.read_flow_run = AsyncMock()
+
+        monkeypatch.setattr(runner, "_run_process", AsyncMock(return_value=1))
+        monkeypatch.setattr(runner, "_release_limit_slot", MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "_remove_flow_run_process_map_entry",
+            AsyncMock(return_value=attempt_conclusion),
+        )
+        monkeypatch.setattr(runner, "_get_flow_run_logger", MagicMock())
+        monkeypatch.setattr(runner, "_propose_crashed_state", propose_crashed)
+        monkeypatch.setattr(runner, "_run_on_crashed_hooks", run_crashed_hooks)
+        runner._client = client
+
+        status_code = await runner._submit_run_and_capture_errors(
+            flow_run,
+            task_status,
+            completion_status=completion_status,
+        )
+
+        assert status_code == 0
+        assert completion_status.result() == 0
+        propose_crashed.assert_not_awaited()
+        run_crashed_hooks.assert_not_awaited()
+        client.read_flow_run.assert_not_awaited()
+
+    async def test_legacy_execution_preserves_nonzero_exit_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        runner = Runner()
+        flow_run = MagicMock(id=uuid.uuid4(), name="test-flow-run")
+        task_status = MagicMock(spec=anyio.abc.TaskStatus)
+        completion_status: asyncio.Future[int | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+        crashed_state = Crashed(message="Process crashed")
+        propose_crashed = AsyncMock(return_value=crashed_state)
+        run_crashed_hooks = AsyncMock()
+        client = MagicMock()
+        client.read_flow_run = AsyncMock()
+
+        monkeypatch.setattr(runner, "_run_process", AsyncMock(return_value=7))
+        monkeypatch.setattr(runner, "_release_limit_slot", MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "_remove_flow_run_process_map_entry",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(runner, "_get_flow_run_logger", MagicMock())
+        monkeypatch.setattr(runner, "_propose_crashed_state", propose_crashed)
+        monkeypatch.setattr(runner, "_run_on_crashed_hooks", run_crashed_hooks)
+        runner._client = client
+
+        status_code = await runner._submit_run_and_capture_errors(
+            flow_run,
+            task_status,
+            completion_status=completion_status,
+        )
+
+        assert status_code == 7
+        assert completion_status.result() == 7
+        propose_crashed.assert_awaited_once()
+        run_crashed_hooks.assert_awaited_once_with(
+            flow_run=flow_run,
+            state=crashed_state,
+        )
+        client.read_flow_run.assert_not_awaited()
 
     @pytest.mark.skipif(
         sys.platform != "win32",

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 from starlette import status
 
 import prefect.runner
+import prefect.runner._starter_direct as starter_mod
 from prefect import __version__, aserve, flow, serve, task
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect._internal.versioning import VersionType
@@ -58,6 +59,9 @@ from prefect.events.clients import (
 from prefect.events.schemas.automations import Posture
 from prefect.events.schemas.deployment_triggers import DeploymentEventTrigger
 from prefect.exceptions import ScriptError
+from prefect.flow_engine import (
+    run_flow_in_subprocess as original_run_flow_in_subprocess,
+)
 from prefect.flows import Flow
 from prefect.logging.loggers import flow_run_logger
 from prefect.runner.runner import Runner
@@ -5411,11 +5415,6 @@ class TestResolveStarter:
         not via `python -m prefect.engine`. Patches the direct starter module
         to prove the in-memory path is taken.
         """
-        import prefect.runner._starter_direct as starter_mod
-        from prefect.flow_engine import (
-            run_flow_in_subprocess as original_run_flow_in_subprocess,
-        )
-
         called = False
 
         def tracking_run_flow(*args, **kwargs):
@@ -5444,11 +5443,6 @@ class TestResolveStarter:
         prefect_client: PrefectClient,
         caplog: pytest.LogCaptureFixture,
     ):
-        import prefect.runner._starter_direct as starter_mod
-        from prefect.flow_engine import (
-            run_flow_in_subprocess as original_run_flow_in_subprocess,
-        )
-
         @flow(on_crashed=[on_crashed])
         def failed_flow():
             raise ValueError("application failure")

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1436,6 +1436,46 @@ class TestRunner:
         assert flow_run.state.is_completed()
 
     @pytest.mark.usefixtures("use_hosted_api_server")
+    async def test_runner_preserves_failed_engine_command_outcome(
+        self,
+        prefect_client: PrefectClient,
+        temp_storage: MockStorage,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        temp_storage.code = dedent(
+            """\
+            from prefect import flow
+            from prefect.logging.loggers import flow_run_logger
+
+            def on_crashed(flow, flow_run, state):
+                flow_run_logger(flow_run, flow).error("runner crash hook ran")
+
+            @flow(on_crashed=[on_crashed])
+            def failed_flow():
+                raise ValueError("application failure")
+            """
+        )
+        runner = Runner()
+        deployment = await (
+            await flow.from_source(
+                source=temp_storage,
+                entrypoint="flows.py:failed_flow",
+            )
+        ).to_deployment(__file__)
+        deployment_id = await runner.add_deployment(deployment)
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        await runner.start(run_once=True)
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert flow_run.state is not None
+        assert flow_run.state.is_failed()
+        assert "runner crash hook ran" not in caplog.text
+        assert "Process exited with status code: 1" not in caplog.text
+
+    @pytest.mark.usefixtures("use_hosted_api_server")
     async def test_runner_caches_adhoc_pulls(self, prefect_client):
         runner = Runner()
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1450,6 +1450,16 @@ class TestRunner:
         temp_storage: MockStorage,
         caplog: pytest.LogCaptureFixture,
     ):
+        observed_exit_codes: list[int | None] = []
+        original_run_process = processutils.run_process
+
+        async def run_process_and_record_exit_code(
+            *args: Any, **kwargs: Any
+        ) -> anyio.abc.Process:
+            process = await original_run_process(*args, **kwargs)
+            observed_exit_codes.append(process.returncode)
+            return process
+
         temp_storage.code = dedent(
             """\
             from prefect import flow
@@ -1475,11 +1485,16 @@ class TestRunner:
             deployment_id=deployment_id
         )
 
-        await runner.start(run_once=True)
+        with patch(
+            "prefect.runner._starter_engine.run_process",
+            side_effect=run_process_and_record_exit_code,
+        ):
+            await runner.start(run_once=True)
 
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
         assert flow_run.state is not None
         assert flow_run.state.is_failed()
+        assert observed_exit_codes == [0]
         assert "runner crash hook ran" not in caplog.text
         assert "Process exited with status code: 1" not in caplog.text
 
@@ -2743,6 +2758,39 @@ class TestRunner:
                 "PREFECT__CONTROL_PORT": "4321",
                 "PREFECT__CONTROL_TOKEN": "token-123",
             }
+
+        async def test_execute_bundle_preserves_receipt_with_nonzero_child_exit(
+            self,
+            prefect_client: PrefectClient,
+            monkeypatch: pytest.MonkeyPatch,
+        ):
+            @flow
+            def failed_flow():
+                raise ValueError("application failure")
+
+            flow_run = await prefect_client.create_flow_run(failed_flow)
+            bundle = create_bundle_for_flow_run(failed_flow, flow_run)["bundle"]
+            receipt = EngineOutcomeReceipt.state_reported(
+                state_id=uuid.uuid4(),
+                state_type="FAILED",
+                state_name="Failed",
+            )
+            process = MagicMock(pid=12345, exitcode=1, join=MagicMock())
+            monkeypatch.setattr(
+                prefect.runner.runner,
+                "execute_bundle_in_subprocess",
+                MagicMock(return_value=process),
+            )
+
+            async with Runner() as runner:
+                runner._control_channel.unregister = MagicMock(return_value=receipt)
+                runner._state_proposer.propose_crashed = AsyncMock()
+                runner._hook_runner.run_crashed_hooks = AsyncMock()
+
+                await runner.execute_bundle(bundle)
+
+            runner._state_proposer.propose_crashed.assert_not_awaited()
+            runner._hook_runner.run_crashed_hooks.assert_not_awaited()
 
         async def test_handled_crashed_bundle_execution_does_not_repeat_hook(
             self, prefect_client: PrefectClient, caplog: pytest.LogCaptureFixture
@@ -5538,7 +5586,7 @@ class TestResolveStarter:
             infrastructure_result = await runner.start(run_once=True)
 
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
-        assert processes[0].exitcode == 1
+        assert processes[0].exitcode == 0
         assert infrastructure_result is None
         assert flow_run.state is not None
         assert flow_run.state.is_failed()

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -70,6 +70,7 @@ from prefect.flow_engine import (
 )
 from prefect.flows import Flow
 from prefect.logging.loggers import flow_run_logger
+from prefect.runner._control_channel import ControlSignalStatus
 from prefect.runner.runner import Runner
 from prefect.runner.server import perform_health_check
 from prefect.schedules import Cron, Interval
@@ -148,6 +149,8 @@ class ClassWithCancellableFlow:
 def instance_on_crashed(flow, flow_run, state):
     logger = flow_run_logger(flow_run, flow)
     logger.info("Instance method flow crashed!")
+    if marker_path := os.environ.get("PREFECT_TEST_INSTANCE_CRASH_HOOK_MARKER"):
+        Path(marker_path).touch()
 
 
 class ClassWithCrashingFlow:
@@ -1584,9 +1587,9 @@ class TestRunner:
 
         call_order: list[tuple[Any, ...]] = []
 
-        async def _signal(flow_run_id: uuid.UUID, intent: str) -> bool:
+        async def _signal(flow_run_id: uuid.UUID, intent: str) -> ControlSignalStatus:
             call_order.append(("signal", flow_run_id, intent))
-            return True
+            return ControlSignalStatus.ACKNOWLEDGED
 
         async def _wait(
             flow_run_id: uuid.UUID, pid: int, *, grace_seconds: float
@@ -1659,7 +1662,9 @@ class TestRunner:
         }
 
         runner._control_channel = MagicMock()
-        runner._control_channel.signal = AsyncMock(return_value=True)
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
         runner._wait_for_process_exit = AsyncMock(return_value=True)
         runner._kill_process = AsyncMock()
         runner._run_on_cancellation_hooks = AsyncMock()
@@ -1701,7 +1706,9 @@ class TestRunner:
         }
 
         runner._control_channel = MagicMock()
-        runner._control_channel.signal = AsyncMock(return_value=True)
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
         runner._wait_for_process_exit = AsyncMock(return_value=True)
         runner._kill_process = AsyncMock()
         runner._run_on_cancellation_hooks = AsyncMock()
@@ -1739,7 +1746,9 @@ class TestRunner:
         }
 
         runner._control_channel = MagicMock()
-        runner._control_channel.signal = AsyncMock(return_value=True)
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
         runner._wait_for_process_exit = AsyncMock(return_value=False)
         runner._kill_process = AsyncMock(
             side_effect=RuntimeError(
@@ -1784,7 +1793,9 @@ class TestRunner:
         }
 
         runner._control_channel = MagicMock()
-        runner._control_channel.signal = AsyncMock(return_value=True)
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
         runner._wait_for_process_exit = AsyncMock()
         runner._kill_process = AsyncMock()
         runner._run_on_cancellation_hooks = AsyncMock()
@@ -1797,6 +1808,39 @@ class TestRunner:
 
         runner._wait_for_process_exit.assert_not_awaited()
         runner._kill_process.assert_awaited_once_with(12345, grace_seconds=30.0)
+
+    async def test_runner_cancel_run_stops_when_engine_receipt_already_concluded_attempt(
+        self,
+    ):
+        runner = Runner(pause_on_shutdown=False)
+
+        flow_run = MagicMock()
+        flow_run.id = uuid.uuid4()
+        flow_run.name = "legacy-run"
+        flow_run.state = Cancelling()
+
+        runner._flow_run_process_map[flow_run.id] = {
+            "pid": 12345,
+            "flow_run": flow_run,
+        }
+        runner._control_channel = MagicMock()
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ALREADY_CONCLUDED
+        )
+        runner._wait_for_process_exit = AsyncMock()
+        runner._kill_process = AsyncMock()
+        runner._run_on_cancellation_hooks = AsyncMock()
+        runner._mark_flow_run_as_cancelled = AsyncMock(return_value=True)
+        runner._emit_flow_run_cancelled_event = AsyncMock()
+        runner._get_flow_run_logger = MagicMock(return_value=MagicMock())
+
+        await runner._cancel_run(flow_run)
+
+        runner._wait_for_process_exit.assert_not_awaited()
+        runner._kill_process.assert_not_awaited()
+        runner._run_on_cancellation_hooks.assert_not_awaited()
+        runner._mark_flow_run_as_cancelled.assert_not_awaited()
+        runner._emit_flow_run_cancelled_event.assert_not_awaited()
 
     async def test_runner_cancel_run_skips_cancelled_finalization_when_acked_process_already_completed(
         self,
@@ -1814,7 +1858,9 @@ class TestRunner:
         }
 
         runner._control_channel = MagicMock()
-        runner._control_channel.signal = AsyncMock(return_value=True)
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.ACKNOWLEDGED
+        )
         runner._kill_process = AsyncMock(
             side_effect=RuntimeError(
                 "Unable to kill process 12345: The process was not found."
@@ -1919,7 +1965,9 @@ class TestRunner:
         }
 
         runner._control_channel = MagicMock()
-        runner._control_channel.signal = AsyncMock(return_value=False)
+        runner._control_channel.signal = AsyncMock(
+            return_value=ControlSignalStatus.NOT_ACKNOWLEDGED
+        )
         runner._kill_process = AsyncMock()
         runner._run_on_cancellation_hooks = AsyncMock()
         runner._mark_flow_run_as_cancelled = AsyncMock(return_value=False)
@@ -2993,7 +3041,8 @@ async def test_runner_runs_on_cancellation_hooks_for_instance_method_flows(
 
 async def test_runner_runs_on_crashed_hooks_for_instance_method_flows(
     prefect_client: PrefectClient,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ):
     """Test that crashed hooks work correctly for instance method flows."""
     runner = Runner()
@@ -3008,13 +3057,15 @@ async def test_runner_runs_on_crashed_hooks_for_instance_method_flows(
     flow_run = await prefect_client.create_flow_run_from_deployment(
         deployment_id=deployment_id
     )
+    hook_marker = tmp_path / "instance-crash-hook"
+    monkeypatch.setenv("PREFECT_TEST_INSTANCE_CRASH_HOOK_MARKER", str(hook_marker))
 
     await runner.execute_flow_run(flow_run.id)
 
     flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
     assert flow_run.state
     assert flow_run.state.is_crashed()
-    assert "Instance method flow crashed!" in caplog.text
+    assert hook_marker.exists()
 
 
 async def test_run_hooks_with_partial_hooks(

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -2668,7 +2668,7 @@ class TestRunner:
                 "PREFECT__CONTROL_TOKEN": "token-123",
             }
 
-        async def test_crashed_bundle_execution(
+        async def test_handled_crashed_bundle_execution_does_not_repeat_hook(
             self, prefect_client: PrefectClient, caplog: pytest.LogCaptureFixture
         ):
             runner = Runner()
@@ -2693,7 +2693,7 @@ class TestRunner:
             assert flow_run.state
             assert flow_run.state.is_crashed()
 
-            assert "This flow crashed!" in caplog.text
+            assert "This flow crashed!" not in caplog.text
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")
@@ -5437,6 +5437,87 @@ class TestResolveStarter:
         assert flow_run.state
         assert flow_run.state.is_completed()
         assert called, "run_flow_in_subprocess was not called — add_flow path is broken"
+
+    @pytest.mark.usefixtures("use_hosted_api_server")
+    async def test_add_flow_preserves_failed_direct_subprocess_outcome(
+        self,
+        prefect_client: PrefectClient,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        import prefect.runner._starter_direct as starter_mod
+        from prefect.flow_engine import (
+            run_flow_in_subprocess as original_run_flow_in_subprocess,
+        )
+
+        @flow(on_crashed=[on_crashed])
+        def failed_flow():
+            raise ValueError("application failure")
+
+        processes: list[Any] = []
+
+        def tracking_run_flow(*args: Any, **kwargs: Any):
+            process = original_run_flow_in_subprocess(*args, **kwargs)
+            processes.append(process)
+            return process
+
+        runner = Runner()
+        deployment_id = await runner.add_flow(failed_flow, __file__, interval=3600)
+        flow_run = await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+        with patch.object(
+            starter_mod,
+            "run_flow_in_subprocess",
+            side_effect=tracking_run_flow,
+        ):
+            infrastructure_result = await runner.start(run_once=True)
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert processes[0].exitcode == 1
+        assert infrastructure_result is None
+        assert flow_run.state is not None
+        assert flow_run.state.is_failed()
+        assert "This flow crashed!" not in caplog.text
+        assert "Process exited with status code: 1" not in caplog.text
+
+    @pytest.mark.usefixtures("use_hosted_api_server")
+    async def test_add_flow_preserves_direct_subprocess_crash_fallback(
+        self,
+        prefect_client: PrefectClient,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        import prefect.runner._starter_direct as starter_mod
+        from prefect.flow_engine import (
+            run_flow_in_subprocess as original_run_flow_in_subprocess,
+        )
+
+        @flow(on_crashed=[on_crashed])
+        def crashed_flow():
+            os._exit(7)
+
+        processes: list[Any] = []
+
+        def tracking_run_flow(*args: Any, **kwargs: Any):
+            process = original_run_flow_in_subprocess(*args, **kwargs)
+            processes.append(process)
+            return process
+
+        runner = Runner()
+        deployment_id = await runner.add_flow(crashed_flow, __file__, interval=3600)
+        flow_run = await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+        with patch.object(
+            starter_mod,
+            "run_flow_in_subprocess",
+            side_effect=tracking_run_flow,
+        ):
+            await runner.start(run_once=True)
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert processes[0].exitcode == 7
+        assert flow_run.state is not None
+        assert flow_run.state.is_crashed()
+        assert "This flow crashed!" in caplog.text
+        assert "Process exited with status code: 7" in caplog.text
 
     async def test_storage_deployment_uses_engine_command_starter(
         self, prefect_client: PrefectClient

--- a/tests/test-projects/import-project/my_module/flow.py
+++ b/tests/test-projects/import-project/my_module/flow.py
@@ -1,4 +1,10 @@
+import os
+from pathlib import Path
+from typing import Any
+
 import prefect
+from prefect.client.schemas.objects import FlowRun, State
+from prefect.flows import Flow
 
 from .utils import get_output
 
@@ -11,3 +17,15 @@ def test_flow():
 @prefect.flow(name="test")
 def prod_flow():
     return get_output()
+
+
+def mark_crashed_hook(
+    flow: Flow[Any, Any], flow_run: FlowRun, state: State[Any]
+) -> None:
+    if marker_path := os.environ.get("PREFECT_TEST_PROCESS_WORKER_CRASH_MARKER"):
+        Path(marker_path).touch()
+
+
+@prefect.flow(name="failed", on_crashed=[mark_crashed_hook])
+def failed_flow() -> None:
+    raise ValueError("application failure")

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -4,6 +4,7 @@ import signal
 import threading
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager, contextmanager, nullcontext
 from textwrap import dedent
 from types import SimpleNamespace
@@ -564,6 +565,61 @@ class TestStartAsyncFlowRunEngine:
 
 @pytest.mark.parametrize("engine_type", ["sync", "async"])
 class TestEngineOutcomeReceipts:
+    @pytest.fixture
+    def run_rejected_terminal_transition(
+        self,
+        engine_type: Literal["sync", "async"],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> Callable[[BaseException], Awaitable[None]]:
+        if engine_type == "sync":
+            original_propose_state = flow_engine_module.propose_state_sync
+
+            async def run_sync_engine(exception: BaseException) -> None:
+                def reject_terminal_state(
+                    client: Any, state: states.State[Any], **kwargs: Any
+                ) -> Any:
+                    if state.is_final():
+                        raise exception
+                    return original_propose_state(client, state, **kwargs)
+
+                monkeypatch.setattr(
+                    flow_engine_module,
+                    "propose_state_sync",
+                    reject_terminal_state,
+                )
+
+                @flow
+                def test_flow() -> str:
+                    return "done"
+
+                run_flow_sync(test_flow)
+
+            return run_sync_engine
+
+        original_propose_state = flow_engine_module.propose_state
+
+        async def run_async_engine(exception: BaseException) -> None:
+            async def reject_terminal_state(
+                client: Any, state: states.State[Any], **kwargs: Any
+            ) -> Any:
+                if state.is_final():
+                    raise exception
+                return await original_propose_state(client, state, **kwargs)
+
+            monkeypatch.setattr(
+                flow_engine_module,
+                "propose_state",
+                reject_terminal_state,
+            )
+
+            @flow
+            async def test_flow() -> str:
+                return "done"
+
+            await run_flow_async(test_flow)
+
+        return run_async_engine
+
     @pytest.mark.parametrize(
         ("state_type", "raised_exception"),
         [
@@ -588,24 +644,16 @@ class TestEngineOutcomeReceipts:
             "report_engine_outcome",
             report_engine_outcome,
         )
-        if state_type == StateType.CANCELLED:
 
-            async def terminal_state_from_result(*_args: Any, **_kwargs: Any):
-                return states.Cancelled(data="private result")
-
-            monkeypatch.setattr(
-                flow_engine_module,
-                "return_value_to_state",
-                terminal_state_from_result,
-            )
-
-        def sync_flow_body() -> str:
+        def sync_flow_body() -> Any:
             nonlocal flow_run_id
             flow_run_id = FlowRunContext.get().flow_run.id
             if raised_exception is ValueError:
                 raise ValueError("application failure")
             if raised_exception is KeyboardInterrupt:
                 raise KeyboardInterrupt()
+            if state_type == StateType.CANCELLED:
+                return states.Cancelled(data="private result")
             return "completed"
 
         if engine_type == "sync":
@@ -616,7 +664,12 @@ class TestEngineOutcomeReceipts:
             async def test_flow() -> str:
                 return sync_flow_body()
 
-        if raised_exception is None:
+        if state_type == StateType.CANCELLED:
+            if engine_type == "sync":
+                run_flow_sync(test_flow, return_type="state")
+            else:
+                await run_flow_async(test_flow, return_type="state")
+        elif raised_exception is None:
             if engine_type == "sync":
                 assert run_flow_sync(test_flow) == "completed"
             else:
@@ -640,10 +693,46 @@ class TestEngineOutcomeReceipts:
             )
         )
 
-    async def test_reports_state_from_rejected_paused_transition(
+    async def test_reports_empty_authoritative_state_name(
         self,
         engine_type: Literal["sync", "async"],
         monkeypatch: pytest.MonkeyPatch,
+    ):
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        if engine_type == "sync":
+
+            @flow
+            def test_flow() -> states.State[str]:
+                return states.Completed(name="", data="private result")
+
+            state = run_flow_sync(test_flow, return_type="state")
+        else:
+
+            @flow
+            async def test_flow() -> states.State[str]:
+                return states.Completed(name="", data="private result")
+
+            state = await run_flow_async(test_flow, return_type="state")
+
+        assert isinstance(state, states.State)
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=state.id,
+                state_type=state.type.value,
+                state_name="",
+            )
+        )
+
+    async def test_reports_state_from_rejected_paused_transition(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        run_rejected_terminal_transition: Callable[[BaseException], Awaitable[None]],
     ):
         paused_state = states.Paused(
             id=uuid.uuid4(),
@@ -658,46 +747,10 @@ class TestEngineOutcomeReceipts:
             report_engine_outcome,
         )
 
-        if engine_type == "sync":
-            original_propose_state = flow_engine_module.propose_state_sync
-
-            def reject_terminal_state_sync(client, state, **kwargs):
-                if state.is_final():
-                    raise Pause("paused by orchestration", state=paused_state)
-                return original_propose_state(client, state, **kwargs)
-
-            monkeypatch.setattr(
-                flow_engine_module,
-                "propose_state_sync",
-                reject_terminal_state_sync,
+        with pytest.raises(Pause, match="paused by orchestration"):
+            await run_rejected_terminal_transition(
+                Pause("paused by orchestration", state=paused_state)
             )
-
-            @flow
-            def test_flow():
-                return "done"
-
-            with pytest.raises(Pause, match="paused by orchestration"):
-                run_flow_sync(test_flow)
-        else:
-            original_propose_state = flow_engine_module.propose_state
-
-            async def reject_terminal_state_async(client, state, **kwargs):
-                if state.is_final():
-                    raise Pause("paused by orchestration", state=paused_state)
-                return await original_propose_state(client, state, **kwargs)
-
-            monkeypatch.setattr(
-                flow_engine_module,
-                "propose_state",
-                reject_terminal_state_async,
-            )
-
-            @flow
-            async def test_flow():
-                return "done"
-
-            with pytest.raises(Pause, match="paused by orchestration"):
-                await run_flow_async(test_flow)
 
         report_engine_outcome.assert_called_once_with(
             EngineOutcomeReceipt.state_reported(
@@ -709,8 +762,8 @@ class TestEngineOutcomeReceipts:
 
     async def test_reports_orchestration_abort_without_state(
         self,
-        engine_type: Literal["sync", "async"],
         monkeypatch: pytest.MonkeyPatch,
+        run_rejected_terminal_transition: Callable[[BaseException], Awaitable[None]],
     ):
         report_engine_outcome = MagicMock(return_value=True)
         monkeypatch.setattr(
@@ -719,46 +772,8 @@ class TestEngineOutcomeReceipts:
             report_engine_outcome,
         )
 
-        if engine_type == "sync":
-            original_propose_state = flow_engine_module.propose_state_sync
-
-            def abort_terminal_state_sync(client, state, **kwargs):
-                if state.is_final():
-                    raise Abort("aborted by orchestration")
-                return original_propose_state(client, state, **kwargs)
-
-            monkeypatch.setattr(
-                flow_engine_module,
-                "propose_state_sync",
-                abort_terminal_state_sync,
-            )
-
-            @flow
-            def test_flow():
-                return "done"
-
-            with pytest.raises(Abort, match="aborted by orchestration"):
-                run_flow_sync(test_flow)
-        else:
-            original_propose_state = flow_engine_module.propose_state
-
-            async def abort_terminal_state_async(client, state, **kwargs):
-                if state.is_final():
-                    raise Abort("aborted by orchestration")
-                return await original_propose_state(client, state, **kwargs)
-
-            monkeypatch.setattr(
-                flow_engine_module,
-                "propose_state",
-                abort_terminal_state_async,
-            )
-
-            @flow
-            async def test_flow():
-                return "done"
-
-            with pytest.raises(Abort, match="aborted by orchestration"):
-                await run_flow_async(test_flow)
+        with pytest.raises(Abort, match="aborted by orchestration"):
+            await run_rejected_terminal_transition(Abort("aborted by orchestration"))
 
         report_engine_outcome.assert_called_once_with(
             EngineOutcomeReceipt.orchestration_aborted()

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -365,7 +365,7 @@ class TestAsyncFlowRunEngine:
 
 
 class TestCancellationAndCrashedHookGating:
-    def test_runner_managed_subflows_respect_env_suppression(
+    def test_runner_managed_subflows_suppress_only_cancellation_hooks(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         hook_calls: list[str] = []
@@ -391,7 +391,35 @@ class TestCancellationAndCrashedHookGating:
         engine.call_hooks(states.Cancelling())
         engine.call_hooks(states.Crashed(message="boom"))
 
-        assert hook_calls == []
+        assert hook_calls == ["crash"]
+
+    async def test_async_runner_managed_subflows_suppress_only_cancellation_hooks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        hook_calls: list[str] = []
+        monkeypatch.setenv("PREFECT__ENABLE_CANCELLATION_AND_CRASHED_HOOKS", "false")
+
+        async def on_cancellation(flow, flow_run, state):
+            hook_calls.append("cancel")
+
+        async def on_crashed(flow, flow_run, state):
+            hook_calls.append("crash")
+
+        @flow(on_cancellation=[on_cancellation], on_crashed=[on_crashed])
+        async def child_flow():
+            return None
+
+        flow_run = MagicMock()
+        flow_run.parent_task_run_id = uuid.uuid4()
+        flow_run.deployment_id = uuid.uuid4()
+
+        engine = AsyncFlowRunEngine(flow=child_flow, flow_run=flow_run)
+        engine._started_with_in_process_parent_flow_run_context = False
+
+        await engine.call_hooks(states.Cancelling())
+        await engine.call_hooks(states.Crashed(message="boom"))
+
+        assert hook_calls == ["crash"]
 
     def test_same_process_subflows_ignore_env_suppression(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -562,6 +562,270 @@ class TestStartAsyncFlowRunEngine:
             await engine.begin_run()
 
 
+@pytest.mark.parametrize("engine_type", ["sync", "async"])
+class TestEngineOutcomeReceipts:
+    @pytest.mark.parametrize(
+        ("state_type", "raised_exception"),
+        [
+            (StateType.COMPLETED, None),
+            (StateType.FAILED, ValueError),
+            (StateType.CANCELLED, None),
+            (StateType.CRASHED, KeyboardInterrupt),
+        ],
+    )
+    async def test_reports_authoritative_terminal_state(
+        self,
+        engine_type: Literal["sync", "async"],
+        state_type: StateType,
+        raised_exception: type[BaseException] | None,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        flow_run_id: UUID | None = None
+        report_engine_outcome = MagicMock(return_value=False)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+        if state_type == StateType.CANCELLED:
+
+            async def terminal_state_from_result(*_args: Any, **_kwargs: Any):
+                return states.Cancelled(data="private result")
+
+            monkeypatch.setattr(
+                flow_engine_module,
+                "return_value_to_state",
+                terminal_state_from_result,
+            )
+
+        def sync_flow_body() -> str:
+            nonlocal flow_run_id
+            flow_run_id = FlowRunContext.get().flow_run.id
+            if raised_exception is ValueError:
+                raise ValueError("application failure")
+            if raised_exception is KeyboardInterrupt:
+                raise KeyboardInterrupt()
+            return "completed"
+
+        if engine_type == "sync":
+            test_flow = flow(sync_flow_body)
+        else:
+
+            @flow
+            async def test_flow() -> str:
+                return sync_flow_body()
+
+        if raised_exception is None:
+            if engine_type == "sync":
+                assert run_flow_sync(test_flow) == "completed"
+            else:
+                assert await run_flow_async(test_flow) == "completed"
+        else:
+            with pytest.raises(raised_exception):
+                if engine_type == "sync":
+                    run_flow_sync(test_flow)
+                else:
+                    await run_flow_async(test_flow)
+
+        assert flow_run_id is not None
+        flow_run = sync_prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state is not None
+        assert flow_run.state.type == state_type
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=flow_run.state.id,
+                state_type=flow_run.state.type.value,
+                state_name=flow_run.state.name,
+            )
+        )
+
+    async def test_reports_state_from_rejected_paused_transition(
+        self,
+        engine_type: Literal["sync", "async"],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        paused_state = states.Paused(
+            id=uuid.uuid4(),
+            name="PausedByOrchestration",
+            message="private message",
+            data="private result",
+        )
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        if engine_type == "sync":
+            original_propose_state = flow_engine_module.propose_state_sync
+
+            def reject_terminal_state_sync(client, state, **kwargs):
+                if state.is_final():
+                    raise Pause("paused by orchestration", state=paused_state)
+                return original_propose_state(client, state, **kwargs)
+
+            monkeypatch.setattr(
+                flow_engine_module,
+                "propose_state_sync",
+                reject_terminal_state_sync,
+            )
+
+            @flow
+            def test_flow():
+                return "done"
+
+            with pytest.raises(Pause, match="paused by orchestration"):
+                run_flow_sync(test_flow)
+        else:
+            original_propose_state = flow_engine_module.propose_state
+
+            async def reject_terminal_state_async(client, state, **kwargs):
+                if state.is_final():
+                    raise Pause("paused by orchestration", state=paused_state)
+                return await original_propose_state(client, state, **kwargs)
+
+            monkeypatch.setattr(
+                flow_engine_module,
+                "propose_state",
+                reject_terminal_state_async,
+            )
+
+            @flow
+            async def test_flow():
+                return "done"
+
+            with pytest.raises(Pause, match="paused by orchestration"):
+                await run_flow_async(test_flow)
+
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=paused_state.id,
+                state_type=paused_state.type.value,
+                state_name=paused_state.name,
+            )
+        )
+
+    async def test_reports_orchestration_abort_without_state(
+        self,
+        engine_type: Literal["sync", "async"],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        if engine_type == "sync":
+            original_propose_state = flow_engine_module.propose_state_sync
+
+            def abort_terminal_state_sync(client, state, **kwargs):
+                if state.is_final():
+                    raise Abort("aborted by orchestration")
+                return original_propose_state(client, state, **kwargs)
+
+            monkeypatch.setattr(
+                flow_engine_module,
+                "propose_state_sync",
+                abort_terminal_state_sync,
+            )
+
+            @flow
+            def test_flow():
+                return "done"
+
+            with pytest.raises(Abort, match="aborted by orchestration"):
+                run_flow_sync(test_flow)
+        else:
+            original_propose_state = flow_engine_module.propose_state
+
+            async def abort_terminal_state_async(client, state, **kwargs):
+                if state.is_final():
+                    raise Abort("aborted by orchestration")
+                return await original_propose_state(client, state, **kwargs)
+
+            monkeypatch.setattr(
+                flow_engine_module,
+                "propose_state",
+                abort_terminal_state_async,
+            )
+
+            @flow
+            async def test_flow():
+                return "done"
+
+            with pytest.raises(Abort, match="aborted by orchestration"):
+                await run_flow_async(test_flow)
+
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.orchestration_aborted()
+        )
+
+    @pytest.mark.parametrize(
+        "eventual_state_type", [StateType.COMPLETED, StateType.FAILED]
+    )
+    async def test_retry_reports_only_eventual_attempt_conclusion(
+        self,
+        engine_type: Literal["sync", "async"],
+        eventual_state_type: StateType,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        attempts = 0
+        flow_run_id: UUID | None = None
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        def flow_body() -> str:
+            nonlocal attempts, flow_run_id
+            attempts += 1
+            flow_run_id = FlowRunContext.get().flow_run.id
+            if attempts > 1:
+                report_engine_outcome.assert_not_called()
+            if attempts == 1 or eventual_state_type == StateType.FAILED:
+                raise ValueError(f"attempt {attempts} failed")
+            return "completed after retry"
+
+        if engine_type == "sync":
+            test_flow = flow(retries=1)(flow_body)
+            if eventual_state_type == StateType.FAILED:
+                with pytest.raises(ValueError, match="attempt 2 failed"):
+                    run_flow_sync(test_flow)
+            else:
+                assert run_flow_sync(test_flow) == "completed after retry"
+        else:
+
+            @flow(retries=1)
+            async def test_flow() -> str:
+                return flow_body()
+
+            if eventual_state_type == StateType.FAILED:
+                with pytest.raises(ValueError, match="attempt 2 failed"):
+                    await run_flow_async(test_flow)
+            else:
+                assert await run_flow_async(test_flow) == "completed after retry"
+
+        assert attempts == 2
+        assert flow_run_id is not None
+        flow_run = sync_prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state is not None
+        assert flow_run.state.type == eventual_state_type
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=flow_run.state.id,
+                state_type=flow_run.state.type.value,
+                state_name=flow_run.state.name,
+            )
+        )
+
+
 class TestFlowRunsAsync:
     async def test_basic(self):
         @flow
@@ -920,43 +1184,13 @@ class TestFlowRunsSync:
 
         assert run.state_type == StateType.FAILED
 
-    async def test_failed_flow_reports_authoritative_state_before_raising(
+    async def test_failed_subflow_does_not_report_child_attempt_outcome(
         self,
         sync_prefect_client: SyncPrefectClient,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        flow_run_id: UUID | None = None
-        report_engine_outcome = MagicMock(return_value=True)
-        monkeypatch.setattr(
-            flow_engine_module,
-            "report_engine_outcome",
-            report_engine_outcome,
-        )
-
-        @flow
-        def fails():
-            nonlocal flow_run_id
-            flow_run_id = FlowRunContext.get().flow_run.id
-            raise ValueError("application failure")
-
-        with pytest.raises(ValueError, match="application failure"):
-            run_flow_sync(fails)
-
-        assert flow_run_id is not None
-        flow_run = sync_prefect_client.read_flow_run(flow_run_id)
-        assert flow_run.state is not None
-        report_engine_outcome.assert_called_once_with(
-            EngineOutcomeReceipt.state_reported(
-                state_id=flow_run.state.id,
-                state_type=flow_run.state.type.value,
-                state_name=flow_run.state.name,
-            )
-        )
-
-    async def test_failed_subflow_does_not_report_parent_attempt_outcome(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ):
+        child_flow_run_id: UUID | None = None
+        parent_flow_run_id: UUID | None = None
         report_engine_outcome = MagicMock(return_value=True)
         monkeypatch.setattr(
             flow_engine_module,
@@ -966,16 +1200,34 @@ class TestFlowRunsSync:
 
         @flow
         def child():
+            nonlocal child_flow_run_id
+            child_flow_run_id = FlowRunContext.get().flow_run.id
             raise ValueError("child failure")
 
         @flow
         def parent():
+            nonlocal parent_flow_run_id
+            parent_flow_run_id = FlowRunContext.get().flow_run.id
             with pytest.raises(ValueError, match="child failure"):
                 child()
 
         run_flow_sync(parent)
 
-        report_engine_outcome.assert_not_called()
+        assert child_flow_run_id is not None
+        assert parent_flow_run_id is not None
+        child_flow_run = sync_prefect_client.read_flow_run(child_flow_run_id)
+        parent_flow_run = sync_prefect_client.read_flow_run(parent_flow_run_id)
+        assert child_flow_run.state is not None
+        assert child_flow_run.state.is_failed()
+        assert parent_flow_run.state is not None
+        assert parent_flow_run.state.is_completed()
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=parent_flow_run.state.id,
+                state_type=parent_flow_run.state.type.value,
+                state_name=parent_flow_run.state.name,
+            )
+        )
 
     async def test_with_provided_context(self, prefect_client: PrefectClient):
         tags_context = TagsContext(current_tags={"foo", "bar"})

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -23,6 +23,7 @@ from prefect._flow_run_suspension import (
     FlowRunSuspensionRequest,
     mark_flow_run_suspension_requested,
 )
+from prefect._internal.attempt_control import EngineOutcomeReceipt
 from prefect.cache_policies import INPUTS
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter
@@ -918,6 +919,63 @@ class TestFlowRunsSync:
         run = sync_prefect_client.read_flow_run(ID)
 
         assert run.state_type == StateType.FAILED
+
+    async def test_failed_flow_reports_authoritative_state_before_raising(
+        self,
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        flow_run_id: UUID | None = None
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        @flow
+        def fails():
+            nonlocal flow_run_id
+            flow_run_id = FlowRunContext.get().flow_run.id
+            raise ValueError("application failure")
+
+        with pytest.raises(ValueError, match="application failure"):
+            run_flow_sync(fails)
+
+        assert flow_run_id is not None
+        flow_run = sync_prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state is not None
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=flow_run.state.id,
+                state_type=flow_run.state.type.value,
+                state_name=flow_run.state.name,
+            )
+        )
+
+    async def test_failed_subflow_does_not_report_parent_attempt_outcome(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        @flow
+        def child():
+            raise ValueError("child failure")
+
+        @flow
+        def parent():
+            with pytest.raises(ValueError, match="child failure"):
+                child()
+
+        run_flow_sync(parent)
+
+        report_engine_outcome.assert_not_called()
 
     async def test_with_provided_context(self, prefect_client: PrefectClient):
         tags_context = TagsContext(current_tags={"foo", "bar"})

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -693,9 +693,11 @@ class TestEngineOutcomeReceipts:
             )
         )
 
-    async def test_reports_empty_authoritative_state_name(
+    @pytest.mark.parametrize("state_name", ["", "x" * 257])
+    async def test_reports_authoritative_state_name_without_altering_it(
         self,
         engine_type: Literal["sync", "async"],
+        state_name: str,
         monkeypatch: pytest.MonkeyPatch,
     ):
         report_engine_outcome = MagicMock(return_value=True)
@@ -709,14 +711,14 @@ class TestEngineOutcomeReceipts:
 
             @flow
             def test_flow() -> states.State[str]:
-                return states.Completed(name="", data="private result")
+                return states.Completed(name=state_name, data="private result")
 
             state = run_flow_sync(test_flow, return_type="state")
         else:
 
             @flow
             async def test_flow() -> states.State[str]:
-                return states.Completed(name="", data="private result")
+                return states.Completed(name=state_name, data="private result")
 
             state = await run_flow_async(test_flow, return_type="state")
 
@@ -725,7 +727,7 @@ class TestEngineOutcomeReceipts:
             EngineOutcomeReceipt.state_reported(
                 state_id=state.id,
                 state_type=state.type.value,
-                state_name="",
+                state_name=state_name,
             )
         )
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -2575,10 +2575,22 @@ class TestHandleEngineSignals:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.setattr("prefect.engine.get_intent", lambda: None)
+        monkeypatch.setattr("prefect.engine.engine_outcome_is_handled", lambda: False)
 
         with pytest.raises(TerminationSignal):
             with handle_engine_signals(uuid.uuid4()):
                 raise TerminationSignal(signal=signal.SIGTERM)
+
+    def test_handled_engine_outcome_exits_zero_on_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr("prefect.engine.engine_outcome_is_handled", lambda: True)
+
+        with pytest.raises(SystemExit) as exc:
+            with handle_engine_signals(uuid.uuid4()):
+                raise ValueError("application failure")
+
+        assert exc.value.code == 0
 
 
 class TestDriveRunFlowResult:
@@ -5150,7 +5162,7 @@ class TestRunFlowInSubprocess:
         process = run_flow_in_subprocess(foo)
 
         process.join()
-        assert process.exitcode == 1
+        assert process.exitcode == 0
 
         flow_run = await self.get_flow_run_for_flow(foo.name)
 
@@ -5376,7 +5388,7 @@ class TestRunFlowInSubprocess:
 
         process = run_flow_in_subprocess(foo)
         process.join()
-        assert process.exitcode == 1
+        assert process.exitcode == 0
 
         flow_run = await self.get_flow_run_for_flow(foo.name)
         assert flow_run.state.is_crashed()

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -4,7 +4,7 @@ import signal
 import threading
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import asynccontextmanager, contextmanager, nullcontext
 from textwrap import dedent
 from types import SimpleNamespace
@@ -563,6 +563,228 @@ class TestStartAsyncFlowRunEngine:
             await engine.begin_run()
 
 
+FlowExecutionShape = Literal["sync", "async", "generator", "async-generator"]
+
+
+def _reject_terminal_transition(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    async_engine: bool,
+    exception: BaseException,
+) -> None:
+    if not async_engine:
+        original_propose_state = flow_engine_module.propose_state_sync
+
+        def reject_terminal_state(
+            client: Any, state: states.State[Any], **kwargs: Any
+        ) -> Any:
+            if state.is_final():
+                raise exception
+            return original_propose_state(client, state, **kwargs)
+
+        monkeypatch.setattr(
+            flow_engine_module,
+            "propose_state_sync",
+            reject_terminal_state,
+        )
+        return
+
+    original_propose_state = flow_engine_module.propose_state
+
+    async def reject_terminal_state_async(
+        client: Any, state: states.State[Any], **kwargs: Any
+    ) -> Any:
+        if state.is_final():
+            raise exception
+        return await original_propose_state(client, state, **kwargs)
+
+    monkeypatch.setattr(
+        flow_engine_module,
+        "propose_state",
+        reject_terminal_state_async,
+    )
+
+
+@pytest.mark.parametrize(
+    "execution_shape", ["sync", "async", "generator", "async-generator"]
+)
+class TestEngineOutcomeReceiptExecutionShapes:
+    @pytest.fixture
+    def build_flow_shape(
+        self,
+        execution_shape: FlowExecutionShape,
+    ) -> Callable[[Callable[[], str], int], Flow[Any, Any]]:
+        def build(flow_body: Callable[[], str], retries: int = 0) -> Flow[Any, Any]:
+            if execution_shape == "sync":
+
+                @flow(retries=retries)
+                def test_flow() -> str:
+                    return flow_body()
+
+            elif execution_shape == "async":
+
+                @flow(retries=retries)
+                async def test_flow() -> str:
+                    return flow_body()
+
+            elif execution_shape == "generator":
+
+                @flow(retries=retries)
+                def test_flow() -> Generator[str, None, str]:
+                    yield "yielded"
+                    return flow_body()
+
+            else:
+
+                @flow(retries=retries)
+                async def test_flow() -> AsyncGenerator[str, None]:
+                    yield "yielded"
+                    flow_body()
+
+            return test_flow
+
+        return build
+
+    @pytest.fixture
+    def run_flow_shape(
+        self,
+        execution_shape: FlowExecutionShape,
+    ) -> Callable[[Flow[Any, Any], list[Any]], Awaitable[Any]]:
+        async def run(test_flow: Flow[Any, Any], yielded: list[Any]) -> Any:
+            flow_result: Any = test_flow()
+            if execution_shape == "sync":
+                return flow_result
+            if execution_shape == "async":
+                return await flow_result
+            if execution_shape == "generator":
+                yielded.extend(flow_result)
+                return yielded
+            async for value in flow_result:
+                yielded.append(value)
+            return yielded
+
+        return run
+
+    @pytest.mark.parametrize(
+        ("eventual_state_type", "retries"),
+        [
+            (StateType.COMPLETED, 0),
+            (StateType.FAILED, 0),
+            (StateType.COMPLETED, 1),
+            (StateType.FAILED, 1),
+        ],
+    )
+    async def test_reports_one_authoritative_conclusion(
+        self,
+        execution_shape: FlowExecutionShape,
+        eventual_state_type: StateType,
+        retries: int,
+        build_flow_shape: Callable[[Callable[[], str], int], Flow[Any, Any]],
+        run_flow_shape: Callable[[Flow[Any, Any], list[Any]], Awaitable[Any]],
+        sync_prefect_client: SyncPrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        attempts = 0
+        flow_run_id: UUID | None = None
+        observed_events: list[str] = []
+
+        def record_receipt(_receipt: EngineOutcomeReceipt) -> bool:
+            observed_events.append("receipt")
+            return True
+
+        report_engine_outcome = MagicMock(side_effect=record_receipt)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        def begin_attempt() -> None:
+            nonlocal attempts, flow_run_id
+            attempts += 1
+            flow_run_id = FlowRunContext.get().flow_run.id
+            if attempts > 1:
+                report_engine_outcome.assert_not_called()
+
+        def finish_attempt() -> str:
+            if attempts <= retries or eventual_state_type == StateType.FAILED:
+                raise ValueError(f"attempt {attempts} failed")
+            return "completed"
+
+        def flow_body() -> str:
+            begin_attempt()
+            return finish_attempt()
+
+        yielded: list[Any] = []
+        test_flow = build_flow_shape(flow_body, retries)
+        if eventual_state_type == StateType.FAILED:
+            with pytest.raises(ValueError, match=f"attempt {retries + 1} failed"):
+                await run_flow_shape(test_flow, yielded)
+            observed_events.append("exception")
+            assert observed_events == ["receipt", "exception"]
+        else:
+            result = await run_flow_shape(test_flow, yielded)
+            if execution_shape in ("generator", "async-generator"):
+                assert result == ["yielded"] * (retries + 1)
+            else:
+                assert result == "completed"
+            assert observed_events == ["receipt"]
+
+        assert attempts == retries + 1
+        assert flow_run_id is not None
+        flow_run = sync_prefect_client.read_flow_run(flow_run_id)
+        assert flow_run.state is not None
+        assert flow_run.state.type == eventual_state_type
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=flow_run.state.id,
+                state_type=flow_run.state.type.value,
+                state_name=flow_run.state.name,
+            )
+        )
+
+    async def test_reports_rejected_paused_transition(
+        self,
+        execution_shape: FlowExecutionShape,
+        build_flow_shape: Callable[[Callable[[], str], int], Flow[Any, Any]],
+        run_flow_shape: Callable[[Flow[Any, Any], list[Any]], Awaitable[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        paused_state = states.Paused(
+            id=uuid.uuid4(),
+            name="PausedByOrchestration",
+            message="private message",
+            data="private result",
+        )
+        report_engine_outcome = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "report_engine_outcome",
+            report_engine_outcome,
+        )
+
+        _reject_terminal_transition(
+            monkeypatch,
+            async_engine=execution_shape in ("async", "async-generator"),
+            exception=Pause("paused by orchestration", state=paused_state),
+        )
+
+        yielded: list[Any] = []
+        test_flow = build_flow_shape(lambda: "completed", 0)
+        with pytest.raises(Pause, match="paused by orchestration"):
+            await run_flow_shape(test_flow, yielded)
+
+        if execution_shape in ("generator", "async-generator"):
+            assert yielded == ["yielded"]
+        report_engine_outcome.assert_called_once_with(
+            EngineOutcomeReceipt.state_reported(
+                state_id=paused_state.id,
+                state_type=paused_state.type.value,
+                state_name=paused_state.name,
+            )
+        )
+
+
 @pytest.mark.parametrize("engine_type", ["sync", "async"])
 class TestEngineOutcomeReceipts:
     @pytest.fixture
@@ -572,20 +794,10 @@ class TestEngineOutcomeReceipts:
         monkeypatch: pytest.MonkeyPatch,
     ) -> Callable[[BaseException], Awaitable[None]]:
         if engine_type == "sync":
-            original_propose_state = flow_engine_module.propose_state_sync
 
             async def run_sync_engine(exception: BaseException) -> None:
-                def reject_terminal_state(
-                    client: Any, state: states.State[Any], **kwargs: Any
-                ) -> Any:
-                    if state.is_final():
-                        raise exception
-                    return original_propose_state(client, state, **kwargs)
-
-                monkeypatch.setattr(
-                    flow_engine_module,
-                    "propose_state_sync",
-                    reject_terminal_state,
+                _reject_terminal_transition(
+                    monkeypatch, async_engine=False, exception=exception
                 )
 
                 @flow
@@ -596,20 +808,9 @@ class TestEngineOutcomeReceipts:
 
             return run_sync_engine
 
-        original_propose_state = flow_engine_module.propose_state
-
         async def run_async_engine(exception: BaseException) -> None:
-            async def reject_terminal_state(
-                client: Any, state: states.State[Any], **kwargs: Any
-            ) -> Any:
-                if state.is_final():
-                    raise exception
-                return await original_propose_state(client, state, **kwargs)
-
-            monkeypatch.setattr(
-                flow_engine_module,
-                "propose_state",
-                reject_terminal_state,
+            _reject_terminal_transition(
+                monkeypatch, async_engine=True, exception=exception
             )
 
             @flow
@@ -623,13 +824,11 @@ class TestEngineOutcomeReceipts:
     @pytest.mark.parametrize(
         ("state_type", "raised_exception"),
         [
-            (StateType.COMPLETED, None),
-            (StateType.FAILED, ValueError),
             (StateType.CANCELLED, None),
             (StateType.CRASHED, KeyboardInterrupt),
         ],
     )
-    async def test_reports_authoritative_terminal_state(
+    async def test_reports_nonstandard_authoritative_terminal_state(
         self,
         engine_type: Literal["sync", "async"],
         state_type: StateType,
@@ -731,37 +930,6 @@ class TestEngineOutcomeReceipts:
             )
         )
 
-    async def test_reports_state_from_rejected_paused_transition(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        run_rejected_terminal_transition: Callable[[BaseException], Awaitable[None]],
-    ):
-        paused_state = states.Paused(
-            id=uuid.uuid4(),
-            name="PausedByOrchestration",
-            message="private message",
-            data="private result",
-        )
-        report_engine_outcome = MagicMock(return_value=True)
-        monkeypatch.setattr(
-            flow_engine_module,
-            "report_engine_outcome",
-            report_engine_outcome,
-        )
-
-        with pytest.raises(Pause, match="paused by orchestration"):
-            await run_rejected_terminal_transition(
-                Pause("paused by orchestration", state=paused_state)
-            )
-
-        report_engine_outcome.assert_called_once_with(
-            EngineOutcomeReceipt.state_reported(
-                state_id=paused_state.id,
-                state_type=paused_state.type.value,
-                state_name=paused_state.name,
-            )
-        )
-
     async def test_reports_orchestration_abort_without_state(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -779,67 +947,6 @@ class TestEngineOutcomeReceipts:
 
         report_engine_outcome.assert_called_once_with(
             EngineOutcomeReceipt.orchestration_aborted()
-        )
-
-    @pytest.mark.parametrize(
-        "eventual_state_type", [StateType.COMPLETED, StateType.FAILED]
-    )
-    async def test_retry_reports_only_eventual_attempt_conclusion(
-        self,
-        engine_type: Literal["sync", "async"],
-        eventual_state_type: StateType,
-        sync_prefect_client: SyncPrefectClient,
-        monkeypatch: pytest.MonkeyPatch,
-    ):
-        attempts = 0
-        flow_run_id: UUID | None = None
-        report_engine_outcome = MagicMock(return_value=True)
-        monkeypatch.setattr(
-            flow_engine_module,
-            "report_engine_outcome",
-            report_engine_outcome,
-        )
-
-        def flow_body() -> str:
-            nonlocal attempts, flow_run_id
-            attempts += 1
-            flow_run_id = FlowRunContext.get().flow_run.id
-            if attempts > 1:
-                report_engine_outcome.assert_not_called()
-            if attempts == 1 or eventual_state_type == StateType.FAILED:
-                raise ValueError(f"attempt {attempts} failed")
-            return "completed after retry"
-
-        if engine_type == "sync":
-            test_flow = flow(retries=1)(flow_body)
-            if eventual_state_type == StateType.FAILED:
-                with pytest.raises(ValueError, match="attempt 2 failed"):
-                    run_flow_sync(test_flow)
-            else:
-                assert run_flow_sync(test_flow) == "completed after retry"
-        else:
-
-            @flow(retries=1)
-            async def test_flow() -> str:
-                return flow_body()
-
-            if eventual_state_type == StateType.FAILED:
-                with pytest.raises(ValueError, match="attempt 2 failed"):
-                    await run_flow_async(test_flow)
-            else:
-                assert await run_flow_async(test_flow) == "completed after retry"
-
-        assert attempts == 2
-        assert flow_run_id is not None
-        flow_run = sync_prefect_client.read_flow_run(flow_run_id)
-        assert flow_run.state is not None
-        assert flow_run.state.type == eventual_state_type
-        report_engine_outcome.assert_called_once_with(
-            EngineOutcomeReceipt.state_reported(
-                state_id=flow_run.state.id,
-                state_type=flow_run.state.type.value,
-                state_name=flow_run.state.name,
-            )
         )
 
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -2471,7 +2471,10 @@ class TestFlowCrashDetection:
         engine.handle_cancellation = AsyncMock()
         engine.handle_crash = AsyncMock()
 
-        monkeypatch.setattr("prefect.flow_engine._termination_intent", lambda: "cancel")
+        monkeypatch.setattr(
+            "prefect._internal.control_listener.get_intent", lambda: "cancel"
+        )
+        monkeypatch.setattr("prefect.flow_engine.get_intent", lambda: "cancel")
 
         with pytest.raises(TerminationSignal) as exc_info:
             async with engine.initialize_run():
@@ -2534,7 +2537,10 @@ class TestRunFlowBaseExceptionErrorLogger:
 
         error_logger = MagicMock()
 
-        monkeypatch.setattr("prefect.flow_engine._termination_intent", lambda: "cancel")
+        monkeypatch.setattr(
+            "prefect._internal.control_listener.get_intent", lambda: "cancel"
+        )
+        monkeypatch.setattr("prefect.flow_engine.get_intent", lambda: "cancel")
 
         with mock.patch.object(
             FlowRunEngine,
@@ -2663,7 +2669,10 @@ class TestCaptureSigterm:
         engine = FlowRunEngine(flow=foo, flow_run=MagicMock(state=states.Pending()))
         engine.cancel_all_tasks = MagicMock()
         engine.handle_crash = MagicMock()
-        monkeypatch.setattr("prefect.flow_engine._termination_intent", lambda: intent)
+        monkeypatch.setattr(
+            "prefect._internal.control_listener.get_intent", lambda: intent
+        )
+        monkeypatch.setattr("prefect.flow_engine.get_intent", lambda: intent)
         monkeypatch.setattr(
             "prefect.flow_engine.SyncClientContext.get_or_create",
             _fake_sync_client_context,
@@ -2701,8 +2710,9 @@ class TestCaptureSigterm:
         engine.cancel_all_tasks = MagicMock()
         engine.handle_crash = AsyncMock()
         monkeypatch.setattr(
-            "prefect.flow_engine._termination_intent", lambda: "relinquish"
+            "prefect._internal.control_listener.get_intent", lambda: "relinquish"
         )
+        monkeypatch.setattr("prefect.flow_engine.get_intent", lambda: "relinquish")
         monkeypatch.setattr(
             "prefect.flow_engine.AsyncClientContext.get_or_create",
             _fake_async_client_context,
@@ -2762,8 +2772,9 @@ class TestCaptureSigterm:
         TerminationSignal; it must bubble rather than crash the run."""
         engine = async_cancellation_engine
         monkeypatch.setattr(
-            "prefect.flow_engine._termination_intent", lambda: "relinquish"
+            "prefect._internal.control_listener.get_intent", lambda: "relinquish"
         )
+        monkeypatch.setattr("prefect.flow_engine.get_intent", lambda: "relinquish")
 
         with pytest.raises(TerminationSignal):
             async with engine.initialize_run():
@@ -2779,7 +2790,10 @@ class TestCaptureSigterm:
         """An ordinary cancellation (e.g. a flow timeout) carries no intent, so it
         must still crash rather than be mistaken for a supervisor termination."""
         engine = async_cancellation_engine
-        monkeypatch.setattr("prefect.flow_engine._termination_intent", lambda: None)
+        monkeypatch.setattr(
+            "prefect._internal.control_listener.get_intent", lambda: None
+        )
+        monkeypatch.setattr("prefect.flow_engine.get_intent", lambda: None)
 
         with pytest.raises(anyio.get_cancelled_exc_class()):
             async with engine.initialize_run():

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -4047,7 +4047,7 @@ class TestFlowHooksOnCrashed:
             my_flow(return_state=True)
         my_mock.assert_not_called()
 
-    def test_on_crashed_hooks_respect_env_var(self, monkeypatch):
+    def test_on_crashed_hooks_remain_engine_owned_with_env_var_false(self, monkeypatch):
         my_mock = MagicMock()
         monkeypatch.setenv("PREFECT__ENABLE_CANCELLATION_AND_CRASHED_HOOKS", "false")
 
@@ -4063,7 +4063,7 @@ class TestFlowHooksOnCrashed:
 
         state = my_flow(return_state=True)
         assert state.type == StateType.CRASHED
-        my_mock.assert_not_called()
+        assert my_mock.mock_calls == [call("crashed_hook1"), call("crashed_hook2")]
 
 
 class TestFlowHooksOnRunning:

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -16,6 +16,7 @@ from prefect.client import schemas as client_schemas
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas import State
 from prefect.client.schemas.objects import Deployment, FlowRun, StateType, WorkPool
+from prefect.runner.runner import _FlowRunProcessResult
 from prefect.server import models
 from prefect.server.database.orm_models import Flow
 from prefect.server.schemas.actions import (
@@ -166,9 +167,12 @@ def mock_open_process(monkeypatch: pytest.MonkeyPatch):
 def mock_runner_execute_flow_run(monkeypatch: pytest.MonkeyPatch):
     mock_process = MagicMock(returncode=0, pid=1000)
     mock_execute_flow_run = AsyncMock()
-    mock_execute_flow_run.return_value = mock_process
+    mock_execute_flow_run.return_value = _FlowRunProcessResult(
+        process=mock_process,
+        status_code=0,
+    )
     monkeypatch.setattr(
-        "prefect.runner.runner.Runner.execute_flow_run", mock_execute_flow_run
+        "prefect.runner.runner.Runner._execute_flow_run", mock_execute_flow_run
     )
     return mock_execute_flow_run
 
@@ -243,6 +247,47 @@ async def test_worker_process_run_flow_run(
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state is not None
         assert flow_run.state.type == StateType.COMPLETED
+
+
+async def test_process_worker_preserves_handled_failed_outcome(
+    prefect_client: PrefectClient,
+    process_work_pool: WorkPool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    flow_id = await prefect_client.create_flow(flow=example_process_worker_flow)
+    deployment_id = await prefect_client.create_deployment(
+        flow_id=flow_id,
+        name=f"test-process-worker-failed-deployment-{uuid.uuid4()}",
+        path=str(
+            prefect.__development_base_path__
+            / "tests"
+            / "test-projects"
+            / "import-project"
+        ),
+        entrypoint="my_module/flow.py:failed_flow",
+    )
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        deployment_id=deployment_id,
+        state=State(
+            type=client_schemas.StateType.SCHEDULED,
+            state_details=client_schemas.StateDetails(
+                scheduled_time=now("UTC") - timedelta(minutes=5)
+            ),
+        ),
+    )
+    crash_marker = tmp_path / "crash-hook-ran"
+    monkeypatch.setenv("PREFECT_TEST_PROCESS_WORKER_CRASH_MARKER", str(crash_marker))
+
+    async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
+        result = await worker._submit_run_and_capture_errors(flow_run)
+
+    assert isinstance(result, ProcessWorkerResult)
+    assert result.status_code == 0
+    flow_run = await prefect_client.read_flow_run(flow_run.id)
+    assert flow_run.state is not None
+    assert flow_run.state.is_failed()
+    assert not crash_marker.exists()
 
 
 async def test_worker_process_run_flow_run_with_env_variables_job_config_defaults(

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import anyio
 import anyio.abc
@@ -16,7 +16,7 @@ from prefect.client import schemas as client_schemas
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas import State
 from prefect.client.schemas.objects import Deployment, FlowRun, StateType, WorkPool
-from prefect.runner.runner import _FlowRunProcessResult
+from prefect.runner._process_manager import ProcessHandle
 from prefect.server import models
 from prefect.server.database.orm_models import Flow
 from prefect.server.schemas.actions import (
@@ -164,17 +164,18 @@ def mock_open_process(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def mock_runner_execute_flow_run(monkeypatch: pytest.MonkeyPatch):
+def mock_engine_command_starter(monkeypatch: pytest.MonkeyPatch):
     mock_process = MagicMock(returncode=0, pid=1000)
-    mock_execute_flow_run = AsyncMock()
-    mock_execute_flow_run.return_value = _FlowRunProcessResult(
-        process=mock_process,
-        status_code=0,
-    )
-    monkeypatch.setattr(
-        "prefect.runner.runner.Runner._execute_flow_run", mock_execute_flow_run
-    )
-    return mock_execute_flow_run
+    handle = ProcessHandle(mock_process)
+    starter = MagicMock()
+
+    async def start(_flow_run, task_status=anyio.TASK_STATUS_IGNORED):
+        task_status.started(handle)
+
+    starter.start = AsyncMock(side_effect=start)
+    starter_factory = MagicMock(return_value=starter)
+    monkeypatch.setattr("prefect.workers.process.EngineCommandStarter", starter_factory)
+    return starter_factory
 
 
 @pytest.fixture(autouse=True)
@@ -292,7 +293,7 @@ async def test_process_worker_preserves_handled_failed_outcome(
 
 async def test_worker_process_run_flow_run_with_env_variables_job_config_defaults(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     work_pool_with_default_env: WorkPool,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -319,16 +320,15 @@ async def test_worker_process_run_flow_run_with_env_variables_job_config_default
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
 
-    call_kwargs = mock_runner_execute_flow_run.call_args[1]
+    call_kwargs = mock_engine_command_starter.call_args.kwargs
 
     # should always execute in a tmp directory if working_dir not provided
     assert "tmp" in call_kwargs.pop("cwd")
     assert call_kwargs == dict(
-        flow_run_id=flow_run.id,
         command=configuration.command,
         env=configuration.env,
         stream_output=configuration.stream_output,
-        task_status=anyio.TASK_STATUS_IGNORED,
+        control_channel=ANY,
     )
 
     assert configuration.env["CONFIG_ENV_VAR"] == "from_job_configuration"
@@ -337,7 +337,7 @@ async def test_worker_process_run_flow_run_with_env_variables_job_config_default
 
 async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
     flow_run_with_deployment_overrides: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     work_pool_with_default_env: WorkPool,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -361,13 +361,12 @@ async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
 
-    mock_runner_execute_flow_run.assert_awaited_once_with(
-        flow_run_id=flow_run_with_deployment_overrides.id,
+    mock_engine_command_starter.assert_called_once_with(
         command=configuration.command,
         cwd=configuration.working_dir,
         env=configuration.env,
         stream_output=configuration.stream_output,
-        task_status=anyio.TASK_STATUS_IGNORED,
+        control_channel=mock_engine_command_starter.call_args.kwargs["control_channel"],
     )
     assert configuration.env["NEW_ENV_VAR"] == "from_deployment"
     assert configuration.env["EXISTING_ENV_VAR"] == "from_os"
@@ -463,7 +462,7 @@ async def test_flow_run_vars_and_deployment_vars_get_merged(
 
 async def test_process_worker_working_dir_override(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,
 ):
@@ -485,7 +484,7 @@ async def test_process_worker_working_dir_override(
 
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
-        assert mock_runner_execute_flow_run.call_args.kwargs["cwd"] != Path(
+        assert mock_engine_command_starter.call_args.kwargs["cwd"] != Path(
             path_override_value
         )
 
@@ -512,7 +511,7 @@ async def test_process_worker_working_dir_override(
 
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
-        assert mock_runner_execute_flow_run.call_args.kwargs["cwd"] == Path(
+        assert mock_engine_command_starter.call_args.kwargs["cwd"] == Path(
             path_override_value
         )
 
@@ -573,7 +572,7 @@ async def run_flow_run_with_job_variables(
 
 async def test_process_worker_uses_auto_uv_command_for_project_working_dir(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,
     uv_project: Path,
@@ -586,14 +585,14 @@ async def test_process_worker_uses_auto_uv_command_for_project_working_dir(
             {"working_dir": str(uv_project)},
         )
 
-    assert mock_runner_execute_flow_run.call_args.kwargs[
+    assert mock_engine_command_starter.call_args.kwargs[
         "command"
     ] == expected_uv_command(uv_project)
 
 
 async def test_process_worker_auto_uv_command_uses_absolute_project_path(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -611,14 +610,14 @@ async def test_process_worker_auto_uv_command_uses_absolute_project_path(
             {"working_dir": uv_project.name},
         )
 
-    assert mock_runner_execute_flow_run.call_args.kwargs[
+    assert mock_engine_command_starter.call_args.kwargs[
         "command"
     ] == expected_uv_command(uv_project)
 
 
 async def test_process_worker_preserves_explicitly_configured_engine_command(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,
     uv_project: Path,
@@ -635,14 +634,14 @@ async def test_process_worker_preserves_explicitly_configured_engine_command(
         )
 
     assert (
-        mock_runner_execute_flow_run.call_args.kwargs["command"]
+        mock_engine_command_starter.call_args.kwargs["command"]
         == "python -m prefect.engine"
     )
 
 
 async def test_process_worker_auto_uv_command_honors_job_variable_env(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,
     uv_project: Path,
@@ -659,14 +658,14 @@ async def test_process_worker_auto_uv_command_honors_job_variable_env(
             },
         )
 
-    assert mock_runner_execute_flow_run.call_args.kwargs[
+    assert mock_engine_command_starter.call_args.kwargs[
         "command"
     ] == expected_uv_command(uv_project)
 
 
 async def test_process_worker_keeps_engine_command_without_project(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
 ):
     with temporary_settings({PREFECT_RUNNER_AUTO_INSTALL_DEPENDENCIES: True}):
@@ -680,14 +679,14 @@ async def test_process_worker_keeps_engine_command_without_project(
             )
             await worker.run(flow_run=flow_run, configuration=configuration)
 
-    assert mock_runner_execute_flow_run.call_args.kwargs[
-        "command"
-    ] == command_to_string([get_sys_executable(), "-m", "prefect.engine"])
+    assert mock_engine_command_starter.call_args.kwargs["command"] == command_to_string(
+        [get_sys_executable(), "-m", "prefect.engine"]
+    )
 
 
 async def test_process_worker_stream_output_override(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     prefect_client: PrefectClient,
 ):
@@ -706,7 +705,7 @@ async def test_process_worker_stream_output_override(
 
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
-        assert mock_runner_execute_flow_run.call_args.kwargs["stream_output"] is True
+        assert mock_engine_command_starter.call_args.kwargs["stream_output"] is True
 
     assert flow_run.deployment_id is not None
     await prefect_client.update_deployment(
@@ -731,14 +730,13 @@ async def test_process_worker_stream_output_override(
 
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
-        assert mock_runner_execute_flow_run.call_args.kwargs["stream_output"] is False
+        assert mock_engine_command_starter.call_args.kwargs["stream_output"] is False
 
 
-async def test_process_worker_executes_flow_run_with_runner(
+async def test_process_worker_executes_flow_run_with_engine_starter(
     flow_run: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     async with ProcessWorker(work_pool_name=process_work_pool.name) as worker:
         configuration = await worker.job_configuration.resolve_for_flow_run(
@@ -759,23 +757,22 @@ async def test_process_worker_executes_flow_run_with_runner(
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
 
-        call_kwargs = mock_runner_execute_flow_run.call_args[1]
+        call_kwargs = mock_engine_command_starter.call_args.kwargs
 
         # should always execute in a tmp directory if working_dir not provided
         assert "tmp" in call_kwargs.pop("cwd")
         assert call_kwargs == dict(
-            flow_run_id=flow_run.id,
             command=configuration.command,
             env=configuration.env,
             stream_output=configuration.stream_output,
-            task_status=anyio.TASK_STATUS_IGNORED,
+            control_channel=ANY,
         )
 
 
 async def test_process_worker_command_override(
     deployment_with_overrides: Deployment,
     flow_run_with_deployment_overrides: FlowRun,
-    mock_runner_execute_flow_run: MagicMock,
+    mock_engine_command_starter: MagicMock,
     process_work_pool: WorkPool,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -795,13 +792,14 @@ async def test_process_worker_command_override(
 
         assert isinstance(result, ProcessWorkerResult)
         assert result.status_code == 0
-        mock_runner_execute_flow_run.assert_awaited_once_with(
-            flow_run_id=flow_run_with_deployment_overrides.id,
+        mock_engine_command_starter.assert_called_once_with(
             command=override_command,
             cwd=configuration.working_dir,
             env=configuration.env,
             stream_output=configuration.stream_output,
-            task_status=anyio.TASK_STATUS_IGNORED,
+            control_channel=mock_engine_command_starter.call_args.kwargs[
+                "control_channel"
+            ],
         )
 
 


### PR DESCRIPTION
this PR stops runners and workers from replacing a final state that the flow engine already reported.

Before this change, an engine could report a state such as Completed, Failed, Crashed, or Paused and then exit with a non-zero code. The runner only saw the exit code, so it could mark the run as an infrastructure crash and replace the real state.

## What changes

Each run attempt now uses an authenticated local control connection. After the API accepts a final state, the engine can send a small outcome receipt to the runner. The first valid outcome receipt or accepted control request wins for that attempt.

If the runner receives an outcome receipt, it keeps the engine state. If it receives no receipt, it still uses the process exit code. This keeps the old fallback behavior for crashes and older processes.

Late cancellation or reschedule requests cannot replace a state backed by a receipt. Only the thread that owns the control session can send a receipt, so a threaded subflow cannot report an outcome for its parent. Closing the control connection during startup is also handled safely.

The same rules now apply to command runs, direct subprocess runs, bundles, and ProcessWorker runs.

The engine still runs hooks for states that it reports. The runner only runs crashed hooks when it has no receipt and must classify an unclear process exit.

## Compatibility and limits

Older processes do not support outcome receipts. They continue to use the existing control protocol and exit-code behavior.

One race cannot be removed: a process may report its state to the API and die before its receipt reaches the runner. In that case, the runner has no proof that the engine handled the run, so it uses the exit code.