### PR TITLE
Use total_seconds in the worker polling healthcheck

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1290,7 +1290,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         seconds_since_last_poll = (
             prefect.types._datetime.now("UTC") - self._last_polled_time
-        ).seconds
+        ).total_seconds()
 
         is_still_polling = seconds_since_last_poll <= threshold_seconds
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2434,6 +2434,13 @@ async def test_worker_last_polled_health_check(work_pool: WorkPool):
                 with travel_to(now + timedelta(minutes=30, seconds=1)):
                     resp = worker.is_worker_still_polling(query_interval_seconds=60)
                     assert resp is False
+
+                # a day-scale gap must not report healthy: timedelta.seconds
+                # discards the days component, so a worker dead for a day and
+                # 30 seconds used to pass the 300 second threshold again
+                with travel_to(now + timedelta(days=1, seconds=30)):
+                    resp = worker.is_worker_still_polling(query_interval_seconds=10)
+                    assert resp is False
     except ExceptionGroup as e:
         raise e.exceptions[0]
 


### PR DESCRIPTION
`is_worker_still_polling`, which backs the `/health` endpoint of `prefect worker start --with-healthcheck`, measures the gap since the last poll like this:

```python
seconds_since_last_poll = (
    prefect.types._datetime.now("UTC") - self._last_polled_time
).seconds
```

`timedelta.seconds` is only the seconds component of the delta and discards days. A worker whose polling loop has been dead for 24 hours and 2 minutes yields `.seconds == 120`, which passes the `threshold_seconds` check, so a Kubernetes liveness probe pointed at the healthcheck gets a 200 for a worker that has been dead a full day. It then reports healthy again for a threshold-wide window every subsequent 24 hours, which is exactly the kind of flapping that defeats probe failure counters. The error log on the unhealthy path prints the same wrapped number, so the operator-facing message understates the outage too.

The fix is `.total_seconds()`.

The existing `test_worker_last_polled_health_check` only travels up to 30 minutes, which is why this survived: every case stays inside the first day where `.seconds` and `.total_seconds()` agree. The added case travels to `now + timedelta(days=1, seconds=30)` with a 300 second threshold and asserts unhealthy. On the old code that case fails with the healthcheck reporting `True`, since the day is discarded and 30 is under the threshold, so the test pins the bug rather than just the happy path.

I ran the arithmetic both ways rather than the full worker suite in this environment: `timedelta(days=1, seconds=30).seconds` is 30 and `.total_seconds()` is 86430, and the test is a straight extension of the existing travel_to cases in the same function.
