### PR TITLE
Extract flow-run state proposal orchestration

### DIFF
--- a/src/prefect/utilities/AGENTS.md
+++ b/src/prefect/utilities/AGENTS.md
@@ -37,6 +37,7 @@ These modules have no dedicated intent node yet. Promote any one of them to a su
 - `dockerutils.py` — Docker image building, Python version detection, Docker client helpers
 - `timeout.py` — Timeout context managers for async/sync code
 - `services.py` — Client metrics server and resilient service loop with backoff
+- `flow_run_state_proposals.py` — Server-authoritative flow-run state proposal retries and response interpretation
 - `visualization.py` — Flow/task graph visualization via Graphviz (`build_task_dependencies`) or Mermaid (`build_mermaid_dependencies`); the Mermaid path has no system dependency
 - `urls.py` — URL validation and UI path formatting
 - `names.py` — Slug generation and obfuscation helpers

--- a/src/prefect/utilities/AGENTS.md
+++ b/src/prefect/utilities/AGENTS.md
@@ -37,7 +37,7 @@ These modules have no dedicated intent node yet. Promote any one of them to a su
 - `dockerutils.py` — Docker image building, Python version detection, Docker client helpers
 - `timeout.py` — Timeout context managers for async/sync code
 - `services.py` — Client metrics server and resilient service loop with backoff
-- `flow_run_state_proposals.py` — Server-authoritative flow-run state proposal retries and response interpretation
+- `_flow_run_state_proposals.py` — Internal server-authoritative flow-run state proposal retries and response interpretation
 - `visualization.py` — Flow/task graph visualization via Graphviz (`build_task_dependencies`) or Mermaid (`build_mermaid_dependencies`); the Mermaid path has no system dependency
 - `urls.py` — URL validation and UI path formatting
 - `names.py` — Slug generation and obfuscation helpers

--- a/src/prefect/utilities/_flow_run_state_proposals.py
+++ b/src/prefect/utilities/_flow_run_state_proposals.py
@@ -17,8 +17,6 @@ from prefect.exceptions import Abort, Pause
 from prefect.logging.loggers import get_logger
 from prefect.states import State
 
-__all__ = ["FlowRunStateProposer", "SyncFlowRunStateProposer"]
-
 T = TypeVar("T")
 _proposal_logger = get_logger("engine")
 

--- a/src/prefect/utilities/engine/__init__.py
+++ b/src/prefect/utilities/engine/__init__.py
@@ -5,8 +5,7 @@ import signal
 import threading
 import time
 import weakref
