### PR TITLE
fix(ui-v2): carry rounded-up seconds into larger units

### DIFF
--- a/ui-v2/src/utils/seconds.test.ts
+++ b/ui-v2/src/utils/seconds.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "vitest";
+import { secondsToApproximateString, secondsToString } from "./seconds";
+
+// Regression tests for https://github.com/PrefectHQ/prefect/issues/17039
+// Fractional seconds were rounded up without carrying into the next unit,
+// producing impossible durations like "4m 60s".
+
+test("carries a rounded-up second into minutes", () => {
+	const RESULT = secondsToApproximateString(299.5);
+	const EXPECTED = "5m";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("carries through minutes into hours", () => {
+	const RESULT = secondsToApproximateString(3599.5);
+	// Note: an exact hour renders as "1h 0m" both before and after this fix;
+	// that quirk lives in the switch in secondsToApproximateString and is out of scope.
+	const EXPECTED = "1h 0m";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("carries through hours into days", () => {
+	const RESULT = secondsToApproximateString(86399.5);
+	const EXPECTED = "1d";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("never renders 60 seconds", () => {
+	const RESULT = secondsToApproximateString(59.5);
+	const EXPECTED = "1m";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("carries in the long-form string as well", () => {
+	const RESULT = secondsToString(299.5);
+	const EXPECTED = "5 minutes";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+// Behavior that must not regress: sub-second durations still round up to 1s
+// rather than displaying as "0s".
+
+test("sub-second durations still display as 1s", () => {
+	const RESULT = secondsToApproximateString(0.4);
+	const EXPECTED = "1s";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("whole values are unchanged", () => {
+	expect(secondsToApproximateString(25)).toEqual("25s");
+	expect(secondsToApproximateString(3661)).toEqual("1h 1m");
+	expect(secondsToApproximateString(90061)).toEqual("1d 1h");
+	expect(secondsToString(3661)).toEqual("1 hour 1 minute 1 second");
+});

--- a/ui-v2/src/utils/seconds.ts
+++ b/ui-v2/src/utils/seconds.ts
@@ -46,19 +46,22 @@ type IntervalTypesShort = "y" | "d" | "h" | "m" | "s";
 type IntervalTypesPlural = `${keyof typeof intervals}s`;
 
 function aggregateSeconds(input: number): Record<IntervalTypesPlural, number> {
-	const years = Math.floor(input / intervals.year);
-	const days = Math.floor((input % intervals.year) / intervals.day);
+	// Round up front rather than per-unit. Rounding the seconds on their own
+	// let them reach 60 without carrying, rendering durations like "4m 60s".
+	const total = Math.ceil(input);
+
+	const years = Math.floor(total / intervals.year);
+	const days = Math.floor((total % intervals.year) / intervals.day);
 	const hours = Math.floor(
-		((input % intervals.year) % intervals.day) / intervals.hour,
+		((total % intervals.year) % intervals.day) / intervals.hour,
 	);
 	const minutes = Math.floor(
-		(((input % intervals.year) % intervals.day) % intervals.hour) /
+		(((total % intervals.year) % intervals.day) % intervals.hour) /
 			intervals.minute,
 	);
-	const seconds = Math.ceil(
-		(((input % intervals.year) % intervals.day) % intervals.hour) %
-			intervals.minute,
-	);
+	const seconds =
+		(((total % intervals.year) % intervals.day) % intervals.hour) %
+		intervals.minute;
 
 	return { years, days, hours, minutes, seconds };
 }


### PR DESCRIPTION
`aggregateSeconds` floored every unit but applied `Math.ceil` to the seconds alone. When a fractional duration pushed the seconds to 60, nothing carried into minutes, so durations rendered as "4m 60s".

This only fires when `input % 60` falls between 59 and 60 — a one-second window per minute. Whole-number durations never hit it (300s renders as `5m` fine), which is why it looked intermittent. It compounds at higher units too: 3599.5s rendered as "59m 60s" and 86399.5s as "23h 59m", silently dropping the seconds.

**Repro** (self-hosted): a flow running `time.sleep(59.5)` records `total_run_time: 59.526701`, and the flow run header shows `60s` instead of `1m`.

**Fix:** round the input once up front and derive every unit from that total with `Math.floor`, so a value of 60 can no longer occur. Sub-second durations still round up to "1s" rather than "0s".

Adds regression tests covering each carry boundary plus guards for the documented examples and sub-second behavior.

**Scope:** #17039 predates this file (added Dec 2025), so the original report was the Vue V1 UI. I checked both — V1 and V2 have the bug, implemented separately. This fixes the V2 instance only; V1's fix would live in `prefect-ui-library`, so I haven't marked this as closing the issue.

Refs #17039

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - See scope note above — this fixes the V2 instance only, so I've left this unchecked rather than auto-closing #17039.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - No docs cover duration formatting; the JSDoc examples in the file are unchanged and covered by tests.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.