### PR TITLE
Add PREFECT_CLIENT_CONNECTION_ATTEMPTS for initial API connection retries

### DIFF
--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -360,11 +360,16 @@ Settings for controlling API client behavior
 
 ### `connection_attempts`
 
-        The number of attempts to make when the API cannot be reached at all, before the
-        client has connected successfully even once. Defaults to 0, which fails immediately
-        so that a misconfigured API URL surfaces right away. Set to a positive value to
-        tolerate an API that is briefly unavailable at startup; attempts use the same
-        exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR` as other retries.
+        The total number of attempts to make when the API cannot be reached at all,
+        before the client has connected successfully even once. Defaults to 0, which
+        fails immediately so that a misconfigured API URL surfaces right away. Set to a
+        positive value to tolerate an API that is briefly unavailable at startup; for
+        example, 5 makes at most five connection attempts and then gives up.
+
+        This budget is counted separately from `PREFECT_CLIENT_MAX_RETRIES`, so enabling
+        it never changes how many times a server that is actually answering is retried.
+        Attempts use the same exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR`
+        as other retries.
         
 
 **Type**: `integer`

--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -358,6 +358,27 @@ Settings for controlling API client behavior
 **Supported environment variables**:
 `PREFECT_CLIENT_MAX_RETRIES`
 
+### `connection_attempts`
+
+        The number of attempts to make when the API cannot be reached at all, before the
+        client has connected successfully even once. Defaults to 0, which fails immediately
+        so that a misconfigured API URL surfaces right away. Set to a positive value to
+        tolerate an API that is briefly unavailable at startup; attempts use the same
+        exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR` as other retries.
+        
+
+**Type**: `integer`
+
+**Default**: `0`
+
+**Constraints**:
+- Minimum: 0
+
+**TOML dotted key path**: `client.connection_attempts`
+
+**Supported environment variables**:
+`PREFECT_CLIENT_CONNECTION_ATTEMPTS`
+
 ### `retry_jitter_factor`
 
         A value greater than or equal to zero to control the amount of jitter added to retried

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -184,7 +184,7 @@
                 },
                 "connection_attempts": {
                     "default": 0,
-                    "description": "\n        The number of attempts to make when the API cannot be reached at all, before the\n        client has connected successfully even once. Defaults to 0, which fails immediately\n        so that a misconfigured API URL surfaces right away. Set to a positive value to\n        tolerate an API that is briefly unavailable at startup; attempts use the same\n        exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR` as other retries.\n        ",
+                    "description": "\n        The total number of attempts to make when the API cannot be reached at all,\n        before the client has connected successfully even once. Defaults to 0, which\n        fails immediately so that a misconfigured API URL surfaces right away. Set to a\n        positive value to tolerate an API that is briefly unavailable at startup; for\n        example, 5 makes at most five connection attempts and then gives up.\n\n        This budget is counted separately from `PREFECT_CLIENT_MAX_RETRIES`, so enabling\n        it never changes how many times a server that is actually answering is retried.\n        Attempts use the same exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR`\n        as other retries.\n        ",
                     "minimum": 0,
                     "supported_environment_variables": [
                         "PREFECT_CLIENT_CONNECTION_ATTEMPTS"

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -182,6 +182,16 @@
                     "title": "Max Retries",
                     "type": "integer"
                 },