-from collections.abc import Awaitable, Callable, Generator
-from functools import partial
+from collections.abc import Callable, Generator
 from logging import Logger
 from typing import (
     TYPE_CHECKING,
@@ -19,29 +18,19 @@ from typing import (
 )
 from uuid import UUID
 
-import anyio
 from opentelemetry import propagate, trace
 from typing_extensions import TypeIs
 
-import prefect
-import prefect.exceptions
 from prefect._internal.concurrency.cancellation import get_deadline
-from prefect.client.schemas import FlowRunResult, OrchestrationResult, TaskRun
+from prefect.client.schemas import FlowRunResult, TaskRun
 from prefect.client.schemas.objects import (
     FlowRun,
     RunType,
     TaskRunResult,
 )
-from prefect.client.schemas.responses import (
-    SetStateStatus,
-    StateAbortDetails,
-    StateRejectDetails,
-    StateWaitDetails,
-)
 from prefect.context import FlowRunContext
 from prefect.events import Event, emit_event
 from prefect.exceptions import (
-    Pause,
     PrefectException,
     TerminationSignal,
     UpstreamTaskError,
@@ -55,6 +44,10 @@ from prefect.states import State
 from prefect.tasks import Task
 from prefect.utilities.annotations import allow_failure, opaque, quote
 from prefect.utilities.collections import StopVisiting, visit_collection
+from prefect.utilities.flow_run_state_proposals import (
+    FlowRunStateProposer,
+    SyncFlowRunStateProposer,
+)
 from prefect.utilities.text import truncated_to
 
 if TYPE_CHECKING:
@@ -557,56 +550,9 @@ async def propose_state(
 
         link_state_to_flow_run_result(state, result)
 
-    # Handle repeated WAITs in a loop instead of recursively, to avoid
-    # reaching max recursion depth in extreme cases.
-    async def set_state_and_handle_waits(
-        set_state_func: Callable[[], Awaitable[OrchestrationResult[Any]]],
-    ) -> OrchestrationResult[Any]:
-        response = await set_state_func()
-        while response.status == SetStateStatus.WAIT:
-            if TYPE_CHECKING:
-                assert isinstance(response.details, StateWaitDetails)
-            engine_logger.debug(
-                f"Received wait instruction for {response.details.delay_seconds}s: "
-                f"{response.details.reason}"
-            )
-            await anyio.sleep(response.details.delay_seconds)
-            response = await set_state_func()
-        return response
-
-    set_state = partial(client.set_flow_run_state, flow_run_id, state, force=force)
-    response = await set_state_and_handle_waits(set_state)
-
-    # Parse the response to return the new state
-    if response.status == SetStateStatus.ACCEPT:
-        # Update the state with the details if provided
-        if TYPE_CHECKING:
-            assert response.state is not None
-        state.id = response.state.id
-        state.timestamp = response.state.timestamp
-        if response.state.state_details:
-            state.state_details = response.state.state_details
-        return state
-
-    elif response.status == SetStateStatus.ABORT:
-        if TYPE_CHECKING:
-            assert isinstance(response.details, StateAbortDetails)
-
-        raise prefect.exceptions.Abort(response.details.reason)
-
-    elif response.status == SetStateStatus.REJECT:
-        if TYPE_CHECKING:
-            assert response.state is not None
-            assert isinstance(response.details, StateRejectDetails)
-
-        if response.state.is_paused():
-            raise Pause(response.details.reason, state=response.state)
-        return response.state
-
-    else:
-        raise ValueError(
-            f"Received unexpected `SetStateStatus` from server: {response.status!r}"
-        )
+    return await FlowRunStateProposer(client.set_flow_run_state).propose(
+        flow_run_id, state, force=force
+    )
 
 
 def propose_state_sync(
@@ -652,55 +598,9 @@ def propose_state_sync(
 
         link_state_to_flow_run_result(state, result)
 
-    # Handle repeated WAITs in a loop instead of recursively, to avoid
-    # reaching max recursion depth in extreme cases.
-    def set_state_and_handle_waits(
-        set_state_func: Callable[[], OrchestrationResult[Any]],
-    ) -> OrchestrationResult[Any]:
-        response = set_state_func()
-        while response.status == SetStateStatus.WAIT:
-            if TYPE_CHECKING:
-                assert isinstance(response.details, StateWaitDetails)
-            engine_logger.debug(
-                f"Received wait instruction for {response.details.delay_seconds}s: "
-                f"{response.details.reason}"
-            )
-            time.sleep(response.details.delay_seconds)
-            response = set_state_func()
-        return response
-
-    # Attempt to set the state
-    set_state = partial(client.set_flow_run_state, flow_run_id, state, force=force)
-    response = set_state_and_handle_waits(set_state)
-
-    # Parse the response to return the new state
-    if response.status == SetStateStatus.ACCEPT:
-        if TYPE_CHECKING:
-            assert response.state is not None
-        # Update the state with the details if provided
-        state.id = response.state.id
-        state.timestamp = response.state.timestamp
-        if response.state.state_details:
-            state.state_details = response.state.state_details
-        return state
-
-    elif response.status == SetStateStatus.ABORT:
-        if TYPE_CHECKING:
-            assert isinstance(response.details, StateAbortDetails)
-        raise prefect.exceptions.Abort(response.details.reason)
-
-    elif response.status == SetStateStatus.REJECT:
-        if TYPE_CHECKING:
-            assert response.state is not None
-            assert isinstance(response.details, StateRejectDetails)
-        if response.state.is_paused():
-            raise Pause(response.details.reason, state=response.state)
-        return response.state
-
-    else:
-        raise ValueError(
-            f"Received unexpected `SetStateStatus` from server: {response.status!r}"
-        )
+    return SyncFlowRunStateProposer(client.set_flow_run_state).propose(
+        flow_run_id, state, force=force
+    )
 
 
 def get_state_for_result(obj: Any) -> Optional[tuple[State, RunType]]:

--- a/src/prefect/utilities/engine/__init__.py
+++ b/src/prefect/utilities/engine/__init__.py
@@ -44,7 +44,7 @@ from prefect.states import State
 from prefect.tasks import Task
 from prefect.utilities.annotations import allow_failure, opaque, quote
 from prefect.utilities.collections import StopVisiting, visit_collection
-from prefect.utilities.flow_run_state_proposals import (
+from prefect.utilities._flow_run_state_proposals import (
     FlowRunStateProposer,
     SyncFlowRunStateProposer,
 )

--- a/src/prefect/utilities/flow_run_state_proposals.py
+++ b/src/prefect/utilities/flow_run_state_proposals.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol, TypeVar, cast
+from uuid import UUID
+
+import anyio
+
+from prefect.client.schemas import OrchestrationResult
+from prefect.client.schemas.responses import (
+    SetStateStatus,
+    StateAbortDetails,
+    StateRejectDetails,
+    StateWaitDetails,
+)
+from prefect.exceptions import Abort, Pause
+from prefect.logging.loggers import get_logger
+from prefect.states import State
+
+__all__ = ["FlowRunStateProposer", "SyncFlowRunStateProposer"]
+
+T = TypeVar("T")
+_proposal_logger = get_logger("engine")
+
+
+class _FlowRunStateRequest(Protocol):
+    """A single asynchronous request to set a flow-run state."""
+
+    async def __call__(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]: ...
+
+
+class _SyncFlowRunStateRequest(Protocol):
+    """A single synchronous request to set a flow-run state."""
+
+    def __call__(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]: ...
+
+
+class FlowRunStateProposer:
+    """Resolve asynchronous flow-run state proposals through orchestration.
+
+    The bound request performs exactly one server attempt. This proposer owns
+    retries after `WAIT` responses and interprets the server's authoritative
+    response.
+    """
+
+    def __init__(self, request: _FlowRunStateRequest) -> None:
+        self._request = request
+
+    async def propose(
+        self,
+        flow_run_id: UUID,
+        state: State[T],
+        *,
+        force: bool = False,
+    ) -> State[T]:
+        """Propose `state` until the server returns a non-`WAIT` response."""
+        _require_flow_run_id(flow_run_id)
+
+        response = await self._request(flow_run_id, state, force=force)
+        while response.status == SetStateStatus.WAIT:
+            details = _wait_details(response)
+            _proposal_logger.debug(
+                "Received wait instruction for %ss: %s",
+                details.delay_seconds,
+                details.reason,
+            )
+            await anyio.sleep(details.delay_seconds)
+            response = await self._request(flow_run_id, state, force=force)
+
+        return _resolve_response(state, response)
+
+
+class SyncFlowRunStateProposer:
+    """Resolve synchronous flow-run state proposals through orchestration.
+
+    The bound request performs exactly one server attempt. This proposer owns
+    retries after `WAIT` responses and interprets the server's authoritative
+    response.
+    """
+
+    def __init__(self, request: _SyncFlowRunStateRequest) -> None:
+        self._request = request
+
+    def propose(
+        self,
+        flow_run_id: UUID,
+        state: State[T],
+        *,
+        force: bool = False,
+    ) -> State[T]:
+        """Propose `state` until the server returns a non-`WAIT` response."""
+        _require_flow_run_id(flow_run_id)
+
+        response = self._request(flow_run_id, state, force=force)
+        while response.status == SetStateStatus.WAIT:
+            details = _wait_details(response)
+            _proposal_logger.debug(
+                "Received wait instruction for %ss: %s",
+                details.delay_seconds,
+                details.reason,
+            )
+            time.sleep(details.delay_seconds)
+            response = self._request(flow_run_id, state, force=force)
+
+        return _resolve_response(state, response)
+
+
+def _require_flow_run_id(flow_run_id: UUID) -> None:
+    if not flow_run_id:
+        raise ValueError("You must provide a `flow_run_id`")
+
+
+def _wait_details(response: OrchestrationResult[Any]) -> StateWaitDetails:
+    if not isinstance(response.details, StateWaitDetails):
+        raise TypeError("Received a WAIT response without wait details")
+    return response.details
+
+
+def _resolve_response(
+    proposed_state: State[T], response: OrchestrationResult[Any]
+) -> State[T]:
+    if response.status == SetStateStatus.ACCEPT:
+        if response.state is None:
+            raise ValueError("Received an ACCEPT response without a state")
+        proposed_state.id = response.state.id
+        proposed_state.timestamp = response.state.timestamp
+        if response.state.state_details:
+            proposed_state.state_details = response.state.state_details
+        return proposed_state
+
+    if response.status == SetStateStatus.ABORT:
+        if not isinstance(response.details, StateAbortDetails):
+            raise ValueError("Received an ABORT response without abort details")
+        raise Abort(response.details.reason)
+
+    if response.status == SetStateStatus.REJECT:
+        if response.state is None or not isinstance(
+            response.details, StateRejectDetails
+        ):
+            raise ValueError("Received a REJECT response without a state and details")
+        if response.state.is_paused():
+            raise Pause(response.details.reason, state=response.state)
+        return cast(State[T], response.state)
+
+    raise ValueError(
+        f"Received unexpected `SetStateStatus` from server: {response.status!r}"
+    )

--- a/tests/utilities/test_flow_run_state_proposals.py
+++ b/tests/utilities/test_flow_run_state_proposals.py
@@ -1,0 +1,200 @@
+from dataclasses import dataclass
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+import pytest
+
+from prefect.client.schemas import OrchestrationResult
+from prefect.client.schemas.objects import StateDetails
+from prefect.client.schemas.responses import (
+    SetStateStatus,
+    StateAbortDetails,
+    StateAcceptDetails,
+    StateRejectDetails,
+    StateResponseDetails,
+    StateWaitDetails,
+)
+from prefect.exceptions import Abort, Pause
+from prefect.states import Paused, Pending, Running, State
+from prefect.types._datetime import now
+from prefect.utilities.flow_run_state_proposals import (
+    FlowRunStateProposer,
+    SyncFlowRunStateProposer,
+)
+
+Mode = Literal["async", "sync"]
+
+
+@dataclass(frozen=True)
+class RequestCall:
+    flow_run_id: UUID | str
+    state: State[Any]
+    force: bool
+
+
+class ScriptedStateRequest:
+    def __init__(self, responses: list[OrchestrationResult[Any]]) -> None:
+        self.responses = responses.copy()
+        self.calls: list[RequestCall] = []
+
+    def __call__(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]:
+        self.calls.append(RequestCall(flow_run_id, state, force))
+        return self.responses.pop(0)
+
+
+class ScriptedAsyncStateRequest:
+    def __init__(self, responses: list[OrchestrationResult[Any]]) -> None:
+        self.responses = responses.copy()
+        self.calls: list[RequestCall] = []
+
+    async def __call__(
+        self,
+        flow_run_id: UUID | str,
+        state: State[Any],
+        force: bool = False,
+    ) -> OrchestrationResult[Any]:
+        self.calls.append(RequestCall(flow_run_id, state, force))
+        return self.responses.pop(0)
+
+
+def orchestration_result(
+    status: SetStateStatus,
+    details: StateResponseDetails,
+    state: State[Any] | None = None,
+) -> OrchestrationResult[Any]:
+    return OrchestrationResult(status=status, details=details, state=state)
+
+
+async def propose_with_script(
+    mode: Mode,
+    responses: list[OrchestrationResult[Any]],
+    flow_run_id: UUID,
+    state: State[Any],
+    *,
+    force: bool = False,
+) -> tuple[State[Any], list[RequestCall]]:
+    if mode == "async":
+        request = ScriptedAsyncStateRequest(responses)
+        returned = await FlowRunStateProposer(request).propose(
+            flow_run_id, state, force=force
+        )
+    else:
+        request = ScriptedStateRequest(responses)
+        returned = SyncFlowRunStateProposer(request).propose(
+            flow_run_id, state, force=force
+        )
+    return returned, request.calls
+
+
+@pytest.mark.parametrize("mode", ["async", "sync"])
+async def test_waits_then_hydrates_accepted_state(mode: Mode):
+    flow_run_id = uuid4()
+    proposed = Running(message="client proposal", data={"result": 42})
+    accepted = Running(
+        id=uuid4(),
+        timestamp=now("UTC"),
+        state_details=StateDetails(flow_run_id=flow_run_id),
+    )
+
+    returned, calls = await propose_with_script(
+        mode,
+        [
+            orchestration_result(
+                SetStateStatus.WAIT,
+                StateWaitDetails(delay_seconds=0, reason="try again"),
+            ),
+            orchestration_result(
+                SetStateStatus.ACCEPT,
+                StateAcceptDetails(),
+                accepted,
+            ),
+        ],
+        flow_run_id,
+        proposed,
+        force=True,
+    )
+
+    assert returned is proposed
+    assert returned.id == accepted.id
+    assert returned.timestamp == accepted.timestamp
+    assert returned.state_details == accepted.state_details
+    assert returned.message == "client proposal"
+    assert returned.data == {"result": 42}
+    assert calls == [
+        RequestCall(flow_run_id, proposed, True),
+        RequestCall(flow_run_id, proposed, True),
+    ]
+
+
+@pytest.mark.parametrize("mode", ["async", "sync"])
+async def test_returns_server_state_when_proposal_is_rejected(mode: Mode):
+    flow_run_id = uuid4()
+    rejected = Pending(message="retry later")
+    response = orchestration_result(
+        SetStateStatus.REJECT,
+        StateRejectDetails(reason="not ready"),
+        rejected,
+    )
+
+    returned, calls = await propose_with_script(
+        mode,
+        [response],
+        flow_run_id,
+        Running(),
+    )
+
+    assert returned is response.state
+    assert returned == rejected
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("mode", ["async", "sync"])
+@pytest.mark.parametrize(
+    ("response", "expected_exception"),
+    [
+        (
+            orchestration_result(
+                SetStateStatus.REJECT,
+                StateRejectDetails(reason="paused"),
+                Paused(),
+            ),
+            Pause,
+        ),
+        (
+            orchestration_result(
+                SetStateStatus.ABORT,
+                StateAbortDetails(reason="stop"),
+            ),
+            Abort,
+        ),
+    ],
+)
+async def test_raises_for_terminal_orchestration_instructions(
+    mode: Mode,
+    response: OrchestrationResult[Any],
+    expected_exception: type[Exception],
+):
+    with pytest.raises(expected_exception):
+        await propose_with_script(mode, [response], uuid4(), Running())
+
+
+@pytest.mark.parametrize("mode", ["async", "sync"])
+async def test_requires_flow_run_id_before_requesting_state(mode: Mode):
+    response = orchestration_result(
+        SetStateStatus.ACCEPT,
+        StateAcceptDetails(),
+        Running(),
+    )
+
+    with pytest.raises(ValueError, match="flow_run_id"):
+        await propose_with_script(
+            mode,
+            [response],
+            None,  # type: ignore[arg-type]
+            Running(),
+        )

--- a/tests/utilities/test_flow_run_state_proposals.py
+++ b/tests/utilities/test_flow_run_state_proposals.py
@@ -17,7 +17,7 @@ from prefect.client.schemas.responses import (
 from prefect.exceptions import Abort, Pause
 from prefect.states import Paused, Pending, Running, State
 from prefect.types._datetime import now
-from prefect.utilities.flow_run_state_proposals import (
+from prefect.utilities._flow_run_state_proposals import (
     FlowRunStateProposer,
     SyncFlowRunStateProposer,
 )


### PR DESCRIPTION
Related to #21932

This PR moves flow-run state proposal retries and response interpretation into dedicated sync and async proposer classes. Existing `propose_state` entry points remain compatibility facades, so callers retain current behavior while follow-up PRs migrate to the narrower request interface.

<details>
<summary>Details</summary>

- Binds one state-request operation instead of requiring a complete Prefect client.
- Keeps `WAIT` retries and server-authoritative `ACCEPT`, `REJECT`, paused-rejection, and `ABORT` handling behind the proposer interface.
- Shares response interpretation across sync and async implementations.
- Adds one contract suite covering both implementations with in-memory request adapters.

Follow-up #22946 uses this interface to order heartbeat admission with each state request.

</details>

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - The dependent heartbeat PR closes #21932.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - This refactors internal proposal ownership without changing user-facing behavior.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
