### PR TITLE
Add repository code review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,10 @@ docker build --build-arg EXTRA_PIP_PACKAGES="prefect-aws" -t prefect .  # With e
 - Details in `<details>` tag
 - Include relevant links
 
+## Code Review Rules
+
+When reviewing changes, read and apply [REVIEW.md](REVIEW.md).
+
 # Project Practices
 
 - All PRs require test coverage for new functionality

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -10,8 +10,9 @@ Review every diff along two independent axes:
 - **Standards** — does the change follow the applicable repository instructions?
 - **Spec** — does the change faithfully implement the originating issue or specification?
 
-Prefix findings with `[Standards]` or `[Spec]`. Do not merge or rank findings across axes, and
-do not let success on one axis hide problems on the other.
+Keep the axes separate in the review summary, using `Standards` and `Spec` headings when the
+review surface supports them. Inline comments should lead directly with the problem rather than
+an axis label. Do not let success on one axis hide problems on the other.
 
 ## Standards review
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,63 @@
+# Code review guidance
+
+Repo-specific guidance for human and automated reviewers of Prefect. Implementation standards
+and component contracts belong in the applicable `AGENTS.md` files; do not duplicate them here.
+
+## Review axes
+
+Review every diff along two independent axes:
+
+- **Standards** — does the change follow the applicable repository instructions?
+- **Spec** — does the change faithfully implement the originating issue or specification?
+
+Prefix findings with `[Standards]` or `[Spec]`. Do not merge or rank findings across axes, and
+do not let success on one axis hide problems on the other.
+
+## Standards review
+
+Read every `AGENTS.md` and `REVIEW.md` whose scope contains a changed file, plus the relevant
+contribution guides under `docs/contribute/`. Follow references to paired implementations,
+owning components, architectural boundaries, and other contracts material to the diff. Verify
+those contracts against their implementations rather than reasoning from names or mocks alone.
+
+Cite the instruction file and rule for every hard Standards finding. Repository instructions
+override the following Fowler code-smell baseline, which is always a judgement call:
+
+- Mysterious Name
+- Duplicated Code
+- Feature Envy
+- Data Clumps
+- Primitive Obsession
+- Repeated Switches
+- Shotgun Surgery
+- Divergent Change
+- Speculative Generality
+- Message Chains
+- Middle Man
+- Refused Bequest
+
+Skip formatting, lint, and other failures that automated tooling reliably identifies unless
+they expose a broader behavioral problem.
+
+## Spec review
+
+Find the authoritative specification in this order:
+
+1. A linked GitHub issue and its maintainer decisions, including issue references in commits
+2. A specification explicitly linked from the issue or pull request
+3. A relevant document under `docs/`, `plans/`, or another specification directory
+4. The pull request description as supplemental context
+
+For each Spec finding, cite the requirement it relies on. Report requirements that are missing
+or partial, behavior that was not requested, and implementations that appear to satisfy a
+requirement but do so incorrectly. If no authoritative specification is available, report that
+the Spec axis could not be evaluated instead of inventing requirements.
+
+## Reporting discipline
+
+- Review the diff against its merge base; do not turn adjacent pre-existing problems into
+  findings.
+- Quote the relevant changed code and cite the governing standard or requirement.
+- Distinguish observed failures from inferred risks and state what evidence would confirm an
+  inference.
+- Avoid speculative cleanup and preference-only findings.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -47,12 +47,16 @@ Find the authoritative specification in this order:
 1. A linked GitHub issue and its maintainer decisions, including issue references in commits
 2. A specification explicitly linked from the issue or pull request
 3. A relevant document under `docs/`, `plans/`, or another specification directory
-4. The pull request description as supplemental context
+4. The pull request description for a small, self-contained change allowed without an issue
 
 For each Spec finding, cite the requirement it relies on. Report requirements that are missing
 or partial, behavior that was not requested, and implementations that appear to satisfy a
-requirement but do so incorrectly. If no authoritative specification is available, report that
-the Spec axis could not be evaluated instead of inventing requirements.
+requirement but do so incorrectly.
+
+If no authoritative specification is available, do not invent one. If the contribution guide
+requires prior issue discussion for the change and none is linked, report that as a Standards
+finding. Otherwise, skip the Spec axis; when a summary surface exists, note that it was not
+evaluated rather than creating an inline finding.
 
 ## Reporting discipline
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -10,9 +10,9 @@ Review every diff along two independent axes:
 - **Standards** — does the change follow the applicable repository instructions?
 - **Spec** — does the change faithfully implement the originating issue or specification?
 
-Keep the axes separate in the review summary, using `Standards` and `Spec` headings when the
-review surface supports them. Inline comments should lead directly with the problem rather than
-an axis label. Do not let success on one axis hide problems on the other.
+Evaluate the axes independently even when the review surface reports findings individually.
+Inline comments should lead directly with the problem rather than an axis label. Do not let
+success on one axis hide problems on the other.
 
 ## Standards review
 


### PR DESCRIPTION
this PR adds a root `REVIEW.md` that gives human and automated reviewers a shared two-axis review method without duplicating component standards from `AGENTS.md`.

<details>
<summary>Details</summary>

- Keeps Standards and Spec findings independent.
- Directs reviewers to applicable repository instructions and authoritative specifications.
- Applies the Fowler smell baseline as judgement calls subordinate to repository rules.
- Defines evidence and reporting expectations while leaving Prefect contracts with their owning `AGENTS.md` files.

No runtime behavior changes. Tests are not needed for these instruction-only changes; `uv run pre-commit run --files AGENTS.md REVIEW.md` passed.

</details>

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.