### PR TITLE
Order flow-run heartbeats with state transitions

### DIFF
--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -25,6 +26,76 @@ if TYPE_CHECKING:
 TIGHT_TIMING = timedelta(minutes=5)
 
 logger: "logging.Logger" = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class _PreparedEvent:
+    worker: EventsWorker
+    event: Event
+
+
+def _prepare_event(
+    event: str,
+    resource: dict[str, str],
+    occurred: datetime.datetime | None = None,
+    related: list[dict[str, str]] | list[RelatedResource] | None = None,
+    payload: dict[str, Any] | None = None,
+    id: UUID | None = None,
+    follows: Event | None = None,
+    **kwargs: dict[str, Any] | None,
+) -> _PreparedEvent | None:
+    """Build and validate an event, including any worker initialization."""
+    if not should_emit_events():
+        return None
+
+    operational_clients = [
+        AssertingPassthroughEventsClient,
+        AssertingEventsClient,
+        PrefectCloudEventsClient,
+        PrefectEventsClient,
+        ProcessPoolForwardingEventsClient,
+    ]
+    worker_instance = EventsWorker.instance()
+
+    if worker_instance.client_type not in operational_clients:
+        return None
+
+    event_kwargs: dict[str, Any] = {
+        "event": event,
+        "resource": resource,
+        **kwargs,
+    }
+
+    if occurred is None:
+        occurred = prefect.types._datetime.now("UTC")
+    event_kwargs["occurred"] = occurred
+
+    if related is not None:
+        event_kwargs["related"] = related
+
+    if payload is not None:
+        event_kwargs["payload"] = payload
+
+    if id is not None:
+        event_kwargs["id"] = id
+
+    if follows is not None:
+        if -TIGHT_TIMING < (occurred - follows.occurred) < TIGHT_TIMING:
+            event_kwargs["follows"] = follows.id
+
+    event_obj = Event(**event_kwargs)
+
+    max_size = get_current_settings().server.events.maximum_size_bytes
+    if event_obj.size_bytes > max_size:
+        raise EventTooLarge(event_obj.size_bytes, max_size)
+
+    return _PreparedEvent(worker=worker_instance, event=event_obj)
+
+
+def _enqueue_prepared_event(prepared: _PreparedEvent) -> Event:
+    """Put a prepared event on its in-memory worker queue without network I/O."""
+    prepared.worker.send(prepared.event)
+    return prepared.event
 
 
 def emit_event(
@@ -61,54 +132,20 @@ def emit_event(
         The event that was emitted if worker is using a client that emit
         events, otherwise None
     """
-    if not should_emit_events():
-        return None
-
     try:
-        operational_clients = [
-            AssertingPassthroughEventsClient,
-            AssertingEventsClient,
-            PrefectCloudEventsClient,
-            PrefectEventsClient,
-            ProcessPoolForwardingEventsClient,
-        ]
-        worker_instance = EventsWorker.instance()
-
-        if worker_instance.client_type not in operational_clients:
-            return None
-
-        event_kwargs: dict[str, Any] = {
-            "event": event,
-            "resource": resource,
+        prepared = _prepare_event(
+            event=event,
+            resource=resource,
+            occurred=occurred,
+            related=related,
+            payload=payload,
+            id=id,
+            follows=follows,
             **kwargs,
-        }
-
-        if occurred is None:
-            occurred = prefect.types._datetime.now("UTC")
-        event_kwargs["occurred"] = occurred
-
-        if related is not None:
-            event_kwargs["related"] = related
-
-        if payload is not None:
-            event_kwargs["payload"] = payload
-
-        if id is not None:
-            event_kwargs["id"] = id
-
-        if follows is not None:
-            if -TIGHT_TIMING < (occurred - follows.occurred) < TIGHT_TIMING:
-                event_kwargs["follows"] = follows.id
-
-        event_obj = Event(**event_kwargs)
-
-        max_size = get_current_settings().server.events.maximum_size_bytes
-        if event_obj.size_bytes > max_size:
-            raise EventTooLarge(event_obj.size_bytes, max_size)
-
-        worker_instance.send(event_obj)
-
-        return event_obj
+        )
+        if prepared is None:
+            return None
+        return _enqueue_prepared_event(prepared)
     except EventTooLarge:
         raise
     except Exception:

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -11,7 +11,7 @@ import signal
 import sys
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import (
     AsyncExitStack,
     ExitStack,
@@ -40,6 +40,7 @@ from uuid import UUID
 
 import anyio
 from anyio import CancelScope
+from anyio.to_thread import run_sync as run_sync_in_anyio_worker_thread
 from opentelemetry import propagate, trace
 from typing_extensions import ParamSpec
 
@@ -64,6 +65,7 @@ from prefect._internal.metrics import RunMetrics
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.client.schemas.filters import FlowRunFilter
+from prefect.client.schemas.responses import OrchestrationResult, SetStateStatus
 from prefect.client.schemas.sorting import FlowRunSort
 from prefect.concurrency._leases import (
     amaintain_concurrency_lease,
@@ -85,7 +87,11 @@ from prefect.context import (
 )
 from prefect.engine import _drive_run_flow_result, handle_engine_signals
 from prefect.events.related import RelatedResource, tags_as_related_resources
-from prefect.events.utilities import emit_event
+from prefect.events.utilities import (
+    _enqueue_prepared_event,
+    _prepare_event,
+    emit_event,
+)
 from prefect.exceptions import (
     Abort,
     MissingFlowError,
@@ -160,6 +166,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 MINIMUM_HEARTBEAT_INTERVAL = 30
+_HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS = 2
 _engine_logger = get_logger("engine")
 _CONTROL_CHANNEL_ENV_KEYS = frozenset(
     {"PREFECT__CONTROL_PORT", "PREFECT__CONTROL_TOKEN"}
@@ -302,79 +309,262 @@ def _main(argv: list[str] | None = None) -> int:
     return 0
 
 
-@contextmanager
-def _send_heartbeats(
-    engine: "BaseFlowRunEngine[Any, Any]",
-    join_on_exit: bool = True,
-) -> Generator[None, None, None]:
-    """Context manager that maintains heartbeats for a flow run using a daemon thread.
+class _FlowRunHeartbeatSession:
+    """Order heartbeat sends with authoritative flow-run state requests."""
 
-    Uses a background OS thread instead of an asyncio task so that heartbeats
-    fire even when the event loop is blocked by CPU-bound work.
+    def __init__(
+        self,
+        engine: BaseFlowRunEngine[Any, Any],
+        heartbeat_seconds: int,
+    ) -> None:
+        self._engine = engine
+        self._heartbeat_seconds = heartbeat_seconds
+        self._gate = threading.Lock()
+        self._stop_event = threading.Event()
+        self._resource, self._related = engine._build_heartbeat_event_template()
 
-    Args:
-        engine: The flow run engine instance to emit heartbeats for.
-        join_on_exit: Whether to join the heartbeat thread on exit. Set to
-            `False` in async engines to avoid blocking the event loop.
+        # Copy the current context so the heartbeat thread sees the same
+        # `SettingsContext` (and therefore the same `PREFECT_API_URL`) as the
+        # calling thread. Without this, `threading.Thread` starts with an empty
+        # context and `SettingsContext.get()` falls back to the process-wide
+        # `GLOBAL_SETTINGS_CONTEXT`, which is initialized at import time and can
+        # have a stale `api.url=None`.
+        heartbeat_ctx = contextvars.copy_context()
+        self._thread = threading.Thread(
+            target=heartbeat_ctx.run,
+            args=(self._heartbeat_loop,),
+            daemon=True,
+        )
 
-    Yields:
-        None
-    """
-    heartbeat_seconds = engine.heartbeat_seconds
-    if heartbeat_seconds is None:
-        yield
-        return
-    heartbeat_seconds = max(heartbeat_seconds, MINIMUM_HEARTBEAT_INTERVAL)
+    def start(self) -> None:
+        self._thread.start()
 
-    # Pre-compute the event template once to minimize per-heartbeat GIL hold time
-    resource, related = engine._build_heartbeat_event_template()
+    def _heartbeat_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self.send_heartbeat()
+            except Exception:
+                self._engine.logger.debug("Failed to emit heartbeat", exc_info=True)
 
-    stop_event = threading.Event()
-
-    def heartbeat_loop() -> None:
-        while not stop_event.is_set():
-            # Check state before emitting - don't emit if final
-            if (
-                engine.flow_run
-                and engine.flow_run.state
-                and engine.flow_run.state.is_final()
-            ):
-                engine.logger.debug("Flow run in terminal state, stopping heartbeat")
+            if self._stop_event.wait(self._heartbeat_seconds):
                 return
 
-            try:
-                engine._emit_flow_run_heartbeat(resource, related)
-            except Exception:
-                engine.logger.debug("Failed to emit heartbeat", exc_info=True)
+    def send_heartbeat(self) -> None:
+        if self._stop_event.is_set():
+            return
 
-            # Sleep in increments to allow quick shutdown
-            for _ in range(heartbeat_seconds):
-                if stop_event.is_set():
-                    return
-                time.sleep(1)
+        # Worker initialization and event construction may block, so perform
+        # them before admission. A state request can close the session while
+        # preparation is in flight, in which case the event is dropped below.
+        prepared = _prepare_event(
+            event="prefect.flow-run.heartbeat",
+            resource=self._resource,
+            related=self._related,
+        )
+        if prepared is None:
+            return
 
-    # Copy the current context so the heartbeat thread sees the same
-    # `SettingsContext` (and therefore the same `PREFECT_API_URL`) as the
-    # calling thread. Without this, `threading.Thread` starts with an empty
-    # context and `SettingsContext.get()` falls back to the process-wide
-    # `GLOBAL_SETTINGS_CONTEXT`, which is initialized at import time and can
-    # have a stale `api.url=None`. That caused `EventsWorker.instance()` from
-    # the heartbeat path to spawn an ephemeral `SubprocessASGIServer` during
-    # flow teardown, racing with interpreter shutdown and aborting the
-    # process.
-    heartbeat_ctx = contextvars.copy_context()
-    thread = threading.Thread(
-        target=heartbeat_ctx.run, args=(heartbeat_loop,), daemon=True
+        # The gate covers only the worker's in-memory `put_nowait` enqueue.
+        # A later state request therefore drains admitted sends without waiting
+        # on worker initialization or network I/O.
+        with self._gate:
+            if self._stop_event.is_set():
+                return
+            if (
+                self._engine.flow_run
+                and self._engine.flow_run.state
+                and self._engine.flow_run.state.is_final()
+            ):
+                self._stop_event.set()
+                self._engine.logger.debug(
+                    "Flow run in terminal state, stopping heartbeat"
+                )
+                return
+            _enqueue_prepared_event(prepared)
+
+    def _resolve_state_request(self, response: OrchestrationResult[Any]) -> None:
+        # WAIT explicitly reopens heartbeat admission between server attempts.
+        if response.status == SetStateStatus.WAIT:
+            return
+
+        # A terminal server state is authoritative and absorbing. ABORT and
+        # malformed responses fail closed because the server may have accepted
+        # the transition even if the engine cannot observe its result.
+        if (
+            response.status == SetStateStatus.ABORT
+            or response.state is None
+            or response.state.is_final()
+        ):
+            self._stop_event.set()
+
+    @contextmanager
+    def state_request(
+        self,
+    ) -> Generator[Callable[[OrchestrationResult[Any]], None], None, None]:
+        self._gate.acquire()
+        resolved = False
+        try:
+
+            def resolve(response: OrchestrationResult[Any]) -> None:
+                nonlocal resolved
+                self._resolve_state_request(response)
+                resolved = True
+
+            yield resolve
+        finally:
+            if not resolved:
+                self._stop_event.set()
+            self._gate.release()
+
+    @asynccontextmanager
+    async def state_request_async(
+        self,
+    ) -> AsyncGenerator[Callable[[OrchestrationResult[Any]], None], None]:
+        acquired = False
+        resolved = False
+        try:
+            # Lock acquisition can wait for an in-flight heartbeat, so keep it
+            # off the event loop. Shielding guarantees ownership is recorded
+            # before cancellation can unwind the context manager.
+            with CancelScope(shield=True):
+                await run_sync_in_anyio_worker_thread(
+                    self._gate.acquire,
+                )
+                acquired = True
+
+            def resolve(response: OrchestrationResult[Any]) -> None:
+                nonlocal resolved
+                self._resolve_state_request(response)
+                resolved = True
+
+            yield resolve
+        finally:
+            if acquired:
+                if not resolved:
+                    self._stop_event.set()
+                self._gate.release()
+
+    def close(self) -> None:
+        self._stop_event.set()
+        with self._gate:
+            pass
+        self._thread.join(timeout=_HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS)
+        if self._thread.is_alive():
+            self._engine.logger.error(
+                "Flow-run heartbeat thread did not stop within %s seconds; "
+                "continuing teardown",
+                _HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS,
+            )
+
+    async def aclose(self) -> None:
+        with CancelScope(shield=True):
+            await run_sync_in_anyio_worker_thread(self.close, abandon_on_cancel=False)
+
+
+class _SyncFlowRunStateClient:
+    """Narrow adapter that gates each actual synchronous state request."""
+
+    def __init__(
+        self,
+        client: SyncPrefectClient,
+        heartbeat_session: _FlowRunHeartbeatSession,
+    ) -> None:
+        self._client = client
+        self._heartbeat_session = heartbeat_session
+
+    def set_flow_run_state(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]:
+        with self._heartbeat_session.state_request() as resolve:
+            response = self._client.set_flow_run_state(flow_run_id, state, force=force)
+            resolve(response)
+            return response
+
+
+class _AsyncFlowRunStateClient:
+    """Narrow adapter that gates each actual asynchronous state request."""
+
+    def __init__(
+        self,
+        client: PrefectClient,
+        heartbeat_session: _FlowRunHeartbeatSession,
+    ) -> None:
+        self._client = client
+        self._heartbeat_session = heartbeat_session
+
+    async def set_flow_run_state(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]:
+        async with self._heartbeat_session.state_request_async() as resolve:
+            response = await self._client.set_flow_run_state(
+                flow_run_id, state, force=force
+            )
+            resolve(response)
+            return response
+
+
+def _start_heartbeat_session(
+    engine: BaseFlowRunEngine[Any, Any],
+) -> _FlowRunHeartbeatSession | None:
+    heartbeat_seconds = engine.heartbeat_seconds
+    if heartbeat_seconds is None:
+        return None
+
+    session = _FlowRunHeartbeatSession(
+        engine,
+        max(heartbeat_seconds, MINIMUM_HEARTBEAT_INTERVAL),
     )
-    thread.start()
+    engine._heartbeat_session = session
+    started = False
+    try:
+        session.start()
+        started = True
+    finally:
+        if not started:
+            engine._heartbeat_session = None
     engine.logger.debug("Started flow run heartbeat context")
+    return session
+
+
+@contextmanager
+def _send_heartbeats(
+    engine: BaseFlowRunEngine[Any, Any],
+) -> Generator[None, None, None]:
+    """Maintain flow-run heartbeats from a background OS thread."""
+    session = _start_heartbeat_session(engine)
+    if session is None:
+        yield
+        return
 
     try:
         yield
     finally:
-        stop_event.set()
-        if join_on_exit:
-            thread.join(timeout=2)
+        session.close()
+        engine._heartbeat_session = None
+        engine.logger.debug("Stopped flow run heartbeat context")
+
+
+@asynccontextmanager
+async def _send_heartbeats_async(
+    engine: BaseFlowRunEngine[Any, Any],
+) -> AsyncGenerator[None, None]:
+    """Async counterpart that waits for shutdown without blocking the event loop."""
+    session = _start_heartbeat_session(engine)
+    if session is None:
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        await session.aclose()
+        engine._heartbeat_session = None
         engine.logger.debug("Stopped flow run heartbeat context")
 
 
@@ -386,19 +576,19 @@ def _send_heartbeats(
 def send_heartbeats_sync(
     engine: "FlowRunEngine[Any, Any]",
 ) -> Generator[None, None, None]:
-    with _send_heartbeats(engine, join_on_exit=True):
+    with _send_heartbeats(engine):
         yield
 
 
 @deprecated_callable(
     start_date=datetime.datetime(2026, 3, 1),
-    help="Use `_send_heartbeats` instead.",
+    help="Use `_send_heartbeats_async` instead.",
 )
 @asynccontextmanager
 async def send_heartbeats_async(
     engine: "AsyncFlowRunEngine[Any, Any]",
 ) -> AsyncGenerator[None, None]:
-    with _send_heartbeats(engine, join_on_exit=False):
+    async with _send_heartbeats_async(engine):
         yield
 
 
@@ -424,6 +614,9 @@ class BaseFlowRunEngine(Generic[P, R]):
         default_factory=FlowRunSuspensionRequest
     )
     _attempt_conclusion: EngineOutcomeReceipt | None = field(default=None, init=False)
+    _heartbeat_session: _FlowRunHeartbeatSession | None = field(
+        default=None, init=False
+    )
 
     def __post_init__(self) -> None:
         if self.flow is None and self.flow_run_id is None:
@@ -539,6 +732,9 @@ class BaseFlowRunEngine(Generic[P, R]):
                 If not provided, builds the template on the fly (backward compat).
         """
         if not self.flow_run:
+            return
+
+        if self.flow_run.state and self.flow_run.state.is_final():
             return
 
         if resource is None or related is None:
@@ -757,8 +953,14 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         if self.short_circuit:
             return self.state
 
+        client = self.client
+        if self._heartbeat_session is not None:
+            client = cast(
+                SyncPrefectClient,
+                _SyncFlowRunStateClient(client, self._heartbeat_session),
+            )
         state = propose_state_sync(
-            self.client, state, flow_run_id=self.flow_run.id, force=force
+            client, state, flow_run_id=self.flow_run.id, force=force
         )  # type: ignore
         self.flow_run.state = state  # type: ignore
         self.flow_run.state_name = state.name  # type: ignore
@@ -1460,8 +1662,14 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         if self.short_circuit:
             return self.state
 
+        client = self.client
+        if self._heartbeat_session is not None:
+            client = cast(
+                PrefectClient,
+                _AsyncFlowRunStateClient(client, self._heartbeat_session),
+            )
         state = await propose_state(
-            self.client, state, flow_run_id=self.flow_run.id, force=force
+            client, state, flow_run_id=self.flow_run.id, force=force
         )  # type: ignore
         self.flow_run.state = state  # type: ignore
         self.flow_run.state_name = state.name  # type: ignore
@@ -2024,7 +2232,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     seconds=self.flow.timeout_seconds,
                     timeout_exc_type=FlowRunTimeoutError,
                 ):
-                    with _send_heartbeats(self, join_on_exit=False):
+                    async with _send_heartbeats_async(self):
                         self.logger.debug(
                             f"Executing flow {self.flow.name!r} for flow run {self.flow_run.name!r}..."
                         )

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -11,7 +11,7 @@ import signal
 import sys
 import threading
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import (
     AsyncExitStack,
     ExitStack,
@@ -20,7 +20,7 @@ from contextlib import (
     nullcontext,
 )
 from dataclasses import dataclass, field
-from functools import wraps
+from functools import partial, wraps
 from typing import (
     Any,
     AsyncGenerator,
@@ -114,6 +114,7 @@ from prefect.logging.loggers import (
     patch_print,
 )
 from prefect.results import (
+    ResultRecord,
     ResultStore,
     _aget_default_persist_result,
     _get_default_persist_result,
@@ -154,9 +155,11 @@ from prefect.utilities.collections import visit_collection
 from prefect.utilities.engine import (
     capture_sigterm,
     link_state_to_flow_run_result,
-    propose_state,
-    propose_state_sync,
     resolve_to_final_result,
+)
+from prefect.utilities.flow_run_state_proposals import (
+    FlowRunStateProposer,
+    SyncFlowRunStateProposer,
 )
 from prefect.utilities.processutils import sanitize_subprocess_env
 from prefect.utilities.timeout import timeout, timeout_async
@@ -460,53 +463,42 @@ class _FlowRunHeartbeatSession:
         with CancelScope(shield=True):
             await run_sync_in_anyio_worker_thread(self.close, abandon_on_cancel=False)
 
-
-class _SyncFlowRunStateClient:
-    """Narrow adapter that gates each actual synchronous state request."""
-
-    def __init__(
+    def run_state_request(
         self,
-        client: SyncPrefectClient,
-        heartbeat_session: _FlowRunHeartbeatSession,
-    ) -> None:
-        self._client = client
-        self._heartbeat_session = heartbeat_session
-
-    def set_flow_run_state(
-        self,
+        request: Callable[[UUID | str, State[Any], bool], OrchestrationResult[Any]],
         flow_run_id: UUID | str,
         state: State[Any],
         force: bool = False,
     ) -> OrchestrationResult[Any]:
-        with self._heartbeat_session.state_request() as resolve:
-            response = self._client.set_flow_run_state(flow_run_id, state, force=force)
+        """Order one synchronous state request with heartbeat admission."""
+        with self.state_request() as resolve:
+            response = request(flow_run_id, state, force)
             resolve(response)
             return response
 
-
-class _AsyncFlowRunStateClient:
-    """Narrow adapter that gates each actual asynchronous state request."""
-
-    def __init__(
+    async def run_state_request_async(
         self,
-        client: PrefectClient,
-        heartbeat_session: _FlowRunHeartbeatSession,
-    ) -> None:
-        self._client = client
-        self._heartbeat_session = heartbeat_session
-
-    async def set_flow_run_state(
-        self,
+        request: Callable[
+            [UUID | str, State[Any], bool],
+            Awaitable[OrchestrationResult[Any]],
+        ],
         flow_run_id: UUID | str,
         state: State[Any],
         force: bool = False,
     ) -> OrchestrationResult[Any]:
-        async with self._heartbeat_session.state_request_async() as resolve:
-            response = await self._client.set_flow_run_state(
-                flow_run_id, state, force=force
-            )
+        """Order one asynchronous state request with heartbeat admission."""
+        async with self.state_request_async() as resolve:
+            response = await request(flow_run_id, state, force)
             resolve(response)
             return response
+
+
+def _link_final_state_to_result(state: State[Any]) -> None:
+    """Preserve dependency tracking before proposing a terminal state."""
+    if not state.is_final():
+        return
+    result = state.data.result if isinstance(state.data, ResultRecord) else state.data
+    link_state_to_flow_run_result(state, result)
 
 
 def _start_heartbeat_session(
@@ -953,15 +945,18 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         if self.short_circuit:
             return self.state
 
-        client = self.client
+        _link_final_state_to_result(state)
+        request = self.client.set_flow_run_state
         if self._heartbeat_session is not None:
-            client = cast(
-                SyncPrefectClient,
-                _SyncFlowRunStateClient(client, self._heartbeat_session),
+            request = partial(
+                self._heartbeat_session.run_state_request,
+                request,
             )
-        state = propose_state_sync(
-            client, state, flow_run_id=self.flow_run.id, force=force
-        )  # type: ignore
+        state = SyncFlowRunStateProposer(request).propose(
+            self.flow_run.id,  # type: ignore[union-attr]
+            state,
+            force=force,
+        )
         self.flow_run.state = state  # type: ignore
         self.flow_run.state_name = state.name  # type: ignore
         self.flow_run.state_type = state.type  # type: ignore
@@ -1662,15 +1657,18 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         if self.short_circuit:
             return self.state
 
-        client = self.client
+        _link_final_state_to_result(state)
+        request = self.client.set_flow_run_state
         if self._heartbeat_session is not None:
-            client = cast(
-                PrefectClient,
-                _AsyncFlowRunStateClient(client, self._heartbeat_session),
+            request = partial(
+                self._heartbeat_session.run_state_request_async,
+                request,
             )
-        state = await propose_state(
-            client, state, flow_run_id=self.flow_run.id, force=force
-        )  # type: ignore
+        state = await FlowRunStateProposer(request).propose(
+            self.flow_run.id,  # type: ignore[union-attr]
+            state,
+            force=force,
+        )
         self.flow_run.state = state  # type: ignore
         self.flow_run.state_name = state.name  # type: ignore
         self.flow_run.state_type = state.type  # type: ignore

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -142,6 +142,10 @@ from prefect.telemetry.run_telemetry import (
     RunTelemetry,
 )
 from prefect.types import KeyValueLabels
+from prefect.utilities._flow_run_state_proposals import (
+    FlowRunStateProposer,
+    SyncFlowRunStateProposer,
+)
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.callables import (
@@ -156,10 +160,6 @@ from prefect.utilities.engine import (
     capture_sigterm,
     link_state_to_flow_run_result,
     resolve_to_final_result,
-)
-from prefect.utilities.flow_run_state_proposals import (
-    FlowRunStateProposer,
-    SyncFlowRunStateProposer,
 )
 from prefect.utilities.processutils import sanitize_subprocess_env
 from prefect.utilities.timeout import timeout, timeout_async

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -161,6 +161,12 @@ from prefect.utilities.engine import (
     link_state_to_flow_run_result,
     resolve_to_final_result,
 )
+from prefect.utilities.engine import (
+    propose_state as propose_state,
+)
+from prefect.utilities.engine import (
+    propose_state_sync as propose_state_sync,
+)
 from prefect.utilities.processutils import sanitize_subprocess_env
 from prefect.utilities.timeout import timeout, timeout_async
 from prefect.utilities.urls import url_for

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import asynccontextmanager, contextmanager, nullcontext
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, cast
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock
 from uuid import UUID
@@ -28,7 +28,7 @@ from prefect._internal.attempt_control import EngineOutcomeReceipt
 from prefect.cache_policies import INPUTS
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter
-from prefect.client.schemas.objects import State, StateType
+from prefect.client.schemas.objects import FlowRun, State, StateType
 from prefect.client.schemas.responses import (
     OrchestrationResult,
     SetStateStatus,
@@ -45,6 +45,8 @@ from prefect.context import (
     get_run_context,
 )
 from prefect.engine import _drive_run_flow_result, handle_engine_signals
+from prefect.events.clients import AssertingEventsClient
+from prefect.events.worker import EventsWorker
 from prefect.exceptions import (
     Abort,
     CrashedRun,
@@ -80,7 +82,11 @@ from prefect.results import get_result_store
 from prefect.runtime import flow_run as runtime_flow_run
 from prefect.server.schemas.core import ConcurrencyLimitV2
 from prefect.server.schemas.core import FlowRun as ServerFlowRun
-from prefect.settings import PREFECT_LOGGING_LOG_PRINTS, temporary_settings
+from prefect.settings import (
+    PREFECT_FLOWS_HEARTBEAT_FREQUENCY,
+    PREFECT_LOGGING_LOG_PRINTS,
+    temporary_settings,
+)
 from prefect.states import Running
 from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.engine import capture_sigterm, propose_state, propose_state_sync
@@ -5585,6 +5591,42 @@ class TestLeaseRenewal:
         )
 
 
+@pytest.fixture
+def running_heartbeat_flow_run() -> FlowRun:
+    return FlowRun(
+        id=uuid.uuid4(),
+        flow_id=uuid.uuid4(),
+        name="test-flow-run",
+        state=states.Running(),
+    )
+
+
+class _SyncStateClientFake:
+    def __init__(self, request: Callable[[], OrchestrationResult[Any]]) -> None:
+        self._request = request
+
+    def set_flow_run_state(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]:
+        return self._request()
+
+
+class _AsyncStateClientFake:
+    def __init__(self, request: Callable[[], OrchestrationResult[Any]]) -> None:
+        self._request = request
+
+    async def set_flow_run_state(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]:
+        return self._request()
+
+
 class _InstrumentedHeartbeatGate:
     """Signal state-request admission attempts without timing assertions."""
 
@@ -5611,7 +5653,7 @@ class TestFlowRunEngineHeartbeat:
     """Tests for heartbeat integration in the flow run engine."""
 
     @staticmethod
-    def _mock_heartbeat_pipeline(
+    def _set_heartbeat_enqueue_barrier(
         monkeypatch: pytest.MonkeyPatch,
         enqueue: Callable[[object], None],
     ) -> None:
@@ -5635,23 +5677,13 @@ class TestFlowRunEngineHeartbeat:
         return OrchestrationResult(status=status, state=state, details=details)
 
     def test_heartbeat_session_reopens_until_server_returns_final_state(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        running_heartbeat_flow_run: FlowRun,
+        asserting_events_worker: EventsWorker,
     ):
-        emitted_events: list[object] = []
-        self._mock_heartbeat_pipeline(
-            monkeypatch,
-            emitted_events.append,
-        )
         engine = FlowRunEngine(
             flow=flow(lambda: None),
-            flow_run=MagicMock(
-                id=uuid.uuid4(),
-                name="test-flow-run",
-                tags=[],
-                flow_id=None,
-                deployment_id=None,
-                state=states.Running(),
-            ),
+            flow_run=running_heartbeat_flow_run,
         )
         session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
 
@@ -5676,26 +5708,22 @@ class TestFlowRunEngineHeartbeat:
         session.send_heartbeat()
 
         assert engine.flow_run.state.is_running()
-        assert len(emitted_events) == 2
+        asserting_events_worker.drain()
+        client = asserting_events_worker._client
+        assert isinstance(client, AssertingEventsClient)
+        assert [event.event for event in client.events] == [
+            "prefect.flow-run.heartbeat",
+            "prefect.flow-run.heartbeat",
+        ]
 
     async def test_async_heartbeat_session_reopens_until_server_returns_final_state(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        running_heartbeat_flow_run: FlowRun,
+        asserting_events_worker: EventsWorker,
     ):
-        emitted_events: list[object] = []
-        self._mock_heartbeat_pipeline(
-            monkeypatch,
-            emitted_events.append,
-        )
         engine = AsyncFlowRunEngine(
             flow=flow(lambda: None),
-            flow_run=MagicMock(
-                id=uuid.uuid4(),
-                name="test-flow-run",
-                tags=[],
-                flow_id=None,
-                deployment_id=None,
-                state=states.Running(),
-            ),
+            flow_run=running_heartbeat_flow_run,
         )
         session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
 
@@ -5720,10 +5748,18 @@ class TestFlowRunEngineHeartbeat:
         session.send_heartbeat()
 
         assert engine.flow_run.state.is_running()
-        assert len(emitted_events) == 2
+        await asserting_events_worker.drain()
+        client = asserting_events_worker._client
+        assert isinstance(client, AssertingEventsClient)
+        assert [event.event for event in client.events] == [
+            "prefect.flow-run.heartbeat",
+            "prefect.flow-run.heartbeat",
+        ]
 
     def test_terminal_transition_closes_heartbeat_during_event_preparation(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        running_heartbeat_flow_run: FlowRun,
     ):
         preparation_started = threading.Event()
         allow_preparation = threading.Event()
@@ -5751,17 +5787,13 @@ class TestFlowRunEngineHeartbeat:
         )
         engine = FlowRunEngine(
             flow=flow(lambda: None),
-            flow_run=MagicMock(
-                id=uuid.uuid4(),
-                name="test-flow-run",
-                tags=[],
-                flow_id=None,
-                deployment_id=None,
-                state=states.Running(),
-            ),
+            flow_run=running_heartbeat_flow_run,
         )
         engine._is_started = True
-        engine._client = MagicMock(set_flow_run_state=set_flow_run_state)
+        engine._client = cast(
+            SyncPrefectClient,
+            _SyncStateClientFake(set_flow_run_state),
+        )
         session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
         engine._heartbeat_session = session
         transition_result: list[State[Any]] = []
@@ -6212,7 +6244,9 @@ class TestFlowRunEngineHeartbeat:
         )
 
     def test_no_heartbeat_emitted_after_terminal_transition_sync(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        running_heartbeat_flow_run: FlowRun,
     ):
         timeline: list[str] = []
         heartbeat_send_started = threading.Event()
@@ -6223,9 +6257,7 @@ class TestFlowRunEngineHeartbeat:
             allow_heartbeat_send.wait()
             timeline.append("heartbeat")
 
-        def set_flow_run_state(
-            *args: object, **kwargs: object
-        ) -> OrchestrationResult[Any]:
+        def set_flow_run_state() -> OrchestrationResult[Any]:
             timeline.append("completed")
             return OrchestrationResult(
                 state=states.Completed(),
@@ -6233,24 +6265,16 @@ class TestFlowRunEngineHeartbeat:
                 details=StateAcceptDetails(),
             )
 
-        self._mock_heartbeat_pipeline(monkeypatch, enqueue_heartbeat)
-        monkeypatch.setattr(
-            "prefect.flow_engine.get_current_settings",
-            lambda: MagicMock(flows=MagicMock(heartbeat_frequency=30)),
-        )
+        self._set_heartbeat_enqueue_barrier(monkeypatch, enqueue_heartbeat)
         engine = FlowRunEngine(
             flow=flow(lambda: None),
-            flow_run=MagicMock(
-                id=uuid.uuid4(),
-                name="test-flow-run",
-                tags=[],
-                flow_id=None,
-                deployment_id=None,
-                state=states.Running(),
-            ),
+            flow_run=running_heartbeat_flow_run,
         )
         engine._is_started = True
-        engine._client = MagicMock(set_flow_run_state=set_flow_run_state)
+        engine._client = cast(
+            SyncPrefectClient,
+            _SyncStateClientFake(set_flow_run_state),
+        )
         session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
         gate = _InstrumentedHeartbeatGate()
         session._gate = gate  # type: ignore[assignment]
@@ -6281,7 +6305,9 @@ class TestFlowRunEngineHeartbeat:
         assert timeline == ["heartbeat", "completed"]
 
     async def test_no_heartbeat_emitted_after_terminal_transition_async(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        running_heartbeat_flow_run: FlowRun,
     ):
         timeline: list[str] = []
         heartbeat_send_started = threading.Event()
@@ -6292,9 +6318,7 @@ class TestFlowRunEngineHeartbeat:
             allow_heartbeat_send.wait()
             timeline.append("heartbeat")
 
-        async def set_flow_run_state(
-            *args: object, **kwargs: object
-        ) -> OrchestrationResult[Any]:
+        def set_flow_run_state() -> OrchestrationResult[Any]:
             timeline.append("completed")
             return OrchestrationResult(
                 state=states.Completed(),
@@ -6302,24 +6326,16 @@ class TestFlowRunEngineHeartbeat:
                 details=StateAcceptDetails(),
             )
 
-        self._mock_heartbeat_pipeline(monkeypatch, enqueue_heartbeat)
-        monkeypatch.setattr(
-            "prefect.flow_engine.get_current_settings",
-            lambda: MagicMock(flows=MagicMock(heartbeat_frequency=30)),
-        )
+        self._set_heartbeat_enqueue_barrier(monkeypatch, enqueue_heartbeat)
         engine = AsyncFlowRunEngine(
             flow=flow(lambda: None),
-            flow_run=MagicMock(
-                id=uuid.uuid4(),
-                name="test-flow-run",
-                tags=[],
-                flow_id=None,
-                deployment_id=None,
-                state=states.Running(),
-            ),
+            flow_run=running_heartbeat_flow_run,
         )
         engine._is_started = True
-        engine._client = MagicMock(set_flow_run_state=set_flow_run_state)
+        engine._client = cast(
+            PrefectClient,
+            _AsyncStateClientFake(set_flow_run_state),
+        )
         session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
         gate = _InstrumentedHeartbeatGate()
         session._gate = gate  # type: ignore[assignment]
@@ -6432,32 +6448,27 @@ class TestFlowRunEngineHeartbeat:
             assert flow_related[0]["prefect.resource.name"] == "my-flow"
 
     def test_async_heartbeats_fire_when_event_loop_blocked(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        asserting_events_worker: EventsWorker,
     ):
         """Heartbeats use a daemon thread, so they fire even when the event loop is blocked.
 
         This is the core fix for issue #20887: CPU-bound async flows previously
         starved the asyncio-based heartbeat task.
         """
-        heartbeat_count = 0
-
-        def enqueue_heartbeat(prepared: object) -> None:
-            nonlocal heartbeat_count
-            heartbeat_count += 1
-
-        self._mock_heartbeat_pipeline(monkeypatch, enqueue_heartbeat)
-        monkeypatch.setattr(
-            "prefect.flow_engine.get_current_settings",
-            lambda: MagicMock(flows=MagicMock(heartbeat_frequency=30)),
-        )
-
         engine = FlowRunEngine(flow=flow(lambda: None))
 
-        with engine.initialize_run():
-            with _send_heartbeats(engine):
-                # Block the current thread for 3 seconds — simulates a
-                # CPU-bound task that would starve an asyncio heartbeat task.
-                # The daemon thread should still emit at least one heartbeat.
-                time.sleep(3)
+        with temporary_settings({PREFECT_FLOWS_HEARTBEAT_FREQUENCY: 30}):
+            with engine.initialize_run():
+                with _send_heartbeats(engine):
+                    # Block the current thread for 3 seconds — simulates a
+                    # CPU-bound task that would starve an asyncio heartbeat task.
+                    # The daemon thread should still emit at least one heartbeat.
+                    time.sleep(3)
 
-        assert heartbeat_count >= 1
+        asserting_events_worker.drain()
+        client = asserting_events_worker._client
+        assert isinstance(client, AssertingEventsClient)
+        assert any(
+            event.event == "prefect.flow-run.heartbeat" for event in client.events
+        )

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -28,7 +28,13 @@ from prefect._internal.attempt_control import EngineOutcomeReceipt
 from prefect.cache_policies import INPUTS
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter
-from prefect.client.schemas.objects import StateType
+from prefect.client.schemas.objects import State, StateType
+from prefect.client.schemas.responses import (
+    OrchestrationResult,
+    SetStateStatus,
+    StateAcceptDetails,
+    StateWaitDetails,
+)
 from prefect.client.schemas.sorting import FlowRunSort
 from prefect.concurrency.asyncio import concurrency as aconcurrency
 from prefect.concurrency.sync import concurrency
@@ -52,12 +58,14 @@ from prefect.flow_engine import (
     AsyncFlowRunEngine,
     FlowRunEngine,
     NotSet,
+    _FlowRunHeartbeatSession,
     _load_flow_from_runtime_entrypoint,
     _main,
     _run_flow_from_runtime_entrypoint,
     _run_serialized_call_with_control_bootstrap,
     _runtime_subprocess_env,
     _send_heartbeats,
+    _send_heartbeats_async,
     load_flow_and_flow_run,
     run_flow,
     run_flow_async,
@@ -5577,8 +5585,208 @@ class TestLeaseRenewal:
         )
 
 
+class _InstrumentedHeartbeatGate:
+    """Signal state-request admission attempts without timing assertions."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.state_request_started = threading.Event()
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        self.state_request_started.set()
+        return self._lock.acquire(blocking, timeout)
+
+    def release(self) -> None:
+        self._lock.release()
+
+    def __enter__(self) -> "_InstrumentedHeartbeatGate":
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._lock.release()
+
+
 class TestFlowRunEngineHeartbeat:
     """Tests for heartbeat integration in the flow run engine."""
+
+    @staticmethod
+    def _mock_heartbeat_pipeline(
+        monkeypatch: pytest.MonkeyPatch,
+        enqueue: Callable[[object], None],
+    ) -> None:
+        prepared_event = object()
+
+        def prepare_event(**kwargs: object) -> object:
+            return prepared_event
+
+        monkeypatch.setattr(flow_engine_module, "_prepare_event", prepare_event)
+        monkeypatch.setattr(flow_engine_module, "_enqueue_prepared_event", enqueue)
+
+    @staticmethod
+    def _heartbeat_session_response(
+        status: SetStateStatus, state: State[Any] | None = None
+    ) -> OrchestrationResult[Any]:
+        details = (
+            StateWaitDetails(delay_seconds=0)
+            if status == SetStateStatus.WAIT
+            else StateAcceptDetails()
+        )
+        return OrchestrationResult(status=status, state=state, details=details)
+
+    def test_heartbeat_session_reopens_until_server_returns_final_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        emitted_events: list[object] = []
+        self._mock_heartbeat_pipeline(
+            monkeypatch,
+            emitted_events.append,
+        )
+        engine = FlowRunEngine(
+            flow=flow(lambda: None),
+            flow_run=MagicMock(
+                id=uuid.uuid4(),
+                name="test-flow-run",
+                tags=[],
+                flow_id=None,
+                deployment_id=None,
+                state=states.Running(),
+            ),
+        )
+        session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
+
+        with session.state_request() as resolve:
+            resolve(self._heartbeat_session_response(SetStateStatus.WAIT))
+        session.send_heartbeat()
+
+        with session.state_request() as resolve:
+            resolve(
+                self._heartbeat_session_response(
+                    SetStateStatus.ACCEPT, states.Running()
+                )
+            )
+        session.send_heartbeat()
+
+        with session.state_request() as resolve:
+            resolve(
+                self._heartbeat_session_response(
+                    SetStateStatus.ACCEPT, states.Completed()
+                )
+            )
+        session.send_heartbeat()
+
+        assert engine.flow_run.state.is_running()
+        assert len(emitted_events) == 2
+
+    async def test_async_heartbeat_session_reopens_until_server_returns_final_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        emitted_events: list[object] = []
+        self._mock_heartbeat_pipeline(
+            monkeypatch,
+            emitted_events.append,
+        )
+        engine = AsyncFlowRunEngine(
+            flow=flow(lambda: None),
+            flow_run=MagicMock(
+                id=uuid.uuid4(),
+                name="test-flow-run",
+                tags=[],
+                flow_id=None,
+                deployment_id=None,
+                state=states.Running(),
+            ),
+        )
+        session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
+
+        async with session.state_request_async() as resolve:
+            resolve(self._heartbeat_session_response(SetStateStatus.WAIT))
+        session.send_heartbeat()
+
+        async with session.state_request_async() as resolve:
+            resolve(
+                self._heartbeat_session_response(
+                    SetStateStatus.ACCEPT, states.Running()
+                )
+            )
+        session.send_heartbeat()
+
+        async with session.state_request_async() as resolve:
+            resolve(
+                self._heartbeat_session_response(
+                    SetStateStatus.ACCEPT, states.Completed()
+                )
+            )
+        session.send_heartbeat()
+
+        assert engine.flow_run.state.is_running()
+        assert len(emitted_events) == 2
+
+    def test_terminal_transition_closes_heartbeat_during_event_preparation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        preparation_started = threading.Event()
+        allow_preparation = threading.Event()
+        state_request_started = threading.Event()
+        enqueued_events: list[object] = []
+
+        def prepare_event(**kwargs: object) -> object:
+            preparation_started.set()
+            allow_preparation.wait()
+            return object()
+
+        def set_flow_run_state(
+            *args: object, **kwargs: object
+        ) -> OrchestrationResult[Any]:
+            state_request_started.set()
+            return self._heartbeat_session_response(
+                SetStateStatus.ACCEPT, states.Completed()
+            )
+
+        monkeypatch.setattr(flow_engine_module, "_prepare_event", prepare_event)
+        monkeypatch.setattr(
+            flow_engine_module,
+            "_enqueue_prepared_event",
+            enqueued_events.append,
+        )
+        engine = FlowRunEngine(
+            flow=flow(lambda: None),
+            flow_run=MagicMock(
+                id=uuid.uuid4(),
+                name="test-flow-run",
+                tags=[],
+                flow_id=None,
+                deployment_id=None,
+                state=states.Running(),
+            ),
+        )
+        engine._is_started = True
+        engine._client = MagicMock(set_flow_run_state=set_flow_run_state)
+        session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
+        engine._heartbeat_session = session
+        transition_result: list[State[Any]] = []
+
+        def transition_to_completed() -> None:
+            transition_result.append(engine.set_state(states.Completed()))
+
+        transition_thread: threading.Thread | None = None
+        session.start()
+        try:
+            assert preparation_started.wait(timeout=1)
+            transition_thread = threading.Thread(target=transition_to_completed)
+            transition_thread.start()
+            assert state_request_started.wait(timeout=1)
+        finally:
+            allow_preparation.set()
+            if transition_thread is not None:
+                transition_thread.join(timeout=3)
+            session.close()
+            engine._heartbeat_session = None
+
+        assert transition_thread is not None
+        assert not transition_thread.is_alive()
+        assert transition_result[0].is_completed()
+        assert enqueued_events == []
 
     def test_heartbeat_context_manager_used_during_flow_execution_sync(
         self, monkeypatch: pytest.MonkeyPatch
@@ -5621,11 +5829,13 @@ class TestFlowRunEngineHeartbeat:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         """Test that heartbeat context manager is used during async flow execution."""
-        context_entered = []
-        context_exited = []
+        context_entered: list[AsyncFlowRunEngine[Any, Any]] = []
+        context_exited: list[AsyncFlowRunEngine[Any, Any]] = []
 
-        @contextmanager
-        def mock__send_heartbeats(engine, **kwargs):
+        @asynccontextmanager
+        async def mock__send_heartbeats_async(
+            engine: AsyncFlowRunEngine[Any, Any], **kwargs: object
+        ) -> AsyncGenerator[None, None]:
             context_entered.append(engine)
             try:
                 yield
@@ -5633,7 +5843,8 @@ class TestFlowRunEngineHeartbeat:
                 context_exited.append(engine)
 
         monkeypatch.setattr(
-            "prefect.flow_engine._send_heartbeats", mock__send_heartbeats
+            "prefect.flow_engine._send_heartbeats_async",
+            mock__send_heartbeats_async,
         )
 
         monkeypatch.setattr(
@@ -5793,11 +6004,13 @@ class TestFlowRunEngineHeartbeat:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         """Test that heartbeat context manager cleans up even when an exception occurs."""
-        context_entered = []
-        context_exited = []
+        context_entered: list[AsyncFlowRunEngine[Any, Any]] = []
+        context_exited: list[AsyncFlowRunEngine[Any, Any]] = []
 
-        @contextmanager
-        def mock__send_heartbeats(engine, **kwargs):
+        @asynccontextmanager
+        async def mock__send_heartbeats_async(
+            engine: AsyncFlowRunEngine[Any, Any], **kwargs: object
+        ) -> AsyncGenerator[None, None]:
             context_entered.append(engine)
             try:
                 yield
@@ -5805,7 +6018,8 @@ class TestFlowRunEngineHeartbeat:
                 context_exited.append(engine)
 
         monkeypatch.setattr(
-            "prefect.flow_engine._send_heartbeats", mock__send_heartbeats
+            "prefect.flow_engine._send_heartbeats_async",
+            mock__send_heartbeats_async,
         )
 
         monkeypatch.setattr(
@@ -5899,7 +6113,7 @@ class TestFlowRunEngineHeartbeat:
         the race condition where heartbeats could be emitted after a flow run
         completes, incorrectly triggering zombie flow detection automations.
         """
-        heartbeat_state_checks = []
+        heartbeat_state_checks: list[tuple[str, StateType | None]] = []
 
         # Track the original _send_heartbeats to wrap it
         original__send_heartbeats = _send_heartbeats
@@ -5952,18 +6166,20 @@ class TestFlowRunEngineHeartbeat:
         Async version: Verifies that the heartbeat context manager checks flow
         state before emitting heartbeats and stops if the state is terminal.
         """
-        heartbeat_state_checks = []
+        heartbeat_state_checks: list[tuple[str, StateType | None]] = []
 
-        # Track the original _send_heartbeats to wrap it
-        original__send_heartbeats = _send_heartbeats
+        # Track the original _send_heartbeats_async to wrap it
+        original__send_heartbeats_async = _send_heartbeats_async
 
-        @contextmanager
-        def tracking__send_heartbeats(engine, **kwargs):
+        @asynccontextmanager
+        async def tracking__send_heartbeats_async(
+            engine: AsyncFlowRunEngine[Any, Any], **kwargs: object
+        ) -> AsyncGenerator[None, None]:
             # Record state when entering context
             heartbeat_state_checks.append(
                 ("enter", engine.flow_run.state.type if engine.flow_run else None)
             )
-            with original__send_heartbeats(engine):
+            async with original__send_heartbeats_async(engine):
                 yield
             # Record state when exiting context
             heartbeat_state_checks.append(
@@ -5971,7 +6187,8 @@ class TestFlowRunEngineHeartbeat:
             )
 
         monkeypatch.setattr(
-            "prefect.flow_engine._send_heartbeats", tracking__send_heartbeats
+            "prefect.flow_engine._send_heartbeats_async",
+            tracking__send_heartbeats_async,
         )
 
         monkeypatch.setattr(
@@ -5993,6 +6210,142 @@ class TestFlowRunEngineHeartbeat:
             for state_type in exit_states
             if state_type is not None
         )
+
+    def test_no_heartbeat_emitted_after_terminal_transition_sync(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        timeline: list[str] = []
+        heartbeat_send_started = threading.Event()
+        allow_heartbeat_send = threading.Event()
+
+        def enqueue_heartbeat(prepared: object) -> None:
+            heartbeat_send_started.set()
+            allow_heartbeat_send.wait()
+            timeline.append("heartbeat")
+
+        def set_flow_run_state(
+            *args: object, **kwargs: object
+        ) -> OrchestrationResult[Any]:
+            timeline.append("completed")
+            return OrchestrationResult(
+                state=states.Completed(),
+                status=SetStateStatus.ACCEPT,
+                details=StateAcceptDetails(),
+            )
+
+        self._mock_heartbeat_pipeline(monkeypatch, enqueue_heartbeat)
+        monkeypatch.setattr(
+            "prefect.flow_engine.get_current_settings",
+            lambda: MagicMock(flows=MagicMock(heartbeat_frequency=30)),
+        )
+        engine = FlowRunEngine(
+            flow=flow(lambda: None),
+            flow_run=MagicMock(
+                id=uuid.uuid4(),
+                name="test-flow-run",
+                tags=[],
+                flow_id=None,
+                deployment_id=None,
+                state=states.Running(),
+            ),
+        )
+        engine._is_started = True
+        engine._client = MagicMock(set_flow_run_state=set_flow_run_state)
+        session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
+        gate = _InstrumentedHeartbeatGate()
+        session._gate = gate  # type: ignore[assignment]
+        engine._heartbeat_session = session
+
+        transition_result: list[State[Any]] = []
+
+        def transition_to_completed() -> None:
+            transition_result.append(engine.set_state(states.Completed()))
+
+        transition_thread: threading.Thread | None = None
+        session.start()
+        try:
+            assert heartbeat_send_started.wait(timeout=1)
+            transition_thread = threading.Thread(target=transition_to_completed)
+            transition_thread.start()
+            assert gate.state_request_started.wait(timeout=1)
+        finally:
+            allow_heartbeat_send.set()
+            if transition_thread is not None:
+                transition_thread.join(timeout=3)
+            session.close()
+            engine._heartbeat_session = None
+
+        assert transition_thread is not None
+        assert not transition_thread.is_alive()
+        assert transition_result[0].is_completed()
+        assert timeline == ["heartbeat", "completed"]
+
+    async def test_no_heartbeat_emitted_after_terminal_transition_async(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        timeline: list[str] = []
+        heartbeat_send_started = threading.Event()
+        allow_heartbeat_send = threading.Event()
+
+        def enqueue_heartbeat(prepared: object) -> None:
+            heartbeat_send_started.set()
+            allow_heartbeat_send.wait()
+            timeline.append("heartbeat")
+
+        async def set_flow_run_state(
+            *args: object, **kwargs: object
+        ) -> OrchestrationResult[Any]:
+            timeline.append("completed")
+            return OrchestrationResult(
+                state=states.Completed(),
+                status=SetStateStatus.ACCEPT,
+                details=StateAcceptDetails(),
+            )
+
+        self._mock_heartbeat_pipeline(monkeypatch, enqueue_heartbeat)
+        monkeypatch.setattr(
+            "prefect.flow_engine.get_current_settings",
+            lambda: MagicMock(flows=MagicMock(heartbeat_frequency=30)),
+        )
+        engine = AsyncFlowRunEngine(
+            flow=flow(lambda: None),
+            flow_run=MagicMock(
+                id=uuid.uuid4(),
+                name="test-flow-run",
+                tags=[],
+                flow_id=None,
+                deployment_id=None,
+                state=states.Running(),
+            ),
+        )
+        engine._is_started = True
+        engine._client = MagicMock(set_flow_run_state=set_flow_run_state)
+        session = _FlowRunHeartbeatSession(engine, heartbeat_seconds=30)
+        gate = _InstrumentedHeartbeatGate()
+        session._gate = gate  # type: ignore[assignment]
+        engine._heartbeat_session = session
+
+        transition: asyncio.Task[State[Any]] | None = None
+        transition_result: State[Any] | None = None
+        session.start()
+        try:
+            assert await asyncio.to_thread(heartbeat_send_started.wait, 1)
+            transition = asyncio.create_task(engine.set_state(states.Completed()))
+            assert await asyncio.to_thread(gate.state_request_started.wait, 1)
+        finally:
+            allow_heartbeat_send.set()
+            try:
+                if transition is not None:
+                    with anyio.fail_after(3):
+                        transition_result = await transition
+            finally:
+                await session.aclose()
+                engine._heartbeat_session = None
+
+        assert transition is not None
+        assert transition_result is not None
+        assert transition_result.is_completed()
+        assert timeline == ["heartbeat", "completed"]
 
     @pytest.mark.parametrize("low_value", [1, 5, 10, 29])
     def test_heartbeat_seconds_property_clamps_low_values(
@@ -6088,12 +6441,11 @@ class TestFlowRunEngineHeartbeat:
         """
         heartbeat_count = 0
 
-        def mock_emit_event(**kwargs: object) -> None:
+        def enqueue_heartbeat(prepared: object) -> None:
             nonlocal heartbeat_count
-            if kwargs.get("event") == "prefect.flow-run.heartbeat":
-                heartbeat_count += 1
+            heartbeat_count += 1
 
-        monkeypatch.setattr("prefect.flow_engine.emit_event", mock_emit_event)
+        self._mock_heartbeat_pipeline(monkeypatch, enqueue_heartbeat)
         monkeypatch.setattr(
             "prefect.flow_engine.get_current_settings",
             lambda: MagicMock(flows=MagicMock(heartbeat_frequency=30)),

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -615,34 +615,40 @@ def _reject_terminal_transition(
     exception: BaseException,
 ) -> None:
     if not async_engine:
-        original_propose_state = flow_engine_module.propose_state_sync
+        original_propose_state = flow_engine_module.SyncFlowRunStateProposer.propose
 
         def reject_terminal_state(
-            client: Any, state: states.State[Any], **kwargs: Any
+            proposer: Any,
+            flow_run_id: uuid.UUID,
+            state: states.State[Any],
+            **kwargs: Any,
         ) -> Any:
             if state.is_final():
                 raise exception
-            return original_propose_state(client, state, **kwargs)
+            return original_propose_state(proposer, flow_run_id, state, **kwargs)
 
         monkeypatch.setattr(
-            flow_engine_module,
-            "propose_state_sync",
+            flow_engine_module.SyncFlowRunStateProposer,
+            "propose",
             reject_terminal_state,
         )
         return
 
-    original_propose_state = flow_engine_module.propose_state
+    original_propose_state = flow_engine_module.FlowRunStateProposer.propose
 
     async def reject_terminal_state_async(
-        client: Any, state: states.State[Any], **kwargs: Any
+        proposer: Any,
+        flow_run_id: uuid.UUID,
+        state: states.State[Any],
+        **kwargs: Any,
     ) -> Any:
         if state.is_final():
             raise exception
-        return await original_propose_state(client, state, **kwargs)
+        return await original_propose_state(proposer, flow_run_id, state, **kwargs)
 
     monkeypatch.setattr(
-        flow_engine_module,
-        "propose_state",
+        flow_engine_module.FlowRunStateProposer,
+        "propose",
         reject_terminal_state_async,
     )
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -98,6 +98,11 @@ async def foo():
     return 42
 
 
+def test_state_proposal_compatibility_aliases():
+    assert flow_engine_module.propose_state is propose_state
+    assert flow_engine_module.propose_state_sync is propose_state_sync
+
+
 class TestFlowRunNameSetBeforeRunningEvent:
     @staticmethod
     def _track_sync_running_names(
@@ -105,15 +110,24 @@ class TestFlowRunNameSetBeforeRunningEvent:
         monkeypatch: pytest.MonkeyPatch,
     ) -> list[str]:
         names_at_running_transition: list[str] = []
-        original_propose = propose_state_sync
+        original_propose = flow_engine_module.SyncFlowRunStateProposer.propose
 
-        def tracking_propose(client, state, **kwargs):
+        def tracking_propose(
+            proposer: Any,
+            flow_run_id: UUID,
+            state: states.State[Any],
+            **kwargs: Any,
+        ) -> states.State[Any]:
             if state.is_running():
-                flow_run = sync_prefect_client.read_flow_run(kwargs["flow_run_id"])
+                flow_run = sync_prefect_client.read_flow_run(flow_run_id)
                 names_at_running_transition.append(flow_run.name)
-            return original_propose(client, state, **kwargs)
+            return original_propose(proposer, flow_run_id, state, **kwargs)
 
-        monkeypatch.setattr("prefect.flow_engine.propose_state_sync", tracking_propose)
+        monkeypatch.setattr(
+            flow_engine_module.SyncFlowRunStateProposer,
+            "propose",
+            tracking_propose,
+        )
         return names_at_running_transition
 
     @staticmethod
@@ -122,15 +136,24 @@ class TestFlowRunNameSetBeforeRunningEvent:
         monkeypatch: pytest.MonkeyPatch,
     ) -> list[str]:
         names_at_running_transition: list[str] = []
-        original_propose = propose_state
+        original_propose = flow_engine_module.FlowRunStateProposer.propose
 
-        async def tracking_propose(client, state, **kwargs):
+        async def tracking_propose(
+            proposer: Any,
+            flow_run_id: UUID,
+            state: states.State[Any],
+            **kwargs: Any,
+        ) -> states.State[Any]:
             if state.is_running():
-                flow_run = sync_prefect_client.read_flow_run(kwargs["flow_run_id"])
+                flow_run = sync_prefect_client.read_flow_run(flow_run_id)
                 names_at_running_transition.append(flow_run.name)
-            return await original_propose(client, state, **kwargs)
+            return await original_propose(proposer, flow_run_id, state, **kwargs)
 
-        monkeypatch.setattr("prefect.flow_engine.propose_state", tracking_propose)
+        monkeypatch.setattr(
+            flow_engine_module.FlowRunStateProposer,
+            "propose",
+            tracking_propose,
+        )
         return names_at_running_transition
 
     async def test_sync_flow_string_template_name_set_before_running(


### PR DESCRIPTION
closes #21932

Depends on #22948

This PR orders flow-run heartbeat admission with server-authoritative state requests, preventing a heartbeat from being enqueued after the server accepts a terminal transition.

<details>
<summary>Details</summary>

- Builds and validates heartbeat events before admission, then gates only the in-memory enqueue with each state request.
- Drains an admitted enqueue before sending the state request and permanently closes admission when the server returns a final state.
- Reopens admission after `WAIT` and accepted nonfinal responses.
- Uses the proposal module's narrow request interface so each retry is ordered without wrapping a partial client.
- Applies the same contract to sync and async engines, with regression coverage for both race orderings and shutdown.

Supersedes #22897 and carries forward Devin's initial work.

</details>

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - The documented automation pattern already describes the intended behavior; this changes client heartbeat ordering only.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
