### PR TITLE
Add direct-failure-only handling to allow_failure

### DIFF
--- a/docs/v3/how-to-guides/workflows/run-work-concurrently.mdx
+++ b/docs/v3/how-to-guides/workflows/run-work-concurrently.mdx
@@ -386,6 +386,7 @@ To continue only when the annotated run executed and failed directly, set
 `include_blocked=False`. A dependency blocked by any earlier run will continue to
 block the downstream task:
 
+{/* pmd-metadata: notest */}
 ```python
 cleanup.submit(
     wait_for=[allow_failure(transformed, include_blocked=False)]

--- a/docs/v3/how-to-guides/workflows/run-work-concurrently.mdx
+++ b/docs/v3/how-to-guides/workflows/run-work-concurrently.mdx
@@ -357,6 +357,41 @@ def my_flow():
     d = task_d(wait_for=[c])
 ```
 
+By default, a task does not run when a `wait_for` dependency fails or is blocked by
+an earlier failure. Wrap a dependency with `allow_failure` when the downstream task
+should run for cleanup or reporting even if that dependency failed:
+
+```python
+from prefect import allow_failure, flow, task
+
+@task
+def transform():
+    raise ValueError("Could not transform data")
+
+@task
+def cleanup():
+    pass
+
+@flow
+def cleanup_flow():
+    transformed = transform.submit()
+    cleanup.submit(wait_for=[allow_failure(transformed)])
+```
+
+The default `allow_failure` policy is transitive: cleanup also runs if `transformed`
+did not run because an earlier dependency failed. It does not allow dependencies
+blocked by a cancelled or crashed run.
+
+To continue only when the annotated run executed and failed directly, set
+`include_blocked=False`. A dependency blocked by any earlier run will continue to
+block the downstream task:
+
+```python
+cleanup.submit(
+    wait_for=[allow_failure(transformed, include_blocked=False)]
+)
+```
+
 ## Handling failures in concurrent work
 
 Instead of failing your entire workflow when a single concurrent task fails, you may want to run concurrent work to completion, even if some tasks fail. To run tasks concurrently and handle failures afterwards, use the `wait()` utility along with the `.state` attribute on futures:

--- a/src/prefect/_internal/dependency_policy.py
+++ b/src/prefect/_internal/dependency_policy.py
@@ -1,0 +1,91 @@
+"""Internal dependency resolution policy and blocked-state construction."""
+
+from typing import Any
+
+from prefect.client.schemas.objects import StateDetails, StateType
+from prefect.exceptions import UpstreamTaskError
+from prefect.states import Pending, State
+from prefect.utilities.annotations import allow_failure
+
+
+def state_has_upstream_cause(state: State[Any]) -> bool:
+    details = state.state_details
+    return any(
+        value is not None
+        for value in (
+            details.upstream_cause_flow_run_id,
+            details.upstream_cause_task_run_id,
+            details.upstream_cause_state_type,
+            details.upstream_cause_state_name,
+        )
+    )
+
+
+def dependency_state_allowed(state: State[Any], annotation: Any) -> bool:
+    """Return whether a dependency state satisfies the active annotation policy."""
+    if state.is_completed():
+        return True
+
+    if not isinstance(annotation, allow_failure):
+        return False
+
+    if not annotation.include_blocked:
+        return state.is_failed() and not state_has_upstream_cause(state)
+
+    if state.is_failed():
+        return True
+
+    if not (state.is_pending() and state.name == "NotReady"):
+        return False
+
+    if not state_has_upstream_cause(state):
+        # Historical NotReady states have no causal provenance. Preserve the
+        # existing transitive behavior for the default policy.
+        return True
+
+    return state.state_details.upstream_cause_state_type == StateType.FAILED
+
+
+def upstream_task_error_from_state(state: State[Any]) -> UpstreamTaskError:
+    """Create an upstream error with immediate and root-cause metadata."""
+    details = state.state_details
+    has_root_cause = state_has_upstream_cause(state)
+    return UpstreamTaskError(
+        f"Upstream task run '{details.task_run_id}' did not reach a 'COMPLETED' state.",
+        upstream_flow_run_id=details.flow_run_id,
+        upstream_task_run_id=details.task_run_id,
+        upstream_state_type=state.type,
+        upstream_state_name=state.name,
+        root_cause_flow_run_id=(
+            details.upstream_cause_flow_run_id
+            if has_root_cause
+            else details.flow_run_id
+        ),
+        root_cause_task_run_id=(
+            details.upstream_cause_task_run_id
+            if has_root_cause
+            else details.task_run_id
+        ),
+        root_cause_state_type=(
+            details.upstream_cause_state_type if has_root_cause else state.type
+        ),
+        root_cause_state_name=(
+            details.upstream_cause_state_name if has_root_cause else state.name
+        ),
+    )
+
+
+def not_ready_state_from_upstream_error(
+    error: UpstreamTaskError,
+) -> State[Any]:
+    """Create a NotReady state retaining the rejected dependency's root cause."""
+    return Pending(
+        name="NotReady",
+        message=str(error),
+        state_details=StateDetails(
+            upstream_cause_flow_run_id=error.root_cause_flow_run_id,
+            upstream_cause_task_run_id=error.root_cause_task_run_id,
+            upstream_cause_state_type=error.root_cause_state_type,
+            upstream_cause_state_name=error.root_cause_state_name,
+        ),
+    )

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -191,6 +191,10 @@ class ConcurrencyLeaseHolder(PrefectBaseModel):
 class StateDetails(PrefectBaseModel):
     flow_run_id: Optional[UUID] = None
     task_run_id: Optional[UUID] = None
