### PR TITLE
Set SF_PARTNER in SPCS flow-run containers for Snowflake partner attribution

### DIFF
--- a/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
@@ -60,6 +60,8 @@ SPCS_DEFAULT_MEMORY_LIMIT = None
 
 DEFAULT_CONTAINER_ENTRYPOINT = "/opt/prefect/entrypoint.sh"
 
+PREFECT_SNOWFLAKE_APPLICATION = "Prefect_Snowflake_Collection"
+
 MAX_CREATE_SERVICE_ATTEMPTS = 3
 CREATE_SERVICE_MIN_DELAY_SECONDS = 1
 CREATE_SERVICE_MIN_DELAY_JITTER_SECONDS = 0
@@ -296,6 +298,11 @@ class SPCSWorkerConfiguration(BaseJobConfiguration):
 
         # Set the container's environment variables by grabbing them from the worker.
         container["env"] = {**self._base_environment(), **self.env}
+
+        # Attribute usage from the flow-run container to Prefect.
+        # Ensures attribution for non-Prefect Snowflake libraries (raw connector, Snowpark, dbt).
+        # SF_PARTNER is read by the Snowflake Connector for Python to set the application name, if not otherwise set.
+        container["env"].setdefault("SF_PARTNER", PREFECT_SNOWFLAKE_APPLICATION)
 
         # Remove PREFECT_API_KEY and PREFECT_API_AUTH_STRING from the environment variables, if they exist, and there is an equivalent secret.
         secret_env_vars = {
@@ -915,7 +922,7 @@ class SPCSWorker(BaseWorker):
                 "account": os.getenv("SNOWFLAKE_ACCOUNT"),
                 "token": Path("/snowflake/session/token").read_text(),
                 "authenticator": "oauth",
-                "application": "Prefect_Snowflake_Collection",
+                "application": PREFECT_SNOWFLAKE_APPLICATION,
             }
         else:
             creds = configuration.snowflake_credentials
@@ -923,7 +930,7 @@ class SPCSWorker(BaseWorker):
                 "account": creds.account,
                 "user": creds.user,
                 "role": creds.role,
-                "application": "Prefect_Snowflake_Collection",
+                "application": PREFECT_SNOWFLAKE_APPLICATION,
             }
             private_key = creds.resolve_private_key()
             if private_key is not None:

--- a/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/experimental/workers/spcs.py
@@ -299,8 +299,7 @@ class SPCSWorkerConfiguration(BaseJobConfiguration):
         # Set the container's environment variables by grabbing them from the worker.
         container["env"] = {**self._base_environment(), **self.env}
 
-        # Attribute usage from the flow-run container to Prefect.
-        # Ensures attribution for non-Prefect Snowflake libraries (raw connector, Snowpark, dbt).
+        # Attribute usage from the flow-run container to Prefect as a fallback for non-Prefect Snowflake libraries.
         # SF_PARTNER is read by the Snowflake Connector for Python to set the application name, if not otherwise set.
         container["env"].setdefault("SF_PARTNER", PREFECT_SNOWFLAKE_APPLICATION)
 

--- a/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
+++ b/src/integrations/prefect-snowflake/tests/experimental/test_spcs_worker.py
@@ -692,8 +692,23 @@ async def test_job_manifest_env_variables(snowflake_credentials, worker_flow_run
     # Should have custom vars plus base environment vars.
     assert "CUSTOM_VAR" in container["env"]
     assert container["env"]["CUSTOM_VAR"] == "custom_value"
+    assert container["env"]["SF_PARTNER"] == "Prefect_Snowflake_Collection"
     assert "ANOTHER_VAR" in container["env"]
     assert "PREFECT__FLOW_RUN_ID" in container["env"]
+
+
+async def test_job_manifest_preserves_sf_partner_override(
+    snowflake_credentials, worker_flow_run
+):
+    config = await create_job_configuration(
+        snowflake_credentials,
+        worker_flow_run,
+        {"env": {"SF_PARTNER": "custom_partner"}},
+    )
+
+    container = config.job_manifest["spec"]["containers"][0]
+
+    assert container["env"]["SF_PARTNER"] == "custom_partner"
 
 
 async def test_job_manifest_secrets_remove_api_key(


### PR DESCRIPTION
### Summary

Ensures Snowflake usage from flows and tasks running in SPCS containers is attributed to Prefect in Snowflake's partner telemetry.

### Background

SPCS-based Snowflake usage shows up in two patterns:

1. **Prefect worker (control plane)** — the worker connects to Snowflake to manage SPCS services. Already attributed: `_get_snowflake_connection_parameters` sets `application="Prefect_Snowflake_Collection"` explicitly.
2. **Flows/tasks (data plane)** — user code running inside the flow-run container connects to Snowflake directly. Only attributed when the code goes through `prefect-snowflake`'s `SnowflakeCredentials`, which sets `application=` on the connection. Any connection opened *outside* our library without a configured `application` falls through to the connector's default and reports as `PythonConnector`, so that consumption isn't linked back to Prefect.

This PR closes the data-plane gap for the non-library case.

### Change

Set `SF_PARTNER` in the flow-run container's environment. The Snowflake Connector for Python reads `SF_PARTNER` and uses it as the application name **only when no explicit `application` argument is passed** to `connect()`. The connector's precedence is:

```
explicit application= kwarg  >  SF_PARTNER env  >  connector default (PythonConnector)
```

Because of that precedence:

- Connections through `SnowflakeCredentials` keep their explicit `application=` value (unchanged; it just happens to be the same string).
- Everything else in the container now falls back to `SF_PARTNER` instead of `PythonConnector`.
- `setdefault` is used so an operator who sets their own `SF_PARTNER` on the work pool / job template isn't overwritten.

No changes required from customers.

`SF_PARTNER` is a default here, not a hard lock — an explicit `application=` set by a customer's own code still wins by design, so a customer who is themselves a Snowflake partner with their own CSID won't have their tag clobbered.
