### PR TITLE
fix(settings): support fallback import for SettingsError from pydantic-settings

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -113,7 +113,10 @@ def _initialize_plugins() -> None:
         # Re-raise SystemExit from strict mode
         raise
     except Exception as e:
-        from pydantic_settings.exceptions import SettingsError
+        try:
+            from pydantic_settings.exceptions import SettingsError
+        except ImportError:
+            from pydantic_settings import SettingsError
 
         if isinstance(e, SettingsError):
             return

--- a/src/prefect/cli/_app.py
+++ b/src/prefect/cli/_app.py
@@ -159,7 +159,10 @@ def app() -> None:
         print(prefect.__version__)
         raise SystemExit(0)
 
-    from pydantic_settings.exceptions import SettingsError
+    try:
+        from pydantic_settings.exceptions import SettingsError
+    except ImportError:
+        from pydantic_settings import SettingsError
 
     try:
         _app.meta(_normalize_top_level_flags(args))

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -15,7 +15,10 @@ from pydantic_settings import (
     EnvSettingsSource,
     PydanticBaseSettingsSource,
 )
-from pydantic_settings.exceptions import SettingsError
+try:
+    from pydantic_settings.exceptions import SettingsError
+except ImportError:
+    from pydantic_settings import SettingsError
 from pydantic_settings.sources import (
     ENV_FILE_SENTINEL,
     ConfigFileSourceMixin,


### PR DESCRIPTION
### Summary
Improves import compatibility for \SettingsError\ across various versions of \pydantic-settings\.

### Changes
- Updated imports in \src/prefect/__init__.py\, \src/prefect/cli/_app.py\, and \src/prefect/settings/sources.py\ to use a \	ry/except ImportError\ fallback to support importing \SettingsError\ from both \pydantic_settings.exceptions\ and the top-level \pydantic_settings\ package.

### Verification
- Verified clean module imports and CLI initialization across Python environments.