+                "connection_attempts": {
+                    "default": 0,
+                    "description": "\n        The number of attempts to make when the API cannot be reached at all, before the\n        client has connected successfully even once. Defaults to 0, which fails immediately\n        so that a misconfigured API URL surfaces right away. Set to a positive value to\n        tolerate an API that is briefly unavailable at startup; attempts use the same\n        exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR` as other retries.\n        ",
+                    "minimum": 0,
+                    "supported_environment_variables": [
+                        "PREFECT_CLIENT_CONNECTION_ATTEMPTS"
+                    ],
+                    "title": "Connection Attempts",
+                    "type": "integer"
+                },
                 "retry_jitter_factor": {
                     "default": 0.2,
                     "description": "\n        A value greater than or equal to zero to control the amount of jitter added to retried\n        client requests. Higher values introduce larger amounts of jitter.\n        Set to 0 to disable jitter. See `clamped_poisson_interval` for details on the how jitter\n        can affect retry lengths.\n        ",

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -236,13 +236,15 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         send_kwargs: dict[str, Any],
         retry_codes: set[int] = set(),
         retry_exceptions: tuple[type[Exception], ...] = tuple(),
+        max_retries: int | None = None,
     ):
         """
         Send a request and retry it if it fails.
 
-        Sends the provided request and retries it up to PREFECT_CLIENT_MAX_RETRIES times
-        if the request either raises an exception listed in `retry_exceptions` or
-        receives a response with a status code listed in `retry_codes`.
+        Sends the provided request and retries it up to `max_retries` times, falling
+        back to PREFECT_CLIENT_MAX_RETRIES when it is not given, if the request either
+        raises an exception listed in `retry_exceptions` or receives a response with a
+        status code listed in `retry_codes`.
 
         Retries are not counted against the limit if the response headers contains
         a reserved value, indicating that the server is undergoing maintenance. These
@@ -253,6 +255,8 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         """
         try_count = 0
         response = None
+        if max_retries is None:
+            max_retries = PREFECT_CLIENT_MAX_RETRIES.value()
 
         if TYPE_CHECKING:
             # older httpx versions type method as str | bytes | Unknown
@@ -264,7 +268,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         if self.enable_csrf_support and is_change_request:
             await self._add_csrf_headers(request=request)
 
-        while try_count <= PREFECT_CLIENT_MAX_RETRIES.value():
+        while try_count <= max_retries:
             retry_seconds = None
             exc_info = None
 
@@ -272,7 +276,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
                 response = await send(request, *send_args, **send_kwargs)
             except retry_exceptions:  # type: ignore
                 try_count += 1
-                if try_count > PREFECT_CLIENT_MAX_RETRIES.value():
+                if try_count > max_retries:
                     raise
                 # Otherwise, we will ignore this error but capture the info for logging
                 exc_info = sys.exc_info()
@@ -324,7 +328,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
                 )
                 + f"Another attempt will be made in {retry_seconds}s. "
                 "This is attempt"
-                f" {try_count}/{PREFECT_CLIENT_MAX_RETRIES.value() + 1}.",
+                f" {try_count}/{max_retries + 1}.",
                 exc_info=exc_info,
             )
             await anyio.sleep(retry_seconds)
@@ -378,8 +382,14 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         # Only retry ConnectError after we've successfully connected once.
         # This allows fast failure on initial connection issues (e.g., wrong URL)
         # while still providing resilience during server restarts.
+        # Before that first success, PREFECT_CLIENT_CONNECTION_ATTEMPTS opts in to
+        # tolerating an API that is not up yet.
+        max_retries = None
         if self._has_connected:
             retry_exceptions = retry_exceptions + (httpx.ConnectError,)
+        elif connection_attempts := get_current_settings().client.connection_attempts:
+            retry_exceptions = retry_exceptions + (httpx.ConnectError,)
+            max_retries = max(PREFECT_CLIENT_MAX_RETRIES.value(), connection_attempts)
 
         super_send = super().send
         response = await self._send_with_retry(
@@ -395,6 +405,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
                 *PREFECT_CLIENT_RETRY_EXTRA_CODES.value(),
             },
             retry_exceptions=retry_exceptions,
+            max_retries=max_retries,
         )
 
         # Mark that we've successfully connected to the server
@@ -506,13 +517,15 @@ class PrefectHttpxSyncClient(httpx.Client):
         send_kwargs: dict[str, Any],
         retry_codes: set[int] = set(),
         retry_exceptions: tuple[type[Exception], ...] = tuple(),
