### PR TITLE
Add opt-in Logfire test profiling

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -321,7 +321,7 @@ jobs:
         run: |
           if [[ -z "$LOGFIRE_TOKEN" ]]; then
             echo "::error::Logfire profiling requires the" \
-              "LOGFIRE_TEST_PROFILE_TOKEN repository secret"
+              "LOGFIRE_TEST_PROFILE_TOKEN environment secret"
             exit 1
           fi
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -344,6 +344,7 @@ jobs:
       - name: Run tests with Logfire
         env:
           LOGFIRE_CONSOLE: "false"
+          LOGFIRE_DISTRIBUTED_TRACING: "true"
           LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TEST_PROFILE_TOKEN }}
           PREFECT_LOGFIRE_ENABLED: "false"
         run: |
@@ -354,7 +355,9 @@ jobs:
             exit 1
           fi
 
+          # These tests assert that Prefect's outermost run span has no parent.
           uv run --no-sync pytest ${{ matrix.test-type.modules }} \
+          --ignore=tests/telemetry/test_run_telemetry.py \
           -m "not windows" \
           --numprocesses auto \
           --maxprocesses 6 \

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -6,6 +6,15 @@ env:
   PY_COLORS: 1
 
 on:
+  workflow_dispatch:
+    inputs:
+      logfire_profile:
+        description: >-
+          Trace default-branch Python 3.12/PostgreSQL tests in Logfire
+          (uploads test parameters and failures)
+        required: true
+        default: false
+        type: boolean
   pull_request:
     paths:
       - .github/workflows/python-tests.yaml
@@ -46,9 +55,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  reject-unsafe-logfire-profile:
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch'
+      && inputs.logfire_profile
+      && (github.ref_type != 'branch'
+      || github.ref != format('refs/heads/{0}',
+      github.event.repository.default_branch)) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::Logfire profiles may only run from the default branch"
+          exit 1
+
   run-tests:
+    if: >-
+      ${{ github.event_name != 'workflow_dispatch'
+      || !inputs.logfire_profile
+      || (github.ref_type == 'branch'
+      && github.ref == format('refs/heads/{0}',
+      github.event.repository.default_branch)) }}
     runs-on: ubuntu-latest
     name: ${{ matrix.test-type.name }} - python:${{ matrix.python-version }}, ${{ matrix.database }}
+    environment:
+      name: ${{ matrix.logfire_profile && 'logfire-profiling' || '' }}
+      deployment: false
 
     services:
       redis:
@@ -157,7 +188,22 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+        logfire_profile:
+          - >-
+            ${{ github.event_name == 'workflow_dispatch'
+            && inputs.logfire_profile }}
         exclude:
+          # Logfire profiles cover the canonical Python/PostgreSQL suite only.
+          - logfire_profile: true
+            database: "sqlite"
+          - logfire_profile: true
+            python-version: "3.10"
+          - logfire_profile: true
+            python-version: "3.11"
+          - logfire_profile: true
+            python-version: "3.13"
+          - logfire_profile: true
+            python-version: "3.14"
           - database: "sqlite"
             test-type:
               name: "Client Tests: Modules"
@@ -222,7 +268,7 @@ jobs:
               name: Runner, Worker, Settings, Input, and CLI Tests
               modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
 
-    timeout-minutes: 15
+    timeout-minutes: ${{ matrix.logfire_profile && 30 || 15 }}
 
     steps:
       - name: Display current test matrix
@@ -242,13 +288,19 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install packages
+        if: ${{ !matrix.logfire_profile }}
         run: uv sync --locked
+
+      - name: Install packages for Logfire profiling
+        if: matrix.logfire_profile
+        run: uv sync --locked --group perf
 
       - name: Set database connection URL
         if: ${{ startsWith(matrix.database, 'postgres') }}
         run: echo "PREFECT_SERVER_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
+        if: ${{ !matrix.logfire_profile }}
         run: |
           uv run pytest ${{ matrix.test-type.modules }} \
           -m "not windows" \
