### PR TITLE
feat(concurrency-limits): add pagination and server side filtering on concurrency limits

### DIFF
--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -92,27 +92,34 @@ async def read_concurrency_limit_v2(
 async def read_all_concurrency_limits_v2(
     limit: int = LimitBody(),
     offset: int = Body(0, ge=0),
+    concurrency_limits: Optional[schemas.filters.ConcurrencyLimitV2Filter] = None,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.responses.GlobalConcurrencyLimitResponse]:
     async with db.session_context() as session:
-        query = sa.select(
-            db.ConcurrencyLimitV2,
-            models.concurrency_limits_v2.active_slots_after_decay(db).label(
-                "active_slots"
-            ),
-        ).order_by(db.ConcurrencyLimitV2.name)
-
-        if offset is not None:
-            query = query.offset(offset)
-        if limit is not None:
-            query = query.limit(limit)
-
-        result = await session.execute(query)
-        rows = result.all()
+        rows = await models.concurrency_limits_v2.read_all_concurrency_limits_with_active_slots(
+            session=session,
+            limit=limit,
+            offset=offset,
+            concurrency_limit_filter=concurrency_limits,
+        )
 
     return [
         _global_concurrency_limit_response(row[0], row.active_slots) for row in rows
     ]
+
+
+@router.post("/count")
+async def count_concurrency_limits_v2(
+    concurrency_limits: Optional[schemas.filters.ConcurrencyLimitV2Filter] = Body(
+        None, embed=True
+    ),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> int:
+    async with db.session_context() as session:
+        return await models.concurrency_limits_v2.count_concurrency_limits(
+            session=session,
+            concurrency_limit_filter=concurrency_limits,
+        )
 
 
 @router.patch("/{id_or_name}", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/prefect/server/models/concurrency_limits_v2.py
+++ b/src/prefect/server/models/concurrency_limits_v2.py
@@ -162,8 +162,12 @@ async def read_all_concurrency_limits(
     session: AsyncSession,
     limit: int,
     offset: int,
+    concurrency_limit_filter: Optional[schemas.filters.ConcurrencyLimitV2Filter] = None,
 ) -> Sequence[orm_models.ConcurrencyLimitV2]:
     query = sa.select(db.ConcurrencyLimitV2).order_by(db.ConcurrencyLimitV2.name)
+
+    if concurrency_limit_filter:
+        query = query.where(concurrency_limit_filter.as_sql_filter())
 
     if offset is not None:
         query = query.offset(offset)
@@ -172,6 +176,48 @@ async def read_all_concurrency_limits(
 
     result = await session.execute(query)
     return result.scalars().unique().all()
+
+
+@db_injector
+async def read_all_concurrency_limits_with_active_slots(
+    db: PrefectDBInterface,
+    session: AsyncSession,
+    limit: int,
+    offset: int,
+    concurrency_limit_filter: Optional[schemas.filters.ConcurrencyLimitV2Filter] = None,
+) -> Sequence[sa.Row[tuple[orm_models.ConcurrencyLimitV2, float]]]:
+    """Like `read_all_concurrency_limits`, but each row also carries the
+    decay-adjusted `active_slots` value, matching `read_concurrency_limit`."""
+    query = sa.select(
+        db.ConcurrencyLimitV2,
+        active_slots_after_decay(db).label("active_slots"),
+    ).order_by(db.ConcurrencyLimitV2.name)
+
+    if concurrency_limit_filter:
+        query = query.where(concurrency_limit_filter.as_sql_filter())
+
+    if offset is not None:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+
+    result = await session.execute(query)
+    return result.all()
+
+
+@db_injector
+async def count_concurrency_limits(
+    db: PrefectDBInterface,
+    session: AsyncSession,
+    concurrency_limit_filter: Optional[schemas.filters.ConcurrencyLimitV2Filter] = None,
+) -> int:
+    query = sa.select(sa.func.count()).select_from(db.ConcurrencyLimitV2)
+
+    if concurrency_limit_filter:
+        query = query.where(concurrency_limit_filter.as_sql_filter())
+
+    result = await session.execute(query)
+    return result.scalar_one()
 
 
 @db_injector

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -2563,3 +2563,46 @@ class VariableFilter(PrefectOperatorFilterBaseModel):
         if self.tags is not None:
             filters.append(self.tags.as_sql_filter())
         return filters
+
+
+class ConcurrencyLimitV2FilterName(PrefectFilterBaseModel):
+    """Filter by `ConcurrencyLimitV2.name`."""
+
+    any_: Optional[list[str]] = Field(
+        default=None, description="A list of concurrency limit names to include"
+    )
+    like_: Optional[str] = Field(
+        default=None,
+        description=(
+            "A string to match concurrency limit names against. This can include "
+            "SQL wildcard characters like `%` and `_`."
+        ),
+        examples=["my_limit_%"],
+    )
+
+    def _get_filter_list(
+        self, db: "PrefectDBInterface"
+    ) -> Iterable[sa.ColumnExpressionArgument[bool]]:
+        filters: list[sa.ColumnExpressionArgument[bool]] = []
+        if self.any_ is not None:
+            filters.append(db.ConcurrencyLimitV2.name.in_(self.any_))
+        if self.like_:
+            filters.append(db.ConcurrencyLimitV2.name.ilike(f"%{self.like_}%"))
+        return filters
+
+
+class ConcurrencyLimitV2Filter(PrefectOperatorFilterBaseModel):
+    """Filter concurrency limits. Only concurrency limits matching all criteria will be returned"""
+
+    name: Optional[ConcurrencyLimitV2FilterName] = Field(
+        default=None, description="Filter criteria for `ConcurrencyLimitV2.name`"
+    )
+
+    def _get_filter_list(
+        self, db: "PrefectDBInterface"
+    ) -> Iterable[sa.ColumnExpressionArgument[bool]]:
+        filters: list[sa.ColumnExpressionArgument[bool]] = []
+
+        if self.name is not None:
+            filters.append(self.name.as_sql_filter())
+        return filters

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -254,6 +254,75 @@ async def test_read_all_concurrency_limits_returns_decayed_active_slots(
     assert limits_by_id[str(concurrency_limit.id)]["active_slots"] == 7
 
 
+async def test_read_all_concurrency_limits_filters_by_name_like(
+    concurrency_limit: ConcurrencyLimitV2,
+    locked_concurrency_limit: ConcurrencyLimitV2,
+    concurrency_limit_with_decay: ConcurrencyLimitV2,
+    client: AsyncClient,
+):
+    response = await client.post(
+        "/v2/concurrency_limits/filter",
+        json={"concurrency_limits": {"name": {"like_": "test_limit"}}},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert {limit["id"] for limit in data} == {
+        str(concurrency_limit.id),
+        str(concurrency_limit_with_decay.id),
+    }
+
+
+async def test_read_all_concurrency_limits_filters_by_name_any(
+    concurrency_limit: ConcurrencyLimitV2,
+    locked_concurrency_limit: ConcurrencyLimitV2,
+    client: AsyncClient,
+):
+    response = await client.post(
+        "/v2/concurrency_limits/filter",
+        json={"concurrency_limits": {"name": {"any_": [concurrency_limit.name]}}},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert {limit["id"] for limit in data} == {str(concurrency_limit.id)}
+
+
+async def test_read_all_concurrency_limits_respects_limit_and_offset(
+    concurrency_limit: ConcurrencyLimitV2,
+    locked_concurrency_limit: ConcurrencyLimitV2,
+    concurrency_limit_with_decay: ConcurrencyLimitV2,
+    client: AsyncClient,
+):
+    response = await client.post("/v2/concurrency_limits/filter", json={"limit": 1})
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+    response = await client.post(
+        "/v2/concurrency_limits/filter", json={"limit": 1, "offset": 1}
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+async def test_count_concurrency_limits(
+    concurrency_limit: ConcurrencyLimitV2,
+    locked_concurrency_limit: ConcurrencyLimitV2,
+    concurrency_limit_with_decay: ConcurrencyLimitV2,
+    client: AsyncClient,
+):
+    response = await client.post("/v2/concurrency_limits/count")
+    assert response.status_code == 200
+    assert response.json() == 3
+
+    response = await client.post(
+        "/v2/concurrency_limits/count",
+        json={"concurrency_limits": {"name": {"like_": "test_limit"}}},
+    )
+    assert response.status_code == 200
+    assert response.json() == 2
+
+
 async def test_update_concurrency_limit_by_id(
     concurrency_limit: ConcurrencyLimitV2,
     client: AsyncClient,

--- a/ui-v2/e2e/concurrency-limits/concurrency-limits.spec.ts
+++ b/ui-v2/e2e/concurrency-limits/concurrency-limits.spec.ts
@@ -1,6 +1,7 @@
 import {
 	cleanupGlobalConcurrencyLimits,
 	cleanupTaskRunConcurrencyLimits,
+	createGlobalConcurrencyLimit,
 	expect,
 	listGlobalConcurrencyLimits,
 	listTaskRunConcurrencyLimits,
@@ -120,6 +121,39 @@ test.describe("Concurrency Limits Page", () => {
 		// Verify delete via API
 		const limits = await listGlobalConcurrencyLimits(apiClient);
 		expect(limits.find((l) => l.name === limitName)).toBeUndefined();
+	});
+
+	test("Global Concurrency Limits - search finds a limit beyond the default API page size", async ({
+		page,
+		apiClient,
+	}) => {
+		// The concurrency-limits API defaults to returning 200 results per page. Seed
+		// more than that so a limit created near the end can only be found through
+		// server-side filtering, not by scrolling/paginating through the first page.
+		const runId = Date.now();
+		const targetName = `${TEST_PREFIX}${runId}-target`;
+
+		const seedNames = Array.from(
+			{ length: 205 },
+			(_, i) => `${TEST_PREFIX}${runId}-seed-${i}`,
+		);
+		await Promise.all(
+			seedNames.map((name) =>
+				createGlobalConcurrencyLimit(apiClient, { name, limit: 1 }),
+			),
+		);
+		await createGlobalConcurrencyLimit(apiClient, {
+			name: targetName,
+			limit: 1,
+		});
+
+		await page.goto("/concurrency-limits?tab=global");
+
+		await page
+			.getByPlaceholder(/search global concurrency limit/i)
+			.fill(targetName);
+
+		await expect(page.getByText(targetName, { exact: true })).toBeVisible();
 	});
 
 	test("Task Run Concurrency Limits - CRUD flow", async ({

--- a/ui-v2/src/api/global-concurrency-limits/global-concurrency-limits.ts
+++ b/ui-v2/src/api/global-concurrency-limits/global-concurrency-limits.ts
@@ -1,4 +1,5 @@
 import {
+	keepPreviousData,
 	queryOptions,
 	useMutation,
 	useQueryClient,
@@ -11,6 +12,8 @@ export type GlobalConcurrencyLimit =
 	components["schemas"]["GlobalConcurrencyLimitResponse"];
 export type GlobalConcurrencyLimitsFilter =
 	components["schemas"]["Body_read_all_concurrency_limits_v2_v2_concurrency_limits_filter_post"];
+export type GlobalConcurrencyLimitsCountFilter =
+	components["schemas"]["Body_count_concurrency_limits_v2_v2_concurrency_limits_count_post"];
 
 /**
  * ```
@@ -19,6 +22,8 @@ export type GlobalConcurrencyLimitsFilter =
  *  list  =>   ['global-concurrency-limits', 'list'] // key to match ['global-concurrency-limits', 'list', ...
  *             ['global-concurrency-limits', 'list', { ...filter1 }]
  *             ['global-concurrency-limits', 'list', { ...filter2 }]
+ *  counts =>  ['global-concurrency-limits', 'counts']
+ *  count  =>  ['global-concurrency-limits', 'counts', { ...filter }]
  * ```
  * */
 export const queryKeyFactory = {
@@ -26,7 +31,46 @@ export const queryKeyFactory = {
 	lists: () => [...queryKeyFactory.all(), "list"] as const,
 	list: (filter: GlobalConcurrencyLimitsFilter) =>
 		[...queryKeyFactory.lists(), filter] as const,
+	counts: () => [...queryKeyFactory.all(), "counts"] as const,
+	count: (filter?: GlobalConcurrencyLimitsCountFilter) =>
+		[...queryKeyFactory.counts(), filter] as const,
 };
+
+export type GlobalConcurrencyLimitsSearch = {
+	search?: string;
+	offset?: number;
+	limit?: number;
+};
+
+/**
+ * Builds the server-side filter for the global concurrency limits list query from the
+ * page's search parameters, so name filtering and pagination apply across the full
+ * dataset rather than only whatever page was fetched from the API.
+ */
+export const buildGlobalConcurrencyLimitsFilter = (
+	search?: GlobalConcurrencyLimitsSearch,
+): GlobalConcurrencyLimitsFilter => ({
+	offset: search?.offset ?? 0,
+	limit: search?.limit ?? 10,
+	...(search?.search && {
+		concurrency_limits: {
+			operator: "and_" as const,
+			name: { like_: search.search },
+		},
+	}),
+});
+
+export const buildGlobalConcurrencyLimitsCountFilter = (
+	search?: GlobalConcurrencyLimitsSearch,
+): GlobalConcurrencyLimitsCountFilter | undefined =>
+	search?.search
+		? {
+				concurrency_limits: {
+					operator: "and_" as const,
+					name: { like_: search.search },
+				},
+			}
+		: undefined;
 
 // ----- 🔑 Queries 🗄️
 // ----------------------------
@@ -43,6 +87,7 @@ export const buildListGlobalConcurrencyLimitsQuery = (
 			return res.data ?? [];
 		},
 		refetchInterval: 30_000,
+		placeholderData: keepPreviousData,
 	});
 
 /**
@@ -54,6 +99,27 @@ export const buildListGlobalConcurrencyLimitsQuery = (
 export const useListGlobalConcurrencyLimits = (
 	filter: GlobalConcurrencyLimitsFilter = { offset: 0 },
 ) => useSuspenseQuery(buildListGlobalConcurrencyLimitsQuery(filter));
+
+/**
+ * Builds a query configuration for counting global concurrency limits based on filter criteria
+ *
+ * @param filter - Optional filter options for the count query
+ * @returns Query configuration object for use with TanStack Query
+ */
+export const buildCountGlobalConcurrencyLimitsQuery = (
+	filter?: GlobalConcurrencyLimitsCountFilter,
+) =>
+	queryOptions({
+		queryKey: queryKeyFactory.count(filter),
+		queryFn: async () => {
+			const res = await (await getQueryService()).POST(
+				"/v2/concurrency_limits/count",
+				{ body: filter },
+			);
+			return res.data ?? 0;
+		},
+		placeholderData: keepPreviousData,
+	});
 
 // ----- ✍🏼 Mutations 🗄️
 // ----------------------------
@@ -86,9 +152,10 @@ export const useDeleteGlobalConcurrencyLimit = () => {
 				params: { path: { id_or_name } },
 			}),
 		onSuccess: () => {
-			// After a successful deletion, invalidate the listing queries only to refetch
+			// After a successful deletion, invalidate the listing and count queries to refetch
+			void queryClient.invalidateQueries({ queryKey: queryKeyFactory.lists() });
 			return queryClient.invalidateQueries({
-				queryKey: queryKeyFactory.lists(),
+				queryKey: queryKeyFactory.counts(),
 			});
 		},
 	});
@@ -135,9 +202,10 @@ export const useCreateGlobalConcurrencyLimit = () => {
 				body,
 			}),
 		onSuccess: () => {
-			// After a successful creation, invalidate the listing queries only to refetch
+			// After a successful creation, invalidate the listing and count queries to refetch
+			void queryClient.invalidateQueries({ queryKey: queryKeyFactory.lists() });
 			return queryClient.invalidateQueries({
-				queryKey: queryKeyFactory.lists(),
+				queryKey: queryKeyFactory.counts(),
 			});
 		},
 	});

--- a/ui-v2/src/api/global-concurrency-limits/index.ts
+++ b/ui-v2/src/api/global-concurrency-limits/index.ts
@@ -1,6 +1,12 @@
 export {
+	buildCountGlobalConcurrencyLimitsQuery,
+	buildGlobalConcurrencyLimitsCountFilter,
+	buildGlobalConcurrencyLimitsFilter,
 	buildListGlobalConcurrencyLimitsQuery,
 	type GlobalConcurrencyLimit,
+	type GlobalConcurrencyLimitsCountFilter,
+	type GlobalConcurrencyLimitsFilter,
+	type GlobalConcurrencyLimitsSearch,
 	useCreateGlobalConcurrencyLimit,
 	useDeleteGlobalConcurrencyLimit,
 	useListGlobalConcurrencyLimits,

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -1492,6 +1492,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/concurrency_limits/count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Count Concurrency Limits V2 */
+        post: operations["count_concurrency_limits_v2_v2_concurrency_limits_count_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/concurrency_limits/increment": {
         parameters: {
             query?: never;
@@ -3649,6 +3666,8 @@ export interface components {
              * @default and_
              */
             operator: components["schemas"]["Operator"];
+            /** @description Filter criteria for `Automation.id` */
+            id?: components["schemas"]["AutomationFilterId"] | null;
             /** @description Filter criteria for `Automation.name` */
             name?: components["schemas"]["AutomationFilterName"] | null;
             /** @description Filter criteria for `Automation.created` */
@@ -3666,6 +3685,17 @@ export interface components {
              * @description Only include automations created before this datetime
              */
             before_?: string | null;
+        };
+        /**
+         * AutomationFilterId
+         * @description Filter by `Automation.id`.
+         */
+        AutomationFilterId: {
+            /**
+             * Any
+             * @description A list of automation ids to include
+             */
+            any_?: string[] | null;
         };
         /**
          * AutomationFilterName
@@ -4396,11 +4426,19 @@ export interface components {
             flows?: components["schemas"]["FlowFilter"];
             deployments?: components["schemas"]["DeploymentFilter"];
         };
+        /** Body_count_automations_automations_count_post */
+        Body_count_automations_automations_count_post: {
+            automations?: components["schemas"]["AutomationFilter"] | null;
+        };
         /** Body_count_block_documents_block_documents_count_post */
         Body_count_block_documents_block_documents_count_post: {
             block_documents?: components["schemas"]["BlockDocumentFilter"] | null;
             block_types?: components["schemas"]["BlockTypeFilter"] | null;
             block_schemas?: components["schemas"]["BlockSchemaFilter"] | null;
+        };
+        /** Body_count_concurrency_limits_v2_v2_concurrency_limits_count_post */
+        Body_count_concurrency_limits_v2_v2_concurrency_limits_count_post: {
+            concurrency_limits?: components["schemas"]["ConcurrencyLimitV2Filter"] | null;
         };
         /** Body_count_deployments_by_flow_ui_flows_count_deployments_post */
         Body_count_deployments_by_flow_ui_flows_count_deployments_post: {
@@ -4555,7 +4593,7 @@ export interface components {
             scheduled_before?: string;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4580,7 +4618,7 @@ export interface components {
             scheduled_after?: string;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4620,7 +4658,7 @@ export interface components {
             sort: components["schemas"]["DeploymentSort"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4641,7 +4679,7 @@ export interface components {
             work_pool_queues?: components["schemas"]["WorkQueueFilter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4661,7 +4699,7 @@ export interface components {
             sort: components["schemas"]["FlowSort"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4680,7 +4718,7 @@ export interface components {
             deployments?: components["schemas"]["DeploymentFilter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4691,9 +4729,10 @@ export interface components {
              * @default 0
              */
             offset: number;
+            concurrency_limits?: components["schemas"]["ConcurrencyLimitV2Filter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4713,7 +4752,7 @@ export interface components {
             deployments?: components["schemas"]["DeploymentFilter"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4729,7 +4768,7 @@ export interface components {
             automations?: components["schemas"]["AutomationFilter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4753,7 +4792,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4767,7 +4806,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4782,7 +4821,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4795,7 +4834,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4825,7 +4864,7 @@ export interface components {
             sort: components["schemas"]["DeploymentSort"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4877,7 +4916,7 @@ export interface components {
             work_pool_queues?: components["schemas"]["WorkQueueFilter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4897,7 +4936,7 @@ export interface components {
             sort: components["schemas"]["FlowSort"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4917,7 +4956,7 @@ export interface components {
             deployments?: components["schemas"]["DeploymentFilter"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4933,7 +4972,7 @@ export interface components {
             sort: components["schemas"]["LogSort"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4946,7 +4985,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4972,7 +5011,7 @@ export interface components {
             deployments?: components["schemas"]["DeploymentFilter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -4993,7 +5032,7 @@ export interface components {
             sort: components["schemas"]["VariableSort"];
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5012,7 +5051,7 @@ export interface components {
             flow_run_limit: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5026,7 +5065,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5039,7 +5078,7 @@ export interface components {
             page: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5053,7 +5092,7 @@ export interface components {
             scheduled_before?: string;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5067,7 +5106,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5081,7 +5120,7 @@ export interface components {
             work_queues?: components["schemas"]["WorkQueueFilter"] | null;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5095,7 +5134,7 @@ export interface components {
             offset: number;
             /**
              * Limit
-             * @description Defaults to PREFECT_API_DEFAULT_LIMIT if not provided.
+             * @description Defaults to PREFECT_SERVER_API_DEFAULT_LIMIT if not provided.
              */
             limit?: number;
         };
@@ -5647,6 +5686,36 @@ export interface components {
              * @default 0
              */
             slot_decay_per_second: number;
+        };
+        /**
+         * ConcurrencyLimitV2Filter
+         * @description Filter concurrency limits. Only concurrency limits matching all criteria will be returned
+         */
+        ConcurrencyLimitV2Filter: {
+            /**
+             * @description Operator for combining filter criteria. Defaults to 'and_'.
+             * @default and_
+             */
+            operator: components["schemas"]["Operator"];
+            /** @description Filter criteria for `ConcurrencyLimitV2.name` */
+            name?: components["schemas"]["ConcurrencyLimitV2FilterName"] | null;
+        };
+        /**
+         * ConcurrencyLimitV2FilterName
+         * @description Filter by `ConcurrencyLimitV2.name`.
+         */
+        ConcurrencyLimitV2FilterName: {
+            /**
+             * Any
+             * @description A list of concurrency limit names to include
+             */
+            any_?: string[] | null;
+            /**
+             * Like
+             * @description A string to match concurrency limit names against. This can include SQL wildcard characters like `%` and `_`.
+             * @example my_limit_%
+             */
+            like_?: string | null;
         };
         /**
          * ConcurrencyLimitV2Update
@@ -15794,6 +15863,41 @@ export interface operations {
             };
         };
     };
+    count_concurrency_limits_v2_v2_concurrency_limits_count_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["Body_count_concurrency_limits_v2_v2_concurrency_limits_count_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": number;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     bulk_increment_active_slots_v2_concurrency_limits_increment_post: {
         parameters: {
             query?: never;
@@ -18657,7 +18761,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["Body_count_automations_automations_count_post"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/global-concurrency-limits-data-table.stories.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/global-concurrency-limits-data-table.stories.tsx
@@ -19,11 +19,16 @@ const meta = {
 	decorators: [reactQueryDecorator, toastDecorator],
 	args: {
 		data: MOCK_DATA,
+		currentCount: MOCK_DATA.length,
+		pagination: { pageIndex: 0, pageSize: 10 },
+		onPaginationChange: fn(),
 		onDeleteRow: fn(),
 		onEditRow: fn(),
 		onResetRow: fn(),
 		onSearchChange: fn(),
 		searchValue: "",
+		showFilteredEmptyState: false,
+		onClearSearch: fn(),
 	},
 } satisfies Meta<typeof GlobalConcurrencyLimitsDataTable>;
 

--- a/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/global-concurrency-limits-data-table.test.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/global-concurrency-limits-data-table.test.tsx
@@ -16,11 +16,16 @@ const MOCK_ROW = {
 	slot_decay_per_second: 0,
 };
 
+const DEFAULT_PAGINATION = { pageIndex: 0, pageSize: 10 };
+
 describe("GlobalConcurrencyLimitTable -- table", () => {
 	it("renders row data", () => {
 		render(
 			<Table
 				data={[MOCK_ROW]}
+				currentCount={1}
+				pagination={DEFAULT_PAGINATION}
+				onPaginationChange={vi.fn()}
 				onDeleteRow={vi.fn()}
 				onEditRow={vi.fn()}
 				onResetRow={vi.fn()}
@@ -47,6 +52,9 @@ describe("GlobalConcurrencyLimitTable -- table", () => {
 		render(
 			<Table
 				data={[MOCK_ROW]}
+				currentCount={1}
+				pagination={DEFAULT_PAGINATION}
+				onPaginationChange={vi.fn()}
 				onDeleteRow={mockFn}
 				onEditRow={vi.fn()}
 				onResetRow={vi.fn()}
@@ -70,6 +78,9 @@ describe("GlobalConcurrencyLimitTable -- table", () => {
 		render(
 			<Table
 				data={[MOCK_ROW]}
+				currentCount={1}
+				pagination={DEFAULT_PAGINATION}
+				onPaginationChange={vi.fn()}
 				onDeleteRow={vi.fn()}
 				onEditRow={mockFn}
 				onResetRow={vi.fn()}
@@ -94,6 +105,9 @@ describe("GlobalConcurrencyLimitTable -- table", () => {
 		render(
 			<Table
 				data={[MOCK_ROW]}
+				currentCount={1}
+				pagination={DEFAULT_PAGINATION}
+				onPaginationChange={vi.fn()}
 				onDeleteRow={vi.fn()}
 				onEditRow={vi.fn()}
 				onResetRow={mockFn}
@@ -119,6 +133,9 @@ describe("GlobalConcurrencyLimitTable -- table", () => {
 				<Toaster />
 				<Table
 					data={[MOCK_ROW]}
+					currentCount={1}
+					pagination={DEFAULT_PAGINATION}
+					onPaginationChange={vi.fn()}
 					onDeleteRow={vi.fn()}
 					onEditRow={vi.fn()}
 					onResetRow={vi.fn()}
@@ -147,6 +164,9 @@ describe("GlobalConcurrencyLimitTable -- table", () => {
 		rerender(
 			<Table
 				data={[{ ...MOCK_ROW, active: false }]}
+				currentCount={1}
+				pagination={DEFAULT_PAGINATION}
+				onPaginationChange={vi.fn()}
 				onDeleteRow={vi.fn()}
 				onEditRow={vi.fn()}
 				onResetRow={vi.fn()}

--- a/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/global-concurrency-limits-data-table.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/global-concurrency-limits-data-table.tsx
@@ -1,5 +1,5 @@
-import { getRouteApi } from "@tanstack/react-router";
-import { useDeferredValue, useMemo } from "react";
+import type { OnChangeFn, PaginationState } from "@tanstack/react-table";
+import { useCallback } from "react";
 import type { GlobalConcurrencyLimit } from "@/api/global-concurrency-limits";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -14,8 +14,6 @@ import { SearchInput } from "@/components/ui/input";
 import { createColumnHelper, useTable } from "@/lib/tanstack-table";
 import { ActionsCell } from "./actions-cell";
 import { ActiveCell } from "./active-cell";
-
-const routeApi = getRouteApi("/concurrency-limits/");
 
 const columnHelper = createColumnHelper<GlobalConcurrencyLimit>();
 
@@ -62,52 +60,45 @@ const createColumns = ({
 
 type GlobalConcurrencyLimitsDataTableProps = {
 	data: Array<GlobalConcurrencyLimit>;
+	currentCount: number;
+	pagination: PaginationState;
+	onPaginationChange: (newPagination: PaginationState) => void;
 	onEditRow: (row: GlobalConcurrencyLimit) => void;
 	onDeleteRow: (row: GlobalConcurrencyLimit) => void;
 	onResetRow: (row: GlobalConcurrencyLimit) => void;
+	searchValue: string | undefined;
+	onSearchChange: (value: string) => void;
+	showFilteredEmptyState: boolean;
+	onClearSearch: () => void;
 };
 
 export const GlobalConcurrencyLimitsDataTable = ({
 	data,
+	currentCount,
+	pagination,
+	onPaginationChange,
 	onEditRow,
 	onDeleteRow,
 	onResetRow,
-}: GlobalConcurrencyLimitsDataTableProps) => {
-	const navigate = routeApi.useNavigate();
-	const { search } = routeApi.useSearch();
-	const deferredSearch = useDeferredValue(search ?? "");
-
-	const filteredData = useMemo(() => {
-		return data.filter((row) =>
-			row.name.toLowerCase().includes(deferredSearch.toLowerCase()),
-		);
-	}, [data, deferredSearch]);
-
-	const onClearSearch = () => {
-		void navigate({
-			to: ".",
-			search: (prev) => ({ ...prev, search: "" }),
-		});
-	};
-
-	return (
-		<Table
-			data={filteredData}
-			onDeleteRow={onDeleteRow}
-			onEditRow={onEditRow}
-			onResetRow={onResetRow}
-			searchValue={search}
-			onSearchChange={(value) =>
-				void navigate({
-					to: ".",
-					search: (prev) => ({ ...prev, search: value }),
-				})
-			}
-			showFilteredEmptyState={data.length > 0 && filteredData.length === 0}
-			onClearSearch={onClearSearch}
-		/>
-	);
-};
+	searchValue,
+	onSearchChange,
+	showFilteredEmptyState,
+	onClearSearch,
+}: GlobalConcurrencyLimitsDataTableProps) => (
+	<Table
+		data={data}
+		currentCount={currentCount}
+		pagination={pagination}
+		onPaginationChange={onPaginationChange}
+		onDeleteRow={onDeleteRow}
+		onEditRow={onEditRow}
+		onResetRow={onResetRow}
+		searchValue={searchValue}
+		onSearchChange={onSearchChange}
+		showFilteredEmptyState={showFilteredEmptyState}
+		onClearSearch={onClearSearch}
+	/>
+);
 
 const GlobalConcurrencyLimitsFilteredEmptyState = ({
 	onClearSearch,
@@ -132,6 +123,9 @@ const GlobalConcurrencyLimitsFilteredEmptyState = ({
 
 type TableProps = {
 	data: Array<GlobalConcurrencyLimit>;
+	currentCount: number;
+	pagination: PaginationState;
+	onPaginationChange: (newPagination: PaginationState) => void;
 	onDeleteRow: (row: GlobalConcurrencyLimit) => void;
 	onEditRow: (row: GlobalConcurrencyLimit) => void;
 	onResetRow: (row: GlobalConcurrencyLimit) => void;
@@ -143,6 +137,9 @@ type TableProps = {
 
 export function Table({
 	data,
+	currentCount,
+	pagination,
+	onPaginationChange,
 	onDeleteRow,
 	onEditRow,
 	onResetRow,
@@ -151,9 +148,24 @@ export function Table({
 	showFilteredEmptyState,
 	onClearSearch,
 }: TableProps) {
+	const handlePaginationChange: OnChangeFn<PaginationState> = useCallback(
+		(updater) => {
+			const newPagination =
+				typeof updater === "function" ? updater(pagination) : updater;
+			onPaginationChange(newPagination);
+		},
+		[pagination, onPaginationChange],
+	);
+
 	const table = useTable({
 		data,
 		columns: createColumns({ onDeleteRow, onEditRow, onResetRow }),
+		state: {
+			pagination,
+		},
+		manualPagination: true,
+		onPaginationChange: handlePaginationChange,
+		rowCount: currentCount,
 	});
 
 	return (

--- a/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-view/index.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-view/index.tsx
@@ -1,7 +1,13 @@
-import { useState } from "react";
+import { useSuspenseQueries } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
+import type { PaginationState } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
 import {
+	buildCountGlobalConcurrencyLimitsQuery,
+	buildGlobalConcurrencyLimitsCountFilter,
+	buildGlobalConcurrencyLimitsFilter,
+	buildListGlobalConcurrencyLimitsQuery,
 	type GlobalConcurrencyLimit,
-	useListGlobalConcurrencyLimits,
 } from "@/api/global-concurrency-limits";
 
 import { GlobalConcurrencyLimitsDataTable } from "@/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table";
@@ -13,13 +19,74 @@ import {
 	GlobalConcurrencyLimitsDialog,
 } from "./global-conccurency-limits-dialog";
 
+const routeApi = getRouteApi("/concurrency-limits/");
+
 export const GlobalConcurrencyLimitsView = () => {
 	const [openDialog, setOpenDialog] = useState<DialogState>({
 		dialog: null,
 		data: undefined,
 	});
 
-	const { data } = useListGlobalConcurrencyLimits();
+	const search = routeApi.useSearch();
+	const navigate = routeApi.useNavigate();
+
+	const filter = useMemo(
+		() => buildGlobalConcurrencyLimitsFilter(search),
+		[search],
+	);
+	const countFilter = useMemo(
+		() => buildGlobalConcurrencyLimitsCountFilter(search),
+		[search],
+	);
+
+	const [{ data }, { data: filteredCount }, { data: totalCount }] =
+		useSuspenseQueries({
+			queries: [
+				buildListGlobalConcurrencyLimitsQuery(filter),
+				buildCountGlobalConcurrencyLimitsQuery(countFilter),
+				buildCountGlobalConcurrencyLimitsQuery(),
+			],
+		});
+
+	const pagination: PaginationState = useMemo(
+		() => ({
+			pageIndex: search.offset ? Math.floor(search.offset / search.limit) : 0,
+			pageSize: search.limit,
+		}),
+		[search.offset, search.limit],
+	);
+
+	const onPaginationChange = useCallback(
+		(newPagination: PaginationState) => {
+			void navigate({
+				to: ".",
+				search: (prev) => ({
+					...prev,
+					offset: newPagination.pageIndex * newPagination.pageSize,
+					limit: newPagination.pageSize,
+				}),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	const onSearchChange = useCallback(
+		(value: string) => {
+			void navigate({
+				to: ".",
+				search: (prev) => ({
+					...prev,
+					search: value || undefined,
+					offset: 0,
+				}),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	const onClearSearch = useCallback(() => onSearchChange(""), [onSearchChange]);
 
 	const handleAddRow = () =>
 		setOpenDialog({ dialog: "create", data: undefined });
@@ -43,17 +110,27 @@ export const GlobalConcurrencyLimitsView = () => {
 		}
 	};
 
+	const hasLimits = (totalCount ?? 0) > 0;
+	const showFilteredEmptyState = hasLimits && (filteredCount ?? 0) === 0;
+
 	return (
 		<div className="flex flex-col gap-4">
 			<GlobalConcurrencyLimitsHeader onAdd={handleAddRow} />
-			{data.length === 0 ? (
+			{!hasLimits ? (
 				<GlobalConcurrencyLimitsEmptyState onAdd={handleAddRow} />
 			) : (
 				<GlobalConcurrencyLimitsDataTable
 					data={data}
+					currentCount={filteredCount ?? 0}
+					pagination={pagination}
+					onPaginationChange={onPaginationChange}
 					onEditRow={handleEditRow}
 					onDeleteRow={handleDeleteRow}
 					onResetRow={handleResetRow}
+					searchValue={search.search}
+					onSearchChange={onSearchChange}
+					showFilteredEmptyState={showFilteredEmptyState}
+					onClearSearch={onClearSearch}
 				/>
 			)}
 			<GlobalConcurrencyLimitsDialog

--- a/ui-v2/src/routes/concurrency-limits/index.tsx
+++ b/ui-v2/src/routes/concurrency-limits/index.tsx
@@ -2,7 +2,12 @@ import type { ErrorComponentProps } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { categorizeError } from "@/api/error-utils";
-import { buildListGlobalConcurrencyLimitsQuery } from "@/api/global-concurrency-limits";
+import {
+	buildCountGlobalConcurrencyLimitsQuery,
+	buildGlobalConcurrencyLimitsCountFilter,
+	buildGlobalConcurrencyLimitsFilter,
+	buildListGlobalConcurrencyLimitsQuery,
+} from "@/api/global-concurrency-limits";
 import { buildListTaskRunConcurrencyLimitsQuery } from "@/api/task-run-concurrency-limits";
 import { ConcurrencyLimitsPage } from "@/components/concurrency/concurrency-limits-page";
 import { PrefectLoading } from "@/components/ui/loading";
@@ -12,10 +17,14 @@ import { RouteErrorState } from "@/components/ui/route-error-state";
  * Schema for validating URL search parameters for the Concurrency Limits page.
  * @property {string} search used to filter data table
  * @property {'global' | 'task-run'} tab used designate which tab view to display
+ * @property {number} offset used to paginate the global concurrency limits table
+ * @property {number} limit used to paginate the global concurrency limits table
  */
 const searchParams = z.object({
 	search: z.string().optional(),
 	tab: z.enum(["global", "task-run"]).default("global"),
+	offset: z.number().int().nonnegative().optional().default(0).catch(0),
+	limit: z.number().int().positive().optional().default(10).catch(10),
 });
 
 export type TabOptions = z.infer<typeof searchParams>["tab"];
@@ -25,10 +34,21 @@ export const Route = createFileRoute("/concurrency-limits/")({
 	component: ConcurrencyLimitsPage,
 	wrapInSuspense: true,
 	pendingComponent: PrefectLoading,
-	loader: ({ context }) =>
+	loaderDeps: ({ search }) => search,
+	loader: ({ deps, context }) =>
 		Promise.all([
 			context.queryClient.ensureQueryData(
-				buildListGlobalConcurrencyLimitsQuery(),
+				buildListGlobalConcurrencyLimitsQuery(
+					buildGlobalConcurrencyLimitsFilter(deps),
+				),
+			),
+			context.queryClient.ensureQueryData(
+				buildCountGlobalConcurrencyLimitsQuery(
+					buildGlobalConcurrencyLimitsCountFilter(deps),
+				),
+			),
+			context.queryClient.ensureQueryData(
+				buildCountGlobalConcurrencyLimitsQuery(),
 			),
 			context.queryClient.ensureQueryData(
 				buildListTaskRunConcurrencyLimitsQuery(),


### PR DESCRIPTION
feat(concurrency-limits): add pagination and server side filtering on concurrency limits

Makes sure the pagination is correct vs the total number of concurrency limits.
Make the search filter work with backend filtering to fetch items outside of current scope.

<img width="1668" height="910" alt="Screen Recording 2026-09-01 at 14 14 02" src="https://github.com/user-attachments/assets/8a3f30b4-a0d3-494b-aca9-d4540f548cff" />

### Checklist
closes https://github.com/PrefectHQ/prefect/issues/23002
- [x] This pull request references any related issue
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