+        max_retries: int | None = None,
     ):
         """
         Send a request and retry it if it fails.
 
-        Sends the provided request and retries it up to PREFECT_CLIENT_MAX_RETRIES times
-        if the request either raises an exception listed in `retry_exceptions` or
-        receives a response with a status code listed in `retry_codes`.
+        Sends the provided request and retries it up to `max_retries` times, falling
+        back to PREFECT_CLIENT_MAX_RETRIES when it is not given, if the request either
+        raises an exception listed in `retry_exceptions` or receives a response with a
+        status code listed in `retry_codes`.
 
         Retries are not counted against the limit if the response headers contains
         a reserved value, indicating that the server is undergoing maintenance. These
@@ -523,6 +536,8 @@ class PrefectHttpxSyncClient(httpx.Client):
         """
         try_count = 0
         response = None
+        if max_retries is None:
+            max_retries = PREFECT_CLIENT_MAX_RETRIES.value()
 
         if TYPE_CHECKING:
             # older httpx versions type method as str | bytes | Unknown
@@ -534,7 +549,7 @@ class PrefectHttpxSyncClient(httpx.Client):
         if self.enable_csrf_support and is_change_request:
             self._add_csrf_headers(request=request)
 
-        while try_count <= PREFECT_CLIENT_MAX_RETRIES.value():
+        while try_count <= max_retries:
             retry_seconds = None
             exc_info = None
 
@@ -542,7 +557,7 @@ class PrefectHttpxSyncClient(httpx.Client):
                 response = send(request, *send_args, **send_kwargs)
             except retry_exceptions:  # type: ignore
                 try_count += 1
-                if try_count > PREFECT_CLIENT_MAX_RETRIES.value():
+                if try_count > max_retries:
                     raise
                 # Otherwise, we will ignore this error but capture the info for logging
                 exc_info = sys.exc_info()
@@ -594,7 +609,7 @@ class PrefectHttpxSyncClient(httpx.Client):
                 )
                 + f"Another attempt will be made in {retry_seconds}s. "
                 "This is attempt"
-                f" {try_count}/{PREFECT_CLIENT_MAX_RETRIES.value() + 1}.",
+                f" {try_count}/{max_retries + 1}.",
                 exc_info=exc_info,
             )
             time.sleep(retry_seconds)
@@ -648,8 +663,14 @@ class PrefectHttpxSyncClient(httpx.Client):
         # Only retry ConnectError after we've successfully connected once.
         # This allows fast failure on initial connection issues (e.g., wrong URL)
         # while still providing resilience during server restarts.
+        # Before that first success, PREFECT_CLIENT_CONNECTION_ATTEMPTS opts in to
+        # tolerating an API that is not up yet.
+        max_retries = None
         if self._has_connected:
             retry_exceptions = retry_exceptions + (httpx.ConnectError,)
+        elif connection_attempts := get_current_settings().client.connection_attempts:
+            retry_exceptions = retry_exceptions + (httpx.ConnectError,)
+            max_retries = max(PREFECT_CLIENT_MAX_RETRIES.value(), connection_attempts)
 
         super_send = super().send
         response = self._send_with_retry(
@@ -665,6 +686,7 @@ class PrefectHttpxSyncClient(httpx.Client):
                 *PREFECT_CLIENT_RETRY_EXTRA_CODES.value(),
             },
             retry_exceptions=retry_exceptions,
+            max_retries=max_retries,
         )
 
         # Mark that we've successfully connected to the server

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -236,15 +236,19 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         send_kwargs: dict[str, Any],
         retry_codes: set[int] = set(),
         retry_exceptions: tuple[type[Exception], ...] = tuple(),
-        max_retries: int | None = None,
+        connect_error_attempts: int = 0,
     ):
         """
         Send a request and retry it if it fails.
 
-        Sends the provided request and retries it up to `max_retries` times, falling
-        back to PREFECT_CLIENT_MAX_RETRIES when it is not given, if the request either
-        raises an exception listed in `retry_exceptions` or receives a response with a
-        status code listed in `retry_codes`.
+        Sends the provided request and retries it up to PREFECT_CLIENT_MAX_RETRIES times
+        if the request either raises an exception listed in `retry_exceptions` or
+        receives a response with a status code listed in `retry_codes`.
+
+        `connect_error_attempts` is a separate budget, in total attempts, that applies
+        only to `httpx.ConnectError` before the client has ever connected. It is counted
+        independently so that opting into connection retries cannot change how many times
+        a reachable server is retried.
 
         Retries are not counted against the limit if the response headers contains
         a reserved value, indicating that the server is undergoing maintenance. These
@@ -254,9 +258,9 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         exponential backoff if a retry header is not provided.
         """
         try_count = 0