+    upstream_cause_flow_run_id: UUID | None = None
+    upstream_cause_task_run_id: UUID | None = None
+    upstream_cause_state_type: StateType | None = None
+    upstream_cause_state_name: str | None = None
     child_flow_run_id: Optional[UUID] = None
     scheduled_time: Optional[DateTime] = None
     cache_key: Optional[str] = None

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -7,12 +7,14 @@ import traceback
 from collections.abc import Iterable
 from types import ModuleType, TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Optional
+from uuid import UUID
 
 from httpx import HTTPStatusError
 from pydantic import ValidationError
 from typing_extensions import Self
 
 if TYPE_CHECKING:
+    from prefect.client.schemas.objects import StateType
     from prefect.states import State
 
 
@@ -265,6 +267,29 @@ class UpstreamTaskError(PrefectException):
     Raised when a task relies on the result of another task but that task is not
     'COMPLETE'
     """
+
+    def __init__(
+        self,
+        *args: Any,
+        upstream_flow_run_id: UUID | None = None,
+        upstream_task_run_id: UUID | None = None,
+        upstream_state_type: "StateType | None" = None,
+        upstream_state_name: str | None = None,
+        root_cause_flow_run_id: UUID | None = None,
+        root_cause_task_run_id: UUID | None = None,
+        root_cause_state_type: "StateType | None" = None,
+        root_cause_state_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.upstream_flow_run_id = upstream_flow_run_id
+        self.upstream_task_run_id = upstream_task_run_id
+        self.upstream_state_type = upstream_state_type
+        self.upstream_state_name = upstream_state_name
+        self.root_cause_flow_run_id = root_cause_flow_run_id
+        self.root_cause_task_run_id = root_cause_task_run_id
+        self.root_cause_state_type = root_cause_state_type
+        self.root_cause_state_name = root_cause_state_name
 
 
 class MissingContextError(PrefectException, RuntimeError):

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -59,6 +59,7 @@ from prefect._internal.control_listener import (
     get_intent,
     report_engine_outcome,
 )
+from prefect._internal.dependency_policy import not_ready_state_from_upstream_error
 from prefect._internal.engine import get_hook_name, resolve_custom_flow_run_name
 from prefect._internal.metrics import RunMetrics
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
@@ -691,10 +692,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             self._wait_for_dependencies()
         except UpstreamTaskError as upstream_exc:
             state = self.set_state(
-                Pending(
-                    name="NotReady",
-                    message=str(upstream_exc),
-                ),
+                not_ready_state_from_upstream_error(upstream_exc),
                 # if orchestrating a run already in a pending state, force orchestration to
                 # update the state name
                 force=self.state.is_pending(),
@@ -1394,10 +1392,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             self._wait_for_dependencies()
         except UpstreamTaskError as upstream_exc:
             state = await self.set_state(
-                Pending(
-                    name="NotReady",
-                    message=str(upstream_exc),
-                ),
+                not_ready_state_from_upstream_error(upstream_exc),
                 # if orchestrating a run already in a pending state, force orchestration to
                 # update the state name
                 force=self.state.is_pending(),

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -81,6 +81,10 @@ TERMINAL_STATES = {
 class StateDetails(PrefectBaseModel):
     flow_run_id: Optional[UUID] = None
     task_run_id: Optional[UUID] = None
+    upstream_cause_flow_run_id: UUID | None = None
+    upstream_cause_task_run_id: UUID | None = None
+    upstream_cause_state_type: StateType | None = None
+    upstream_cause_state_name: str | None = None
     # for task runs that represent subflows, the subflow's run ID
     child_flow_run_id: Optional[UUID] = None
     scheduled_time: Optional[DateTime] = None

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -38,6 +38,7 @@ import prefect.states
 import prefect.types._datetime
 from prefect._flow_run_suspension import raise_if_flow_run_suspension_requested
 from prefect._internal.compatibility import deprecated
+from prefect._internal.dependency_policy import not_ready_state_from_upstream_error
 from prefect._internal.engine import dynamic_key_for_task_run, get_hook_name
 from prefect._internal.states import (
     exception_to_crashed_state_sync,
@@ -93,7 +94,6 @@ from prefect.states import (
     AwaitingRetry,
     Completed,
     Failed,
-    Pending,
     Retrying,
     Running,
     exception_to_crashed_state,
@@ -934,10 +934,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     self._wait_for_dependencies()
                 except UpstreamTaskError as upstream_exc:
                     self.set_state(
-                        Pending(
-                            name="NotReady",
-                            message=str(upstream_exc),
-                        ),
+                        not_ready_state_from_upstream_error(upstream_exc),
                         # if orchestrating a run already in a pending state, force orchestration to
                         # update the state name
                         force=self.state.is_pending(),
@@ -1130,10 +1127,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             self._set_custom_task_run_name()
         except UpstreamTaskError as upstream_exc:
             state = await self.set_state(
-                Pending(
-                    name="NotReady",
-                    message=str(upstream_exc),
-                ),
+                not_ready_state_from_upstream_error(upstream_exc),
                 # if orchestrating a run already in a pending state, force orchestration to
                 # update the state name
                 force=self.state.is_pending(),
@@ -1565,10 +1559,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     self._wait_for_dependencies()
                 except UpstreamTaskError as upstream_exc:
                     await self.set_state(
-                        Pending(
-                            name="NotReady",
-                            message=str(upstream_exc),
-                        ),
+                        not_ready_state_from_upstream_error(upstream_exc),
                         # if orchestrating a run already in a pending state, force orchestration to
                         # update the state name
                         force=self.state.is_pending(),

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -35,7 +35,7 @@ from prefect.futures import (
     PrefectDistributedFuture,
     PrefectFuture,
     PrefectFutureList,
-    wait,
+    resolve_futures_to_states,
 )
 from prefect.logging.handlers import APILogWorker, set_api_log_sink
 from prefect.logging.loggers import get_logger, get_run_logger
@@ -1099,16 +1099,12 @@ class ProcessPoolTaskRunner(TaskRunner[PrefectConcurrentFuture[Any]]):
         """
         from prefect.utilities.engine import resolve_inputs_sync
 
