### PR TITLE
Point the server's UI at the server that serves it

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -139,6 +139,7 @@ def start(
         PREFECT_SERVER_SERVICES_LATE_RUNS_ENABLED,
         PREFECT_SERVER_SERVICES_SCHEDULER_ENABLED,
         PREFECT_SERVER_UI_ENABLED,
+        get_current_settings,
     )
 
     # Resolve settings-backed defaults
@@ -184,6 +185,12 @@ def start(
 
     if no_services:
         server_settings["PREFECT_SERVER_ANALYTICS_ENABLED"] = "False"
+
+    # Unset, PREFECT_UI_API_URL falls back to PREFECT_API_URL — the active
+    # profile's server, which may be Cloud. Only a user-set value is theirs to
+    # keep; the reverse-proxy case is what that setting is for.
+    if "api_url" not in get_current_settings().server.ui.model_fields_set:
+        server_settings["PREFECT_UI_API_URL"] = f"{base_url}/api"
 
     pid_file = Path(PREFECT_HOME.value()) / SERVER_PID_FILE_NAME
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -188,8 +188,12 @@ def start(
 
     # Unset, PREFECT_UI_API_URL falls back to PREFECT_API_URL — the active
     # profile's server, which may be Cloud. Only a user-set value is theirs to
-    # keep; the reverse-proxy case is what that setting is for.
-    if "api_url" not in get_current_settings().server.ui.model_fields_set:
+    # keep; the reverse-proxy case is what that setting is for. A wildcard bind
+    # is not an address a browser can use, so leave that case alone too.
+    if (
+        host not in ("0.0.0.0", "::", "")
+        and "api_url" not in get_current_settings().server.ui.model_fields_set
+    ):
         server_settings["PREFECT_UI_API_URL"] = f"{base_url}/api"
 
     pid_file = Path(PREFECT_HOME.value()) / SERVER_PID_FILE_NAME

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -27,6 +27,7 @@ from prefect.settings import (
     PREFECT_PROFILES_PATH,
     PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE,
     PREFECT_SERVER_EVENTS_CAUSAL_ORDERING,
+    PREFECT_UI_API_URL,
     Profile,
     ProfilesCollection,
     get_current_settings,
@@ -862,3 +863,63 @@ class TestFormatHostForUrl:
         Regression test for https://github.com/PrefectHQ/prefect/issues/20343
         """
         assert _format_host_for_url(host) == expected
+
+
+class TestUIAPIURL:
+    """Regression test for https://github.com/PrefectHQ/prefect/issues/18764
+
+    The UI served by `prefect server start` was pointed at PREFECT_API_URL from
+    the active profile rather than at the server serving it, so starting a
+    local server while a Cloud or remote profile was active produced a UI that
+    could not reach its own API.
+    """
+
+    def _mock_foreground(self, monkeypatch: pytest.MonkeyPatch) -> "MagicMock":
+        from unittest.mock import MagicMock
+
+        mock_foreground = MagicMock()
+        monkeypatch.setattr(
+            "prefect.cli._server_utils._run_in_foreground", mock_foreground
+        )
+        monkeypatch.setattr("prefect.cli._server_utils.prestart_check", MagicMock())
+        monkeypatch.setattr("prefect.cli._app.is_interactive", lambda: False)
+        return mock_foreground
+
+    def test_ui_api_url_points_at_the_started_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A remote PREFECT_API_URL must not be handed to the local UI."""
+        mock_foreground = self._mock_foreground(monkeypatch)
+
+        with temporary_settings(
+            {
+                PREFECT_API_URL: (
+                    "https://api.prefect.cloud/api/accounts/abc/workspaces/def"
+                )
+            }
+        ):
+            invoke_and_assert(
+                command=["server", "start", "--port", "4242"],
+                expected_code=0,
+            )
+
+        assert mock_foreground.called
+        server_settings = mock_foreground.call_args[0][1]
+        assert server_settings["PREFECT_UI_API_URL"] == "http://127.0.0.1:4242/api"
+
+    def test_explicit_ui_api_url_is_not_overridden(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A PREFECT_UI_API_URL the user set on purpose — the reverse-proxy case
+        the setting exists for — must survive."""
+        mock_foreground = self._mock_foreground(monkeypatch)
+
+        with temporary_settings({PREFECT_UI_API_URL: "https://proxy.example.com/api"}):
+            invoke_and_assert(
+                command=["server", "start", "--port", "4243"],
+                expected_code=0,
+            )
+
+        assert mock_foreground.called
+        server_settings = mock_foreground.call_args[0][1]
+        assert "PREFECT_UI_API_URL" not in server_settings

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -923,3 +923,22 @@ class TestUIAPIURL:
         assert mock_foreground.called
         server_settings = mock_foreground.call_args[0][1]
         assert "PREFECT_UI_API_URL" not in server_settings
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+    def test_wildcard_host_is_left_alone(
+        self, host: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A wildcard bind is not an address a browser can use, so the profile's
+        URL — which may be the externally reachable one, as in a container — is
+        a better answer than the bind address."""
+        mock_foreground = self._mock_foreground(monkeypatch)
+
+        with temporary_settings({PREFECT_API_URL: "https://prefect.example.com/api"}):
+            invoke_and_assert(
+                command=["server", "start", "--host", host, "--port", "4244"],
+                expected_code=0,
+            )
+
+        assert mock_foreground.called
+        server_settings = mock_foreground.call_args[0][1]
+        assert "PREFECT_UI_API_URL" not in server_settings


### PR DESCRIPTION
`prefect server start` serves a UI that is configured from `PREFECT_API_URL`,
which belongs to the active profile. If that profile points anywhere but the
local server — Cloud, a Kubernetes deployment — the server you just started
serves a UI that cannot reach its own API:

```
Can't connect to Server API at
https://api.prefect.cloud/api/accounts/.../workspaces/... Check that it's
accessible from your machine.
```

Switching to a profile whose `PREFECT_API_URL` is the local server makes it
work, which is what points at the cause: only the URL handed to the UI is
wrong.

### Why it happens

`PREFECT_UI_API_URL` is unset by default, and `Settings` then fills it from
`api.url` (`settings/models/root.py`), falling back to the server's own host
and port only when there is no `api.url` at all. That order is right for a
client — a worker or a CLI talking to Cloud should use the profile's URL — but
the process *serving* the UI has better information: it has already computed
its own address for the welcome message.

### The change

`prefect server start` now puts `PREFECT_UI_API_URL` into the settings it
hands the server process, pointing at the server it is starting.

An explicitly configured `PREFECT_UI_API_URL` is left alone. That is the
reverse-proxy case the setting exists for, and the test for it is
`"api_url" not in get_current_settings().server.ui.model_fields_set` — the same
marker `root.py` leaves behind when it defaults the value rather than taking a
configured one.

I considered changing that default in `root.py` instead and decided against
it: it is correct for every client use, and only the server-start path knows
better.

### How it was checked

- two tests in `tests/cli/test_start_server.py::TestUIAPIURL` — one for the
  remote-profile case, one guarding the explicit `PREFECT_UI_API_URL`. The
  guard is not decoration: an earlier version of this change overrode the
  explicit value and the guard is what caught it;
- with the change reverted, the first test fails with
  `KeyError: 'PREFECT_UI_API_URL'`;
- `tests/cli/test_start_server.py` is 38 passed, 1 skipped with the change
  against 36 passed, 1 skipped without it — the two added, nothing else moved;
- `ruff check` reports the same 19 pre-existing findings on the touched files
  before and after, and `ruff format --check` is clean.

closes https://github.com/PrefectHQ/prefect/issues/18764

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  - Not complex: seven lines in the CLI, no behaviour change for anyone who
    has set `PREFECT_UI_API_URL`. Happy to adjust if you would rather this
    lived in `root.py` or keyed off something other than `model_fields_set`.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - The documented behaviour of `PREFECT_UI_API_URL` ("Defaults to
    `PREFECT_API_URL` if set") is unchanged; what changes is that
    `server start` now sets it. Say the word if you would like that noted in
    the settings reference.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
