### PR TITLE
Defer deployment resource loading in event combobox

### DIFF
--- a/ui-v2/src/components/automations/automations-wizard/trigger-step/event-resource-combobox/event-resource-combobox.test.tsx
+++ b/ui-v2/src/components/automations/automations-wizard/trigger-step/event-resource-combobox/event-resource-combobox.test.tsx
@@ -41,6 +41,8 @@ const MOCK_WORK_QUEUES = [
 	createFakeWorkQueue({ id: "work-queue-2", name: "Test Work Queue 2" }),
 ];
 
+let deploymentFilterRequestCount = 0;
+
 const mockResourceAPIs = () => {
 	server.use(
 		http.post(buildApiUrl("/automations/filter"), () => {
@@ -50,6 +52,7 @@ const mockResourceAPIs = () => {
 			return HttpResponse.json(MOCK_BLOCKS);
 		}),
 		http.post(buildApiUrl("/deployments/filter"), () => {
+			deploymentFilterRequestCount += 1;
 			return HttpResponse.json(MOCK_DEPLOYMENTS);
 		}),
 		http.post(buildApiUrl("/flows/filter"), () => {
@@ -73,6 +76,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+	deploymentFilterRequestCount = 0;
 	mockResourceAPIs();
 });
 
@@ -103,6 +107,25 @@ describe("EventResourceCombobox", () => {
 
 		await waitFor(() => {
 			expect(screen.getByText("Select resources")).toBeInTheDocument();
+		});
+	});
+
+	it("loads deployments only after the dropdown is opened", async () => {
+		const user = userEvent.setup();
+		render(
+			<EventResourceCombobox
+				selectedResourceIds={[]}
+				onToggleResource={vi.fn()}
+			/>,
+			{ wrapper: createWrapper() },
+		);
+
+		expect(deploymentFilterRequestCount).toBe(0);
+
+		await user.click(await screen.findByRole("button"));
+
+		await waitFor(() => {
+			expect(deploymentFilterRequestCount).toBe(1);
 		});
 	});
 

--- a/ui-v2/src/components/automations/automations-wizard/trigger-step/event-resource-combobox/event-resource-combobox.tsx
+++ b/ui-v2/src/components/automations/automations-wizard/trigger-step/event-resource-combobox/event-resource-combobox.tsx
@@ -37,6 +37,7 @@ export function EventResourceCombobox({
 	onToggleResource,
 	emptyMessage = "All resources",
 }: EventResourceComboboxProps) {
+	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
 	const deferredSearch = useDeferredValue(search);
 	const [containerWidth, setContainerWidth] = useState(0);
@@ -58,8 +59,10 @@ export function EventResourceCombobox({
 		return () => observer.disconnect();
 	}, []);
 
-	// Use existing hook that fetches all resource types
-	const { resourceOptions } = useResourceOptions();
+	// Deployment lists can be large, so defer that request until the dropdown is opened.
+	const { resourceOptions } = useResourceOptions({
+		deploymentsEnabled: open,
+	});
 
 	// Group resources by type
 	const groupedResources = useMemo(() => {
@@ -209,7 +212,7 @@ export function EventResourceCombobox({
 	};
 
 	return (
-		<Combobox>
+		<Combobox onOpenChange={setOpen}>
 			<ComboboxTrigger selected={selectedResourceIds.length > 0}>
 				{renderSelectedResources()}
 			</ComboboxTrigger>

--- a/ui-v2/src/components/events/events-resource-filter/use-resource-options.ts
+++ b/ui-v2/src/components/events/events-resource-filter/use-resource-options.ts
@@ -20,7 +20,14 @@ export type ResourceOption = {
 	resourceId: string;
 };
 
-export const useResourceOptions = (): { resourceOptions: ResourceOption[] } => {
+export type UseResourceOptionsParams = {
+	/** Whether to fetch the potentially large deployment resource list. */
+	deploymentsEnabled?: boolean;
+};
+
+export const useResourceOptions = ({
+	deploymentsEnabled = true,
+}: UseResourceOptionsParams = {}): { resourceOptions: ResourceOption[] } => {
 	const [
 		{ data: automations },
 		{ data: blocks },
@@ -32,7 +39,9 @@ export const useResourceOptions = (): { resourceOptions: ResourceOption[] } => {
 		queries: [
 			buildListAutomationsQuery(),
 			buildListFilterBlockDocumentsQuery(),
-			buildFilterDeploymentsQuery(),
+			buildFilterDeploymentsQuery(undefined, {
+				enabled: deploymentsEnabled,
+			}),
 			buildListFlowsQuery(),
 			buildFilterWorkPoolsQuery(),
 			buildFilterWorkQueuesQuery(),

--- a/ui-v2/src/components/ui/combobox/combobox.tsx
+++ b/ui-v2/src/components/ui/combobox/combobox.tsx
@@ -21,11 +21,22 @@ const ComboboxContext = createContext<{
 	setOpen: (open: boolean) => void;
 } | null>(null);
 
-const Combobox = ({ children }: { children: React.ReactNode }) => {
+type ComboboxProps = {
+	children: React.ReactNode;
+	onOpenChange?: (open: boolean) => void;
+};
+
+const Combobox = ({ children, onOpenChange }: ComboboxProps) => {
 	const [open, setOpen] = useState(false);
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		onOpenChange?.(nextOpen);
+	};
+
 	return (
-		<ComboboxContext.Provider value={{ open, setOpen }}>
-			<Popover open={open} onOpenChange={setOpen}>
+		<ComboboxContext.Provider value={{ open, setOpen: handleOpenChange }}>
+			<Popover open={open} onOpenChange={handleOpenChange}>
 				{children}
 			</Popover>
 		</ComboboxContext.Provider>


### PR DESCRIPTION
## Summary

- Defer the deployment resource query in `EventResourceCombobox` until the dropdown is opened.
- Expose an `onOpenChange` callback from the shared `Combobox` component so consumers can control lazy query state.
- Add a regression test that verifies the deployment filter endpoint is not requested on initial render.

## Why

`useResourceOptions` is used by the automation trigger resource combobox and currently starts all resource queries as soon as the component mounts. The deployment filter is unbounded and can return a large catalog on self-hosted installations, so it adds avoidable work to the initial deployment page load.

The hook keeps deployment loading enabled by default for existing consumers. Only `EventResourceCombobox` opts into the lazy behavior, and opening the dropdown enables the existing query without changing the API contract or filtering semantics.

Relates to #22505.

## Validation

- `npm test -- --run src/components/automations/automations-wizard/trigger-step/event-resource-combobox/event-resource-combobox.test.tsx src/components/events/events-resource-filter/use-resource-options.test.ts`
- `npx biome check` on the four changed files
- `npx eslint .` (no errors; existing repository warnings remain)
- `npm run validate:types -- --pretty false`
- `npm run build`