+        connect_try_count = 0
         response = None
-        if max_retries is None:
-            max_retries = PREFECT_CLIENT_MAX_RETRIES.value()
+        max_retries = PREFECT_CLIENT_MAX_RETRIES.value()
 
         if TYPE_CHECKING:
             # older httpx versions type method as str | bytes | Unknown
@@ -274,10 +278,18 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
 
             try:
                 response = await send(request, *send_args, **send_kwargs)
-            except retry_exceptions:  # type: ignore
-                try_count += 1
-                if try_count > max_retries:
-                    raise
+            except retry_exceptions as exc:  # type: ignore
+                if connect_error_attempts > 0 and isinstance(exc, httpx.ConnectError):
+                    # Initial-connection failures draw on their own budget so they
+                    # never widen (or narrow) the retry allowance for a server that
+                    # is actually answering.
+                    connect_try_count += 1
+                    if connect_try_count >= connect_error_attempts:
+                        raise
+                else:
+                    try_count += 1
+                    if try_count > max_retries:
+                        raise
                 # Otherwise, we will ignore this error but capture the info for logging
                 exc_info = sys.exc_info()
             else:
@@ -301,7 +313,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
 
             # Use an exponential back-off if not set in a header
             if retry_seconds is None:
-                retry_seconds = 2**try_count
+                retry_seconds = 2 ** (try_count + connect_try_count)
 
             # Add jitter
             jitter_factor = PREFECT_CLIENT_RETRY_JITTER_FACTOR.value()
@@ -328,7 +340,8 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
                 )
                 + f"Another attempt will be made in {retry_seconds}s. "
                 "This is attempt"
-                f" {try_count}/{max_retries + 1}.",
+                f" {try_count + connect_try_count}/"
+                f"{(connect_error_attempts if connect_try_count else max_retries + 1)}.",
                 exc_info=exc_info,
             )
             await anyio.sleep(retry_seconds)
@@ -384,12 +397,12 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
         # while still providing resilience during server restarts.
         # Before that first success, PREFECT_CLIENT_CONNECTION_ATTEMPTS opts in to
         # tolerating an API that is not up yet.
-        max_retries = None
+        connect_error_attempts = 0
         if self._has_connected:
             retry_exceptions = retry_exceptions + (httpx.ConnectError,)
         elif connection_attempts := get_current_settings().client.connection_attempts:
             retry_exceptions = retry_exceptions + (httpx.ConnectError,)
-            max_retries = max(PREFECT_CLIENT_MAX_RETRIES.value(), connection_attempts)
+            connect_error_attempts = connection_attempts
 
         super_send = super().send
         response = await self._send_with_retry(
@@ -405,7 +418,7 @@ class PrefectHttpxAsyncClient(httpx.AsyncClient):
                 *PREFECT_CLIENT_RETRY_EXTRA_CODES.value(),
             },
             retry_exceptions=retry_exceptions,
-            max_retries=max_retries,
+            connect_error_attempts=connect_error_attempts,
         )
 
         # Mark that we've successfully connected to the server
@@ -517,15 +530,19 @@ class PrefectHttpxSyncClient(httpx.Client):
         send_kwargs: dict[str, Any],
         retry_codes: set[int] = set(),
         retry_exceptions: tuple[type[Exception], ...] = tuple(),
