### PR TITLE
[2.x] Reject option-like Git branch values

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -129,6 +129,10 @@ class GitRepository:
                 "If a username is provided, an access token or password must also be"
                 " provided."
             )
+
+        if branch and branch.startswith("-"):
+            raise ValueError("Branch names cannot start with '-'.")
+
         self._url = url
         self._branch = branch
         self._credentials = credentials

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -416,6 +416,17 @@ def git_repository_mock(monkeypatch):
 
 
 class TestGitCloneStep:
+    async def test_git_clone_rejects_option_like_branch(self):
+        with pytest.raises(ValueError, match="Branch names cannot start with '-'"):
+            await run_step(
+                {
+                    "prefect.deployments.steps.git_clone": {
+                        "repository": "https://github.com/org/repo.git",
+                        "branch": "--upload-pack=touch /tmp/pwned",
+                    }
+                }
+            )
+
     async def test_git_clone(self, git_repository_mock):
         output = await run_step(
             {

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -122,6 +122,20 @@ class TestGitRepository:
             ]
         )
 
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "--upload-pack=touch /tmp/pwned",
+            "-u touch /tmp/pwned",
+        ],
+    )
+    def test_init_rejects_option_like_branch(self, branch: str):
+        with pytest.raises(ValueError, match="Branch names cannot start with '-'"):
+            GitRepository(
+                url="https://github.com/org/repo.git",
+                branch=branch,
+            )
+
     def test_init_with_username_no_token(self):
         with pytest.raises(
             ValueError,


### PR DESCRIPTION
Backports #22819 to the 2.x release line.

this PR rejects Git branch values beginning with `-` before command construction, preventing Git from interpreting the branch as an option when updating an existing repository.

<details>
<summary>Details</summary>

- validate at the shared `GitRepository` construction boundary
- cover direct storage use and the `git_clone` deployment pull step
- preserve ordinary branch and tag values
- verified with `python -m pytest tests/runner/test_storage.py tests/deployment/test_steps.py -x --tb=short` (124 passed, 1 skipped)
- checked focused Ruff syntax/import rules and `git diff --check`

Related: [CVE-2026-72538](https://github.com/advisories/GHSA-42fh-94w4-956q)
</details>