### PR TITLE
Guard seven-field cron expressions in the schedule UI

### DIFF
--- a/ui-v2/src/components/AGENTS.md
+++ b/ui-v2/src/components/AGENTS.md
@@ -46,7 +46,7 @@ This directory contains React components for the Prefect UI migration from Vue t
 
 ## Cron Expression Divergence
 
-`cronstrue.toString()` can successfully describe cron expressions that behave differently on the server, which schedules on `croniter` (e.g., slash-steps starting at a field's max value like `23/6 * * *`, equal low/high ranges, or 6-field crons). Guard any cron string from user input or the API with `divergesFromServerCron()` from `@/components/ui/cron-input` before trusting `cronstrue` output — reject on input forms, but fall back to rendering the raw cron string when displaying an already-saved schedule.
+`cronstrue.toString()` can successfully describe cron expressions that behave differently on the server, which schedules on `croniter` (e.g., slash-steps starting at a field's max value like `23/6 * * *`, equal low/high ranges, or 6- and 7-field crons). Guard any cron string from user input or the API with `divergesFromServerCron()` from `@/components/ui/cron-input` before trusting `cronstrue` output — reject on input forms, but fall back to rendering the raw cron string when displaying an already-saved schedule.
 
 ## Code Style
 

--- a/ui-v2/src/components/deployments/deployment-schedules/get-schedule-title.test.ts
+++ b/ui-v2/src/components/deployments/deployment-schedules/get-schedule-title.test.ts
@@ -79,6 +79,21 @@ describe("getScheduleTitle()", () => {
 		expect(RESULT).toBe("59/15 * * * * *");
 	});
 
+	it("returns the raw cron string for a seven-field cron expression", () => {
+		const mockDeploymentSchedule: DeploymentSchedule = {
+			...baseDeploymentSchedule,
+			schedule: {
+				cron: "* 12-23 * * * */30 2027",
+				timezone: "UTC",
+				day_or: true,
+			},
+		};
+
+		const RESULT = getScheduleTitle(mockDeploymentSchedule);
+
+		expect(RESULT).toBe("* 12-23 * * * */30 2027");
+	});
+
 	it("returns the raw cron string for a diverging step", () => {
 		const mockDeploymentSchedule: DeploymentSchedule = {
 			...baseDeploymentSchedule,

--- a/ui-v2/src/components/ui/cron-input/utils.ts
+++ b/ui-v2/src/components/ui/cron-input/utils.ts
@@ -1,6 +1,6 @@
 /**
  * Guards against croniter whole-cycle mismatches: low==high ranges, max-start
- * slash steps, and 6-field seconds-position parsing.
+ * slash steps, and seconds-position parsing in 6- and 7-field expressions.
  */
 const FIELD_MAX = [59, 23, 31, 12, 6];
 
@@ -70,7 +70,10 @@ const tokenDiverges = (token: string, index: number): boolean => {
 export const divergesFromServerCron = (cron: string): boolean => {
 	const fields = cron.trim().split(/\s+/);
 
-	if (fields.length === 6) {
+	// croniter reads the seconds field last (and an optional year after it),
+	// while cronstrue reads seconds first, so no 6- or 7-field expression can
+	// be described from the raw string.
+	if (fields.length >= 6) {
 		return true;
 	}
 

--- a/ui-v2/src/components/ui/schedule-badge/schedule-badge.test.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/schedule-badge.test.tsx
@@ -61,6 +61,25 @@ describe("ScheduleBadge", () => {
 		);
 	});
 
+	it("renders a seven-field cron schedule using the raw cron string", () => {
+		const schedule = {
+			id: "test-id",
+			created: new Date().toISOString(),
+			updated: new Date().toISOString(),
+			active: true,
+			schedule: {
+				cron: "* 12-23 * * * */30 2027",
+				timezone: "UTC",
+				day_or: false,
+			},
+		};
+
+		render(<ScheduleBadge schedule={schedule} />);
+
+		expect(screen.getByText("* 12-23 * * * */30 2027")).toBeInTheDocument();
+		expect(screen.queryByText(/every second/i)).not.toBeInTheDocument();
+	});
+
 	it("renders a paused cron schedule correctly", async () => {
 		const user = userEvent.setup();
 		const schedule = {


### PR DESCRIPTION
`divergesFromServerCron()` guards six-field cron expressions, but seven-field expressions fall through to `cronstrue`, which describes them with the seconds field in the wrong position. The UI then shows a schedule description that contradicts what the server will actually run.

Follow-up to #22404, which introduced the guard.

### Reproduction

`* 12-23 * * * */30 2027` is accepted by the API — `validate_cron_string()` only checks `croniter.is_valid()`, which returns `True` for seven fields — so it can be saved through `prefect.yaml` or the REST API and then rendered by the UI.

| | interpretation |
|---|---|
| `croniter` (server, seconds second-to-last) | every 30 seconds, hours 12–23, during 2027 |
| `cronstrue` (UI, seconds first) | "Every second, minutes 12 through 23 past the hour, every 30 days of the week, only in 2027" |

Server-side, using the vendored croniter:

```python
from prefect._vendor.croniter import croniter
import datetime

it = croniter("* 12-23 * * * */30 2027", datetime.datetime(2026, 1, 1, 13, 0, 0))
[str(it.get_next(datetime.datetime)) for _ in range(3)]
# ['2027-01-01 12:00:00', '2027-01-01 12:00:30', '2027-01-01 12:01:00']
```

Before this change, `ScheduleBadge` rendered that schedule as:

```
Every second, minutes 12 through 23 past the hour, every 30 days of the week, only in 2027
```

### Fix

`divergesFromServerCron()` now treats any expression with six or more fields as divergent, rather than exactly six. The two display sites — `getScheduleTitle()` and `ScheduleBadge` — fall back to rendering the raw cron string, which is the behaviour `ui-v2/src/components/AGENTS.md` already prescribes.

The input paths were already safe, but incidentally rather than by the guard: both `CronInput` and `cron-schedule-form` call `CronExpressionParser.parse()` first, and `cron-parser` throws `"too many fields"` on seven fields before `divergesFromServerCron()` is consulted. Only the display paths for already-saved schedules were affected.

### Tests

Added a seven-field case alongside the existing six-field case in both display sites' suites. Both fail before the change and pass after:

- `get-schedule-title.test.ts` — "returns the raw cron string for a seven-field cron expression"
- `schedule-badge.test.tsx` — "renders a seven-field cron schedule using the raw cron string"

`tsc -b --noEmit` and `biome check` are clean. The full `ui-v2` suite shows no change against unmodified `main` — the only failures locally are pre-existing timezone-dependent date-formatting tests that fail identically on `main`.
