### PR TITLE
fix(ui-v2): pass skipUpdateTransform=false to fix invisible graph nodes

### DIFF
--- a/ui-v2/src/graphs/objects/culling.ts
+++ b/ui-v2/src/graphs/objects/culling.ts
@@ -41,11 +41,18 @@ export async function startCulling(): Promise<void> {
 			labelCuller?.toggle(labelsVisible);
 			iconCuller?.toggle(iconsVisible);
 			toggleCuller?.toggle(togglesVisible);
-			// Use PixiJS v8 native culling via Culler.shared
+			// Use PixiJS v8 native culling via Culler.shared.
+			// skipUpdateTransform must be false so bounds are computed from current
+			// position values rather than the cached worldTransform. The cache is
+			// only refreshed by the renderer (LOW priority), which runs after this
+			// culling callback (NORMAL priority) in the same ticker frame. Without
+			// this, nodes culled during the frame after centerViewport() moves the
+			// viewport remain invisible until the next user interaction.
 			const { screen } = application;
 			Culler.shared.cull(
 				application.stage,
 				new Rectangle(screen.x, screen.y, screen.width, screen.height),
+				false,
 			);
 
 			viewport.dirty = false;


### PR DESCRIPTION

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.


## Problem                                                                                                                                                            
   
In complicated flow run graphs, some task nodes were invisible on initial page load. Any user interaction (zoom, pan) would immediately make them visible again.      
                                                                                                                                                                      
## Root Cause                                                                                                                                                         
                                                                                                                                                                      
`Culler.shared.cull()` defaults to `skipUpdateTransform = true`, meaning it uses **cached** world transforms from the previous render cycle. The culling ticker runs  at `NORMAL` priority in `application.ticker`, while the renderer runs at `LOW` priority — so culling always fires before transforms are updated. Meanwhile,  pixi-viewport runs on a separate `Ticker.shared` instance. After `centerViewport()` moved the viewport to its correct position, the next culling pass still used stale transforms reflecting the old viewport position, causing nodes at large coordinates to be incorrectly culled.                                                      

## Fix                                                                                                                                                                
  
Pass `false` as the `skipUpdateTransform` argument to `Culler.shared.cull()` so bounds are computed from current position values rather than the stale cache.                                                                                                                                                               
                                                                                                                                                                                                                                   
🤖 Root cause identified and fix written by AI. Tested on a real flow run by a human.
  
Screenshots:                                                                                                                                                      
                                                                                                                                                                        
Before                                                                                                                                                                
<img width="1151" height="524" alt="Screenshot 2026-08-17 at 15 42 38" src="https://github.com/user-attachments/assets/2323fe22-fd9b-40d5-9a29-c88c1f12accd" />
                                                                                                                                                       
After
<img width="1151" height="524" alt="Screenshot 2026-08-17 at 15 43 10" src="https://github.com/user-attachments/assets/2aba21c9-e9db-4683-b271-434ec50fdad1" />
