### PR TITLE
Enforce sync timeouts on Windows

### DIFF
--- a/src/prefect/_internal/concurrency/cancellation.py
+++ b/src/prefect/_internal/concurrency/cancellation.py
@@ -560,24 +560,23 @@ def cancel_sync_after(timeout: Optional[float], name: Optional[str] = None):
     Cancel any sync calls within the context if it does not exit after the given
     timeout.
 
-    The timeout method varies depending on if this is called in the main thread or not.
-    See `AlarmCancelScope` and `WatcherThreadCancelScope` for details.
+    The timeout method varies depending on the platform and on if this is called in
+    the main thread or not. See `AlarmCancelScope` and `WatcherThreadCancelScope` for
+    details.
 
     Yields a `CancelContext`.
     """
 
-    if sys.platform.startswith("win"):
-        yield NullCancelScope(reason="cancellation is not supported on Windows")
-        return
-
     thread = threading.current_thread()
-    existing_alarm_handler = signal.getsignal(signal.SIGALRM) != signal.SIG_DFL
 
     if (
-        thread is threading.main_thread()
+        # Alarms are not available on Windows, which has no `SIGALRM`; the watcher
+        # thread scope does not use signals and works there
+        not sys.platform.startswith("win")
+        and thread is threading.main_thread()
         # Avoid nested alarm handlers; it's hard to follow and they will interfere with
         # each other
-        and not existing_alarm_handler
+        and signal.getsignal(signal.SIGALRM) == signal.SIG_DFL
         # Avoid using an alarm when there is no timeout; it's better saved for that case
         and timeout is not None
     ):

--- a/tests/_internal/concurrency/test_cancellation.py
+++ b/tests/_internal/concurrency/test_cancellation.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import signal
+import sys
 import threading
 import time
 from unittest.mock import MagicMock
@@ -141,6 +142,38 @@ def test_cancel_sync_after_in_worker_thread():
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future = executor.submit(on_worker_thread)
         scope = future.result()
+
+    assert scope.cancelled()
+    assert not completed
+
+
+def test_cancel_sync_after_uses_watcher_thread_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Windows has no `SIGALRM`, so the alarm scope is unavailable there. The watcher
+    thread scope uses no signals and must be used instead.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    with cancel_sync_after(1) as scope:
+        pass
+
+    assert isinstance(scope, WatcherThreadCancelScope)
+
+
+def test_cancel_sync_after_in_main_thread_on_windows(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    completed = False
+    with pytest.raises(CancelledError):
+        with cancel_sync_after(0.1) as scope:
+            # this timeout method does not interrupt sleep calls, the timeout is
+            # raised on the next instruction
+            for _ in range(20):
+                time.sleep(0.1)
+
+            completed = True
 
     assert scope.cancelled()
     assert not completed


### PR DESCRIPTION
`@flow(timeout_seconds=...)` never fires on Windows. The flow in #17699 runs
past its deadline forever, no error is raised, and nothing is logged at default
level, so a timeout set to stop a runaway flow silently does nothing.

`cancel_sync_after` returns a `NullCancelScope` and bails out early when
`sys.platform` starts with `win`. That stands in for `AlarmCancelScope`, which
needs `signal.SIGALRM` and genuinely cannot work there. But the other scope in
the same module, `WatcherThreadCancelScope`, uses a watcher thread and
`PyThreadState_SetAsyncExc` and no signals at all — it is already what every
non-main thread gets on every platform. Only the alarm is Unix-only; the early
return gave up the portable path along with it.

This picks the alarm scope where alarms exist and falls through to the watcher
thread otherwise, with the `signal.getsignal(signal.SIGALRM)` lookup left
behind the platform check so it is never reached on Windows. Off Windows the
condition is the same test as before, with the negation moved. The watcher
thread cannot interrupt a blocking call — `_send_exception_to_thread` says so
in its own docstring — so a flow parked in a single long `time.sleep` still
will not be cancelled until it returns; that is the existing trade for every
non-main-thread sync timeout, and here it replaces nothing happening at all.
`NullCancelScope` now has no callers; I left it in place rather than widen the
diff, and can remove it if you would rather.

Two tests in `tests/_internal/concurrency/test_cancellation.py`.
`test_cancel_sync_after_uses_watcher_thread_on_windows` asserts which scope is
chosen, and `test_cancel_sync_after_in_main_thread_on_windows` is the issue's
loop of short sleeps; on main it fails with `Failed: DID NOT RAISE
CancelledError`. Both force the branch with `monkeypatch.setattr(sys,
"platform", "win32")` and I ran them on Linux — I have not run this against a
real Windows host, so that is worth knowing when reading the proof. The job
that would cover it, `windows-tests.yaml`, has a `paths:` filter naming neither
of these two files, so it will not run on this pull request; I have not touched
that workflow, but I am glad to add the paths if you want the coverage.

Closes https://github.com/PrefectHQ/prefect/issues/17699

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed. — no doc change: the timeout documentation carries no Windows caveat today, so this makes the behaviour match what is already written.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