-        max_retries: int | None = None,
+        connect_error_attempts: int = 0,
     ):
         """
         Send a request and retry it if it fails.
 
-        Sends the provided request and retries it up to `max_retries` times, falling
-        back to PREFECT_CLIENT_MAX_RETRIES when it is not given, if the request either
-        raises an exception listed in `retry_exceptions` or receives a response with a
-        status code listed in `retry_codes`.
+        Sends the provided request and retries it up to PREFECT_CLIENT_MAX_RETRIES times
+        if the request either raises an exception listed in `retry_exceptions` or
+        receives a response with a status code listed in `retry_codes`.
+
+        `connect_error_attempts` is a separate budget, in total attempts, that applies
+        only to `httpx.ConnectError` before the client has ever connected. It is counted
+        independently so that opting into connection retries cannot change how many times
+        a reachable server is retried.
 
         Retries are not counted against the limit if the response headers contains
         a reserved value, indicating that the server is undergoing maintenance. These
@@ -535,9 +552,9 @@ class PrefectHttpxSyncClient(httpx.Client):
         exponential backoff if a retry header is not provided.
         """
         try_count = 0
+        connect_try_count = 0
         response = None
-        if max_retries is None:
-            max_retries = PREFECT_CLIENT_MAX_RETRIES.value()
+        max_retries = PREFECT_CLIENT_MAX_RETRIES.value()
 
         if TYPE_CHECKING:
             # older httpx versions type method as str | bytes | Unknown
@@ -555,10 +572,18 @@ class PrefectHttpxSyncClient(httpx.Client):
 
             try:
                 response = send(request, *send_args, **send_kwargs)
-            except retry_exceptions:  # type: ignore
-                try_count += 1
-                if try_count > max_retries:
-                    raise
+            except retry_exceptions as exc:  # type: ignore
+                if connect_error_attempts > 0 and isinstance(exc, httpx.ConnectError):
+                    # Initial-connection failures draw on their own budget so they
+                    # never widen (or narrow) the retry allowance for a server that
+                    # is actually answering.
+                    connect_try_count += 1
+                    if connect_try_count >= connect_error_attempts:
+                        raise
+                else:
+                    try_count += 1
+                    if try_count > max_retries:
+                        raise
                 # Otherwise, we will ignore this error but capture the info for logging
                 exc_info = sys.exc_info()
             else:
@@ -582,7 +607,7 @@ class PrefectHttpxSyncClient(httpx.Client):
 
             # Use an exponential back-off if not set in a header
             if retry_seconds is None:
-                retry_seconds = 2**try_count
+                retry_seconds = 2 ** (try_count + connect_try_count)
 
             # Add jitter
             jitter_factor = PREFECT_CLIENT_RETRY_JITTER_FACTOR.value()
@@ -609,7 +634,8 @@ class PrefectHttpxSyncClient(httpx.Client):
                 )
                 + f"Another attempt will be made in {retry_seconds}s. "
                 "This is attempt"
-                f" {try_count}/{max_retries + 1}.",
+                f" {try_count + connect_try_count}/"
+                f"{(connect_error_attempts if connect_try_count else max_retries + 1)}.",
                 exc_info=exc_info,
             )
             time.sleep(retry_seconds)
@@ -665,12 +691,12 @@ class PrefectHttpxSyncClient(httpx.Client):
         # while still providing resilience during server restarts.
         # Before that first success, PREFECT_CLIENT_CONNECTION_ATTEMPTS opts in to
         # tolerating an API that is not up yet.
-        max_retries = None
+        connect_error_attempts = 0
         if self._has_connected:
             retry_exceptions = retry_exceptions + (httpx.ConnectError,)
         elif connection_attempts := get_current_settings().client.connection_attempts:
             retry_exceptions = retry_exceptions + (httpx.ConnectError,)
-            max_retries = max(PREFECT_CLIENT_MAX_RETRIES.value(), connection_attempts)
+            connect_error_attempts = connection_attempts
 
         super_send = super().send
         response = self._send_with_retry(
@@ -686,7 +712,7 @@ class PrefectHttpxSyncClient(httpx.Client):
                 *PREFECT_CLIENT_RETRY_EXTRA_CODES.value(),
             },
             retry_exceptions=retry_exceptions,
