### PR TITLE
Fix lost expiration index updates in the filesystem lease storage

### DIFF
--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import tempfile
-import weakref
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, ClassVar, TypedDict
+from typing import Any, TypedDict
 from uuid import UUID
 
 import anyio
 
+from prefect.locking._filelock import FileLock
 from prefect.server.concurrency.lease_storage import (
     ConcurrencyLeaseHolder,
     ConcurrencyLimitLeaseMetadata,
@@ -36,32 +35,6 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
     A file-based concurrency lease storage implementation that stores leases on disk.
     """
 
-    # Guards the index's read-modify-write cycle within this process.
-    # _atomic_write_json only keeps a single write from being torn; it does
-    # nothing to stop two renewals from reading the same snapshot and one
-    # clobbering the other's update on save. A class-level lock registry is
-    # required because get_concurrency_lease_storage() builds a fresh
-    # instance per call, so an instance attribute here would never be shared
-    # between the concurrent renewals it's meant to serialize. The registry
-    # is keyed by event loop, rather than holding one asyncio.Lock directly,
-    # because an asyncio.Lock binds to whichever loop first awaits it and
-    # raises if a later loop (an embedded server restart, a fresh
-    # asyncio.run() call) tries to use it. Keying by loop with a
-    # WeakKeyDictionary hands each loop its own lock and lets old ones be
-    # collected once their loop is gone.
-    _index_locks: ClassVar[
-        weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]
-    ] = weakref.WeakKeyDictionary()
-
-    @classmethod
-    def _get_index_lock(cls) -> asyncio.Lock:
-        loop = asyncio.get_running_loop()
-        lock = cls._index_locks.get(loop)
-        if lock is None:
-            lock = asyncio.Lock()
-            cls._index_locks[loop] = lock
-        return lock
-
     def __init__(self, storage_path: Path | None = None):
         prefect_home = get_current_settings().home
         self.storage_path: Path = Path(
@@ -77,6 +50,22 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
 
     def _expiration_index_path(self) -> anyio.Path:
         return anyio.Path(self.storage_path / "expirations.json")
+
+    def _index_lock_path(self) -> Path:
+        # Guards the index's read-modify-write cycle. _atomic_write_json
+        # only keeps a single write from being torn; it does nothing to
+        # stop two renewals from reading the same snapshot and one
+        # clobbering the other's update on save. get_concurrency_lease_storage()
+        # builds a fresh instance per call, so an instance-level lock would
+        # never be shared between the concurrent renewals it's meant to
+        # serialize, and a plain asyncio.Lock is bound to whichever event
+        # loop first awaits it, so it can't serialize renewals coming from
+        # different loops in the same process (an embedded server restart,
+        # separate worker threads each running their own loop) or from
+        # separate processes sharing this storage path. A lock file next to
+        # the index itself works across all of those the same way, and its
+        # aacquire() polls without blocking the event loop while waiting.
+        return self.storage_path / "expirations.json.lock"
 
     def _atomic_write_json(self, file_path: Path, data: Any) -> None:
         """
@@ -126,17 +115,25 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         self, lease_id: UUID, expiration: datetime
     ) -> None:
         """Update a single lease's expiration in the index."""
-        async with self._get_index_lock():
+        lock = FileLock(self._index_lock_path())
+        await lock.aacquire()
+        try:
             index = await self._load_expiration_index()
             index[str(lease_id)] = expiration.isoformat()
             self._save_expiration_index(index)
+        finally:
+            lock.release()
 
     async def _remove_from_expiration_index(self, lease_id: UUID) -> None:
         """Remove a lease from the expiration index."""
-        async with self._get_index_lock():
+        lock = FileLock(self._index_lock_path())
+        await lock.aacquire()
+        try:
             index = await self._load_expiration_index()
             index.pop(str(lease_id), None)
             self._save_expiration_index(index)
+        finally:
+            lock.release()
 
     def _serialize_lease(
         self, lease: ResourceLease[ConcurrencyLimitLeaseMetadata]

--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -39,6 +40,11 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         self.storage_path: Path = Path(
             storage_path or prefect_home / "concurrency_leases"
         )
+        # Guards the index's read-modify-write cycle within this process.
+        # _atomic_write_json only keeps a single write from being torn; it
+        # does nothing to stop two renewals from reading the same snapshot
+        # and one clobbering the other's update on save.
+        self._index_lock = asyncio.Lock()
 
     def _ensure_storage_path(self) -> None:
         """Ensure the storage path exists, creating it if necessary."""
@@ -98,15 +104,17 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         self, lease_id: UUID, expiration: datetime
     ) -> None:
         """Update a single lease's expiration in the index."""