-        # Wait for all futures in wait_for to complete and collect their
-        # terminal states.  Futures themselves are not picklable, but State
-        # objects are, and the subprocess task engine's _wait_for_dependencies
-        # handles State objects via resolve_to_final_result — correctly raising
-        # UpstreamTaskError for non-completed upstreams.
-        wait_for_states = None
-        if wait_for:
-            wait_for_list = list(wait_for)
-            wait(wait_for_list)
-            wait_for_states = [f.state for f in wait_for_list]
+        # Futures themselves are not picklable, but State objects are. Preserve
+        # annotations while replacing each future so the subprocess task engine
+        # applies the same dependency policy as in-process runners.
+        wait_for_states = (
+            resolve_futures_to_states(list(wait_for)) if wait_for else None
+        )
 
         # Resolve any futures in parameters to their actual values
         resolved_parameters = resolve_inputs_sync(

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -62,9 +62,34 @@ class allow_failure(BaseAnnotation[T]):
     are failed. This annotation allows you to opt into receiving a failed input
     downstream.
 
+    By default, downstream execution is also allowed when the annotated run was
+    blocked by an upstream failure. Set `include_blocked=False` to allow only runs
+    that executed and failed directly.
+
     If the input is from a failed run, the attached exception will be passed to your
-    function.
+    function. Failure-derived blocked inputs resolve to `None`.
     """
+
+    def __new__(cls, value: T, *, include_blocked: bool = True) -> Self:
+        if cls is allow_failure and not include_blocked:
+            return cast(Self, tuple.__new__(_allow_failure_without_blocked, (value,)))
+        return super().__new__(cls, value)
+
+    @property
+    def include_blocked(self) -> bool:
+        return not isinstance(self, _allow_failure_without_blocked)
+
+    def __repr__(self) -> str:
+        if self.include_blocked:
+            return super().__repr__()
+        return f"allow_failure({self[0]!r}, include_blocked=False)"
+
+    def __getnewargs__(self) -> tuple[T]:
+        return (self[0],)
+
+
+class _allow_failure_without_blocked(allow_failure[T]):
+    """Internal tuple subtype retaining direct-failure-only resolution policy."""
 
 
 class quote(BaseAnnotation[T]):

--- a/src/prefect/utilities/engine/__init__.py
+++ b/src/prefect/utilities/engine/__init__.py
@@ -26,6 +26,10 @@ from typing_extensions import TypeIs
 import prefect
 import prefect.exceptions
 from prefect._internal.concurrency.cancellation import get_deadline
+from prefect._internal.dependency_policy import (
+    dependency_state_allowed,
+    upstream_task_error_from_state,
+)
 from prefect.client.schemas import FlowRunResult, OrchestrationResult, TaskRun
 from prefect.client.schemas.objects import (
     FlowRun,
@@ -454,28 +458,14 @@ async def resolve_inputs(
         else:
             return expr
 
-        # Do not allow uncompleted upstreams unless `allow_failure` has been used
-        # for failed or failure-derived (PENDING/NotReady) states
-        if not state.is_completed() and not (
-            # TODO: Note that the contextual annotation here is only at the current level
-            #       if `allow_failure` is used then another annotation is used, this will
-            #       incorrectly evaluate to false — to resolve this, we must track all
-            #       annotations wrapping the current expression but this is not yet
-            #       implemented.
-            isinstance(context.get("annotation"), allow_failure)
-            and (state.is_failed() or (state.is_pending() and state.name == "NotReady"))
-        ):
-            raise UpstreamTaskError(
-                f"Upstream task run '{state.state_details.task_run_id}' did not reach a"
-                " 'COMPLETED' state."
-            )
+        annotation = context.get("annotation")
+        if not dependency_state_allowed(state, annotation):
+            raise upstream_task_error_from_state(state)
 
         # When allow_failure is used and the state is not final (e.g. PENDING/NotReady
         # from a cascading upstream failure), return state.data directly since
         # result_by_state is only populated for final states.
-        if not state.is_final() and isinstance(
-            context.get("annotation"), allow_failure
-        ):
+        if not state.is_final() and isinstance(annotation, allow_failure):
             return state.data
 
         resolved = result_by_state.get(state)
@@ -1008,26 +998,14 @@ def resolve_to_final_result(expr: Any, context: dict[str, Any]) -> Any:
 
     assert state
 
-    # Do not allow uncompleted upstreams unless `allow_failure` has been used
-    # for failed or failure-derived (PENDING/NotReady) states
-    if not state.is_completed() and not (
-        # TODO: Note that the contextual annotation here is only at the current level
-        #       if `allow_failure` is used then another annotation is used, this will
-        #       incorrectly evaluate to false — to resolve this, we must track all
-        #       annotations wrapping the current expression but this is not yet
-        #       implemented.
-        isinstance(context.get("annotation"), allow_failure)
-        and (state.is_failed() or (state.is_pending() and state.name == "NotReady"))
-    ):
-        raise UpstreamTaskError(
-            f"Upstream task run '{state.state_details.task_run_id}' did not reach a"
-            " 'COMPLETED' state."
-        )
+    annotation = context.get("annotation")
+    if not dependency_state_allowed(state, annotation):
+        raise upstream_task_error_from_state(state)
 
     # When allow_failure is used and the state is not final (e.g. PENDING/NotReady
     # from a cascading upstream failure), we cannot call state.result() because it
     # raises UnfinishedRun.  Return the state's data directly instead.
-    if not state.is_final() and isinstance(context.get("annotation"), allow_failure):
+    if not state.is_final() and isinstance(annotation, allow_failure):
         return state.data
 
     result: Any = state.result(raise_on_failure=False, _sync=True)  # pyright: ignore[reportCallIssue] _sync messes up type inference and can be removed once async_dispatch is removed

--- a/tests/client/test_state_serialization.py
+++ b/tests/client/test_state_serialization.py
@@ -116,6 +116,24 @@ except TypeError as e:
 
         assert "flow_run_id" in result
 
+    def test_state_details_round_trip_upstream_cause(self):
+        task_run_id = uuid4()
+        flow_run_id = uuid4()
+        state_details = StateDetails(
+            upstream_cause_task_run_id=task_run_id,
+            upstream_cause_flow_run_id=flow_run_id,
+            upstream_cause_state_type=StateType.FAILED,
+            upstream_cause_state_name="Failed",
+        )
+
+        serialized = state_details.model_dump(mode="json")
+        restored = StateDetails.model_validate(serialized)
+
+        assert restored.upstream_cause_task_run_id == task_run_id
+        assert restored.upstream_cause_flow_run_id == flow_run_id
+        assert restored.upstream_cause_state_type == StateType.FAILED
+        assert restored.upstream_cause_state_name == "Failed"
+
     def test_state_details_serializer_is_not_mock(self):
         """
         Verify that StateDetails has a proper serializer, not MockValSer.

--- a/tests/server/schemas/test_states.py
+++ b/tests/server/schemas/test_states.py
@@ -59,6 +59,23 @@ class TestState:
         # New state timestamp
         assert new_state.timestamp >= dt
 
+    def test_state_details_round_trip_upstream_cause(self):
+        task_run_id = uuid4()
+        flow_run_id = uuid4()
+        state_details = StateDetails(
+            upstream_cause_task_run_id=task_run_id,
+            upstream_cause_flow_run_id=flow_run_id,
+            upstream_cause_state_type=StateType.FAILED,
+            upstream_cause_state_name="Failed",
+        )
+
+        restored = StateDetails.model_validate(state_details.model_dump(mode="json"))
+
+        assert restored.upstream_cause_task_run_id == task_run_id
+        assert restored.upstream_cause_flow_run_id == flow_run_id
+        assert restored.upstream_cause_state_type == StateType.FAILED
+        assert restored.upstream_cause_state_name == "Failed"
+
 
 class TestStateTypeFunctions:
     @pytest.mark.parametrize("state_type", StateType)

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -31,6 +31,7 @@ from prefect.task_runners import (
 )
 from prefect.task_worker import TaskWorker
 from prefect.tasks import task
+from prefect.utilities.annotations import allow_failure
 
 
 @task(task_run_name=f"my_test_task_{uuid.uuid4()}")
@@ -797,6 +798,63 @@ class TestProcessPoolTaskRunner:
         assert upstream_state.is_failed()
         assert downstream_state.is_pending()
         assert downstream_state.name == "NotReady"
+        assert (
+            downstream_state.state_details.upstream_cause_task_run_id
+            == upstream_state.state_details.task_run_id
+        )
+        assert (
+            downstream_state.state_details.upstream_cause_state_type
+            == upstream_state.type
+        )
+
+    @pytest.mark.parametrize("include_blocked", [True, False])
+    def test_allow_failure_blocked_policy_is_preserved_in_process_pool(
+        self, include_blocked: bool
+    ):
+        @task
+        def failing_task() -> None:
+            raise RuntimeError("I failed!")
+
+        @task
+        def downstream_task() -> str:
+            return "downstream completed"
+
+        @flow(task_runner=ProcessPoolTaskRunner(max_workers=2))
+        def test_flow():
+            upstream = failing_task.submit()
+            blocked = downstream_task.submit(wait_for=[upstream])
+            annotated_blocked = (
+                allow_failure(blocked)
+                if include_blocked
+                else allow_failure(blocked, include_blocked=False)
+            )
+            final = downstream_task.submit(wait_for=[annotated_blocked])
+            upstream.wait()
+            blocked.wait()
+            final.wait()
+            return upstream.state, blocked.state, final.state
+
+        upstream_state, blocked_state, final_state = test_flow()
+
+        assert upstream_state.is_failed()
+        assert blocked_state.is_pending()
+        assert (
+            blocked_state.state_details.upstream_cause_task_run_id
+            == upstream_state.state_details.task_run_id
+        )
+        if include_blocked:
+            assert final_state.is_completed()
+        else:
+            assert final_state.is_pending()
+            assert final_state.name == "NotReady"
+            assert (
+                final_state.state_details.upstream_cause_task_run_id
+                == upstream_state.state_details.task_run_id
+            )
+            assert (
+                final_state.state_details.upstream_cause_state_type
+                == upstream_state.type
+            )
 
     def test_submit_with_future_as_parameter(self):
         """

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -63,7 +63,7 @@ from prefect.settings import (
     PREFECT_UI_URL,
     temporary_settings,
 )
-from prefect.states import Completed, State
+from prefect.states import Cancelled, Completed, Crashed, State
 from prefect.task_worker import read_parameters
 from prefect.tasks import Task, task, task_input_hash
 from prefect.testing.utilities import exceptions_equal
@@ -3632,6 +3632,44 @@ class TestSubflowWaitForTasks:
         assert subflow_state.is_pending()
         assert subflow_state.name == "NotReady"
 
+    async def test_async_subflow_retains_root_cause_through_strict_blocking(self):
+        child_flow_calls: list[str] = []
+
+        @task
+        def fails() -> None:
+            raise ValueError("Fail task!")
+
+        @flow
+        async def child_flow() -> None:
+            child_flow_calls.append("child flow")
+
+        @flow
+        async def parent_flow():
+            failed = fails.submit()
+            blocked = await child_flow(wait_for=[failed], return_state=True)
+            strict = await child_flow(
+                wait_for=[allow_failure(blocked, include_blocked=False)],
+                return_state=True,
+            )
+            failed.wait()
+            return quote((failed.state, blocked, strict))
+
+        failed_state, blocked_state, strict_state = (await parent_flow()).unquote()
+
+        assert failed_state.is_failed()
+        assert blocked_state.is_pending()
+        assert strict_state.is_pending()
+        assert child_flow_calls == []
+        assert (
+            blocked_state.state_details.upstream_cause_task_run_id
+            == failed_state.state_details.task_run_id
+        )
+        assert (
+            strict_state.state_details.upstream_cause_task_run_id
+            == failed_state.state_details.task_run_id
+        )
+        assert strict_state.state_details.upstream_cause_state_type == StateType.FAILED
+
     def test_downstream_runs_if_upstream_succeeds(self):
         @flow
         def foo(x):
@@ -3889,6 +3927,178 @@ class TestTaskWaitFor:
             return result.result()
 
         assert test_flow() == "cleanup done"
+
+    @pytest.mark.parametrize(
+        "include_blocked,expected_task_3_state,expected_task_3_calls",
+        [
+            (True, StateType.COMPLETED, ["task 3"]),
+            (False, StateType.PENDING, []),
+        ],
+    )
+    def test_allow_failure_can_reject_failure_derived_not_ready_states(
+        self,
+        include_blocked: bool,
+        expected_task_3_state: StateType,
+        expected_task_3_calls: list[str],
+    ):
+        task_3_calls: list[str] = []
+        task_3_failure_hook_calls: list[str] = []
+        futures: dict[str, PrefectFuture[Any]] = {}
+
+        def record_task_3_failure(*args: Any, **kwargs: Any) -> None:
+            task_3_failure_hook_calls.append("task 3")
+
+        @task
+        def task_1() -> None:
+            raise ValueError("task 1 failed")
+
+        @task
+        def task_2() -> None:
+            raise AssertionError("task 2 should not run")
+
+        @task(on_failure=[record_task_3_failure])
+        def task_3() -> None:
+            task_3_calls.append("task 3")
+
+        @task
+        def task_4() -> None:
+            raise AssertionError("task 4 should not run")
+
+        @flow
+        def test_flow() -> None:
+            futures["task_1"] = task_1.submit()
+            futures["task_2"] = task_2.submit(wait_for=[futures["task_1"]])
+            wait_for_task_2 = (
+                allow_failure(futures["task_2"])
+                if include_blocked
+                else allow_failure(futures["task_2"], include_blocked=False)
+            )
+            futures["task_3"] = task_3.submit(wait_for=[wait_for_task_2])
+            futures["task_4"] = task_4.submit(wait_for=[futures["task_2"]])
+
+            for future in futures.values():
+                future.wait()
+
+        test_flow()
+
+        task_1_state = futures["task_1"].state
+        task_2_state = futures["task_2"].state
+        task_3_state = futures["task_3"].state
+        task_4_state = futures["task_4"].state
+
+        assert task_1_state.is_failed()
+        assert task_2_state.is_pending()
+        assert task_2_state.name == "NotReady"
+        assert (
+            task_2_state.state_details.upstream_cause_task_run_id
+            == task_1_state.state_details.task_run_id
+        )
+        assert task_2_state.state_details.upstream_cause_state_type == StateType.FAILED
+        assert task_2_state.state_details.upstream_cause_state_name == "Failed"
+        assert task_3_state.type == expected_task_3_state
+        assert task_4_state.is_pending()
+        assert task_4_state.name == "NotReady"
+        assert (
+            task_4_state.state_details.upstream_cause_task_run_id
+            == task_1_state.state_details.task_run_id
+        )
+        assert task_4_state.state_details.upstream_cause_state_type == StateType.FAILED
+        assert task_3_calls == expected_task_3_calls
+        assert task_3_failure_hook_calls == []
+
+        if not include_blocked:
+            assert task_3_state.name == "NotReady"
+            assert (
+                task_3_state.state_details.upstream_cause_task_run_id
+                == task_1_state.state_details.task_run_id
+            )
+            assert (
+                task_3_state.state_details.upstream_cause_state_type == StateType.FAILED
+            )
+
+    def test_async_task_engine_retains_strict_failure_policy(self):
+        task_3_calls: list[str] = []
+        futures: dict[str, PrefectFuture[Any]] = {}
+
+        @task
+        async def task_1() -> None:
+            raise ValueError("task 1 failed")
+
+        @task
+        async def task_2() -> None:
+            raise AssertionError("task 2 should not run")
+
+        @task
+        async def task_3() -> None:
+            task_3_calls.append("task 3")
+
+        @flow
+        def test_flow() -> None:
+            futures["task_1"] = task_1.submit()
+            futures["task_2"] = task_2.submit(wait_for=[futures["task_1"]])
+            futures["task_3"] = task_3.submit(
+                wait_for=[allow_failure(futures["task_2"], include_blocked=False)]
+            )
+            for future in futures.values():
+                future.wait()
+
+        test_flow()
+
+        task_1_state = futures["task_1"].state
+        task_3_state = futures["task_3"].state
+        assert task_3_state.is_pending()
+        assert task_3_calls == []
+        assert (
+            task_3_state.state_details.upstream_cause_task_run_id
+            == task_1_state.state_details.task_run_id
+        )
+        assert task_3_state.state_details.upstream_cause_state_type == StateType.FAILED
+
+    @pytest.mark.parametrize(
+        "root_type",
+        [StateType.CANCELLED, StateType.CRASHED],
+    )
+    def test_allow_failure_does_not_accept_cancelled_or_crashed_not_ready_ancestor(
+        self, root_type: StateType
+    ):
+        root_task_run_id = uuid4()
+        root_state = (
+            Cancelled(state_details={"task_run_id": root_task_run_id})
+            if root_type == StateType.CANCELLED
+            else Crashed(state_details={"task_run_id": root_task_run_id})
+        )
+        task_calls: list[str] = []
+        futures: dict[str, PrefectFuture[Any]] = {}
+
+        @task
+        def should_not_run() -> None:
+            task_calls.append("called")
+
+        @flow
+        def test_flow() -> None:
+            futures["blocked"] = should_not_run.submit(wait_for=[root_state])
+            futures["transitive"] = should_not_run.submit(
+                wait_for=[allow_failure(futures["blocked"])]
+            )
+            for future in futures.values():
+                future.wait()
+
+        test_flow()
+
+        blocked_state = futures["blocked"].state
+        transitive_state = futures["transitive"].state
+        assert blocked_state.is_pending()
+        assert transitive_state.is_pending()
+        assert task_calls == []
+        assert (
+            blocked_state.state_details.upstream_cause_task_run_id == root_task_run_id
+        )
+        assert blocked_state.state_details.upstream_cause_state_type == root_type
+        assert (
+            transitive_state.state_details.upstream_cause_task_run_id
+            == root_task_run_id
+        )
+        assert transitive_state.state_details.upstream_cause_state_type == root_type
 
 
 async def _wait_for_logs(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3613,24 +3613,47 @@ class TestRunResultsIdentityTracking:
 
 class TestSubflowWaitForTasks:
     async def test_downstream_does_not_run_if_upstream_fails(self):
+        child_flow_calls: list[int] = []
+
         @task
-        def fails():
+        def fails() -> None:
             raise ValueError("Fail task!")
 
         @flow
-        def bar(y):
+        def bar(y: int) -> int:
+            child_flow_calls.append(y)
             return y
 
         @flow
         def test_flow():
-            f = fails.submit()
-            b = bar(2, wait_for=[f], return_state=True)
-            return b
+            failed = fails.submit()
+            blocked = bar(2, wait_for=[failed], return_state=True)
+            strict = bar(
+                3,
+                wait_for=[allow_failure(blocked, include_blocked=False)],
+                return_state=True,
+            )
+            return quote((failed.state, blocked, strict))
 
         flow_state = test_flow(return_state=True)
-        subflow_state = await flow_state.result(raise_on_failure=False)
-        assert subflow_state.is_pending()
-        assert subflow_state.name == "NotReady"
+        failed_state, blocked_state, strict_state = (
+            await flow_state.result(raise_on_failure=False)
+        ).unquote()
+
+        assert failed_state.is_failed()
+        assert blocked_state.is_pending()
+        assert blocked_state.name == "NotReady"
+        assert strict_state.is_pending()
+        assert child_flow_calls == []
+        assert (
+            blocked_state.state_details.upstream_cause_task_run_id
+            == failed_state.state_details.task_run_id
+        )
+        assert (
+            strict_state.state_details.upstream_cause_task_run_id
+            == failed_state.state_details.task_run_id
+        )
+        assert strict_state.state_details.upstream_cause_state_type == StateType.FAILED
 
     async def test_async_subflow_retains_root_cause_through_strict_blocking(self):
         child_flow_calls: list[str] = []

--- a/tests/utilities/test_annotations.py
+++ b/tests/utilities/test_annotations.py
@@ -1,3 +1,4 @@
+import pickle
 import random
 from typing import Any
 
@@ -5,7 +6,78 @@ import httpx
 import pytest
 from pydantic import TypeAdapter
 
-from prefect.utilities.annotations import freeze, unmapped
+from prefect.utilities.annotations import allow_failure, freeze, unmapped
+from prefect.utilities.callables import expand_mapping_parameters
+
+
+class TestAllowFailure:
+    @pytest.mark.parametrize(
+        "annotation,expected_repr,include_blocked",
+        [
+            (allow_failure("value"), "allow_failure('value')", True),
+            (
+                allow_failure("value", include_blocked=False),
+                "allow_failure('value', include_blocked=False)",
+                False,
+            ),
+        ],
+    )
+    def test_preserves_one_element_tuple_interface(
+        self,
+        annotation: allow_failure[str],
+        expected_repr: str,
+        include_blocked: bool,
+    ):
+        assert isinstance(annotation, allow_failure)
+        assert len(annotation) == 1
+        assert tuple(annotation) == ("value",)
+        assert annotation.unwrap() == "value"
+        assert annotation.include_blocked is include_blocked
+        assert repr(annotation) == expected_repr
+
+    @pytest.mark.parametrize("include_blocked", [True, False])
+    def test_is_picklable(self, include_blocked: bool):
+        annotation = allow_failure("value", include_blocked=include_blocked)
+
+        restored = pickle.loads(pickle.dumps(annotation))
+
+        assert restored == annotation
+        assert restored.include_blocked is include_blocked
+        assert repr(restored) == repr(annotation)
+
+    @pytest.mark.parametrize("include_blocked", [True, False])
+    def test_rewrap_preserves_policy(self, include_blocked: bool):
+        annotation = allow_failure("old", include_blocked=include_blocked)
+
+        rewrapped = annotation.rewrap("new")
+
+        assert rewrapped.unwrap() == "new"
+        assert rewrapped.include_blocked is include_blocked
+
+    def test_mapping_expansion_preserves_policy(self):
+        def identity(value: str) -> str:
+            return value
+
+        parameters = expand_mapping_parameters(
+            identity,
+            {"value": allow_failure(["first", "second"], include_blocked=False)},
+        )
+
+        assert [parameter["value"].unwrap() for parameter in parameters] == [
+            "first",
+            "second",
+        ]
+        assert all(
+            isinstance(parameter["value"], allow_failure)
+            and not parameter["value"].include_blocked
+            for parameter in parameters
+        )
+
+    def test_equality_is_preserved_for_each_policy(self):
+        assert allow_failure("value") == allow_failure("value")
+        assert allow_failure("value", include_blocked=False) == allow_failure(
+            "value", include_blocked=False
+        )
 
 
 class TestUnmapped:

--- a/tests/utilities/test_engine.py
+++ b/tests/utilities/test_engine.py
@@ -1,0 +1,127 @@
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from prefect.client.schemas.objects import StateDetails, StateType
+from prefect.exceptions import UpstreamTaskError
+from prefect.states import Cancelled, Completed, Crashed, Failed, Pending, State
+from prefect.utilities.annotations import allow_failure
+from prefect.utilities.engine import resolve_inputs, resolve_inputs_sync
+
+
+def dependency_state(case: str) -> State[Any]:
+    state_details = StateDetails(task_run_id=uuid4())
+
+    if case == "completed":
+        return Completed(data="completed", state_details=state_details)
+    if case == "failed":
+        return Failed(data=ValueError("failed"), state_details=state_details)
+    if case == "cancelled":
+        return Cancelled(state_details=state_details)
+    if case == "crashed":
+        return Crashed(state_details=state_details)
+    if case == "legacy_not_ready":
+        return Pending(name="NotReady", state_details=state_details)
+
+    cause_type = {
+        "failed_not_ready": StateType.FAILED,
+        "cancelled_not_ready": StateType.CANCELLED,
+        "crashed_not_ready": StateType.CRASHED,
+    }[case]
+    return Pending(
+        name="NotReady",
+        state_details=StateDetails(
+            task_run_id=state_details.task_run_id,
+            upstream_cause_task_run_id=uuid4(),
+            upstream_cause_state_type=cause_type,
+            upstream_cause_state_name=cause_type.value.capitalize(),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "case,include_blocked,allowed",
+    [
+        ("completed", True, True),
+        ("failed", True, True),
+        ("cancelled", True, False),
+        ("crashed", True, False),
+        ("failed_not_ready", True, True),
+        ("cancelled_not_ready", True, False),
+        ("crashed_not_ready", True, False),
+        ("legacy_not_ready", True, True),
+        ("completed", False, True),
+        ("failed", False, True),
+        ("cancelled", False, False),
+        ("crashed", False, False),
+        ("failed_not_ready", False, False),
+        ("cancelled_not_ready", False, False),
+        ("crashed_not_ready", False, False),
+        ("legacy_not_ready", False, False),
+    ],
+)
+class TestDependencyResolutionPolicy:
+    def test_sync_resolver(self, case: str, include_blocked: bool, allowed: bool):
+        state = dependency_state(case)
+        parameters = {"value": allow_failure(state, include_blocked=include_blocked)}
+
+        if not allowed:
+            with pytest.raises(UpstreamTaskError):
+                resolve_inputs_sync(parameters)
+            return
+
+        resolved = resolve_inputs_sync(parameters)
+        if case == "completed":
+            assert resolved == {"value": "completed"}
+        elif case == "failed":
+            assert isinstance(resolved["value"], ValueError)
+        else:
+            assert resolved == {"value": None}
+
+    async def test_async_resolver(
+        self, case: str, include_blocked: bool, allowed: bool
+    ):
+        state = dependency_state(case)
+        parameters = {"value": allow_failure(state, include_blocked=include_blocked)}
+
+        if not allowed:
+            with pytest.raises(UpstreamTaskError):
+                await resolve_inputs(parameters)
+            return
+
+        resolved = await resolve_inputs(parameters)
+        if case == "completed":
+            assert resolved == {"value": "completed"}
+        elif case == "failed":
+            assert isinstance(resolved["value"], ValueError)
+        else:
+            assert resolved == {"value": None}
+
+
+def test_upstream_error_retains_immediate_and_root_metadata():
+    immediate_task_run_id = uuid4()
+    root_task_run_id = uuid4()
+    state = Pending(
+        name="NotReady",
+        state_details=StateDetails(
+            task_run_id=immediate_task_run_id,
+            upstream_cause_task_run_id=root_task_run_id,
+            upstream_cause_state_type=StateType.FAILED,
+            upstream_cause_state_name="Failed",
+        ),
+    )
+
+    with pytest.raises(UpstreamTaskError) as exc_info:
+        resolve_inputs_sync({"value": allow_failure(state, include_blocked=False)})
+
+    assert str(exc_info.value) == (
+        f"Upstream task run '{immediate_task_run_id}' did not reach a"
+        " 'COMPLETED' state."
+    )
+    assert exc_info.value.upstream_task_run_id == immediate_task_run_id
+    assert exc_info.value.upstream_state_type == StateType.PENDING
+    assert exc_info.value.upstream_state_name == "NotReady"
+    assert exc_info.value.root_cause_task_run_id == root_task_run_id
+    assert exc_info.value.root_cause_state_type == StateType.FAILED
+    assert exc_info.value.root_cause_state_name == "Failed"


### PR DESCRIPTION
closes #22918

this PR adds `allow_failure(..., include_blocked=False)` for downstream runs that should continue only when the annotated run executed and failed directly. The default remains transitive for compatibility with existing cleanup workflows.

<details>
<summary>Details</summary>

- Records the root upstream run IDs, state type, and state name when creating `Pending`/`NotReady` states.
- Applies one dependency policy across sync and async resolution, including mapped tasks and process-pool serialization.
- Allows legacy `NotReady` states without provenance under the default policy, while strict mode rejects every blocked state.
- Prevents cancelled and crashed ancestors from becoming allowable after passing through `NotReady`.
- Documents the default cleanup behavior and direct-failure-only option.
- Adds focused coverage for annotations, causal propagation, sync and async engines, thread and process runners, mapping, hooks, and state serialization. The focused suite passes with 101 tests.

</details>

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