@@ -258,7 +310,33 @@ jobs:
           --disable-docker-image-builds \
           --exclude-service kubernetes \
           --exclude-service docker \
+          --durations 26
+
+      - name: Run tests with Logfire
+        if: matrix.logfire_profile
+        env:
+          LOGFIRE_CONSOLE: "false"
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TEST_PROFILE_TOKEN }}
+          PREFECT_LOGFIRE_ENABLED: "false"
+        run: |
+          if [[ -z "$LOGFIRE_TOKEN" ]]; then
+            echo "::error::Logfire profiling requires the" \
+              "LOGFIRE_TEST_PROFILE_TOKEN repository secret"
+            exit 1
+          fi
+
+          uv run --no-sync pytest ${{ matrix.test-type.modules }} \
+          -m "not windows" \
+          --numprocesses auto \
+          --maxprocesses 6 \
+          --dist worksteal \
+          --disable-docker-image-builds \
+          --exclude-service kubernetes \
+          --exclude-service docker \
           --durations 26 \
+          --logfire \
+          --logfire-trace-phases \
+          --logfire-service-name prefect-pytest-profile
 
       - name: Check database container
         # Only applicable for Postgres, but we want this to run even when tests fail
@@ -285,6 +363,9 @@ jobs:
         run: uv run --with pyyaml --no-project -s scripts/verify_test_selection.py
 
   run-docker-tests:
+    if: >-
+      ${{ github.event_name != 'workflow_dispatch'
+      || !inputs.logfire_profile }}
     runs-on: ubuntu-latest
     name: docker, python:${{ matrix.python-version }}
 
@@ -433,6 +514,9 @@ jobs:
           || echo "Ignoring bad exit code"
 
   run-typesafety-test:
+    if: >-
+      ${{ github.event_name != 'workflow_dispatch'
+      || !inputs.logfire_profile }}
     name: typesafety
     runs-on: ubuntu-latest
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -6,15 +6,10 @@ env:
   PY_COLORS: 1
 
 on:
-  workflow_dispatch:
-    inputs:
-      logfire_profile:
-        description: >-
-          Trace default-branch Python 3.12/PostgreSQL tests in Logfire
-          (uploads test parameters and failures)
-        required: true
-        default: false
-        type: boolean
+  # repository_dispatch executes the workflow definition from the default branch.
+  repository_dispatch:
+    types:
+      - logfire-test-profile
   pull_request:
     paths:
       - .github/workflows/python-tests.yaml
