### PR TITLE
Reduce event persister INSERT compilation CPU

### DIFF
--- a/src/prefect/server/events/storage/database.py
+++ b/src/prefect/server/events/storage/database.py
@@ -260,7 +260,7 @@ async def _write_postgres_events(
         session: a Postgres events session
         events: the events to insert
     """
-    # Early SQLAlchemy 2.0 ORM bulk inserts reject conflict-skipped RETURNING rows.
+    # Use Core DML so ON CONFLICT may return fewer rows than were submitted.
     event_insert = (
         db.queries.insert(db.Event).on_conflict_do_nothing().returning(db.Event.id)
     ).execution_options(dml_strategy="raw")

--- a/src/prefect/server/events/storage/database.py
+++ b/src/prefect/server/events/storage/database.py
@@ -260,14 +260,14 @@ async def _write_postgres_events(
         session: a Postgres events session
         events: the events to insert
     """
+    event_insert = (
+        db.queries.insert(db.Event).on_conflict_do_nothing().returning(db.Event.id)
+    )
+    resource_insert = db.queries.insert(db.EventResource)
+
     for batch in _in_safe_batches(events):
         event_rows = [event.as_database_row() for event in batch]
-        result = await session.scalars(
-            db.queries.insert(db.Event)
-            .on_conflict_do_nothing()
-            .returning(db.Event.id)
-            .values(event_rows)
-        )
+        result = await session.scalars(event_insert, event_rows)
         inserted_event_ids = set(result.all())
 
         resource_rows: list[dict[str, Any]] = []
@@ -282,7 +282,7 @@ async def _write_postgres_events(
         if not resource_rows:
             continue
 
-        await session.execute(db.queries.insert(db.EventResource).values(resource_rows))
+        await session.execute(resource_insert, resource_rows)
 
 
 # Events require a fixed number of parameters per event,...

--- a/src/prefect/server/events/storage/database.py
+++ b/src/prefect/server/events/storage/database.py
@@ -260,9 +260,10 @@ async def _write_postgres_events(
         session: a Postgres events session
         events: the events to insert
     """
+    # Early SQLAlchemy 2.0 ORM bulk inserts reject conflict-skipped RETURNING rows.
     event_insert = (
         db.queries.insert(db.Event).on_conflict_do_nothing().returning(db.Event.id)
-    )
+    ).execution_options(dml_strategy="raw")
     resource_insert = db.queries.insert(db.EventResource)
 
     for batch in _in_safe_batches(events):

--- a/tests/events/server/storage/test_database.py
+++ b/tests/events/server/storage/test_database.py
@@ -1,13 +1,17 @@
 import datetime
 from datetime import timezone
+from types import SimpleNamespace
 from typing import List
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.database import PrefectDBInterface
+from prefect.server.database.query_components import AsyncPostgresQueryComponents
 from prefect.server.events.filters import (
     EventFilter,
     EventIDFilter,
@@ -16,6 +20,7 @@ from prefect.server.events.filters import (
 )
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.storage.database import (
+    _write_postgres_events,
     get_number_of_event_fields,
     get_number_of_resource_fields,
     read_events,
@@ -74,6 +79,39 @@ def other_events() -> List[ReceivedEvent]:
 
 
 class TestWriteEvents:
+    async def test_postgres_write_uses_execution_time_parameters(
+        self,
+        db: PrefectDBInterface,
+        event: ReceivedEvent,
+    ):
+        events = [event, event.model_copy(update={"id": uuid4()})]
+        postgres_db = SimpleNamespace(
+            Event=db.Event,
+            EventResource=db.EventResource,
+            queries=AsyncPostgresQueryComponents(),
+        )
+        session = AsyncMock(spec=AsyncSession)
+        result = MagicMock()
+        result.all.return_value = [event.id for event in events]
+        session.scalars.return_value = result
+
+        await _write_postgres_events.__wrapped__(postgres_db, session, events)
+
+        event_statement, event_rows = session.scalars.await_args.args
+        resource_statement, resource_rows = session.execute.await_args.args
+        dialect = postgresql.dialect()
+
+        assert len(event_rows) == len(events)
+        assert len(resource_rows) == sum(
+            len(event.involved_resources) for event in events
+        )
+        assert len(event_statement.compile(dialect=dialect).params) == (
+            get_number_of_event_fields()
+        )
+        assert len(resource_statement.compile(dialect=dialect).params) == (
+            get_number_of_resource_fields()
+        )
+
     async def test_write_event(self, session: AsyncSession, event: ReceivedEvent):
         # Write the event
         async with session as session:

--- a/tests/events/server/storage/test_database.py
+++ b/tests/events/server/storage/test_database.py
@@ -102,6 +102,7 @@ class TestWriteEvents:
         dialect = postgresql.dialect()
 
         assert len(event_rows) == len(events)
+        assert event_statement.get_execution_options()["dml_strategy"] == "raw"
         assert len(resource_rows) == sum(
             len(event.involved_resources) for event in events
         )


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/22960

This PR passes PostgreSQL event and resource rows as execution parameters instead of embedding them in each `INSERT`. This keeps the statements constant-sized and cuts event INSERT compilation CPU by hundreds-fold in the measured batch.

<details>
<summary>Details</summary>

- Preserves duplicate handling and `RETURNING id`.
- Uses Core DML semantics for compatibility when conflicts suppress returned rows.
- Adds regression coverage for execution-time parameters and constant-sized statements.

Validated against PostgreSQL and SQLite event storage tests and with pre-commit.
</details>

### Checklist

- [x] This pull request references the related issue.
- [x] This focused change does not require architectural approval.
- [x] Tests cover the changed behavior.
- [x] No user-facing documentation changes are required.
- [x] No documentation files were removed.
- [x] No functions or classes were added.