-        index = await self._load_expiration_index()
-        index[str(lease_id)] = expiration.isoformat()
-        self._save_expiration_index(index)
+        async with self._index_lock:
+            index = await self._load_expiration_index()
+            index[str(lease_id)] = expiration.isoformat()
+            self._save_expiration_index(index)
 
     async def _remove_from_expiration_index(self, lease_id: UUID) -> None:
         """Remove a lease from the expiration index."""
-        index = await self._load_expiration_index()
-        index.pop(str(lease_id), None)
-        self._save_expiration_index(index)
+        async with self._index_lock:
+            index = await self._load_expiration_index()
+            index.pop(str(lease_id), None)
+            self._save_expiration_index(index)
 
     def _serialize_lease(
         self, lease: ResourceLease[ConcurrencyLimitLeaseMetadata]
@@ -281,8 +289,22 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
                 lease_id = UUID(lease_id_str)
                 expiration = datetime.fromisoformat(expiration_str)
 
-                if expiration < now:
-                    expired_leases.append(lease_id)
+                if expiration >= now:
+                    continue
+
+                # The index can lag behind a renewal that landed on disk
+                # (a lost update from a concurrent write, or just an older
+                # snapshot read a moment ago). The lease file itself is
+                # what renew_lease actually stamped, so it's the one to
+                # trust before we tell the reaper to kill something that's
+                # still alive. A missing lease file means the index entry
+                # is genuinely orphaned, so we still report it expired -
+                # revoking it just removes the stale entry.
+                lease = await self.read_lease(lease_id)
+                if lease is not None and lease.expiration >= now:
+                    continue
+
+                expired_leases.append(lease_id)
             except (ValueError, TypeError):
                 continue
 

--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, ClassVar, TypedDict
 from uuid import UUID
 
 import anyio
@@ -35,16 +35,20 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
     A file-based concurrency lease storage implementation that stores leases on disk.
     """
 
+    # Guards the index's read-modify-write cycle within this process.
+    # _atomic_write_json only keeps a single write from being torn; it does
+    # nothing to stop two renewals from reading the same snapshot and one
+    # clobbering the other's update on save. A class-level lock is required
+    # because get_concurrency_lease_storage() builds a fresh instance per
+    # call, so an instance attribute here would never be shared between the
+    # concurrent renewals it's meant to serialize.
+    _index_lock: ClassVar[asyncio.Lock] = asyncio.Lock()
+
     def __init__(self, storage_path: Path | None = None):
         prefect_home = get_current_settings().home
         self.storage_path: Path = Path(
             storage_path or prefect_home / "concurrency_leases"
         )
-        # Guards the index's read-modify-write cycle within this process.
-        # _atomic_write_json only keeps a single write from being torn; it
-        # does nothing to stop two renewals from reading the same snapshot
-        # and one clobbering the other's update on save.
-        self._index_lock = asyncio.Lock()
 
     def _ensure_storage_path(self) -> None:
         """Ensure the storage path exists, creating it if necessary."""

--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import tempfile
+import weakref
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, ClassVar, TypedDict
@@ -38,11 +39,28 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
     # Guards the index's read-modify-write cycle within this process.
     # _atomic_write_json only keeps a single write from being torn; it does
     # nothing to stop two renewals from reading the same snapshot and one
-    # clobbering the other's update on save. A class-level lock is required
-    # because get_concurrency_lease_storage() builds a fresh instance per
-    # call, so an instance attribute here would never be shared between the
-    # concurrent renewals it's meant to serialize.
-    _index_lock: ClassVar[asyncio.Lock] = asyncio.Lock()
+    # clobbering the other's update on save. A class-level lock registry is
+    # required because get_concurrency_lease_storage() builds a fresh
+    # instance per call, so an instance attribute here would never be shared
+    # between the concurrent renewals it's meant to serialize. The registry
+    # is keyed by event loop, rather than holding one asyncio.Lock directly,
+    # because an asyncio.Lock binds to whichever loop first awaits it and
+    # raises if a later loop (an embedded server restart, a fresh
+    # asyncio.run() call) tries to use it. Keying by loop with a
+    # WeakKeyDictionary hands each loop its own lock and lets old ones be
+    # collected once their loop is gone.
+    _index_locks: ClassVar[
+        weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]
+    ] = weakref.WeakKeyDictionary()
+
+    @classmethod
+    def _get_index_lock(cls) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = cls._index_locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._index_locks[loop] = lock
+        return lock
 
     def __init__(self, storage_path: Path | None = None):
         prefect_home = get_current_settings().home
@@ -108,14 +126,14 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         self, lease_id: UUID, expiration: datetime
     ) -> None:
         """Update a single lease's expiration in the index."""
-        async with self._index_lock:
+        async with self._get_index_lock():
             index = await self._load_expiration_index()
             index[str(lease_id)] = expiration.isoformat()
             self._save_expiration_index(index)
 
     async def _remove_from_expiration_index(self, lease_id: UUID) -> None:
         """Remove a lease from the expiration index."""
-        async with self._index_lock:
+        async with self._get_index_lock():
             index = await self._load_expiration_index()
             index.pop(str(lease_id), None)
             self._save_expiration_index(index)

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -792,7 +792,12 @@ class TestFilesystemConcurrencyLeaseStorage:
             thread_a_is_mid_update.set()
             # Keep the critical section open long enough that a genuinely
             # concurrent second thread, if nothing serializes it, reads the
-            # same stale snapshot and clobbers this update on save.
+            # same stale snapshot and clobbers this update on save. A fixed
+            # sleep is unavoidable here rather than some cross-thread signal:
+            # with the lock actually working, thread B cannot reach this
+            # function at all until thread A releases it, so waiting for any
+            # signal from B before proceeding would deadlock on the very
+            # serialization this test exists to confirm.
             await asyncio.sleep(0.2)
             return result
 
@@ -836,6 +841,8 @@ class TestFilesystemConcurrencyLeaseStorage:
         thread_b.start()
         thread_a.join(timeout=5)
         thread_b.join(timeout=5)
+        assert not thread_a.is_alive(), "thread A did not finish within the timeout"
+        assert not thread_b.is_alive(), "thread B did not finish within the timeout"
 
         monkeypatch.undo()
         assert not errors, f"concurrent updates from separate loops raised: {errors!r}"

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -764,68 +764,85 @@ class TestFilesystemConcurrencyLeaseStorage:
         assert index.get(str(lease_a.id)) == new_expiration_a.isoformat()
         assert index.get(str(lease_b.id)) == new_expiration_b.isoformat()
 
-    async def test_index_lock_survives_a_new_event_loop(
+    async def test_concurrent_updates_from_separate_event_loops_do_not_lose_a_write(
         self,
         temp_dir: Path,
         sample_resource_ids: list[UUID],
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """An asyncio.Lock only binds to a loop once something actually
-        contends on it (an uncontended acquire never touches the loop at
-        all), and raises if a later loop also contends on it. That means a
-        second round of concurrent renewals, after an embedded server
-        restart or a fresh asyncio.run() call in the same process, has to
-        keep serializing instead of blowing up just because a previous loop
-        is gone.
+        """Two renewals landing on separate event loops in separate threads,
+        which is what actually happens when multiple worker threads each run
+        their own loop against the same storage_path, have to serialize the
+        same way two renewals on the same loop do. A lock keyed per event
+        loop hands each thread's loop its own lock and lets both critical
+        sections run at once, losing whichever update saves first; this
+        forces that overlap instead of hoping the OS schedules the threads
+        unluckily on its own.
         """
-        storage = ConcurrencyLeaseStorage(storage_path=temp_dir)
+        setup_storage = ConcurrencyLeaseStorage(storage_path=temp_dir)
         ttl = timedelta(minutes=5)
-        lease_a = await storage.create_lease(sample_resource_ids, ttl)
-        lease_b = await storage.create_lease(sample_resource_ids, ttl)
+        lease_a = await setup_storage.create_lease(sample_resource_ids, ttl)
+        lease_b = await setup_storage.create_lease(sample_resource_ids, ttl)
 
-        async def contend_on_the_index(
-            first_expiration: datetime, second_expiration: datetime
-        ) -> None:
-            async def hold_the_lock_briefly(lease_id: UUID, expiration: datetime):
-                async with storage._get_index_lock():
-                    await asyncio.sleep(0.05)
-                    index = await storage._load_expiration_index()
-                    index[str(lease_id)] = expiration.isoformat()
-                    storage._save_expiration_index(index)
+        original_load = ConcurrencyLeaseStorage._load_expiration_index
+        thread_a_is_mid_update = threading.Event()
 
-            # gather starts both coroutines, so the second one reaches the
-            # lock while the first is still holding it during its sleep,
-            # which is exactly the real contention the lock has to survive.
-            await asyncio.gather(
-                hold_the_lock_briefly(lease_a.id, first_expiration),
-                hold_the_lock_briefly(lease_b.id, second_expiration),
-            )
+        async def load_then_hold_the_critical_section_open(self):
+            result = await original_load(self)
+            thread_a_is_mid_update.set()
+            # Keep the critical section open long enough that a genuinely
+            # concurrent second thread, if nothing serializes it, reads the
+            # same stale snapshot and clobbers this update on save.
+            await asyncio.sleep(0.2)
+            return result
 
-        # The first round of genuine contention happens on this test's own
-        # event loop, which is what actually binds the lock to it.
-        await contend_on_the_index(
-            datetime.now(timezone.utc) + timedelta(minutes=10),
-            datetime.now(timezone.utc) + timedelta(minutes=20),
+        monkeypatch.setattr(
+            ConcurrencyLeaseStorage,
+            "_load_expiration_index",
+            load_then_hold_the_critical_section_open,
         )
 
-        errors: list[RuntimeError] = []
+        new_expiration_a = datetime.now(timezone.utc) + timedelta(minutes=10)
+        new_expiration_b = datetime.now(timezone.utc) + timedelta(minutes=20)
+        errors: list[Exception] = []
 
-        def run_contention_on_a_fresh_loop() -> None:
-            async def contend_again() -> None:
-                await contend_on_the_index(
-                    datetime.now(timezone.utc) + timedelta(minutes=30),
-                    datetime.now(timezone.utc) + timedelta(minutes=40),
-                )
+        def update_lease_a_on_its_own_loop() -> None:
+            async def update() -> None:
+                storage = ConcurrencyLeaseStorage(storage_path=temp_dir)
+                await storage._update_expiration_index(lease_a.id, new_expiration_a)
 
             try:
-                asyncio.run(contend_again())
-            except RuntimeError as exc:
+                asyncio.run(update())
+            except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 
-        thread = threading.Thread(target=run_contention_on_a_fresh_loop)
-        thread.start()
-        thread.join()
+        def update_lease_b_on_its_own_loop() -> None:
+            # Wait for thread A to already be mid-update before starting, so
+            # this is a genuine overlap rather than a lucky race.
+            assert thread_a_is_mid_update.wait(timeout=5)
 
-        assert not errors, f"contention from a new event loop raised: {errors!r}"
+            async def update() -> None:
+                storage = ConcurrencyLeaseStorage(storage_path=temp_dir)
+                await storage._update_expiration_index(lease_b.id, new_expiration_b)
+
+            try:
+                asyncio.run(update())
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        thread_a = threading.Thread(target=update_lease_a_on_its_own_loop)
+        thread_b = threading.Thread(target=update_lease_b_on_its_own_loop)
+        thread_a.start()
+        thread_b.start()
+        thread_a.join(timeout=5)
+        thread_b.join(timeout=5)
+
+        monkeypatch.undo()
+        assert not errors, f"concurrent updates from separate loops raised: {errors!r}"
+
+        index = await setup_storage._load_expiration_index()
+        assert index.get(str(lease_a.id)) == new_expiration_a.isoformat()
+        assert index.get(str(lease_b.id)) == new_expiration_b.isoformat()
 
     async def test_read_expired_lease_ids_trusts_the_lease_file_over_a_stale_index(
         self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -715,6 +715,54 @@ class TestFilesystemConcurrencyLeaseStorage:
         assert index.get(str(lease_a.id)) == new_expiration_a.isoformat()
         assert index.get(str(lease_b.id)) == new_expiration_b.isoformat()
 
+    async def test_concurrent_updates_from_separate_instances_do_not_lose_a_write(
+        self,
+        temp_dir: Path,
+        sample_resource_ids: list[UUID],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """get_concurrency_lease_storage() builds a fresh instance per call, so
+        two concurrent renewals never share the same Python object even though
+        they share the same storage_path. The lock has to be shared across
+        those instances for it to serialize anything in production.
+        """
+        storage_a = ConcurrencyLeaseStorage(storage_path=temp_dir)
+        storage_b = ConcurrencyLeaseStorage(storage_path=temp_dir)
+
+        ttl = timedelta(minutes=5)
+        lease_a = await storage_a.create_lease(sample_resource_ids, ttl)
+        lease_b = await storage_a.create_lease(sample_resource_ids, ttl)
+
+        original_load = storage_a._load_expiration_index
+        call_count = 0
+
+        async def load_with_a_delay_on_the_first_call():
+            nonlocal call_count
+            call_count += 1
+            result = await original_load()
+            if call_count == 1:
+                # Give the second instance's update a chance to read, write,
+                # and finish before this one acts on what it already read.
+                await asyncio.sleep(0.05)
+            return result
+
+        monkeypatch.setattr(
+            storage_a, "_load_expiration_index", load_with_a_delay_on_the_first_call
+        )
+
+        new_expiration_a = datetime.now(timezone.utc) + timedelta(minutes=10)
+        new_expiration_b = datetime.now(timezone.utc) + timedelta(minutes=20)
+
+        await asyncio.gather(
+            storage_a._update_expiration_index(lease_a.id, new_expiration_a),
+            storage_b._update_expiration_index(lease_b.id, new_expiration_b),
+        )
+
+        monkeypatch.undo()
+        index = await storage_a._load_expiration_index()
+        assert index.get(str(lease_a.id)) == new_expiration_a.isoformat()
+        assert index.get(str(lease_b.id)) == new_expiration_b.isoformat()
+
     async def test_read_expired_lease_ids_trusts_the_lease_file_over_a_stale_index(
         self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
     ):

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import tempfile
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -762,6 +763,69 @@ class TestFilesystemConcurrencyLeaseStorage:
         index = await storage_a._load_expiration_index()
         assert index.get(str(lease_a.id)) == new_expiration_a.isoformat()
         assert index.get(str(lease_b.id)) == new_expiration_b.isoformat()
+
+    async def test_index_lock_survives_a_new_event_loop(
+        self,
+        temp_dir: Path,
+        sample_resource_ids: list[UUID],
+    ):
+        """An asyncio.Lock only binds to a loop once something actually
+        contends on it (an uncontended acquire never touches the loop at
+        all), and raises if a later loop also contends on it. That means a
+        second round of concurrent renewals, after an embedded server
+        restart or a fresh asyncio.run() call in the same process, has to
+        keep serializing instead of blowing up just because a previous loop
+        is gone.
+        """
+        storage = ConcurrencyLeaseStorage(storage_path=temp_dir)
+        ttl = timedelta(minutes=5)
+        lease_a = await storage.create_lease(sample_resource_ids, ttl)
+        lease_b = await storage.create_lease(sample_resource_ids, ttl)
+
+        async def contend_on_the_index(
+            first_expiration: datetime, second_expiration: datetime
+        ) -> None:
+            async def hold_the_lock_briefly(lease_id: UUID, expiration: datetime):
+                async with storage._get_index_lock():
+                    await asyncio.sleep(0.05)
+                    index = await storage._load_expiration_index()
+                    index[str(lease_id)] = expiration.isoformat()
+                    storage._save_expiration_index(index)
+
+            # gather starts both coroutines, so the second one reaches the
+            # lock while the first is still holding it during its sleep,
+            # which is exactly the real contention the lock has to survive.
+            await asyncio.gather(
+                hold_the_lock_briefly(lease_a.id, first_expiration),
+                hold_the_lock_briefly(lease_b.id, second_expiration),
+            )
+
+        # The first round of genuine contention happens on this test's own
+        # event loop, which is what actually binds the lock to it.
+        await contend_on_the_index(
+            datetime.now(timezone.utc) + timedelta(minutes=10),
+            datetime.now(timezone.utc) + timedelta(minutes=20),
+        )
+
+        errors: list[RuntimeError] = []
+
+        def run_contention_on_a_fresh_loop() -> None:
+            async def contend_again() -> None:
+                await contend_on_the_index(
+                    datetime.now(timezone.utc) + timedelta(minutes=30),
+                    datetime.now(timezone.utc) + timedelta(minutes=40),
+                )
+
+            try:
+                asyncio.run(contend_again())
+            except RuntimeError as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=run_contention_on_a_fresh_loop)
+        thread.start()
+        thread.join()
+
+        assert not errors, f"contention from a new event loop raised: {errors!r}"
 
     async def test_read_expired_lease_ids_trusts_the_lease_file_over_a_stale_index(
         self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -667,3 +668,80 @@ class TestFilesystemConcurrencyLeaseStorage:
         # Verify no temp files left behind
         temp_files = list(storage.storage_path.glob(".lease_*.tmp"))
         assert len(temp_files) == 0
+
+    async def test_concurrent_index_updates_do_not_lose_a_write(
+        self,
+        storage: ConcurrencyLeaseStorage,
+        sample_resource_ids: list[UUID],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Two renewals whose index reads and writes interleave should both
+        end up recorded, not just whichever one saved last. The lock around
+        the read-modify-write cycle is what's supposed to guarantee that, so
+        this forces the interleaving instead of hoping the event loop
+        schedules things unluckily on its own.
+        """
+        ttl = timedelta(minutes=5)
+        lease_a = await storage.create_lease(sample_resource_ids, ttl)
+        lease_b = await storage.create_lease(sample_resource_ids, ttl)
+
+        original_load = storage._load_expiration_index
+        call_count = 0
+
+        async def load_with_a_delay_on_the_first_call():
+            nonlocal call_count
+            call_count += 1
+            result = await original_load()
+            if call_count == 1:
+                # Give the second update a chance to read, write, and finish
+                # before this one acts on what it already read.
+                await asyncio.sleep(0.05)
+            return result
+
+        monkeypatch.setattr(
+            storage, "_load_expiration_index", load_with_a_delay_on_the_first_call
+        )
+
+        new_expiration_a = datetime.now(timezone.utc) + timedelta(minutes=10)
+        new_expiration_b = datetime.now(timezone.utc) + timedelta(minutes=20)
+
+        await asyncio.gather(
+            storage._update_expiration_index(lease_a.id, new_expiration_a),
+            storage._update_expiration_index(lease_b.id, new_expiration_b),
+        )
+
+        monkeypatch.undo()
+        index = await storage._load_expiration_index()
+        assert index.get(str(lease_a.id)) == new_expiration_a.isoformat()
+        assert index.get(str(lease_b.id)) == new_expiration_b.isoformat()
+
+    async def test_read_expired_lease_ids_trusts_the_lease_file_over_a_stale_index(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        """If the index says a lease expired but the lease file (the thing
+        renew_lease actually stamped) says it's still good, the reaper
+        shouldn't kill it. A stale index entry, from a lost update or just an
+        old read, is meant to be harmless rather than fatal.
+        """
+        ttl = timedelta(minutes=30)
+        lease = await storage.create_lease(sample_resource_ids, ttl)
+
+        # Back the index entry up to look expired, without touching the
+        # lease file itself, exactly what a lost update would leave behind.
+        stale_expiration = datetime.now(timezone.utc) - timedelta(minutes=5)
+        index = await storage._load_expiration_index()
+        index[str(lease.id)] = stale_expiration.isoformat()
+        storage._save_expiration_index(index)
+
+        expired_ids = await storage.read_expired_lease_ids()
+        assert lease.id not in expired_ids
+
+        # An entry with no matching lease file at all is a genuine orphan,
+        # and should still come back as expired so it gets cleaned up.
+        orphan_id = uuid4()
+        index = await storage._load_expiration_index()
+        index[str(orphan_id)] = stale_expiration.isoformat()
+        storage._save_expiration_index(index)
+
+        expired_ids = await storage.read_expired_lease_ids()
+        assert orphan_id in expired_ids


### PR DESCRIPTION
Closes #22935

Two lease renewals can land close enough together that they both read the same snapshot of the shared `expirations.json` index before either one writes back. Whichever one saves last wins, and the other's update just disappears. Since the reaper only ever looks at that index to decide what's expired, losing a single update is enough to have it revoke a lease that's still perfectly alive. The reporter hit this in production on a long-running flow that got killed with a bare 410 about half an hour in, with every renewal up to that point having succeeded.

I added an `asyncio.Lock` around the read, modify, and write of the index in `_update_expiration_index` and `_remove_from_expiration_index`, so two updates can't interleave anymore.

I also changed `read_expired_lease_ids` to check the actual lease file before reporting something as expired. The lease file is what `renew_lease` stamps directly, so it's the source of truth, and the index is only supposed to be a shortcut to it. This means that if the index ever ends up stale for some other reason down the road, a stale entry becomes harmless instead of fatal. If the lease file is missing entirely, that entry really is orphaned, so it still gets reported as expired and cleaned up.

For tests, I added one that forces the interleaving deterministically (delaying the first index read just long enough for a second concurrent update to finish first, instead of hoping the event loop schedules it unluckily), and one that backdates an index entry while leaving the lease file untouched, to confirm the reaper no longer trusts a stale index on its own. Both fail against the code on main and pass with the fix.

Ran the full `tests/server/concurrency/` and `tests/server/services/test_repossessor.py` suites locally (61 tests, all passing), plus ruff and mypy on the changed files with nothing new flagged.
