### PR TITLE
Use current settings for resource label validation

### DIFF
--- a/src/prefect/server/events/schemas/events.py
+++ b/src/prefect/server/events/schemas/events.py
@@ -32,8 +32,8 @@ from prefect.logging import get_logger
 from prefect.server.events.schemas.labelling import Labelled
 from prefect.server.utilities.schemas import PrefectBaseModel
 from prefect.settings import (
-    PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE,
     PREFECT_EVENTS_MAXIMUM_RELATED_RESOURCES,
+    get_current_settings,
 )
 from prefect.utilities.urls import url_for
 
@@ -48,10 +48,12 @@ class Resource(Labelled):
 
     @model_validator(mode="after")
     def enforce_maximum_labels(self) -> Self:
-        if len(self.root) > PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE.value():
+        maximum_labels = (
+            get_current_settings().server.events.maximum_labels_per_resource
+        )
+        if len(self.root) > maximum_labels:
             raise ValueError(
-                "The maximum number of labels per resource "
-                f"is {PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE.value()}"
+                f"The maximum number of labels per resource is {maximum_labels}"
             )
 
         return self

--- a/tests/events/server/test_resource_schema.py
+++ b/tests/events/server/test_resource_schema.py
@@ -391,15 +391,18 @@ def test_label_diving():
         getattr(diver, "_something_else")
 
 
-def test_limit_on_labels():
+def test_limit_on_labels_uses_current_settings():
+    resource = {
+        "prefect.resource.id": "the.thing",
+        **{str(i): str(i) for i in range(10)},
+    }
+
     with temporary_settings(updates={PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE: 10}):
         with pytest.raises(ValidationError):
-            Resource.model_validate(
-                {
-                    "prefect.resource.id": "the.thing",
-                    **{str(i): str(i) for i in range(10)},
-                }
-            )
+            Resource.model_validate(resource)
+
+    with temporary_settings(updates={PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE: 11}):
+        assert Resource.model_validate(resource).root == resource
 
 
 def test_limit_on_related_resources():


### PR DESCRIPTION
closes #22952

this PR reads the server resource-label limit directly from the current settings model during event validation, avoiding the legacy `Setting.value()` accessor path.

<details>
<summary>Details</summary>

- relies on the existing settings context instead of adding another process-level cache
- preserves setting overrides and validation error behavior
- adds regression coverage for successive settings contexts

Validation: `uv run pytest tests/events/server/test_resource_schema.py -x --tb=short` (110 passed) and applicable pre-commit checks.
</details>