### PR TITLE
fix(ui-v2): selecting enum dropdown in Quick Run dialog navigates away

### DIFF
--- a/ui-v2/src/components/ui/data-table.test.tsx
+++ b/ui-v2/src/components/ui/data-table.test.tsx
@@ -19,6 +19,18 @@ const columns = columnHelper.columns([
 	}),
 ]);
 
+const ignoredColumns = columnHelper.columns([
+	columnHelper.accessor("name", {
+		header: "Name",
+		cell: (info) => (
+			<>
+				<span>{info.getValue()}</span>
+				<span data-row-click-ignore="true">portal content</span>
+			</>
+		),
+	}),
+]);
+
 const resizableColumns = columnHelper.columns([
 	columnHelper.accessor("name", {
 		id: "name",
@@ -49,6 +61,17 @@ const TestTable = ({
 		columns,
 		initialState: sorting ? { sorting } : undefined,
 	});
+	return <DataTable table={table} onRowClick={onRowClick} />;
+};
+
+const IgnoredContentTable = ({
+	data,
+	onRowClick,
+}: {
+	data: TestData[];
+	onRowClick?: (row: TestData) => void;
+}) => {
+	const table = useTable({ data, columns: ignoredColumns });
 	return <DataTable table={table} onRowClick={onRowClick} />;
 };
 
@@ -101,6 +124,15 @@ describe("DataTable", () => {
 		render(<TestTable data={testData} onRowClick={onRowClick} />);
 
 		await userEvent.click(screen.getByRole("button", { name: "Row action 1" }));
+
+		expect(onRowClick).not.toHaveBeenCalled();
+	});
+
+	it("does not call onRowClick when clicking an element with data-row-click-ignore", () => {
+		const onRowClick = vi.fn();
+		render(<IgnoredContentTable data={testData} onRowClick={onRowClick} />);
+
+		fireEvent.click(screen.getAllByText("portal content")[0]);
 
 		expect(onRowClick).not.toHaveBeenCalled();
 	});

--- a/ui-v2/src/components/ui/data-table.test.tsx
+++ b/ui-v2/src/components/ui/data-table.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { createColumnHelper, useTable } from "@/lib/tanstack-table";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import { createColumnHelper, useTable } from "@/lib/tanstack-table";
 import { DataTable } from "./data-table";
 
 type TestData = { id: string; name: string };

--- a/ui-v2/src/components/ui/data-table.test.tsx
+++ b/ui-v2/src/components/ui/data-table.test.tsx
@@ -2,6 +2,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { createColumnHelper, useTable } from "@/lib/tanstack-table";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
 import { DataTable } from "./data-table";
 
 type TestData = { id: string; name: string };
@@ -19,14 +24,18 @@ const columns = columnHelper.columns([
 	}),
 ]);
 
-const ignoredColumns = columnHelper.columns([
+// Renders a Popover that is always open so its portaled content is in the DOM.
+// Used to test that clicks inside a portal do not trigger the row click handler.
+const portalColumns = columnHelper.columns([
 	columnHelper.accessor("name", {
 		header: "Name",
-		cell: (info) => (
-			<>
-				<span>{info.getValue()}</span>
-				<span data-row-click-ignore="true">portal content</span>
-			</>
+		cell: () => (
+			<Popover open>
+				<PopoverTrigger>trigger</PopoverTrigger>
+				<PopoverContent>
+					<span>portal item</span>
+				</PopoverContent>
+			</Popover>
 		),
 	}),
 ]);
@@ -64,14 +73,14 @@ const TestTable = ({
 	return <DataTable table={table} onRowClick={onRowClick} />;
 };
 
-const IgnoredContentTable = ({
+const PortalTable = ({
 	data,
 	onRowClick,
 }: {
 	data: TestData[];
 	onRowClick?: (row: TestData) => void;
 }) => {
-	const table = useTable({ data, columns: ignoredColumns });
+	const table = useTable({ data, columns: portalColumns });
 	return <DataTable table={table} onRowClick={onRowClick} />;
 };
 
@@ -128,11 +137,14 @@ describe("DataTable", () => {
 		expect(onRowClick).not.toHaveBeenCalled();
 	});
 
-	it("does not call onRowClick when clicking an element with data-row-click-ignore", () => {
+	it("does not call onRowClick when clicking inside a portaled popover in a row", () => {
 		const onRowClick = vi.fn();
-		render(<IgnoredContentTable data={testData} onRowClick={onRowClick} />);
+		render(<PortalTable data={testData} onRowClick={onRowClick} />);
 
-		fireEvent.click(screen.getAllByText("portal content")[0]);
+		// "portal item" is rendered in a Radix portal (document.body), outside the
+		// table DOM. Clicking it should NOT trigger the row click handler because
+		// PopoverContent carries data-row-click-ignore="true".
+		fireEvent.click(screen.getAllByText("portal item")[0]);
 
 		expect(onRowClick).not.toHaveBeenCalled();
 	});

--- a/ui-v2/src/components/ui/popover.tsx
+++ b/ui-v2/src/components/ui/popover.tsx
@@ -28,6 +28,7 @@ function PopoverContent({
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content
 				data-slot="popover-content"
+				data-row-click-ignore="true"
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(


### PR DESCRIPTION

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

closes #22954
                                                                                                                                  
This PR fixes a bug where selecting a value from an enum dropdown in the Quick Run parameters dialog (opened from the deployments list) would close the dialog and navigate to the deployment's run page.                                                           

Root cause: ComboboxContent uses Radix PopoverContent, which renders in a portal. Click events on portal content bubble through React's synthetic event system back to the DataTable row click handler, triggering navigation. Adding data-row-click-ignore="true" to PopoverContent makes the existing row click guard suppress these events — consistent with how DialogContent already handles this.

▎ Fix implemented with AI assistance, but verified and tested by a human in a local environment.  