@@ -55,31 +50,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  reject-unsafe-logfire-profile:
-    if: >-
-      ${{ github.event_name == 'workflow_dispatch'
-      && inputs.logfire_profile
-      && (github.ref_type != 'branch'
-      || github.ref != format('refs/heads/{0}',
-      github.event.repository.default_branch)) }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "::error::Logfire profiles may only run from the default branch"
-          exit 1
-
   run-tests:
-    if: >-
-      ${{ github.event_name != 'workflow_dispatch'
-      || !inputs.logfire_profile
-      || (github.ref_type == 'branch'
-      && github.ref == format('refs/heads/{0}',
-      github.event.repository.default_branch)) }}
+    if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     name: ${{ matrix.test-type.name }} - python:${{ matrix.python-version }}, ${{ matrix.database }}
-    environment:
-      name: ${{ matrix.logfire_profile && 'logfire-profiling' || '' }}
-      deployment: false
 
     services:
       redis:
@@ -115,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type:
+        test-type: &python-test-types
           - name: Server Tests
             modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/orchestration/
           - name: Database Tests
@@ -188,22 +162,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
-        logfire_profile:
-          - >-
-            ${{ github.event_name == 'workflow_dispatch'
-            && inputs.logfire_profile }}
         exclude:
-          # Logfire profiles cover the canonical Python/PostgreSQL suite only.
-          - logfire_profile: true
-            database: "sqlite"
-          - logfire_profile: true
-            python-version: "3.10"
-          - logfire_profile: true
-            python-version: "3.11"
-          - logfire_profile: true
-            python-version: "3.13"
-          - logfire_profile: true
-            python-version: "3.14"
           - database: "sqlite"
             test-type:
               name: "Client Tests: Modules"
@@ -268,7 +227,7 @@ jobs:
               name: Runner, Worker, Settings, Input, and CLI Tests
               modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
 
-    timeout-minutes: ${{ matrix.logfire_profile && 30 || 15 }}
+    timeout-minutes: 15
 
     steps:
       - name: Display current test matrix
@@ -288,19 +247,13 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install packages
-        if: ${{ !matrix.logfire_profile }}
         run: uv sync --locked
-
-      - name: Install packages for Logfire profiling
-        if: matrix.logfire_profile
-        run: uv sync --locked --group perf
 
       - name: Set database connection URL
         if: ${{ startsWith(matrix.database, 'postgres') }}
         run: echo "PREFECT_SERVER_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
-        if: ${{ !matrix.logfire_profile }}
         run: |
           uv run pytest ${{ matrix.test-type.modules }} \
           -m "not windows" \
@@ -310,10 +263,85 @@ jobs:
           --disable-docker-image-builds \
           --exclude-service kubernetes \
           --exclude-service docker \
-          --durations 26
+          --durations 26 \
+
+      - name: Check database container
+        # Only applicable for Postgres, but we want this to run even when tests fail
+        if: always()
+        run: |
+          docker container inspect ${{ job.services.postgres.id }} \
+          && docker container logs ${{ job.services.postgres.id }} \
+          || echo "Ignoring bad exit code"
+
+  profile-tests-with-logfire:
+    if: ${{ github.event_name == 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    name: "Logfire: ${{ matrix.test-type.name }}"
+    timeout-minutes: 30
+    environment:
+      name: logfire-profiling
+      deployment: false
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      postgres:
+        image: postgres:14
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: prefect
+          POSTGRES_PASSWORD: prefect
+          POSTGRES_DB: prefect
+          LANG: C.UTF-8
+          LANGUAGE: C.UTF-8
+          LC_ALL: C.UTF-8
+          LC_COLLATE: C.UTF-8
+          LC_CTYPE: C.UTF-8
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --tmpfs /var/lib/postgresql/data
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: *python-test-types
+
+    steps:
+      - name: Display current test matrix
+        run: echo '${{ toJSON(matrix) }}'
+
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Set up uv and Python 3.12
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install packages
+        run: uv sync --locked --group perf
+
+      - name: Set database connection URL
+        run: echo "PREFECT_SERVER_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests with Logfire
-        if: matrix.logfire_profile
         env:
           LOGFIRE_CONSOLE: "false"
           LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TEST_PROFILE_TOKEN }}
@@ -321,7 +349,8 @@ jobs:
         run: |
           if [[ -z "$LOGFIRE_TOKEN" ]]; then
             echo "::error::Logfire profiling requires the" \
-              "LOGFIRE_TEST_PROFILE_TOKEN environment secret"
+              "LOGFIRE_TEST_PROFILE_TOKEN secret in the" \
+              "logfire-profiling environment"
             exit 1
           fi
 
@@ -339,7 +368,6 @@ jobs:
           --logfire-service-name prefect-pytest-profile
 
       - name: Check database container
-        # Only applicable for Postgres, but we want this to run even when tests fail
         if: always()
         run: |
           docker container inspect ${{ job.services.postgres.id }} \
@@ -363,9 +391,7 @@ jobs:
         run: uv run --with pyyaml --no-project -s scripts/verify_test_selection.py
 
   run-docker-tests:
-    if: >-
-      ${{ github.event_name != 'workflow_dispatch'
-      || !inputs.logfire_profile }}
+    if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     name: docker, python:${{ matrix.python-version }}
 
@@ -514,9 +540,7 @@ jobs:
           || echo "Ignoring bad exit code"
 
   run-typesafety-test:
-    if: >-
-      ${{ github.event_name != 'workflow_dispatch'
-      || !inputs.logfire_profile }}
+    if: ${{ github.event_name != 'repository_dispatch' }}
     name: typesafety
     runs-on: ubuntu-latest
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -90,15 +90,20 @@ jobs:
       fail-fast: false
       matrix:
         test-type: &python-test-types
-          - name: Server Tests
+          - id: server
+            name: Server Tests
             modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/orchestration/
-          - name: Database Tests
+          - id: database
+            name: Database Tests
             modules: tests/server/database/
-          - name: "Orchestration Tests: Core"
+          - id: orchestration-core
+            name: "Orchestration Tests: Core"
             modules: tests/server/orchestration/ --ignore=tests/server/orchestration/api/
-          - name: "Orchestration Tests: API"
+          - id: orchestration-api
+            name: "Orchestration Tests: API"
             modules: tests/server/orchestration/api/
-          - name: "Client Tests: Modules"
+          - id: client-modules
+            name: "Client Tests: Modules"
             modules: >-
               tests/
               --ignore=tests/typesafety
@@ -111,7 +116,8 @@ jobs:
               --ignore=tests/test_settings.py
               --ignore=tests/input/
               --ignore-glob="tests/test_*.py"
-          - name: "Client Tests: Top-Level"
+          - id: client-top-level
+            name: "Client Tests: Top-Level"
             modules: >-
               tests/test_artifacts.py
               tests/test_assets.py
@@ -136,7 +142,8 @@ jobs:
               tests/test_ui_build_validation.py
               tests/test_variables.py
               tests/test_versioning.py
-          - name: "Client Tests: Execution"
+          - id: client-execution
+            name: "Client Tests: Execution"
             modules: >-
               tests/test_flow_engine.py
               tests/test_flow_runs.py
@@ -151,7 +158,8 @@ jobs:
               tests/test_tasks.py
               tests/test_transactions.py
               tests/test_waiters.py
-          - name: Runner, Worker, Settings, Input, and CLI Tests
+          - id: runner-worker-settings-input-cli
+            name: Runner, Worker, Settings, Input, and CLI Tests
             modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
         database:
           - "postgres:14"
@@ -165,6 +173,7 @@ jobs:
         exclude:
           - database: "sqlite"
             test-type:
+              id: client-modules
               name: "Client Tests: Modules"
               modules: >-
                 tests/
@@ -180,6 +189,7 @@ jobs:
                 --ignore-glob="tests/test_*.py"
           - database: "sqlite"
             test-type:
+              id: client-top-level
               name: "Client Tests: Top-Level"
               modules: >-
                 tests/test_artifacts.py
@@ -207,6 +217,7 @@ jobs:
                 tests/test_versioning.py
           - database: "sqlite"
             test-type:
+              id: client-execution
               name: "Client Tests: Execution"
               modules: >-
                 tests/test_flow_engine.py
@@ -224,6 +235,7 @@ jobs:
                 tests/test_waiters.py
           - database: "sqlite"
             test-type:
+              id: runner-worker-settings-input-cli
               name: Runner, Worker, Settings, Input, and CLI Tests
               modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
 
@@ -345,6 +357,13 @@ jobs:
         env:
           LOGFIRE_CONSOLE: "false"
           LOGFIRE_DISTRIBUTED_TRACING: "true"
+          LOGFIRE_RESOURCE_ATTRIBUTES: >-
+            vcs.repository.url.full=${{ github.server_url }}/${{ github.repository }},
+            cicd.pipeline.run.id=${{ github.run_id }},
+            github.actions.run.attempt=${{ github.run_attempt }},
+            cicd.pipeline.run.url.full=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }},
+            github.actions.job.check_run_id=${{ job.check_run_id }},
+            prefect.pytest.shard.id=${{ matrix.test-type.id }}
           LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TEST_PROFILE_TOKEN }}
           PREFECT_LOGFIRE_ENABLED: "false"
         run: |
