### PR TITLE
(ui-v2) Fix inconsistent deployment status display on flow detail page

### DIFF
--- a/ui-v2/src/components/flows/detail/deployment-columns.tsx
+++ b/ui-v2/src/components/flows/detail/deployment-columns.tsx
@@ -55,12 +55,12 @@ export const columns: ColumnDef<Deployment>[] = [
 	{
 		accessorKey: "status",
 		header: "Status",
-		cell: ({ row }) => {
-			const status = row.original.paused
-				? "PAUSED"
-				: (row.original.status ?? "NOT_READY");
-			return <StatusBadge status={status} />;
-		},
+		cell: ({ row }) =>
+			row.original.status ? (
+				<StatusBadge status={row.original.status} />
+			) : (
+				<span className="text-muted-foreground text-sm">None</span>
+			),
 	},
 	{
 		accessorKey: "tags",

--- a/ui-v2/src/components/flows/detail/flow-deployments-tab.test.tsx
+++ b/ui-v2/src/components/flows/detail/flow-deployments-tab.test.tsx
@@ -65,4 +65,59 @@ describe("FlowDeploymentsTab", () => {
 			).toHaveAttribute("href", `/deployments/deployment/${deployment.id}`);
 		});
 	});
+
+	it("shows NOT_READY status even when paused is true", async () => {
+		const pausedDeployment = createFakeDeployment({
+			paused: true,
+			status: "NOT_READY",
+			schedules: [],
+		});
+
+		const rootRoute = createRootRoute({
+			component: () => (
+				<FlowDeploymentsTab
+					{...defaultProps}
+					deployments={[pausedDeployment]}
+				/>
+			),
+		});
+
+		const router = createRouter({
+			routeTree: rootRoute,
+			history: createMemoryHistory({ initialEntries: ["/"] }),
+			context: { queryClient: new QueryClient() },
+		});
+
+		render(<RouterProvider router={router} />, { wrapper: createWrapper() });
+
+		await waitFor(() => {
+			expect(screen.getByText("Not Ready")).toBeInTheDocument();
+			expect(screen.queryByText("Paused")).not.toBeInTheDocument();
+		});
+	});
+
+	it("shows None when status is missing", async () => {
+		const noStatusDeployment = createFakeDeployment({ status: undefined });
+
+		const rootRoute = createRootRoute({
+			component: () => (
+				<FlowDeploymentsTab
+					{...defaultProps}
+					deployments={[noStatusDeployment]}
+				/>
+			),
+		});
+
+		const router = createRouter({
+			routeTree: rootRoute,
+			history: createMemoryHistory({ initialEntries: ["/"] }),
+			context: { queryClient: new QueryClient() },
+		});
+
+		render(<RouterProvider router={router} />, { wrapper: createWrapper() });
+
+		await waitFor(() => {
+			expect(screen.getByText("None")).toBeInTheDocument();
+		});
+	});
 });


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.


The deployments list on the flow detail page showed "Paused" for deployments that were actually "Not Ready", while the deployment detail page correctly showed "Not Ready" for the same deployments
                                                                                                                            
The list column was overriding deployment.status with "Paused" whenever deployment.paused === true, but paused can be set to true automatically by the runner on shutdown (via pause_on_shutdown=True default), even when the real status is NOT_READY
This caused the two pages to disagree.                                                                                      
              
This PR aligns the list column with the detail page by reading deployment.status directly, the same way deployment-metadata.tsx does:
```
		{
			field: "Status",
			ComponentValue: () =>
				deployment.status ? (
					<dd>
						<StatusBadge status={deployment.status} />
					</dd>
				) : (
					<None />
				),
		},
```