### PR TITLE
docs: add new Prefect Managed outbound IPs

### DIFF
--- a/docs/v3/how-to-guides/deployment_infra/managed.mdx
+++ b/docs/v3/how-to-guides/deployment_infra/managed.mdx
@@ -73,15 +73,18 @@ Alternatively, you can create a `requirements.txt` file and reference it in your
 
 ## Networking
 
-### Static Outbound IP addresses
+### Static outbound IP addresses
 
-Flows running on Prefect Managed infrastructure can be assigned static IP addresses on outbound traffic, which will pose as the `source` address for requests interacting with your system or database.
+Flows running on Prefect Managed infrastructure use one of the following static IP addresses for outbound traffic. The address may vary between flow runs.
 
-Include these `source` addresses in your firewall rules to explicitly allow flows to communicate with your environment.
+Include all of these `source` addresses in your firewall rules to allow flows to communicate with your environment.
 
 - `184.73.85.134`
 - `52.4.218.198`
 - `44.217.117.74`
+- `18.233.38.236`
+- `54.227.144.94`
+- `50.19.165.169`
 
 ### Images
 


### PR DESCRIPTION
Prefect Managed infrastructure now uses six possible outbound IP addresses. The docs list only three, so firewall allowlists based on the docs can reject runs scheduled in the new availability zones.

This adds the three new addresses and tells readers to allowlist the full set because the address may vary between flow runs.

Related infrastructure change: [PrefectHQ/platform#12350](https://github.com/PrefectHQ/platform/pull/12350)

Validation: `vale v3/how-to-guides/deployment_infra/managed.mdx`

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

<details>
<summary>Session context</summary>

Support reported that a customer's database began rejecting managed flow runs after the AWS network expanded from three to six availability zones. Each new zone has its own stable NAT gateway address, so customers using firewall rules must allowlist all six addresses.

</details>