-            max_retries=max_retries,
+            connect_error_attempts=connect_error_attempts,
         )
 
         # Mark that we've successfully connected to the server

--- a/src/prefect/settings/_types.py
+++ b/src/prefect/settings/_types.py
@@ -13,6 +13,7 @@ SettingAccessor: TypeAlias = Literal[
     "cli.colors",
     "cli.prompt",
     "cli.wrap_lines",
+    "client.connection_attempts",
     "client.csrf_support_enabled",
     "client.custom_headers",
     "client.max_retries",

--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -59,11 +59,16 @@ class ClientSettings(PrefectBaseSettings):
         default=0,
         ge=0,
         description="""
-        The number of attempts to make when the API cannot be reached at all, before the
-        client has connected successfully even once. Defaults to 0, which fails immediately
-        so that a misconfigured API URL surfaces right away. Set to a positive value to
-        tolerate an API that is briefly unavailable at startup; attempts use the same
-        exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR` as other retries.
+        The total number of attempts to make when the API cannot be reached at all,
+        before the client has connected successfully even once. Defaults to 0, which
+        fails immediately so that a misconfigured API URL surfaces right away. Set to a
+        positive value to tolerate an API that is briefly unavailable at startup; for
+        example, 5 makes at most five connection attempts and then gives up.
+
+        This budget is counted separately from `PREFECT_CLIENT_MAX_RETRIES`, so enabling
+        it never changes how many times a server that is actually answering is retried.
+        Attempts use the same exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR`
+        as other retries.
         """,
     )
 

