### PR TITLE
Honor a prefetch_seconds of 0 in BaseWorker

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -673,7 +673,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         self._cleanup_handler_registry = build_cleanup_handler_registry(self)
 
         self._prefetch_seconds: float = (
-            prefetch_seconds or PREFECT_WORKER_PREFETCH_SECONDS.value()
+            prefetch_seconds
+            if prefetch_seconds is not None
+            else PREFECT_WORKER_PREFETCH_SECONDS.value()
         )
         self.heartbeat_interval_seconds: int = (
             heartbeat_interval_seconds or PREFECT_WORKER_HEARTBEAT_SECONDS.value()

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -454,6 +454,15 @@ async def test_worker_respects_prefetch_seconds():
     )
 
 
+async def test_worker_respects_a_prefetch_seconds_of_zero():
+    """0 means no lookahead, and the CLI resolves it with an is-None check, so the
+    worker must not fall back to the setting default."""
+    worker = WorkerTestImpl(
+        name="test", work_pool_name="test-work-pool", prefetch_seconds=0
+    )
+    assert worker.get_status()["settings"]["prefetch_seconds"] == 0
+
+
 async def test_worker_sends_heartbeat_messages(
     prefect_client: PrefectClient,
     worker_channel_endpoint_unavailable: None,


### PR DESCRIPTION
--- LETTER BELOW THIS LINE ---
`BaseWorker.__init__` resolves the prefetch window with `prefetch_seconds or PREFECT_WORKER_PREFETCH_SECONDS.value()`, so passing `0` is treated as if nothing was passed and becomes the default of 10.

`0` is a meaningful value. `_prefetch_seconds` sets the scheduled-run lookahead, `now() + timedelta(seconds=self._prefetch_seconds)`, so `0` means "only claim runs due now", and a positive value widens the window. The CLI already honors it: `cli/worker.py` resolves `--prefetch-seconds` with `if prefetch_seconds is None:`, so `0` survives the parse, then hands it to `BaseWorker`, which discards it. `runner.py` assigns the same kind of value directly. Two of the three handlers for this parameter keep `0`. The worker constructor is the one that drops it.

So `prefect worker start --prefetch-seconds 0` silently looks ahead 10 seconds instead of 0.

Measured against the library: `None` gives 10.0 and `25` gives 25, while both `0` and `0.0` come back as 10.0.

The fix matches the CLI's form, +3/-1:

```python
if prefetch_seconds is not None:
    self._prefetch_seconds = prefetch_seconds
else:
    self._prefetch_seconds = PREFECT_WORKER_PREFETCH_SECONDS.value()
```

I added a test that fails on the current code (`assert 10.0 == 0`) and passes with the fix. `None` still yields 10.0. One file in the suite has a pre-existing failure, `TestSubmit::test_basic`, which also fails on an unmodified checkout and is unrelated to this change.

I did not run a live worker against a server. `heartbeat_interval_seconds` two lines down has the same `or` shape but I left it, since `0` there is a busy loop, not a setting.
