### PR TITLE
Stop the filesystem lease storage from revoking live leases

### DIFF
--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, ClassVar, TypedDict
 from uuid import UUID
 
 import anyio
@@ -33,6 +34,28 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
     """
     A file-based concurrency lease storage implementation that stores leases on disk.
     """
+
+    # The expiration index is a single shared file that is updated by
+    # read-modify-write, so concurrent updates have to be serialized. The lock
+    # cannot live on the instance: `get_concurrency_lease_storage()` builds a
+    # new storage object on every call, so per-instance locks would never
+    # contend with each other. It is rebuilt whenever the running event loop
+    # changes, because an `asyncio.Lock` bound to a loop that has since closed
+    # raises when acquired.
+    #
+    # This serializes updates within a process. Across processes the index can
+    # still lose an update, which is why `read_expired_lease_ids` verifies
+    # candidates against their lease files rather than trusting the index.
+    _index_lock: ClassVar[asyncio.Lock | None] = None
+    _index_lock_loop: ClassVar[asyncio.AbstractEventLoop | None] = None
+
+    @classmethod
+    def _get_index_lock(cls) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        if cls._index_lock is None or cls._index_lock_loop is not loop:
+            cls._index_lock = asyncio.Lock()
+            cls._index_lock_loop = loop
+        return cls._index_lock
 
     def __init__(self, storage_path: Path | None = None):
         prefect_home = get_current_settings().home
@@ -98,15 +121,17 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         self, lease_id: UUID, expiration: datetime
     ) -> None:
         """Update a single lease's expiration in the index."""
-        index = await self._load_expiration_index()
-        index[str(lease_id)] = expiration.isoformat()
-        self._save_expiration_index(index)
+        async with self._get_index_lock():
+            index = await self._load_expiration_index()
+            index[str(lease_id)] = expiration.isoformat()
+            self._save_expiration_index(index)
 
     async def _remove_from_expiration_index(self, lease_id: UUID) -> None:
         """Remove a lease from the expiration index."""