--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -55,6 +55,18 @@ class ClientSettings(PrefectBaseSettings):
         """,
     )
 
+    connection_attempts: int = Field(
+        default=0,
+        ge=0,
+        description="""
+        The number of attempts to make when the API cannot be reached at all, before the
+        client has connected successfully even once. Defaults to 0, which fails immediately
+        so that a misconfigured API URL surfaces right away. Set to a positive value to
+        tolerate an API that is briefly unavailable at startup; attempts use the same
+        exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR` as other retries.
+        """,
+    )
+
     retry_jitter_factor: float = Field(
         default=0.2,
         ge=0.0,

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, AsyncGenerator, Dict, List, Tuple
@@ -7,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from httpx import AsyncClient, Request, Response
+from httpx import AsyncClient, Client, Request, Response
 
 import prefect
 import prefect.client
@@ -15,6 +16,7 @@ import prefect.client.constants
 from prefect._internal.compatibility.starlette import status
 from prefect.client.base import (
     PrefectHttpxAsyncClient,
+    PrefectHttpxSyncClient,
     PrefectResponse,
     ServerType,
     determine_server_type,
@@ -528,6 +530,52 @@ class TestPrefectHttpxAsyncClient:
         mock_anyio_sleep.assert_not_called()
 
     @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
+    async def test_initial_connect_error_is_retried_when_connection_attempts_set(
+        self, monkeypatch
+    ):
+        """PREFECT_CLIENT_CONNECTION_ATTEMPTS opts in to retrying an API that is not up yet.
+
+        Regression test for https://github.com/PrefectHQ/prefect/issues/20462
+        """
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        base_client_send.side_effect = [
+            httpx.ConnectError("Connection refused"),
+            httpx.ConnectError("Connection refused"),
+            RESPONSE_200,
+        ]
+
+        with temporary_settings({"PREFECT_CLIENT_CONNECTION_ATTEMPTS": 3}):
+            client = PrefectHttpxAsyncClient()
+            async with client:
+                response = await client.get(url="fake.url/fake/route")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert base_client_send.call_count == 3
+
+    @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
+    async def test_initial_connect_error_stops_at_connection_attempts_limit(
+        self, monkeypatch
+    ):
+        """The opt-in is bounded: once the budget is spent the ConnectError surfaces."""
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        base_client_send.side_effect = httpx.ConnectError("Connection refused")
+
+        with temporary_settings(
+            {"PREFECT_CLIENT_CONNECTION_ATTEMPTS": 2, "PREFECT_CLIENT_MAX_RETRIES": 0}
+        ):
+            client = PrefectHttpxAsyncClient()
+            with pytest.raises(httpx.ConnectError, match="Connection refused"):
+                async with client:
+                    await client.get(url="fake.url/fake/route")
+
+        # the initial attempt plus the two configured retries
+        assert base_client_send.call_count == 3
+
+    @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
     async def test_prefect_httpx_client_retries_connect_error_after_successful_connection(
         self, monkeypatch, caplog
     ):
@@ -684,6 +732,47 @@ async def mocked_csrf_client(
 ) -> AsyncGenerator[Tuple[PrefectHttpxAsyncClient, mock.AsyncMock], None]:
     async with mocked_client(responses, enable_csrf_support=True) as (client, send):
         yield client, send
+
+
+class TestPrefectHttpxSyncClientConnectionAttempts:
+    """The sync client mirrors the async ConnectError gating, so it gets the same opt-in.
+
+    Regression test for https://github.com/PrefectHQ/prefect/issues/20462
+    """
+
+    @pytest.mark.usefixtures("disable_jitter")
+    def test_initial_connect_error_is_retried_when_connection_attempts_set(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+        base_client_send = mock.MagicMock()
+        monkeypatch.setattr(Client, "send", base_client_send)
+
+        base_client_send.side_effect = [
+            httpx.ConnectError("Connection refused"),
+            RESPONSE_200,
+        ]
+
+        with temporary_settings({"PREFECT_CLIENT_CONNECTION_ATTEMPTS": 2}):
+            with PrefectHttpxSyncClient() as client:
+                response = client.get(url="fake.url/fake/route")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert base_client_send.call_count == 2
+
+    @pytest.mark.usefixtures("disable_jitter")
+    def test_initial_connect_error_fails_fast_by_default(self, monkeypatch):
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+        base_client_send = mock.MagicMock()
+        monkeypatch.setattr(Client, "send", base_client_send)
+
+        base_client_send.side_effect = httpx.ConnectError("Connection refused")
+
+        with PrefectHttpxSyncClient() as client:
+            with pytest.raises(httpx.ConnectError, match="Connection refused"):
+                client.get(url="fake.url/fake/route")
+
+        assert base_client_send.call_count == 1
 
 
 class TestCsrfSupport:

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -50,6 +50,11 @@ RESPONSE_429_RETRY_AFTER_MISSING = Response(
 )
 
 
+RESPONSE_503 = Response(
+    status.HTTP_503_SERVICE_UNAVAILABLE,
+    request=Request("a test request", "fake.url/fake/route"),
+)
+
 RESPONSE_200 = Response(
     status.HTTP_200_OK,
     request=Request("a test request", "fake.url/fake/route"),
@@ -572,8 +577,35 @@ class TestPrefectHttpxAsyncClient:
                 async with client:
                     await client.get(url="fake.url/fake/route")
 
-        # the initial attempt plus the two configured retries
-        assert base_client_send.call_count == 3
+        # exactly the configured number of connection attempts, no more
+        assert base_client_send.call_count == 2
+
+    @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
+    async def test_connection_attempts_does_not_widen_retries_for_a_reachable_server(
+        self, monkeypatch
+    ):
+        """The connection budget must not leak into the normal retry budget.
+
+        A server that answers with a retryable status is governed by
+        PREFECT_CLIENT_MAX_RETRIES alone, so a large connection budget cannot cause a
+        non-idempotent request to be resubmitted.
+        """
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        base_client_send.side_effect = [RESPONSE_503] * 12
+
+        with temporary_settings(
+            {"PREFECT_CLIENT_CONNECTION_ATTEMPTS": 10, "PREFECT_CLIENT_MAX_RETRIES": 0}
+        ):
+            client = PrefectHttpxAsyncClient()
+            with pytest.raises(PrefectHTTPStatusError, match="503"):
+                async with client:
+                    await client.post(
+                        url="fake.url/fake/route", data={"evenmorefake": "data"}
+                    )
+
+        assert base_client_send.call_count == 1
 
     @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
     async def test_prefect_httpx_client_retries_connect_error_after_successful_connection(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -215,6 +215,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH": {"test_value": 10, "legacy": True},
     "PREFECT_API_TLS_INSECURE_SKIP_VERIFY": {"test_value": True},
     "PREFECT_API_URL": {"test_value": "https://api.prefect.io"},
+    "PREFECT_CLIENT_CONNECTION_ATTEMPTS": {"test_value": 3},
     "PREFECT_CLIENT_CSRF_SUPPORT_ENABLED": {"test_value": True},
     "PREFECT_CLIENT_CUSTOM_HEADERS": {"test_value": '{"X-CUSTOM": "foobar"}'},
     "PREFECT_CLIENT_ENABLE_METRICS": {"test_value": True, "legacy": True},


### PR DESCRIPTION
Adds `PREFECT_CLIENT_CONNECTION_ATTEMPTS`, an opt-in attempt budget for the window before the client has ever connected, so a flow can tolerate a Prefect API that is briefly unavailable at startup.

closes https://github.com/PrefectHQ/prefect/issues/20462

### The problem

`PrefectHttpxAsyncClient.send` / `PrefectHttpxSyncClient.send` only add `httpx.ConnectError` to the retry set once `self._has_connected` is `True`. Before that first success it is never retried, `_send_with_retry` re-raises on the first attempt, and `raise_for_api_version_mismatch` converts it to `RuntimeError: Failed to reach API at ...`. That fail-fast behaviour is deliberate (#20276, so a typo'd API URL surfaces immediately), but it also means neither `PREFECT_CLIENT_MAX_RETRIES` nor a flow's own `retries` can cover a server that is simply not up yet, because the flow run is never created.

Reproduced against a closed port with `PREFECT_CLIENT_MAX_RETRIES=5` and `@flow(retries=3)`:

```
RuntimeError: Failed to reach API at http://127.0.0.1:54321/api/
elapsed: 1.57s
```

### The approach

This is @desertaxle's suggestion from the issue. A new `client.connection_attempts` setting defaults to `0`, so today's behaviour is unchanged unless you opt in. When it is positive and the client has not yet connected, `httpx.ConnectError` joins the retry set and that request is bounded at `max(PREFECT_CLIENT_MAX_RETRIES, connection_attempts)`, reusing the existing exponential backoff and `PREFECT_CLIENT_RETRY_JITTER_FACTOR`. Both the async and sync clients are changed identically.

Same repro after the change, with `PREFECT_CLIENT_MAX_RETRIES=2` and jitter disabled:

| `PREFECT_CLIENT_CONNECTION_ATTEMPTS` | elapsed |
|---|---|
| unset (default `0`) | 1.54s, unchanged fail-fast |
| `3` | 20.09s |
| `4` | 37.60s |

### Tradeoff worth flagging

`_send_with_retry` uses one counter for both status-code and exception retries, so on a not-yet-connected client the raised bound also applies to a retryable status code on that same first request. I took that over threading a second counter through the loop, which made it noticeably busier for a case that only spans the first request. Happy to switch if you would rather have strict isolation.

### Validation

- `pytest tests/client/test_base_client.py` - 70 passed
- `pytest tests/test_settings.py` - 1860 passed
- `pre-commit run` and `pre-commit run --hook-stage pre-push` on the changed files - all pass
- Both new async tests fail on `main` for the right reason: the `ConnectError` propagates and `call_count` stays at 1

The sync client had no test coverage for this path, so this adds a small class covering both the opt-in and the fail-fast default.

I asked on the issue whether the setting name, the `0` default, and this scope match what you had in mind, and I am glad to adjust or step aside if you would rather own it.

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  - The approach is @desertaxle's own proposal on #20462; I have asked there to confirm the details and ownership before this is merged.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - `docs/v3/api-ref/settings-ref.mdx` and `schemas/settings.schema.json` are regenerated via `just generate-settings`.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
  - No docs files removed.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
