### PR TITLE
Apply jitter around the backed off interval in critical_service_loop

### DIFF
--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -148,10 +148,16 @@ async def critical_service_loop(
         if run_once:
             return
 
+        # Jitter is applied around the current (possibly backed off) interval so that
+        # it does not cancel out the doubling performed on each backoff
+        backed_off_interval = interval * 2**backoff_count
+
         if jitter_range is not None:
-            sleep = clamped_poisson_interval(interval, clamping_factor=jitter_range)
+            sleep = clamped_poisson_interval(
+                backed_off_interval, clamping_factor=jitter_range
+            )
         else:
-            sleep = interval * 2**backoff_count
+            sleep = backed_off_interval
 
         await anyio.sleep(sleep)
 

--- a/tests/utilities/test_services.py
+++ b/tests/utilities/test_services.py
@@ -354,6 +354,29 @@ async def test_backoff_increases_interval_on_each_consecutive_group(
     assert workload.await_count == 16
 
 
+async def test_backoff_increases_interval_when_jittered(monkeypatch):
+    workload = AsyncMock(
+        side_effect=[httpx.TimeoutException("boo")] * 15 + [UncapturedException]
+    )
+    sleeper = AsyncMock()
+
+    monkeypatch.setattr("prefect.utilities.services.anyio.sleep", sleeper)
+
+    with pytest.raises(UncapturedException):
+        await critical_service_loop(
+            workload, 1, consecutive=3, backoff=6, jitter_range=0.3
+        )
+
+    assert workload.await_count == 16
+
+    # Jitter is drawn around the backed off interval, not around the base interval
+    expected_intervals = [1] * 2 + [2] * 3 + [4] * 3 + [8] * 3 + [16] * 3 + [32]
+    sleep_times = [call.args[0] for call in sleeper.await_args_list]
+    assert len(sleep_times) == len(expected_intervals)
+    for sleep_time, expected in zip(sleep_times, expected_intervals):
+        assert expected * (1 - 0.3) < sleep_time < expected * (1 + 0.3)
+
+
 async def test_sleeps_for_interval(capsys: pytest.CaptureFixture, mock_anyio_sleep):
     workload = AsyncMock(
         side_effect=[


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/22979

This PR draws the jittered sleep in `critical_service_loop` around the backed off interval (`interval * 2**backoff_count`) instead of around the base `interval`.

The two sleep branches were mutually exclusive, so any caller passing `jitter_range` lost the doubling the loop's docstring promises ("On each backoff, the interval will be doubled") — while still printing the increased interval it wasn't using. Every caller in the repo passes `jitter_range=0.3` (`workers/base.py`, `runner/_scheduled_run_poller.py`, `_internal/observers.py`), so a worker that can't reach the API kept polling at ~10s rather than easing off toward the ~1 minute the comment in `workers/base.py` intends.

<details>
<summary>Before and after</summary>

Using the reproduction from the issue (`interval=1, consecutive=3, backoff=6`, 15 consecutive failures, `anyio.sleep` recorded):

Before:

```
jitter_range=None: [1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16, 16, 32]
jitter_range=0.3:  [0.99, 0.94, 1.05, 1.18, 1.01, 0.78, 0.79, 0.96, 1.01, 1.03, 1.27, 0.99, 0.75, 0.84, 0.94]
```

After:

```
jitter_range=None: [1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16, 16, 32]
jitter_range=0.3:  [1.19, 1.27, 1.53, 1.76, 2.59, 5.17, 3.06, 3.06, 9.65, 7.41, 8.3, 18.57, 15.21, 17.57, 27.6]
```

Behavior without `jitter_range` is unchanged, and with `backoff_count == 0` the jittered interval is identical to before.

</details>

<details>
<summary>Tests</summary>

Added `test_backoff_increases_interval_when_jittered`, which asserts each sleep falls within the jitter band of the expected doubled interval. It fails on `main` and passes with the change:

```
$ uv run pytest tests/utilities/test_services.py -q -k backoff   # without the src change
FAILED tests/utilities/test_services.py::test_backoff_increases_interval_when_jittered
1 failed, 4 passed, 16 deselected

$ uv run pytest tests/utilities/test_services.py -q -k "backoff or jitter"   # with the src change
6 passed, 15 deselected
```

The existing suite missed this because `test_jittered_sleeps_between_loops` uses a workload that never fails (so `backoff_count` stays 0) and `test_backoff_increases_interval_on_each_consecutive_group` never passes `jitter_range`.

Other runs (Windows, Python 3.12.10):

- `uv run pytest tests/utilities/test_services.py -q` — 19 passed, 2 failed. The two failures are `test_stopping_metrics_server` and `test_stopping_and_starting_from_async`; both fail identically on an unmodified `main` in this environment.
- `uv run pytest tests/workers/test_base_worker.py -q -n4` — 152 passed, 2 failed (`TestSubmit::test_basic`, `TestSubmit::test_basic_uses_execution_launcher_override`), both also failing on unmodified `main` here.
- `uv run pytest tests/runner/test__scheduled_run_poller.py tests/utilities/test_math.py -q` — 44 passed.
- `uv run ruff check` / `ruff format --check` on the two changed files — no new findings (the pre-existing `UP035`/`UP045`/`SIM117`/`ASYNC210` reports are identical on `main`).
- `SKIP=check-ui-v2 uv run pre-commit run --files src/prefect/utilities/services.py tests/utilities/test_services.py` — ruff, ruff format, codespell, no-double-backticks all pass.

</details>

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  - Not a complex change; scoped to the sleep calculation in one function.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - No docs change: this restores the behavior `critical_service_loop`'s docstring already describes.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
