### PR TITLE
Add `replaces` field for renaming deployments in place

### DIFF
--- a/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
+++ b/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
@@ -930,6 +930,10 @@ When you run `prefect deploy`:
 - No new deployment is created, and no orphaned deployment remains
 - All run history stays attached because the deployment's ID is preserved
 
+Everything else in the deployment definition is applied exactly as it would be on
+any other `prefect deploy` — for example, schedules are reconciled from your YAML
+rather than carried over from the old name.
+
 After a successful deploy, you can remove the `replaces` field from your YAML — it becomes a no-op once the old name no longer exists.
 
 <Note>

--- a/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
+++ b/docs/v3/how-to-guides/deployments/prefect-yaml.mdx
@@ -911,6 +911,31 @@ Each time a step runs, the following actions take place in order:
 
 To update a deployment, make any desired changes to the `prefect.yaml` file, and run `prefect deploy`. Running just this command will prompt you to select a deployment interactively, or you may specify the deployment to update with `--name your-deployment`.
 
+### Rename a deployment
+
+If you need to rename a deployment, use the `replaces` field to indicate which existing deployment should be updated:
+
+```yaml
+deployments:
+  - name: send-emails-v2          # The new name
+    replaces: send-emails         # The old name being replaced
+    entrypoint: flows.py:send_email
+    work_pool:
+      name: my-work-pool
+```
+
+When you run `prefect deploy`:
+- The existing deployment named `send-emails` is updated in place
+- Its name changes to `send-emails-v2`
+- No new deployment is created, and no orphaned deployment remains
+- All run history stays attached because the deployment's ID is preserved
+
+After a successful deploy, you can remove the `replaces` field from your YAML — it becomes a no-op once the old name no longer exists.
+
+<Note>
+If `replaces` points to a name that doesn't exist, the deployment is created normally and a warning is logged.
+</Note>
+
 ## Further reading
 
 Now that you are familiar with creating deployments, you can explore infrastructure options for running your deployments:

--- a/schemas/prefect.yaml.schema.json
+++ b/schemas/prefect.yaml.schema.json
@@ -399,6 +399,18 @@
                     ],
                     "default": null,
                     "title": "Sla"
+                },
+                "replaces": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Replaces"
                 }
             },
             "title": "DeploymentConfig",

--- a/src/prefect/cli/deploy/_core.py
+++ b/src/prefect/cli/deploy/_core.py
@@ -392,6 +392,7 @@ async def _run_single_deploy(
         paused=deploy_config.get("paused"),
         storage=_PullStepStorage(pull_steps),
         job_variables=get_from_dict(deploy_config, "work_pool.job_variables"),
+        replaces=deploy_config.get("replaces"),
     )
 
     deployment._set_defaults_from_flow(flow)

--- a/src/prefect/cli/deploy/_models.py
+++ b/src/prefect/cli/deploy/_models.py
@@ -84,6 +84,8 @@ class DeploymentConfig(BaseModel):
     triggers: Optional[List[Dict[str, Any]]] = None
     sla: Optional[List[SlaTypes]] = None
 
+    replaces: Optional[str] = None  # The name of an existing deployment to replace
+
 
 class PrefectYamlModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="ignore")

--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -72,6 +72,7 @@ class DeploymentClient(BaseClient):
         branch: str | None = None,
         base: UUID | None = None,
         root: UUID | None = None,
+        replaces: str | None = None,
     ) -> UUID:
         """
         Create a deployment.
@@ -123,6 +124,7 @@ class DeploymentClient(BaseClient):
             branch=branch,
             base=base,
             root=root,
+            replaces=replaces,
         )
 
         if work_pool_name is not None:
@@ -146,6 +148,7 @@ class DeploymentClient(BaseClient):
             "branch",
             "base",
             "root",
+            "replaces",
         ]
 
         for field in exclude_if_none:
@@ -779,6 +782,7 @@ class DeploymentAsyncClient(BaseAsyncClient):
         branch: str | None = None,
         base: UUID | None = None,
         root: UUID | None = None,
+        replaces: str | None = None,
     ) -> UUID:
         """
         Create a deployment.