@@ -369,6 +388,34 @@ jobs:
           --logfire \
           --logfire-trace-phases \
           --logfire-service-name prefect-pytest-profile
+
+      - name: Add Logfire filters to job summary
+        if: always()
+        env:
+          LOGFIRE_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+          LOGFIRE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          LOGFIRE_RUN_ID: ${{ github.run_id }}
+          LOGFIRE_SHARD_ID: ${{ matrix.test-type.id }}
+        run: |
+          printf '%s\n' \
+            '### Logfire filters' \
+            '' \
+            'All shards in this workflow attempt:' \
+            '' \
+            '```sql' \
+            "otel_resource_attributes->>'vcs.repository.url.full' = '$LOGFIRE_REPOSITORY_URL'" \
+            "AND otel_resource_attributes->>'cicd.pipeline.run.id' = '$LOGFIRE_RUN_ID'" \
+            "AND otel_resource_attributes->>'github.actions.run.attempt' = '$LOGFIRE_RUN_ATTEMPT'" \
+            '```' \
+            '' \
+            "Shard $LOGFIRE_SHARD_ID:" \
+            '' \
+            '```sql' \
+            "otel_resource_attributes->>'vcs.repository.url.full' = '$LOGFIRE_REPOSITORY_URL'" \
+            "AND otel_resource_attributes->>'cicd.pipeline.run.id' = '$LOGFIRE_RUN_ID'" \
+            "AND otel_resource_attributes->>'github.actions.run.attempt' = '$LOGFIRE_RUN_ATTEMPT'" \
+            "AND otel_resource_attributes->>'prefect.pytest.shard.id' = '$LOGFIRE_SHARD_ID'" \
+            '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check database container
         if: always()

