### PR TITLE
Add batch delete and cancel support for flow runs

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -10,11 +10,12 @@ import asyncio
 import logging
 import os
 import signal
+import sys
 import tempfile
 import webbrowser
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Optional, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import UUID
 
 import anyio
@@ -93,6 +94,52 @@ LOGS_WITH_LIMIT_FLAG_DEFAULT_NUM_LOGS = 20
 logger: logging.Logger = get_logger(__name__)
 
 
+def _parse_flow_run_ids(
+    ids: Sequence[UUID] | None,
+    *,
+    from_stdin: bool,
+) -> list[UUID]:
+    """Resolve flow run IDs from positional args and/or stdin.
+
+    IDs are de-duplicated while preserving first-seen order. Stdin lines may be
+    bare UUIDs or whitespace-separated UUIDs; blank lines are ignored.
+    """
+    resolved: list[UUID] = []
+    seen: set[UUID] = set()
+
+    def _add(flow_run_id: UUID) -> None:
+        if flow_run_id not in seen:
+            seen.add(flow_run_id)
+            resolved.append(flow_run_id)
+
+    for flow_run_id in ids or ():
+        _add(flow_run_id)
+
+    if from_stdin:
+        if sys.stdin.isatty():
+            exit_with_error(
+                "No data on stdin. Pipe flow run IDs (one per line) or omit --stdin."
+            )
+        content = sys.stdin.read()
+        if not content.strip():
+            exit_with_error("No flow run IDs provided on stdin.")
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            for token in line.split():
+                try:
+                    _add(UUID(token))
+                except ValueError:
+                    exit_with_error(
+                        f"Invalid flow run ID on stdin line {line_number}: {token!r}"
+                    )
+
+    if not resolved:
+        exit_with_error(
+            "No flow run IDs provided. Pass one or more IDs, or use --stdin."
+        )
+
+    return resolved
+
+
 async def _get_flow_run_by_id_or_name(
     client: PrefectClient,
     id_or_name: str,
@@ -141,7 +188,7 @@ async def inspect(
         cyclopts.Parameter("--web", help="Open the flow run in a web browser."),
     ] = False,
     output: Annotated[
-        Optional[str],
+        str | None,
         cyclopts.Parameter(
             "--output",
             alias="-o",
@@ -187,7 +234,7 @@ async def inspect(
 async def ls(
     *,
     flow_name: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         cyclopts.Parameter("--flow-name", help="Name of the flow"),
     ] = None,
     limit: Annotated[
@@ -195,15 +242,15 @@ async def ls(
         cyclopts.Parameter("--limit", help="Maximum number of flow runs to list"),
     ] = 15,
     state: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         cyclopts.Parameter("--state", help="Name of the flow run's state"),
     ] = None,
     state_type: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         cyclopts.Parameter("--state-type", help="Type of the flow run's state"),
     ] = None,
     output: Annotated[
-        Optional[str],
+        str | None,
         cyclopts.Parameter(
             "--output",
             alias="-o",
@@ -252,7 +299,7 @@ async def ls(
             else:
                 formatted_states.append(s)
                 logger.warning(
-                    f"State name {repr(s)} is not one of the official Prefect state names."
+                    f"State name {s!r} is not one of the official Prefect state names."
                 )
 
         state_filter["name"] = {"any_": formatted_states}
@@ -320,44 +367,113 @@ async def ls(
 
 @flow_run_app.command()
 @with_cli_exception_handling
-async def delete(id: UUID):
-    """Delete a flow run by ID."""
+async def delete(
+    ids: Annotated[
+        list[UUID] | None,
+        cyclopts.Parameter(
+            name="ids",
+            help="One or more flow run IDs to delete.",
+        ),
+    ] = None,
+    *,
+    stdin: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name="--stdin",
+            help="Read flow run IDs from stdin (one per line).",
+        ),
+    ] = False,
+):
+    """Delete one or more flow runs by ID.
+
+    Examples:
+        ```bash
+        $ prefect flow-run delete <id>
+        $ prefect flow-run delete <id1> <id2> <id3>
+        $ prefect flow-run ls -o json | jq -r '.[].id' | prefect flow-run delete --stdin
+        ```
+    """
     from prefect.cli._prompts import confirm
 
-    async with get_client() as client:
-        try:
-            if _cli.is_interactive() and not confirm(
-                f"Are you sure you want to delete flow run with id {id!r}?",
-                default=False,
-            ):
-                exit_with_error("Deletion aborted.")
-            await client.delete_flow_run(id)
-        except ObjectNotFound:
-            exit_with_error(f"Flow run '{id}' not found!")
+    flow_run_ids = _parse_flow_run_ids(ids, from_stdin=stdin)
 
-    exit_with_success(f"Successfully deleted flow run '{id}'.")
+    # Skip the prompt when reading IDs from stdin — the pipe already consumed
+    # stdin, and scripted deletions are intentional.
+    if _cli.is_interactive() and not stdin:
+        if len(flow_run_ids) == 1:
+            prompt = (
+                f"Are you sure you want to delete flow run with id {flow_run_ids[0]!r}?"
+            )
+        else:
+            prompt = f"Are you sure you want to delete {len(flow_run_ids)} flow run(s)?"
+        if not confirm(prompt, default=False):
+            exit_with_error("Deletion aborted.")
+
+    async with get_client() as client:
+        for flow_run_id in flow_run_ids:
+            try:
+                await client.delete_flow_run(flow_run_id)
+            except ObjectNotFound:
+                exit_with_error(f"Flow run '{flow_run_id}' not found!")
+
+    if len(flow_run_ids) == 1:
+        exit_with_success(f"Successfully deleted flow run '{flow_run_ids[0]}'.")
+    exit_with_success(f"Successfully deleted {len(flow_run_ids)} flow run(s).")
 
 
 @flow_run_app.command()
 @with_cli_exception_handling
-async def cancel(id: UUID):
-    """Cancel a flow run by ID."""
+async def cancel(
+    ids: Annotated[
+        list[UUID] | None,
+        cyclopts.Parameter(
+            name="ids",
+            help="One or more flow run IDs to cancel.",
+        ),
+    ] = None,
+    *,
+    stdin: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name="--stdin",
+            help="Read flow run IDs from stdin (one per line).",
+        ),
+    ] = False,
+):
+    """Cancel one or more flow runs by ID.
+
+    Examples:
+        ```bash
+        $ prefect flow-run cancel <id>
+        $ prefect flow-run cancel <id1> <id2> <id3>
+        $ prefect flow-run ls -o json | jq -r '.[].id' | prefect flow-run cancel --stdin
+        ```
+    """
+    flow_run_ids = _parse_flow_run_ids(ids, from_stdin=stdin)
+
     async with get_client() as client:
         cancelling_state = State(type=StateType.CANCELLING)
-        try:
-            result = await client.set_flow_run_state(
-                flow_run_id=id, state=cancelling_state
-            )
-        except ObjectNotFound:
-            exit_with_error(f"Flow run '{id}' not found!")
+        for flow_run_id in flow_run_ids:
+            try:
+                result = await client.set_flow_run_state(
+                    flow_run_id=flow_run_id, state=cancelling_state
+                )
+            except ObjectNotFound:
+                exit_with_error(f"Flow run '{flow_run_id}' not found!")
 
-    if result.status == SetStateStatus.ABORT:
-        exit_with_error(
-            f"Flow run '{id}' was unable to be cancelled. Reason:"
-            f" '{result.details.reason}'"
+            if result.status == SetStateStatus.ABORT:
+                exit_with_error(
+                    f"Flow run '{flow_run_id}' was unable to be cancelled. Reason:"
+                    f" '{result.details.reason}'"
+                )
+
+    if len(flow_run_ids) == 1:
+        exit_with_success(
+            f"Flow run '{flow_run_ids[0]}' was successfully scheduled for cancellation."
         )
-
-    exit_with_success(f"Flow run '{id}' was successfully scheduled for cancellation.")
+    exit_with_success(
+        f"{len(flow_run_ids)} flow run(s) were successfully scheduled for cancellation."
+    )
 
 
 @flow_run_app.command()
@@ -366,7 +482,7 @@ async def retry(
     id_or_name: str,
     *,
     entrypoint: Annotated[
-        Optional[str],
+        str | None,
         cyclopts.Parameter(
             "--entrypoint",
             alias="-e",
@@ -551,7 +667,7 @@ async def logs(
         ),
     ] = False,
     num_logs: Annotated[
-        Optional[int],
+        int | None,
         cyclopts.Parameter(
             "--num-logs",
             alias="-n",
@@ -581,7 +697,7 @@ async def logs(
         ),
     ] = False,
     output: Annotated[
-        Optional[str],
+        str | None,
         cyclopts.Parameter(
             "--output",
             alias="-o",
@@ -608,7 +724,7 @@ async def logs(
     log_filter = LogFilter(flow_run_id={"any_": [id]})
     sort = LogSort.TIMESTAMP_DESC if reverse or tail else LogSort.TIMESTAMP_ASC
 
-    def render(logs_to_render: "list[Log]") -> None:
+    def render(logs_to_render: list[Log]) -> None:
         if output_json:
             collected_logs.extend(log.model_dump(mode="json") for log in logs_to_render)
             return
@@ -630,7 +746,7 @@ async def logs(
         # Bounded requests start with the requested count to avoid overfetching.
         # If that exceeds the server maximum, retry without a limit to discover
         # the server page size from the first response.
-        page_size: Optional[int] = None
+        page_size: int | None = None
         offset = 0
         num_logs_collected = 0
         tail_buffer: list[Log] = []
@@ -715,7 +831,7 @@ async def watch(
     id: UUID,
     *,
     timeout: Annotated[
-        Optional[int],
+        int | None,
         cyclopts.Parameter("--timeout", help="Timeout in seconds."),
     ] = None,
 ):
@@ -747,7 +863,7 @@ async def watch(
 @flow_run_app.command()
 @with_cli_exception_handling
 async def execute(
-    id: Optional[UUID] = None,
+    id: UUID | None = None,
 ):
     """Execute a flow run by ID."""
     if id is None:

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -4,13 +4,15 @@ import json
 import os
 import signal
 import subprocess
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from time import sleep
-from typing import Any, Awaitable, Callable
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import anyio
+import anyio.lowlevel
 import pytest
 
 import prefect.exceptions
@@ -146,11 +148,72 @@ def test_delete_flow_run_succeeds(
     invoke_and_assert(
         command=["flow-run", "delete", str(flow_run.id)],
         user_input="y",
-        expected_output_contains=f"Successfully deleted flow run '{str(flow_run.id)}'.",
+        expected_output_contains=f"Successfully deleted flow run '{flow_run.id!s}'.",
         expected_code=0,
     )
 
     assert_flow_run_is_deleted_sync(sync_prefect_client, flow_run.id)
+
+
+def test_delete_multiple_flow_runs_succeeds(
+    sync_prefect_client: SyncPrefectClient,
+    flow_run: FlowRun,
+    scheduled_flow_run: FlowRun,
+):
+    invoke_and_assert(
+        command=[
+            "flow-run",
+            "delete",
+            str(flow_run.id),
+            str(scheduled_flow_run.id),
+        ],
+        user_input="y",
+        expected_output_contains="Successfully deleted 2 flow run(s).",
+        expected_code=0,
+    )
+
+    assert_flow_run_is_deleted_sync(sync_prefect_client, flow_run.id)
+    assert_flow_run_is_deleted_sync(sync_prefect_client, scheduled_flow_run.id)
+
+
+def test_delete_multiple_flow_runs_fails_correctly(flow_run: FlowRun):
+    missing_flow_run_id = "ccb86ed0-e824-4d8b-b825-880401320e41"
+
+    invoke_and_assert(
+        command=[
+            "flow-run",
+            "delete",
+            str(flow_run.id),
+            missing_flow_run_id,
+        ],
+        user_input="y",
+        expected_output_contains=f"Flow run '{missing_flow_run_id}' not found!",
+        expected_code=1,
+    )
+
+
+def test_delete_flow_runs_from_stdin(
+    sync_prefect_client: SyncPrefectClient,
+    flow_run: FlowRun,
+    scheduled_flow_run: FlowRun,
+):
+    invoke_and_assert(
+        command=["flow-run", "delete", "--stdin"],
+        user_input=f"{flow_run.id}\n{scheduled_flow_run.id}\n",
+        expected_output_contains="Successfully deleted 2 flow run(s).",
+        expected_code=0,
+    )
+
+    assert_flow_run_is_deleted_sync(sync_prefect_client, flow_run.id)
+    assert_flow_run_is_deleted_sync(sync_prefect_client, scheduled_flow_run.id)
+
+
+def test_delete_flow_runs_requires_ids():
+    invoke_and_assert(
+        command=["flow-run", "delete"],
+        expected_output_contains="No flow run IDs provided",
+        expected_code=1,
+    )
 
 
 @pytest.fixture
@@ -518,6 +581,88 @@ class TestCancelFlowRun:
             expected_code=1,
             expected_output_contains=f"Flow run '{bad_id}' not found!\n",
         )
+
+    async def test_cancel_multiple_flow_runs(self, prefect_client: PrefectClient):
+        first = await prefect_client.create_flow_run(
+            name="first",
+            flow=hello_flow,
+            state=Running(),
+        )
+        second = await prefect_client.create_flow_run(
+            name="second",
+            flow=hello_flow,
+            state=Pending(),
+        )
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=[
+                "flow-run",
+                "cancel",
+                str(first.id),
+                str(second.id),
+            ],
+            expected_code=0,
+            expected_output_contains=(
+                "2 flow run(s) were successfully scheduled for cancellation."
+            ),
+        )
+
+        first_after = await prefect_client.read_flow_run(first.id)
+        second_after = await prefect_client.read_flow_run(second.id)
+
+        assert first_after.state.type == StateType.CANCELLING
+        assert second_after.state.type == StateType.CANCELLING
+
+    async def test_cancel_multiple_flow_runs_with_bad_id(
+        self, prefect_client: PrefectClient
+    ):
+        flow_run = await prefect_client.create_flow_run(
+            name="flow-run",
+            flow=hello_flow,
+            state=Running(),
+        )
+        bad_id = str(uuid4())
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=[
+                "flow-run",
+                "cancel",
+                str(flow_run.id),
+                bad_id,
+            ],
+            expected_code=1,
+            expected_output_contains=f"Flow run '{bad_id}' not found!",
+        )
+
+    async def test_cancel_flow_runs_from_stdin(self, prefect_client: PrefectClient):
+        first = await prefect_client.create_flow_run(
+            name="first",
+            flow=hello_flow,
+            state=Running(),
+        )
+        second = await prefect_client.create_flow_run(
+            name="second",
+            flow=hello_flow,
+            state=Pending(),
+        )
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=["flow-run", "cancel", "--stdin"],
+            user_input=f"{first.id}\n{second.id}\n",
+            expected_code=0,
+            expected_output_contains=(
+                "2 flow run(s) were successfully scheduled for cancellation."
+            ),
+        )
+
+        first_after = await prefect_client.read_flow_run(first.id)
+        second_after = await prefect_client.read_flow_run(second.id)
+
+        assert first_after.state.type == StateType.CANCELLING
+        assert second_after.state.type == StateType.CANCELLING
 
 
 class TestGetFlowRunByIdOrName:
@@ -2052,7 +2197,7 @@ class TestSignalHandling:
 
         async def fake_submit(*_: Any, **__: Any) -> None:
             handlers[0]()
-            await anyio.sleep(0)
+            await anyio.lowlevel.checkpoint()
 
         with (
             patch(


### PR DESCRIPTION
closes #19904

this PR adds multi-ID and `--stdin` support to `prefect flow-run delete` and `prefect flow-run cancel` so cleaning up stuck/orphaned runs no longer requires a one-ID-at-a-time loop.

<details>
<summary>Details</summary>

- Accept one or more positional flow run IDs on `delete` and `cancel`
- Add `--stdin` to read IDs from a pipe (one per line), with de-duplication
- Keep single-ID success messages unchanged for backward compatibility
- Skip the interactive delete confirm when `--stdin` is used (stdin is consumed for IDs; piping is intentional)
- Fail fast on the first missing ID, matching existing single-ID behavior
- Leave filter-based delete (`--state`, `--older-than`, etc.) as a follow-up

Prior attempt #22279 went stale before review; this reopens that work and adds the stdin path from the issue.

</details>

## Test plan
- [x] `uv run pytest tests/cli/test_flow_run.py -k "delete_flow_run or delete_multiple or delete_flow_runs or cancel_multiple or cancel_flow_runs_from or test_non_terminal or test_scheduled_states or test_cancelling_terminal or test_wrong_id"` (20 passed)
- [ ] Manual: `prefect flow-run delete <id1> <id2>`
- [ ] Manual: `prefect flow-run ls -o json | jq -r '.[].id' | head -2 | prefect flow-run delete --stdin`


Made with [Cursor](https://cursor.com)