@@ -830,6 +834,7 @@ class DeploymentAsyncClient(BaseAsyncClient):
             branch=branch,
             base=base,
             root=root,
+            replaces=replaces,
         )
 
         if work_pool_name is not None:
@@ -853,6 +858,7 @@ class DeploymentAsyncClient(BaseAsyncClient):
             "branch",
             "base",
             "root",
+            "replaces",
         ]
 
         for field in exclude_if_none:

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -309,6 +309,11 @@ class DeploymentCreate(ActionBaseModel):
         default=None, description="The root deployment of the deployment."
     )
 
+    replaces: Optional[str] = Field(
+        default=None,
+        description="The name of an existing deployment that this deployment replaces. Used for renaming deployments.",
+    )
+
     def check_valid_configuration(self, base_job_template: dict[str, Any]) -> None:
         """Check that the combination of base_job_template defaults
         and job_variables conforms to the specified schema.

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -283,6 +283,14 @@ class RunnerDeployment(BaseModel):
             " a built runner."
         ),
     )
+    replaces: Optional[str] = Field(
+        default=None,
+        description=(
+            "The name of an existing deployment to replace. When set, the existing"
+            " deployment will be renamed to this deployment's name instead of"
+            " creating a new deployment."
+        ),
+    )
 
     # (Experimental) SLA configuration for the deployment. May be removed or modified at any time. Currently only supported on Prefect Cloud.
     _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = PrivateAttr(
@@ -460,6 +468,7 @@ class RunnerDeployment(BaseModel):
                     exclude_unset=True
                 ),
                 enforce_parameter_schema=self.enforce_parameter_schema,
+                replaces=self.replaces,
             )
 
             if work_pool_name:
@@ -566,6 +575,7 @@ class RunnerDeployment(BaseModel):
                     exclude_unset=True
                 ),
                 enforce_parameter_schema=self.enforce_parameter_schema,
+                replaces=self.replaces,
             )
 
             if work_pool_name:
@@ -625,7 +635,14 @@ class RunnerDeployment(BaseModel):
         update_payload = self.model_dump(
             mode="json",
             exclude_unset=True,
-            exclude={"storage", "name", "flow_name", "triggers", "version_type"},
+            exclude={
+                "storage",
+                "name",
+                "flow_name",
+                "triggers",
+                "version_type",
+                "replaces",
+            },
         )
 
         if self.storage:
@@ -677,7 +694,14 @@ class RunnerDeployment(BaseModel):
         update_payload = self.model_dump(
             mode="json",
             exclude_unset=True,
-            exclude={"storage", "name", "flow_name", "triggers", "version_type"},
+            exclude={
+                "storage",
+                "name",
+                "flow_name",
+                "triggers",
+                "version_type",
+                "replaces",
+            },
         )
 
         if self.storage:
@@ -780,6 +804,23 @@ class RunnerDeployment(BaseModel):
                     ]
                 return await self._create(work_pool_name, image, version_info)
             else:
+                if self.replaces:
+                    # Only error when the old deployment still exists. If it's
+                    # already gone the rename already happened and re-applying
+                    # is idempotent — just fall through to a normal update.
+                    try:
+                        await client.read_deployment_by_name(
+                            f"{self.flow_name}/{self.replaces}"
+                        )
+                    except ObjectNotFound:
+                        pass
+                    else:
+                        raise ValueError(
+                            f"Cannot use 'replaces: {self.replaces}' for deployment"
+                            f" {self.name!r} because a deployment named {self.name!r}"
+                            f" already exists. Remove 'replaces' or delete the existing"
+                            f" {self.name!r} deployment first."
+                        )
                 if image:
                     self.job_variables["image"] = image
                 if work_pool_name:
@@ -825,6 +866,20 @@ class RunnerDeployment(BaseModel):
                     ]
                 return self._create_sync(work_pool_name, image, version_info)
             else:
+                if self.replaces:
+                    try:
+                        client.read_deployment_by_name(
+                            f"{self.flow_name}/{self.replaces}"
+                        )
+                    except ObjectNotFound:
+                        pass
+                    else:
+                        raise ValueError(
+                            f"Cannot use 'replaces: {self.replaces}' for deployment"
+                            f" {self.name!r} because a deployment named {self.name!r}"
+                            f" already exists. Remove 'replaces' or delete the existing"
+                            f" {self.name!r} deployment first."
+                        )
                 if image:
                     self.job_variables["image"] = image
                 if work_pool_name:

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -160,6 +160,7 @@ async def create_deployment(
             )
             deployment_dict["work_queue_id"] = work_queue.id
 
+        replaces = deployment_dict.pop("replaces", None)
         deployment = schemas.core.Deployment(**deployment_dict)
         # check to see if relevant blocks exist, allowing us throw a useful error message
         # for debugging
@@ -198,9 +199,15 @@ async def create_deployment(
                 )
 
         right_now = now("UTC")
-        model = await models.deployments.create_deployment(
-            session=session, deployment=deployment
-        )
+        try:
+            model = await models.deployments.create_deployment(
+                session=session, deployment=deployment, replaces=replaces
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(exc),
+            ) from exc
 
         if model.created >= right_now:
             response.status_code = status.HTTP_201_CREATED

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -49,6 +49,7 @@ T = TypeVar("T", bound=tuple[Any, ...])
 logger: logging.Logger = get_logger("prefect.server.models.deployments")
 
 DEPLOYMENT_EVENT_FIELDS = {
+    "name",
     "description",
     "tags",
     "parameters",

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -111,6 +111,7 @@ async def create_deployment(
     db: PrefectDBInterface,
     session: AsyncSession,
     deployment: schemas.core.Deployment | schemas.actions.DeploymentCreate,
+    replaces: str | None = None,
 ) -> Optional[orm_models.Deployment]:
     """Upserts a deployment.
 
