### PR TITLE
docker: bind-mount the sdist so it stops shipping in the published image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,7 @@ ARG PREFECT_EXTRAS=[redis,client,otel]
 
 # Install prefect from the sdist.
 #
-# The sdist is bind-mounted rather than COPYed. A COPY commits the archive to its
+# The sdist is bind-mounted rather than copied. A COPY commits the archive to its
 # own layer, and a `rm -rf` in a later RUN can only add a whiteout on top of that
 # layer -- it cannot remove it from the image, so the archive ships in everything
 # we push. A bind mount is never committed to a layer.

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,14 +182,18 @@ RUN ldconfig
 # Install UV from official image - pin to specific version for build caching
 COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /bin/uv
 
-# Install prefect from the sdist
-COPY --from=python-builder /opt/prefect/dist ./dist
-
 # Extras to include during installation
 ARG PREFECT_EXTRAS=[redis,client,otel]
+
+# Install prefect from the sdist.
+#
+# The sdist is bind-mounted rather than COPYed. A COPY commits the archive to its
+# own layer, and a `rm -rf` in a later RUN can only add a whiteout on top of that
+# layer -- it cannot remove it from the image, so the archive ships in everything
+# we push. A bind mount is never committed to a layer.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    UV_COMPILE_BYTECODE=1 uv pip install "./dist/prefect.tar.gz${PREFECT_EXTRAS:-""}" && \
-    rm -rf dist/
+    --mount=type=bind,from=python-builder,source=/opt/prefect/dist,target=/dist \
+    UV_COMPILE_BYTECODE=1 uv pip install "/dist/prefect.tar.gz${PREFECT_EXTRAS:-""}"
 
 # Setuptools is required by pip in the conda environment. Remove it only from
 # base images where it is not managed as part of the environment.


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/22831

### The change

`Dockerfile` `COPY`s the built sdist into the final stage, installs it, then `rm -rf dist/`.
The `rm` runs one layer after the `COPY`, so it writes a whiteout instead of removing
the archive and both layers are pushed — 14,493,196 bytes (4.8% of
`prefecthq/prefect:3-latest`) in every published image. The measurement is in the linked issue.

This bind-mounts the sdist instead of copying it. A bind mount is never committed to a
layer, so there is nothing to whiteout and the `rm` is no longer needed.
`--mount=type=cache` is already on this same `RUN`, so BuildKit and the mount syntax are
established in this build; the change adds no new build requirement.

`ARG PREFECT_EXTRAS` moves above the `RUN` because the `COPY` that used to sit between
them is gone. Its value and default are untouched.

### Why this is safe

**The container filesystem is unchanged.** `/opt/prefect/dist` did not exist at runtime
before this change either — it was whiteout-deleted a layer later. The only difference
is which bytes get pushed. Nothing in the repo reads that path at runtime; `Dockerfile`'s
remaining stages and `scripts/entrypoint.sh` do not reference it.

### On validating locally, since the template asks

I should be straight about this rather than leave it implied: **I have no docker daemon
available, so I have not built this image.** I am not going to claim a build I did not
run. What I did do:

- **Measured the defect off your published artifacts**, not off the source — every tag
  and both architectures in the linked issue, read from the registry API.
- **Tested the one thing that could actually break.** The risk in this patch is whether
  `uv pip install` tolerates a read-only mount. Against uv `0.12.3`, the version pinned
  on line 183, an sdist installs from a read-only directory with the `[extras]`
  suffix and `UV_COMPILE_BYTECODE=1`: exit 0, and nothing written back into the mounted
  directory.
- **Checked what CI will do with it.** `.github/workflows/time-docker-build.yaml` fires
  on `pull_request` for `paths: [Dockerfile, .dockerignore]` and builds `linux/amd64,linux/arm64`
  with `--no-cache`, comparing build time against base and failing past +5%. That build
  runs on this PR and is the check that matters here. I would expect time flat or
  slightly down — one fewer layer to commit — but that is a prediction, not a result,
  and the run on this PR settles it.

If you would rather carry this yourself than review a patch its author could not build,
that is a completely reasonable call and the issue stands on its own without the PR.

### Scope

`client/Dockerfile` has the same shape, measured at 926,772 bytes (0.7%) of
`prefecthq/prefect-client:3-latest`. This PR leaves it alone: no `pull_request` workflow builds
that file, so including it would put an unverified change beside a CI-verified one.

### Checklist

- [x] References the related issue — `closes https://github.com/PrefectHQ/prefect/issues/22831`.
- [x] Not a complex change: two instructions in one file, no behaviour change inside the
      container.
- [x] No tests added. This is a build-time change with no runtime surface; the
      `linux/amd64,linux/arm64` image build already triggered by this PR is the test.
- [x] No documentation change. No user-facing behaviour changes — same packages, same
      filesystem, same entrypoint.
- [x] Removes no docs files.
- [x] Adds no functions or classes.

Signed-off-by: Sujeito Operator <operator@sujeito.org>