--- a/scripts/verify_test_selection.py
+++ b/scripts/verify_test_selection.py
@@ -90,7 +90,8 @@ def validate_excluded_test_types(
 ) -> list[str]:
     """Return errors for excludes whose test-type entry no longer matches."""
     known_test_types = {
-        (entry.get("name"), entry.get("modules")) for entry in test_types
+        (entry.get("id"), entry.get("name"), entry.get("modules"))
+        for entry in test_types
     }
 
     errors: list[str] = []
@@ -99,7 +100,11 @@ def validate_excluded_test_types(
         if not isinstance(test_type, dict):
             continue
 
-        key = (test_type.get("name"), test_type.get("modules"))
+        key = (
+            test_type.get("id"),
+            test_type.get("name"),
+            test_type.get("modules"),
+        )
         if key not in known_test_types:
             name = test_type.get("name", "<unnamed>")
             errors.append(


### PR DESCRIPTION
this PR adds an opt-in Logfire profiling mode to the existing Python unit-test workflow.

<details>
<summary>Details</summary>

- Adds a `logfire-test-profile` repository dispatch instead of creating another workflow; GitHub executes this event from the default-branch definition.
- Profiles the eight existing test partitions on Python 3.12 and PostgreSQL; ordinary pull-request and push jobs are unchanged.
- Installs the locked `perf` dependency group and enables Logfire's pytest phase tracing with xdist.
- Acknowledges Prefect's intentional distributed trace propagation so Logfire does not promote its extraction warning to a test failure.
- Omits `tests/telemetry/test_run_telemetry.py` from profiling because its assertions require no ambient tracing span; ordinary pull-request and push runs still cover it.
- Skips Docker and typesafety jobs during profiling dispatches.
- Limits profiling to the default branch and exposes the token only to the pytest step through a protected `logfire-profiling` environment.
- Warns operators that the Logfire pytest plugin sends test parameters and failure details without scrubbing.
- Before first use, create the `logfire-profiling` environment, restrict it to the default branch, and add its `LOGFIRE_TEST_PROFILE_TOKEN` secret.
- Checked with actionlint 1.7.12, the test-selection verifier, a matrix/ordinary-job equivalence check, focused pre-commit hooks, and a 20-test xdist/Logfire probe covering subflow propagation and compatible telemetry tests.

After merge, trigger it with:

```console
gh api --method POST repos/PrefectHQ/prefect/dispatches \
  -f event_type=logfire-test-profile
```

The dispatch cannot be exercised until the workflow definition is present on the default branch.
</details>