@@ -128,12 +129,54 @@ async def create_deployment(
     # even under concurrent upserts for the same (flow_id, name).
     upsert_start = now("UTC")
 
-    # Snapshot existing deployment field values before upsert for change detection
+    # If `replaces` is set, look up the deployment to be renamed so we can
+    # update it in-place (preserving its ID, run history, etc.) rather than
+    # creating a new row.
+    replaces_deployment_id: UUID | None = None
+    if replaces:
+        replaces_id_result = await session.execute(
+            sa.select(db.Deployment.id).where(
+                sa.and_(
+                    db.Deployment.flow_id == deployment.flow_id,
+                    db.Deployment.name == replaces,
+                )
+            )
+        )
+        replaces_deployment_id = replaces_id_result.scalar_one_or_none()
+        if replaces_deployment_id is None:
+            logger.warning(
+                f"Deployment '{deployment.name}' has 'replaces: {replaces}' "
+                f"but no deployment with that name exists for this flow. "
+                f"Creating new deployment."
+            )
+        else:
+            # Check that the target name isn't already taken by a *different* deployment.
+            # If it is, renaming would violate the (flow_id, name) unique constraint.
+            conflict_result = await session.execute(
+                sa.select(db.Deployment.id).where(
+                    sa.and_(
+                        db.Deployment.flow_id == deployment.flow_id,
+                        db.Deployment.name == deployment.name,
+                        db.Deployment.id != replaces_deployment_id,
+                    )
+                )
+            )
+            if conflict_result.scalar_one_or_none() is not None:
+                raise ValueError(
+                    f"Cannot use 'replaces: {replaces}' for deployment"
+                    f" '{deployment.name}' because a deployment named"
+                    f" '{deployment.name}' already exists. Remove 'replaces' or"
+                    f" delete the existing '{deployment.name}' deployment first."
+                )
+
+    # Snapshot existing deployment field values before upsert for change detection.
+    # When using `replaces`, snapshot the deployment being renamed.
+    lookup_name = replaces if replaces_deployment_id else deployment.name
     existing_result = await session.execute(
         sa.select(db.Deployment).where(
             sa.and_(
                 db.Deployment.flow_id == deployment.flow_id,
-                db.Deployment.name == deployment.name,
+                db.Deployment.name == lookup_name,
             )
         )
     )
@@ -156,7 +199,7 @@ async def create_deployment(
 
     schedules = deployment.schedules
     insert_values = deployment.model_dump_for_orm(
-        exclude_unset=True, exclude={"schedules", "version_info"}
+        exclude_unset=True, exclude={"schedules", "version_info", "replaces"}
     )
 
     requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
@@ -177,32 +220,43 @@ async def create_deployment(
             "job_variables",
             "concurrency_limit",
             "version_info",
+            "replaces",
         },
     )
     if job_variables:
         conflict_update_fields["infra_overrides"] = job_variables
 
-    insert_stmt = (
-        db.queries.insert(db.Deployment)
-        .values(**insert_values)
-        .on_conflict_do_update(
-            index_elements=db.orm.deployment_unique_upsert_columns,
-            set_={**conflict_update_fields},
+    if replaces_deployment_id:
+        # Rename in-place: update the existing deployment row rather than upserting.
+        # All run history, schedules, and concurrency limits remain attached via the ID.
+        await session.execute(
+            sa.update(db.Deployment)
+            .where(db.Deployment.id == replaces_deployment_id)
+            .values(**conflict_update_fields)
         )
-    )
-
-    await session.execute(insert_stmt)
-
-    # Get the id of the deployment we just created or updated
-    result = await session.execute(
-        sa.select(db.Deployment.id).where(
-            sa.and_(
-                db.Deployment.flow_id == deployment.flow_id,
-                db.Deployment.name == deployment.name,
+        deployment_id = replaces_deployment_id
+    else:
+        insert_stmt = (
+            db.queries.insert(db.Deployment)
+            .values(**insert_values)
+            .on_conflict_do_update(
+                index_elements=db.orm.deployment_unique_upsert_columns,
+                set_={**conflict_update_fields},
             )
         )
-    )
-    deployment_id = result.scalar_one_or_none()
+
+        await session.execute(insert_stmt)
+
+        # Get the id of the deployment we just created or updated
+        result = await session.execute(
+            sa.select(db.Deployment.id).where(
+                sa.and_(
+                    db.Deployment.flow_id == deployment.flow_id,
+                    db.Deployment.name == deployment.name,
+                )
+            )
+        )
+        deployment_id = result.scalar_one_or_none()
 
     if not deployment_id:
         return None

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -251,6 +251,10 @@ class DeploymentCreate(ActionBaseModel):
     version_info: Optional[schemas.core.VersionInfo] = Field(
         default=None, description="A description of this version of the deployment."
     )
+    replaces: Optional[str] = Field(
+        default=None,
+        description="The name of an existing deployment that this deployment replaces. Used for renaming deployments.",
+    )
 
     def check_valid_configuration(self, base_job_template: dict[str, Any]) -> None:
         """

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -3605,6 +3605,135 @@ class TestSchedules:
         assert deployment.schedules[0].id == original_id  # Same schedule
 
 
+class TestDeployRenameDeployment:
+    @pytest.mark.usefixtures("project_dir")
+    async def test_deploy_with_replaces_renames_deployment(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
+        """Test that replaces field in YAML renames an existing deployment in place.
+        Deploying a second time with the same config (idempotency) must also succeed."""
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        # First deploy with original name
+        deploy_config["deployments"][0]["name"] = "old-name"
+
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n old-name --pool {work_pool.name}",
+            expected_code=0,
+        )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/old-name"
+        )
+        original_id = deployment.id
+
+        # Second deploy with new name and replaces
+        deploy_config["deployments"][0]["name"] = "new-name"
+        deploy_config["deployments"][0]["replaces"] = "old-name"
+
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n new-name --pool {work_pool.name}",
+            expected_code=0,
+        )
+
+        # Same ID, new name
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/new-name"
+        )
+        assert deployment.id == original_id
+        assert deployment.name == "new-name"
+
+        # Old name gone
+        with pytest.raises(ObjectNotFound):
+            await prefect_client.read_deployment_by_name("An important name/old-name")
+
+        # Deploy again with the same config — old-name is already gone (idempotency)
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n new-name --pool {work_pool.name}",
+            expected_code=0,
+        )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/new-name"
+        )
+        assert deployment.id == original_id
+        assert deployment.name == "new-name"
+
+    @pytest.mark.usefixtures("project_dir")
+    async def test_deploy_with_replaces_errors_when_new_name_exists(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
+        """Test that replaces raises an error when the new name already exists."""
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        # Create both deployments
+        for name in ("old-name", "new-name"):
+            deploy_config["deployments"][0]["name"] = name
+            deploy_config["deployments"][0].pop("replaces", None)
+            with prefect_file.open(mode="w") as f:
+                yaml.safe_dump(deploy_config, f)
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=f"deploy ./flows/hello.py:my_flow -n {name} --pool {work_pool.name}",
+                expected_code=0,
+            )
+
+        # Now try replaces with conflicting name
+        deploy_config["deployments"][0]["name"] = "new-name"
+        deploy_config["deployments"][0]["replaces"] = "old-name"
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n new-name --pool {work_pool.name}",
+            expected_code=1,
+            expected_output_contains=[
+                "Cannot use 'replaces: old-name'",
+                "already exists",
+            ],
+        )
+
+    @pytest.mark.usefixtures("project_dir")
+    async def test_deploy_with_replaces_nonexistent_creates_new(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
+        """Test that replaces pointing to a nonexistent name creates a new deployment."""
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["deployments"][0]["name"] = "brand-new"
+        deploy_config["deployments"][0]["replaces"] = "does-not-exist"
+
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n brand-new --pool {work_pool.name}",
+            expected_code=0,
+        )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/brand-new"
+        )
+        assert deployment.name == "brand-new"
+
+
 class TestMultiDeploy:
     @pytest.mark.usefixtures("project_dir")
     async def test_deploy_all(self, prefect_client: PrefectClient, work_pool: WorkPool):

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -1255,6 +1255,114 @@ class TestCreateDeployment:
         assert response.status_code == 201
 
 
+class TestCreateDeploymentReplaces:
+    async def test_replaces_renames_in_place_preserving_id_and_history(
+        self,
+        session,
+        hosted_api_client,
+        flow,
+    ):
+        """replaces renames the existing deployment in place: same ID, run history
+        intact, new fields applied, old name gone. Applying the same payload a
+        second time (idempotency) must also succeed."""
+        # Create original deployment
+        original = DeploymentCreate(
+            name="old-name",
+            flow_id=flow.id,
+            tags=["v1"],
+            description="original",
+        ).model_dump(mode="json")
+        response = await hosted_api_client.post("/deployments/", json=original)
+        assert response.status_code == status.HTTP_201_CREATED
+        original_id = response.json()["id"]
+
+        # Create a flow run under the original deployment
+        run_response = await hosted_api_client.post(
+            f"/deployments/{original_id}/create_flow_run", json={}
+        )
+        assert run_response.status_code == status.HTTP_201_CREATED
+        run_id = run_response.json()["id"]
+
+        # Rename via replaces, also updating fields
+        replacement = DeploymentCreate(
+            name="new-name",
+            flow_id=flow.id,
+            replaces="old-name",
+            tags=["v2"],
+            description="updated",
+        ).model_dump(mode="json")
+        response = await hosted_api_client.post("/deployments/", json=replacement)
+        assert response.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
+        data = response.json()
+
+        # Same ID — renamed in place
+        assert data["id"] == original_id
+        assert data["name"] == "new-name"
+        assert data["tags"] == ["v2"]
+        assert data["description"] == "updated"
+
+        # Old name no longer exists
+        old_response = await hosted_api_client.get(
+            f"/deployments/name/{flow.name}/old-name"
+        )
+        assert old_response.status_code == status.HTTP_404_NOT_FOUND
+
+        # Flow run is still linked to the (renamed) deployment
+        run_detail = await hosted_api_client.get(f"/flow_runs/{run_id}")
+        assert run_detail.status_code == status.HTTP_200_OK
+        assert run_detail.json()["deployment_id"] == original_id
+
+        # Apply the exact same payload again — old-name is already gone (idempotency)
+        response = await hosted_api_client.post("/deployments/", json=replacement)
+        assert response.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
+        data = response.json()
+        assert data["id"] == original_id
+        assert data["name"] == "new-name"
+
+    async def test_replaces_nonexistent_falls_back_to_create(
+        self,
+        hosted_api_client,
+        flow,
+    ):
+        """replaces pointing to a missing deployment creates a new one and warns."""
+        data = DeploymentCreate(
+            name="brand-new",
+            flow_id=flow.id,
+            replaces="does-not-exist",
+        ).model_dump(mode="json")
+        response = await hosted_api_client.post("/deployments/", json=data)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["name"] == "brand-new"
+
+    async def test_replaces_errors_when_new_name_already_exists(
+        self,
+        hosted_api_client,
+        flow,
+    ):
+        """replaces should return 422 when the target name is already taken by
+        a different deployment, rather than crashing with a DB constraint error."""
+        for name in ("old-name", "new-name"):
+            r = await hosted_api_client.post(
+                "/deployments/",
+                json=DeploymentCreate(name=name, flow_id=flow.id).model_dump(
+                    mode="json"
+                ),
+            )
+            assert r.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
+
+        data = DeploymentCreate(
+            name="new-name",
+            flow_id=flow.id,
+            replaces="old-name",
+        ).model_dump(mode="json")
+        response = await hosted_api_client.post("/deployments/", json=data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        detail = response.json()["detail"]
+        assert "replaces: old-name" in detail
+        assert "new-name" in detail
+        assert "already exists" in detail
+
+
 class TestReadDeployment:
     async def test_read_deployment(
         self,

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -1362,6 +1362,56 @@ class TestCreateDeploymentReplaces:
         assert "new-name" in detail
         assert "already exists" in detail
 
+    async def test_replaces_rename_emits_updated_event_with_name_change(
+        self,
+        client,
+        flow,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A rename must emit `prefect.deployment.updated` carrying the old and
+        new names, so subscribers and automations observe the change."""
+        monkeypatch.setattr(
+            "prefect.server.models.deployments.PrefectServerEventsClient",
+            AssertingEventsClient,
+        )
+
+        original = DeploymentCreate(
+            name="old-name",
+            flow_id=flow.id,
+        ).model_dump(mode="json")
+        response = await client.post("/deployments/", json=original)
+        assert response.status_code == status.HTTP_201_CREATED
+        original_id = response.json()["id"]
+
+        AssertingEventsClient.reset()
+
+        # Rename only — no other field changes
+        replacement = DeploymentCreate(
+            name="new-name",
+            flow_id=flow.id,
+            replaces="old-name",
+        ).model_dump(mode="json")
+        response = await client.post("/deployments/", json=replacement)
+        assert response.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
+        assert response.json()["id"] == original_id
+
+        AssertingEventsClient.assert_emitted_event_with(
+            event="prefect.deployment.updated",
+            resource={
+                "prefect.resource.id": f"prefect.deployment.{original_id}",
+                "prefect.resource.name": "new-name",
+            },
+            payload={
+                "updated_fields": ["name"],
+                "updates": {
+                    "name": {
+                        "from": "old-name",
+                        "to": "new-name",
+                    }
+                },
+            },
+        )
+
 
 class TestReadDeployment:
     async def test_read_deployment(

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -6002,6 +6002,11 @@ export interface components {
             };
             /** @description A description of this version of the deployment. */
             version_info?: components["schemas"]["VersionInfo"] | null;
+            /**
+             * Replaces
+             * @description The name of an existing deployment that this deployment replaces. Used for renaming deployments.
+             */
+            replaces?: string | null;
         };
         /**
          * DeploymentFilter


### PR DESCRIPTION
Renaming a deployment in `prefect.yaml` currently creates a second deployment
under the new name and leaves the original behind, splitting run history across
two records and letting users trigger the stale one.

This adds an optional `replaces` field to deployment definitions, naming the
existing deployment to rename:

```yaml
deployments:
  - name: send-emails-v2      # the new name
    replaces: send-emails     # the name being replaced
    entrypoint: flows.py:send_email
    work_pool:
      name: my-work-pool
```

When set, the server updates that deployment row in place rather than upserting
a new one, so the deployment ID — and every flow run, schedule, and concurrency
limit attached to it — is preserved.

Behavior:

- `replaces` naming a deployment that exists: renamed in place
- `replaces` naming one that does not exist: created normally, warning logged
- `replaces` set while both old and new names exist: actionable error, since
  renaming would violate the `(flow_id, name)` unique constraint
- Re-applying after a successful rename is a no-op, so `replaces` can be left
  in the YAML

### Approach

This mirrors the `replaces` field already on deployment schedules (#20460),
which @desertaxle suggested on #20850 as the shape this should take at the
deployment level. Keeping the two consistent seemed more valuable than adding
the separate `deployment_id` the issue originally asked for — a user-facing
identifier distinct from the name would be a much larger change to the
deployment identity model, and `replaces` solves the reported problem without
it.

The rename is a plain `UPDATE` against the resolved deployment's ID rather than
the usual `INSERT ... ON CONFLICT DO UPDATE`, since the upsert keys on
`(flow_id, name)` and a rename by definition changes that key.

### Credit

This revives #21685 by @vyagubov, which implemented @desertaxle's suggestion and
went through two rounds of review. It was auto-closed by the stale bot after the
review feedback had already been addressed; @vyagubov has since said he no
longer needs the feature and deleted the branch, and @leo-selfee asked on the
issue whether it could be picked back up. He is retained as co-author on the
commit.

Relative to that PR, this rebases onto current `main` (the diff still applies
cleanly) and updates two generated files it left stale:

- `schemas/prefect.yaml.schema.json` — without it, editors validating
  `prefect.yaml` against the published schema flag `replaces` as an unknown key.
  The schema test does not check freshness, so nothing caught this.
- `ui-v2/src/api/prefect.ts` — the server schema change flows into the UI's
  generated API types. Only the `DeploymentCreate.replaces` field is included
  here; a full `service-sync` also picks up unrelated drift already present on
  `main`, which seemed out of scope for this PR.

### Tests

`tests/server/orchestration/api/test_deployments.py` covers the server-side
rename (ID and run history preserved, fallback to create, conflict error), and
`tests/cli/test_deploy.py` covers it end to end through `prefect deploy`. The
five new tests asserting rename behavior fail on `main` and pass here.

Also run locally:

- `tests/server/models/test_deployments.py` + `tests/server/orchestration/api/test_deployments.py` — 257 passed, 1 skipped (PostgreSQL-only row locking)
- `tests/runner/test_runner.py` + `tests/deployment/` — 404 passed, 5 skipped
- `pre-commit run` (ruff, ruff-format, codespell, mypy) — passed
- `npx tsc --noEmit` in `ui-v2` — passed

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  - Approach proposed by @desertaxle in [this comment](https://github.com/PrefectHQ/prefect/issues/20850#issuecomment-3961876281) and reviewed across two rounds on #21685
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

closes https://github.com/PrefectHQ/prefect/issues/20850
