### PR TITLE
Fix stale Azure Container Instance examples

### DIFF
--- a/src/integrations/prefect-azure/README.md
+++ b/src/integrations/prefect-azure/README.md
@@ -103,81 +103,19 @@ custom_blob_storage_download_flow = example_blob_storage_download_flow.with_opti
 )
 ```
 
-### Run a command on an Azure container instance
-
-```python
-from prefect import flow
-from prefect_azure import AzureContainerInstanceCredentials
-from prefect_azure.container_instance import AzureContainerInstanceJob
-
-
-@flow
-def container_instance_job_flow():
-    aci_credentials = AzureContainerInstanceCredentials.load("MY_BLOCK_NAME")
-    container_instance_job = AzureContainerInstanceJob(
-        aci_credentials=aci_credentials,
-        resource_group_name="azure_resource_group.example.name",
-        subscription_id="<MY_AZURE_SUBSCRIPTION_ID>",
-        command=["echo", "hello world"],
-    )
-    return container_instance_job.run()
-```
-
-### Use Azure Container Instance as infrastructure
-
-If we have `a_flow_module.py`:
-
-```python
-from prefect import flow
-from prefect.logging import get_run_logger
-
-@flow
-def log_hello_flow(name="Marvin"):
-    logger = get_run_logger()
-    logger.info(f"{name} said hello!")
-
-if __name__ == "__main__":
-    log_hello_flow()
-```
-
-We can run that flow using an Azure Container Instance, but first create the infrastructure block:
-
-```python
-from prefect_azure import AzureContainerInstanceCredentials
-from prefect_azure.container_instance import AzureContainerInstanceJob
-
-container_instance_job = AzureContainerInstanceJob(
-    aci_credentials=AzureContainerInstanceCredentials.load("MY_BLOCK_NAME"),
-    resource_group_name="azure_resource_group.example.name",
-    subscription_id="<MY_AZURE_SUBSCRIPTION_ID>",
-)
-container_instance_job.save("aci-dev")
-```
-
-Then, create the deployment either on the UI or through the CLI:
-
-```bash
-prefect deployment build a_flow_module.py:log_hello_flow --name aci-dev -ib container-instance-job/aci-dev
-```
-
-Visit [Prefect Deployments](https://docs.prefect.io/latest/deploy/) for more information about deployments.
-
 ## Azure Container Instance Worker
 
-The Azure Container Instance worker is an excellent way to run
-your workflows on Azure.
+Use the Azure Container Instance worker to run flow runs in Azure Container
+Instances.
 
 To get started, create an Azure Container Instances typed work pool:
 
-```
-prefect work-pool create -t azure-container-instance my-aci-work-pool
+```bash
+prefect work-pool create --type azure-container-instance my-aci-work-pool
 ```
 
 Then, run a worker that pulls jobs from the work pool:
 
+```bash
+prefect worker start --pool my-aci-work-pool --type azure-container-instance
 ```
-prefect worker start -n my-aci-worker -p my-aci-work-pool
-```
-
-The worker should automatically read the work pool's type and start an
-Azure Container Instance worker.

--- a/src/integrations/prefect-azure/prefect_azure/container_instance.py
+++ b/src/integrations/prefect-azure/prefect_azure/container_instance.py
@@ -1,64 +1,13 @@
 """
-Integrations with the Azure Container Instances service.
-Note this module is experimental. The interfaces within may change without notice.
+Helpers for the Azure Container Instance worker.
 
-The `AzureContainerInstanceJob` infrastructure block in this module is ideally
-configured via the Prefect UI and run via a Prefect agent, but it can be called directly
-as demonstrated in the following examples.
+Use a work pool of type `azure-container-instance` and an Azure Container
+Instance worker to run flow runs in Azure Container Instances.
 
 Examples:
-    Run a command using an Azure Container Instances container.
-    ```python
-    AzureContainerInstanceJob(command=["echo", "hello world"]).run()
-    ```
-
-    Run a command and stream the container's output to the local terminal.
-    ```python
-    AzureContainerInstanceJob(
-        command=["echo", "hello world"],
-        stream_output=True,
-    )
-    ```
-
-    Run a command with a specific image
-    ```python
-    AzureContainerInstanceJob(command=["echo", "hello world"], image="alpine:latest")
-    ```
-
-    Run a task with custom memory and CPU requirements
-    ```python
-    AzureContainerInstanceJob(command=["echo", "hello world"], memory=1.0, cpu=1.0)
-    ```
-
-    Run a task with custom memory and CPU requirements
-    ```python
-    AzureContainerInstanceJob(command=["echo", "hello world"], memory=1.0, cpu=1.0)
-    ```
-
-    Run a task with custom memory, CPU, and GPU requirements
-    ```python
-    AzureContainerInstanceJob(command=["echo", "hello world"], memory=1.0, cpu=1.0,
-    gpu_count=1, gpu_sku="V100")
-    ```
-
-    Run a task with custom environment variables
-    ```python
-    AzureContainerInstanceJob(
-        command=["echo", "hello $PLANET"],
-        env={"PLANET": "earth"}
-    )
-    ```
-
-    Run a task that uses a private ACR registry with a managed identity
-    ```python
-    AzureContainerInstanceJob(
-        command=["echo", "hello $PLANET"],
-        image="my-registry.azurecr.io/my-image",
-        image_registry=ACRManagedIdentity(
-            registry_url="my-registry.azurecr.io",
-            identity="/my/managed/identity/123abc"
-        )
-    )
+    ```bash
+    prefect work-pool create --type azure-container-instance my-aci-work-pool
+    prefect worker start --pool my-aci-work-pool --type azure-container-instance
     ```
 """
 
@@ -124,5 +73,5 @@ class ACRManagedIdentity(BaseModel):
 
 class AzureContainerInstanceJobResult:
     """
-    The result of an `AzureContainerInstanceJob` run.
+    Legacy result type retained for compatibility with earlier integrations.
     """


### PR DESCRIPTION
## Summary

- remove `AzureContainerInstanceJob` examples that no longer work in Prefect 3
- replace them with the supported Azure Container Instance work-pool and worker commands
- clarify that the remaining `AzureContainerInstanceJobResult` type is retained only for compatibility

`AzureContainerInstanceJob` was removed from `prefect-azure`, but the package README and module docstring still imported and invoked it. This left users with examples that fail against the current package. The updated examples now point to the implemented `azure-container-instance` worker path.

Related to #22028. This intentionally does not close the issue because the broader Azure Container Apps/jobs feature request remains open and is outside this documentation-only change.

## Validation

- focused Ruff check and format check on `container_instance.py`
- Python byte-compilation of `container_instance.py`
- focused pre-commit hooks for Ruff, codespell, and documentation formatting
- current CLI help verified for both worker commands
- `git diff --check`

No runtime tests were added because this changes only a README and source docstrings. The generated API-reference page was not edited directly; it is generated from the corrected source docstring.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - The related issue is linked above but is deliberately not closed because its broader feature request remains unresolved.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  - Not applicable; this is a narrow documentation correction.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
  - No functionality changes; validation is documented above.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - This change corrects the user-facing documentation itself.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
  - No documentation files are removed.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
  - No functions or classes are added.
