### PR TITLE
fix(prefect-dbt) Route source freshness logs to enclosing task

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -754,14 +754,30 @@ class PrefectDbtRunner(DbtHookMixin):
 
                 # Skip logging for skipped nodes
                 if node_id not in self._skipped_nodes:
-                    flow_run_context: Optional[dict[str, Any]] = context.get(
-                        "flow_run_context"
-                    )
-                    logger = task_state.get_task_logger(
-                        node_id,
-                        flow_run_context.get("flow_run") if flow_run_context else None,
-                        flow_run_context.get("flow") if flow_run_context else None,
-                    )
+                    task_run_id = task_state.get_task_run_id(node_id)
+                    if task_run_id is not None:
+                        # Node has an associated Prefect task — log into that task.
+                        flow_run_context: Optional[dict[str, Any]] = context.get(
+                            "flow_run_context"
+                        )
+                        logger = task_state.get_task_logger(
+                            node_id,
+                            flow_run_context.get("flow_run")
+                            if flow_run_context
+                            else None,
+                            flow_run_context.get("flow") if flow_run_context else None,
+                        )
+                    else:
+                        # No Prefect task was created for this node (e.g. source
+                        # nodes during `dbt source freshness`). Fall back to the
+                        # caller's run context so logs appear in the enclosing
+                        # task or flow run rather than being lost with
+                        # task_run_id=None.
+                        try:
+                            with hydrated_context(context) as run_context:
+                                logger = get_run_logger(run_context)
+                        except MissingContextError:
+                            logger = None
                 else:
                     logger = None
             else:
@@ -955,14 +971,30 @@ class PrefectDbtRunner(DbtHookMixin):
 
                 # Skip logging for skipped nodes
                 if node_id not in self._skipped_nodes:
-                    flow_run_context: Optional[dict[str, Any]] = context.get(
-                        "flow_run_context"
-                    )
-                    logger = task_state.get_task_logger(
-                        node_id,
-                        flow_run_context.get("flow_run") if flow_run_context else None,
-                        flow_run_context.get("flow") if flow_run_context else None,
-                    )
+                    task_run_id = task_state.get_task_run_id(node_id)
+                    if task_run_id is not None:
+                        # Node has an associated Prefect task — log into that task.
+                        flow_run_context: Optional[dict[str, Any]] = context.get(
+                            "flow_run_context"
+                        )
+                        logger = task_state.get_task_logger(
+                            node_id,
+                            flow_run_context.get("flow_run")
+                            if flow_run_context
+                            else None,
+                            flow_run_context.get("flow") if flow_run_context else None,
+                        )
+                    else:
+                        # No Prefect task was created for this node (e.g. source
+                        # nodes during `dbt source freshness`). Fall back to the
+                        # caller's run context so logs appear in the enclosing
+                        # task or flow run rather than being lost with
+                        # task_run_id=None.
+                        try:
+                            with hydrated_context(context) as run_context:
+                                logger = get_run_logger(run_context)
+                        except MissingContextError:
+                            logger = None
                 else:
                     logger = None
             else:

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -968,6 +968,63 @@ class TestPrefectDbtRunnerCallbackCreation:
             True,
         )
 
+    def test_unified_callback_falls_back_to_context_logger_when_no_task(
+        self, mock_manifest
+    ):
+        """Nodes without an associated Prefect task (e.g. source nodes during
+        `dbt source freshness`) should log into the caller's run context rather
+        than creating a logger with task_run_id=None that routes to the flow."""
+        mock_manifest.nodes = {}
+        runner = PrefectDbtRunner(manifest=mock_manifest)
+        context = {"flow_run_context": {"flow_run": {"id": "fr-1", "name": "my-flow"}}}
+
+        task_state = Mock(spec=NodeTaskTracker)
+        # Simulate no task registered for this node
+        task_state.get_task_run_id.return_value = None
+        task_state.get_task_run_name.return_value = None
+
+        source_node_id = "source.my_project.my_schema.my_table"
+
+        mock_context_logger = Mock()
+
+        with (
+            patch("prefect_dbt.core.runner.hydrated_context") as mock_hydrated_context,
+            patch(
+                "prefect_dbt.core.runner.get_run_logger",
+                return_value=mock_context_logger,
+            ),
+        ):
+            mock_hydrated_context.return_value.__enter__ = Mock(return_value=Mock())
+            mock_hydrated_context.return_value.__exit__ = Mock(return_value=False)
+
+            callback = runner._create_unified_callback(
+                task_state, EventLevel.INFO, context
+            )
+
+            log_event = Mock(spec=EventMsg)
+            log_event.info = Mock()
+            log_event.info.name = "FreshnessCheckDone"
+            log_event.info.level = EventLevel.INFO
+            log_event.info.msg = "source freshness result"
+            log_event.data = Mock()
+            log_event.data.node_info = Mock()
+            log_event.data.node_info.unique_id = source_node_id
+
+            with patch(
+                "prefect_dbt.core.runner.MessageToDict",
+                return_value={"node_info": {"unique_id": source_node_id}},
+            ):
+                callback(log_event)
+
+                if runner._event_queue:
+                    runner._event_queue.join()
+                    runner._stop_callback_processor()
+
+        # Should NOT use task_state.get_task_logger — no task was registered
+        task_state.get_task_logger.assert_not_called()
+        # Should use the context-based logger instead
+        mock_hydrated_context.assert_called_with(context)
+
 
 class TestPrefectDbtRunnerManifestNodeOperations:
     """Test manifest node operations."""


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

closes #22990

When `PrefectDbtRunner.invoke(['source', 'freshness', ...])` is called inside a Prefect task, logs from source node events were routed to the **flow run** instead of the enclosing task.

Root cause:

`_process_logging_sync` always called `task_state.get_task_logger(node_id, ...)` for any event with `node_info`. For `dbt build` this works fine — a Prefect task is registered per model node via `_process_node_started_sync`. But `_get_manifest_node_and_config` only looks in `manifest.nodes`, not `manifest.sources`, so source nodes during `source freshness` never get a task registered. `get_task_run_id(node_id)` returns `None`, the logger is created with `task_run_id=None`, and Prefect routes those logs to the flow.

Meanwhile events *without* `node_info` (e.g. dbt startup lines) already fell back to `hydrated_context(context) + get_run_logger()`, which correctly restores the caller's task run context — that's why `dbt deps` logs appeared in the task but `source freshness` per-source logs did not.