-        index = await self._load_expiration_index()
-        index.pop(str(lease_id), None)
-        self._save_expiration_index(index)
+        async with self._get_index_lock():
+            index = await self._load_expiration_index()
+            index.pop(str(lease_id), None)
+            self._save_expiration_index(index)
 
     def _serialize_lease(
         self, lease: ResourceLease[ConcurrencyLimitLeaseMetadata]
@@ -268,6 +293,17 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
         return all_active[offset : offset + limit]
 
     async def read_expired_lease_ids(self, limit: int = 100) -> list[UUID]:
+        """
+        Return the leases that have expired.
+
+        The index is only an accelerator for this scan: it is a single shared
+        file updated by read-modify-write, so an entry can be stale. The lease
+        file is the source of truth -- `renew_lease` writes it atomically, and
+        writes it first -- so every candidate the index reports is confirmed
+        against its lease file before being handed to the repossessor.
+        Otherwise a stale index entry would have a live lease revoked out from
+        under its holder.
+        """
         expired_leases: list[UUID] = []
         now = datetime.now(timezone.utc)
 
@@ -280,11 +316,29 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
             try:
                 lease_id = UUID(lease_id_str)
                 expiration = datetime.fromisoformat(expiration_str)
-
-                if expiration < now:
-                    expired_leases.append(lease_id)
             except (ValueError, TypeError):
                 continue
+
+            if expiration >= now:
+                continue
+
+            lease = await self.read_lease(lease_id)
+
+            if lease is None:
+                # There is no lease file behind the entry, so the lease really
+                # is gone. Report it so the revocation path clears the orphaned
+                # index entry.
+                expired_leases.append(lease_id)
+                continue
+
+            if lease.expiration >= now:
+                # The lease was renewed but the index kept an older expiration.
+                # Leave the lease alone and repair the entry so the active-lease
+                # reads agree with the lease file again.
+                await self._update_expiration_index(lease_id, lease.expiration)
+                continue
+
+            expired_leases.append(lease_id)
 
         return expired_leases
 

--- a/src/prefect/server/concurrency/lease_storage/filesystem.py
+++ b/src/prefect/server/concurrency/lease_storage/filesystem.py
@@ -313,32 +313,35 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
             if len(expired_leases) >= limit:
                 break
 
+            # Everything that reads an entry stays inside the try, so a single
+            # unparseable or non-comparable entry is skipped rather than
+            # failing the whole scan.
             try:
                 lease_id = UUID(lease_id_str)
                 expiration = datetime.fromisoformat(expiration_str)
+
+                if expiration >= now:
+                    continue
+
+                lease = await self.read_lease(lease_id)
+
+                if lease is None:
+                    # There is no lease file behind the entry, so the lease
+                    # really is gone. Report it so `revoke_expired_lease`
+                    # clears the orphaned index entry.
+                    expired_leases.append(lease_id)
+                    continue
+
+                if lease.expiration >= now:
+                    # The lease was renewed but the index kept an older
+                    # expiration. Leave the lease alone and repair the entry so
+                    # the active-lease reads agree with the lease file again.
+                    await self._update_expiration_index(lease_id, lease.expiration)
+                    continue
+
+                expired_leases.append(lease_id)
             except (ValueError, TypeError):
                 continue
-
-            if expiration >= now:
-                continue
-
-            lease = await self.read_lease(lease_id)
-
-            if lease is None:
-                # There is no lease file behind the entry, so the lease really
-                # is gone. Report it so the revocation path clears the orphaned
-                # index entry.
-                expired_leases.append(lease_id)
-                continue
-
-            if lease.expiration >= now:
-                # The lease was renewed but the index kept an older expiration.
-                # Leave the lease alone and repair the entry so the active-lease
-                # reads agree with the lease file again.
-                await self._update_expiration_index(lease_id, lease.expiration)
-                continue
-
-            expired_leases.append(lease_id)
 
         return expired_leases
 

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -667,3 +668,130 @@ class TestFilesystemConcurrencyLeaseStorage:
         # Verify no temp files left behind
         temp_files = list(storage.storage_path.glob(".lease_*.tmp"))
         assert len(temp_files) == 0
+
+
+class _ReadBarrier:
+    """Holds each index read until `n` of them are in flight.
+
+    That makes the read-modify-write phases of concurrent index updates
+    provably overlap, instead of relying on timing. It falls through on a
+    timeout so that an implementation which serializes the section -- and
+    therefore can never have `n` readers in flight -- still completes.
+    """
+
+    def __init__(self, n: int, timeout: float = 0.5):
+        self.n = n
+        self.timeout = timeout
+        self.arrived = 0
+        self.gate = asyncio.Event()
+
+    async def wait(self) -> None:
+        self.arrived += 1
+        if self.arrived >= self.n:
+            self.gate.set()
+            return
+        try:
+            await asyncio.wait_for(self.gate.wait(), self.timeout)
+        except asyncio.TimeoutError:
+            pass
+
+
+class TestExpirationIndexRaces:
+    """The expiration index must not be able to lose a live lease.
+
+    The index is one shared file rewritten in full on every update, and
+    `read_expired_lease_ids` used to trust it on its own. A renewal whose index
+    write was clobbered by a concurrent one therefore left a stale expiration
+    behind, the repossessor revoked the lease, and the holder -- still alive,
+    still renewing -- got a 410 on its next renewal.
+    """
+
+    @pytest.fixture
+    def temp_dir(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield Path(temp_dir)
+
+    @pytest.fixture
+    def storage(self, temp_dir: Path) -> ConcurrencyLeaseStorage:
+        return ConcurrencyLeaseStorage(storage_path=temp_dir)
+
+    async def test_concurrent_renewals_both_reach_the_index(self, temp_dir: Path):
+        """Interleaved index updates must not drop each other's write."""
+        barrier = _ReadBarrier(2)
+
+        class Interleaving(ConcurrencyLeaseStorage):
+            async def _load_expiration_index(self) -> dict[str, str]:
+                index = await super()._load_expiration_index()
+                await barrier.wait()
+                return index
+
+        storage = Interleaving(storage_path=temp_dir)
+        ttl = timedelta(minutes=5)
+        first = await storage.create_lease([uuid4()], ttl)
+        second = await storage.create_lease([uuid4()], ttl)
+
+        index_path = temp_dir / "expirations.json"
+        before = json.loads(index_path.read_text())
+
+        barrier.arrived = 0
+        barrier.gate = asyncio.Event()
+        await asyncio.gather(
+            storage.renew_lease(first.id, ttl), storage.renew_lease(second.id, ttl)
+        )
+
+        after = json.loads(index_path.read_text())
+        assert after[str(first.id)] != before[str(first.id)]
+        assert after[str(second.id)] != before[str(second.id)]
+
+    async def test_stale_index_entry_does_not_expire_a_live_lease(
+        self, storage: ConcurrencyLeaseStorage, temp_dir: Path
+    ):
+        """A lease file that is still in the future outranks the index."""
+        ttl = timedelta(minutes=5)
+        lease = await storage.create_lease([uuid4()], ttl)
+
+        # What a clobbered index write leaves behind: an expiration in the past
+        # for a lease whose file still says it is alive.
+        index_path = temp_dir / "expirations.json"
+        index = json.loads(index_path.read_text())
+        index[str(lease.id)] = (
+            datetime.now(timezone.utc) - timedelta(seconds=30)
+        ).isoformat()
+        index_path.write_text(json.dumps(index))
+
+        assert await storage.read_expired_lease_ids() == []
+
+    async def test_stale_index_entry_is_repaired(
+        self, storage: ConcurrencyLeaseStorage, temp_dir: Path
+    ):
+        """The scan heals the entry, so the active-lease reads agree again."""
+        ttl = timedelta(minutes=5)
+        lease = await storage.create_lease([uuid4()], ttl)
+
+        index_path = temp_dir / "expirations.json"
+        index = json.loads(index_path.read_text())
+        index[str(lease.id)] = (
+            datetime.now(timezone.utc) - timedelta(seconds=30)
+        ).isoformat()
+        index_path.write_text(json.dumps(index))
+
+        assert await storage.read_active_lease_ids() == []
+        await storage.read_expired_lease_ids()
+        assert await storage.read_active_lease_ids() == [lease.id]
+
+    async def test_expired_lease_is_still_reported(
+        self, storage: ConcurrencyLeaseStorage
+    ):
+        """Verifying against the lease file must not stop expiry altogether."""
+        lease = await storage.create_lease([uuid4()], timedelta(seconds=-1))
+
+        assert await storage.read_expired_lease_ids() == [lease.id]
+
+    async def test_orphaned_index_entry_is_still_reported(
+        self, storage: ConcurrencyLeaseStorage, temp_dir: Path
+    ):
+        """An entry with no lease file behind it is garbage and must be cleared."""
+        lease = await storage.create_lease([uuid4()], timedelta(seconds=-1))
+        (temp_dir / f"{lease.id}.json").unlink()
+
+        assert await storage.read_expired_lease_ids() == [lease.id]

--- a/tests/server/concurrency/test_filesystem_lease_storage.py
+++ b/tests/server/concurrency/test_filesystem_lease_storage.py
@@ -795,3 +795,23 @@ class TestExpirationIndexRaces:
         (temp_dir / f"{lease.id}.json").unlink()
 
         assert await storage.read_expired_lease_ids() == [lease.id]
+
+    async def test_unusable_index_entry_is_skipped(
+        self, storage: ConcurrencyLeaseStorage, temp_dir: Path
+    ):
+        """A bad entry is skipped, not raised, and does not hide the good ones.
+
+        A naive datetime is the interesting case: it parses, so it survives
+        `fromisoformat`, and only blows up on the comparison against an aware
+        `now`.
+        """
+        lease = await storage.create_lease([uuid4()], timedelta(seconds=-1))
+
+        index_path = temp_dir / "expirations.json"
+        index = json.loads(index_path.read_text())
+        index[str(uuid4())] = datetime.now().isoformat()  # naive
+        index[str(uuid4())] = "not a datetime"
+        index["not-a-uuid"] = datetime.now(timezone.utc).isoformat()
+        index_path.write_text(json.dumps(index))
+
+        assert await storage.read_expired_lease_ids() == [lease.id]


### PR DESCRIPTION
Fixes #22935.

### The bug

The filesystem concurrency lease storage keeps one file per lease plus a single shared `expirations.json`. `_update_expiration_index` reads the whole index, edits one key and writes the whole index back — with an `await` between the read and the write:

```python
async def _update_expiration_index(self, lease_id, expiration) -> None:
    index = await self._load_expiration_index()   # <- suspension point
    index[str(lease_id)] = expiration.isoformat()
    self._save_expiration_index(index)            # <- writes the WHOLE index
```

Two renewals that interleave there take the same snapshot, and the second write drops the first one's update. `_atomic_write_json` makes each write atomic, which prevents a torn file — but a lost update is a different failure, and its docstring's claim to "prevent race conditions when multiple processes read and write the same file" does not cover it.

This does not need multiple processes. `_load_expiration_index` awaits, so two concurrent renewal requests interleave inside a single server process.

A lost index write would still be recoverable if the reaper cross-checked, but `read_expired_lease_ids` trusts the index alone, and `services/repossessor.py` acts on what it returns. So the losing lease keeps a stale expiration in the index, gets revoked, and its holder — alive, and still renewing on schedule — gets a `410 Gone` on the next renewal.

At the default renewal cadence of 0.75 × TTL, **a single lost write is always fatal**. A renewal at `t` should leave `t + TTL` in the index; if that write is lost the index still holds the previous renewal's value, `t + 0.25 × TTL`. The repossessor revokes at `t + 0.25 × TTL`; the next renewal is only due at `t + 0.75 × TTL` — half a TTL after the lease is already gone. Surviving one lost write requires a cadence below 0.5 × TTL, which the default is not.

We hit this in production on a single-replica 3.6.13 server with `PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE=...filesystem`: a flow run crashed 30 minutes in with `410 Gone` on its lease, every prior renewal having succeeded without a warning, no server restart, and the other leases held at the same moment untouched. That shape — sudden, single-lease, no failed renewal beforehand, more likely the longer the run — is what a lost index write looks like from outside.

### The fix

**1. `read_expired_lease_ids` confirms each candidate against its lease file.** The lease file is the source of truth — `renew_lease` writes it atomically, and writes it *first* — while the index is only an accelerator for the scan. A lease whose file is still in the future is left alone, and its index entry is repaired so `read_active_lease_ids` / `list_holders_for_limit` agree with the file again. An entry with no lease file behind it is still reported, so the revocation path keeps clearing orphans.

This alone makes a stale index entry non-fatal, in any deployment, however the staleness arose.

**2. An `asyncio.Lock` serializes the index read-modify-write**, removing the race rather than only its consequence. The lock is class-level: `get_concurrency_lease_storage()` builds a new storage instance on every call, so a per-instance lock would never contend with anything. It is rebuilt when the running event loop changes, since a lock bound to a closed loop raises on acquire.

The lock covers a single process. Change (1) is what covers the rest.

### Cost

`read_expired_lease_ids` now reads one lease file per *expired candidate*. In steady state the index reports nothing expired and the scan is unchanged; the extra reads are bounded by `limit` and happen only for leases that are actually about to be revoked — the path that then reads the same file in `revoke_expired_lease` anyway.

### Tests

Five tests in a new `TestExpirationIndexRaces` class. Three of them fail on `main` today:

- `test_concurrent_renewals_both_reach_the_index` — two renewals with deliberately overlapping index phases (a barrier releases both reads before either writes, so it is deterministic rather than timing-dependent); on `main` one of the two updates is lost.
- `test_stale_index_entry_does_not_expire_a_live_lease` — index entry rewound into the past, lease file still in the future; on `main` the live lease is reported expired.
- `test_stale_index_entry_is_repaired` — the same setup, checking the entry is healed.

The other two are regression guards that pass either way, so the file check cannot quietly become "never expire anything":

- `test_expired_lease_is_still_reported`
- `test_orphaned_index_entry_is_still_reported`

`tests/server/concurrency/test_filesystem_lease_storage.py` passes in full (37 tests). `ruff format --check` is clean; `ruff check` reports the same 12 pre-existing `ASYNC230` findings before and after this change, none on new lines.
