### PR TITLE
Don't revoke a lease that was renewed after it was listed as expired

### DIFF
--- a/src/prefect/server/concurrency/lease_storage/memory.py
+++ b/src/prefect/server/concurrency/lease_storage/memory.py
@@ -72,7 +72,12 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
             self.expirations.pop(lease_id, None)
             return False
 
-        self.expirations[lease_id] = datetime.now(timezone.utc) + ttl
+        new_expiration = datetime.now(timezone.utc) + ttl
+        # Both, so that a lease read back after a renewal reports the expiration
+        # it was actually renewed to. The filesystem backend already writes the
+        # renewed expiration into the lease itself.
+        self.leases[lease_id].expiration = new_expiration
+        self.expirations[lease_id] = new_expiration
         return True
 
     async def revoke_lease(self, lease_id: UUID) -> None:

--- a/src/prefect/server/services/repossessor.py
+++ b/src/prefect/server/services/repossessor.py
@@ -44,9 +44,20 @@ async def revoke_expired_lease(
         logger.warning(f"Lease {lease_id} should be revoked but has no metadata")
         return
 
-    occupancy_seconds = (
-        datetime.now(timezone.utc) - expired_lease.created_at
-    ).total_seconds()
+    now = datetime.now(timezone.utc)
+
+    if expired_lease.expiration > now:
+        # The lease was renewed between `monitor_expired_leases` listing it and
+        # this task running. Revoking now would take the slots away from a
+        # holder that is alive and renewing on schedule, and the holder would
+        # only find out on its next renewal.
+        logger.debug(
+            f"Lease {lease_id} was renewed after being scheduled for revocation; "
+            "leaving it alone"
+        )
+        return
+
+    occupancy_seconds = (now - expired_lease.created_at).total_seconds()
 
     logger.info(
         f"Revoking lease {lease_id} for {len(expired_lease.resource_ids)} "

--- a/tests/server/concurrency/test_memory_lease_storage.py
+++ b/tests/server/concurrency/test_memory_lease_storage.py
@@ -152,6 +152,18 @@ class TestMemoryConcurrencyLeaseStorage:
         new_expiration = storage.expirations[lease_id]
         assert new_expiration > original_expiration
 
+    async def test_renew_lease_updates_the_lease_itself(
+        self, storage: ConcurrencyLeaseStorage, sample_resource_ids: list[UUID]
+    ):
+        """A lease read back after a renewal reports the renewed expiration."""
+        lease = await storage.create_lease(sample_resource_ids, timedelta(minutes=5))
+
+        assert await storage.renew_lease(lease.id, timedelta(minutes=30))
+
+        renewed = await storage.read_lease(lease.id)
+        assert renewed is not None
+        assert renewed.expiration == storage.expirations[lease.id]
+
     async def test_renew_lease_non_existing(self, storage: ConcurrencyLeaseStorage):
         non_existing_id = uuid4()
         renewed = await storage.renew_lease(non_existing_id, timedelta(minutes=5))

--- a/tests/server/services/test_repossessor.py
+++ b/tests/server/services/test_repossessor.py
@@ -113,6 +113,40 @@ class TestRevokeExpiredLease:
         # expired forever
         assert lease_storage.expirations == {}
 
+    async def test_revoke_expired_lease_renewed_before_revocation(
+        self, lease_storage, concurrency_limit, session: AsyncSession
+    ):
+        """A lease renewed after being listed as expired must not be revoked.
+
+        `monitor_expired_leases` lists expired leases and schedules a task per
+        lease; the holder can renew in between. Revoking then takes slots away
+        from a holder that is alive and renewing on schedule, and the holder
+        only finds out on its next renewal.
+        """
+        await bulk_increment_active_slots(session, [concurrency_limit.id], 2)
+        await session.commit()
+
+        lease = await lease_storage.create_lease(
+            resource_ids=[concurrency_limit.id],
+            ttl=timedelta(seconds=-1),  # Expired, so it gets scheduled
+            metadata=ConcurrencyLimitLeaseMetadata(slots=2),
+        )
+
+        # The holder renews before the revocation task runs
+        assert await lease_storage.renew_lease(lease.id, timedelta(minutes=5))
+
+        db = provide_database_interface()
+        await revoke_expired_lease(
+            lease.id,
+            db=db,
+            lease_storage=lease_storage,
+        )
+
+        # The lease is untouched and still holds its slots
+        assert len(lease_storage.leases) == 1
+        limits = await bulk_read_concurrency_limits(session, [concurrency_limit.name])
+        assert limits[0].active_slots == 2
+
     async def test_revoke_expired_lease_missing_metadata(
         self, lease_storage, concurrency_limit
     ):


### PR DESCRIPTION
Fixes #22983.

`monitor_expired_leases` lists expired leases and schedules one `revoke_expired_lease` task per lease. The holder can renew in the gap between the two, and nothing rechecks — the task decrements the slots and deletes the lease of a holder that is alive and renewing on schedule. The holder finds out on its next renewal, as a `410 Gone`.

The gap is docket scheduling latency rather than a TTL, so it is a much smaller window than #22935. But it is the same failure on the other side of the boundary, and the check is one comparison against a lease that has already been read.

### Two commits

**1. `Make a renewed in-memory lease report its renewed expiration.`** The guard reads `lease.expiration`, so that field has to be true after a renewal. On the memory backend it was not: `renew_lease` updated `self.expirations` but left `self.leases[lease_id].expiration` at its original value, so a lease read back after a renewal reported an expiration it no longer had — and one that contradicted `read_active_lease_ids`. The filesystem backend already writes the renewed expiration into the lease, so this also brings the two backends into agreement. `list_holders_for_limit` reads `self.expirations` and is unaffected, which is why this has not surfaced before.

**2. `Don't revoke a lease that was renewed after it was listed as expired.`** `revoke_expired_lease` returns early when the lease's expiration is in the future, leaving the lease and its slots alone.

### Tests

- `test_revoke_expired_lease_renewed_before_revocation` — expired lease, renewed, then the revocation task runs; the lease and its two slots must both survive. Fails on `main`.
- `test_renew_lease_updates_the_lease_itself` — a lease read back after a renewal reports the renewed expiration. Fails on `main` without commit 1.

`tests/server/concurrency/test_memory_lease_storage.py` passes in full (22 tests). `test_repossessor.py` needs a database fixture I could not stand up here, so the revocation behaviour was verified out-of-band with a script that passes a database object which raises if it is touched at all — reaching the database means the guard let the call through:

```
                            stock main   with this PR
renewed before revocation ->  revoked      survives
genuinely expired         ->  revoked      revoked
```

`ruff format --check` is clean; `ruff check` reports the same pre-existing findings before and after, none on new lines.

### Relationship to #22982

#22982 keeps a stale expiration-index entry from getting a live lease listed as expired in the first place. This one keeps a lease that was renewed *after* being listed from being revoked. They are independent and do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
