### PR TITLE
Preserve explicit falsy prefect-redis client overrides

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/client.py
+++ b/src/integrations/prefect-redis/prefect_redis/client.py
@@ -238,8 +238,11 @@ def get_async_redis_client(
             _raise_cluster_not_supported()
         return Redis.from_url(
             url,
-            health_check_interval=health_check_interval
-            or settings.health_check_interval,
+            health_check_interval=(
+                health_check_interval
+                if health_check_interval is not None
+                else settings.health_check_interval
+            ),
             decode_responses=decode_responses,
             socket_timeout=resolved_socket_timeout,
             socket_connect_timeout=resolved_socket_connect_timeout,
@@ -248,12 +251,16 @@ def get_async_redis_client(
 
     return Redis(
         host=host or settings.host,
-        port=port or settings.port,
-        db=db or settings.db,
+        port=port if port is not None else settings.port,
+        db=db if db is not None else settings.db,
         password=password or settings.password,
         username=username or settings.username,
-        health_check_interval=health_check_interval or settings.health_check_interval,
-        ssl=ssl or settings.ssl,
+        health_check_interval=(
+            health_check_interval
+            if health_check_interval is not None
+            else settings.health_check_interval
+        ),
+        ssl=ssl if ssl is not None else settings.ssl,
         decode_responses=decode_responses,
         socket_timeout=resolved_socket_timeout,
         socket_connect_timeout=resolved_socket_connect_timeout,

--- a/src/integrations/prefect-redis/tests/test_client.py
+++ b/src/integrations/prefect-redis/tests/test_client.py
@@ -158,6 +158,78 @@ def test_redis_settings_url_no_warning_with_defaults(monkeypatch: pytest.MonkeyP
     assert len(caught) == 0
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"ssl": False}, {"ssl": False}),
+        ({"port": 0}, {"port": 0}),
+        ({"db": 0}, {"db": 0}),
+        ({"health_check_interval": 0}, {"health_check_interval": 0}),
+    ],
+)
+def test_get_async_redis_client_preserves_explicit_falsy_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, bool | int],
+    expected: dict[str, bool | int],
+):
+    settings = RedisMessagingSettings(
+        ssl=True, port=6380, db=1, health_check_interval=30
+    )
+    redis = MagicMock()
+    monkeypatch.setattr("prefect_redis.client.RedisMessagingSettings", lambda: settings)
+    monkeypatch.setattr("prefect_redis.client.Redis", redis)
+    _client_cache.clear()
+
+    try:
+        get_async_redis_client(**overrides)
+
+        for key, value in expected.items():
+            assert redis.call_args.kwargs[key] == value
+    finally:
+        _client_cache.clear()
+
+
+def test_get_async_redis_client_none_overrides_inherit_settings(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = RedisMessagingSettings(
+        ssl=True, port=6380, db=1, health_check_interval=30
+    )
+    redis = MagicMock()
+    monkeypatch.setattr("prefect_redis.client.RedisMessagingSettings", lambda: settings)
+    monkeypatch.setattr("prefect_redis.client.Redis", redis)
+    _client_cache.clear()
+
+    try:
+        get_async_redis_client()
+
+        expected = {
+            "ssl": True,
+            "port": 6380,
+            "db": 1,
+            "health_check_interval": 30,
+        }
+        for key, value in expected.items():
+            assert redis.call_args.kwargs[key] == value
+    finally:
+        _client_cache.clear()
+
+
+def test_get_async_redis_client_url_preserves_explicit_zero_health_check_interval(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    redis = MagicMock()
+    monkeypatch.setattr("prefect_redis.client.Redis", redis)
+    _client_cache.clear()
+
+    try:
+        get_async_redis_client(url="redis://localhost:6379/0", health_check_interval=0)
+
+        assert redis.from_url.call_args.kwargs["health_check_interval"] == 0
+    finally:
+        _client_cache.clear()
+
+
 async def test_get_async_redis_client_defaults():
     """Test that get_async_redis_client creates client with default settings"""
     client = get_async_redis_client()


### PR DESCRIPTION
closes #22973

## Summary

- preserve explicit `False` and `0` values for `ssl`, `port`, `db`, and `health_check_interval` when constructing a Redis client
- keep `None` as the sentinel for inheriting messaging settings
- cover direct and URL-based client construction without requiring a Redis server

The discrete connection fields are ignored in URL mode; the URL-path test therefore covers only the applicable `health_check_interval` option. No documentation change is needed because this corrects the existing override contract.

## Testing

- `PYTHONPATH=src/integrations/prefect-redis .venv/bin/pytest --noconftest src/integrations/prefect-redis/tests/test_client.py -k 'preserves_explicit_falsy_overrides or none_overrides_inherit_settings or url_preserves_explicit_zero_health_check_interval' -q`\n- `.venv/bin/ruff format --check src/integrations/prefect-redis/prefect_redis/client.py src/integrations/prefect-redis/tests/test_client.py`\n- `PYTHONPATH=src/integrations/prefect-redis .venv/bin/mypy src/integrations/prefect-redis/prefect_redis/client.py src/integrations/prefect-redis/tests/test_client.py`\n\nThe regular integration fixture requires Redis at `localhost:6379`; no Redis service is available in this environment, so the focused constructor-only tests were run without that fixture.