### PR TITLE
fix the right shifted plus icon in the combobox

### DIFF
--- a/ui-v2/src/components/automations/automations-wizard/trigger-step/automation-deployment-combobox/index.tsx
+++ b/ui-v2/src/components/automations/automations-wizard/trigger-step/automation-deployment-combobox/index.tsx
@@ -160,12 +160,12 @@ export const AutomationDeploymentCombobox = ({
 		return (
 			<div
 				ref={containerRef}
-				className="flex flex-1 min-w-0 items-center gap-2"
+				className="flex min-w-0 items-center justify-start gap-1"
 			>
-				<div className="flex flex-1 min-w-0 items-center gap-2 overflow-hidden">
-					<span className="truncate">{visible.join(", ")}</span>
-				</div>
-				{extraCount > 0 && <p className="text-sm shrink-0">+ {extraCount}</p>}
+				<span className="truncate min-w-0 text-left">{visible.join(", ")}</span>
+				{extraCount > 0 && (
+					<span className="shrink-0 text-muted-foreground">+{extraCount}</span>
+				)}
 				{/* Hidden element for measuring text width */}
 				<div
 					ref={measureRef}

--- a/ui-v2/src/components/automations/automations-wizard/trigger-step/automation-deployment-combobox/index.tsx
+++ b/ui-v2/src/components/automations/automations-wizard/trigger-step/automation-deployment-combobox/index.tsx
@@ -160,7 +160,7 @@ export const AutomationDeploymentCombobox = ({
 		return (
 			<div
 				ref={containerRef}
-				className="flex min-w-0 items-center justify-start gap-1"
+				className="flex flex-1 min-w-0 items-center justify-start gap-1"
 			>
 				<span className="truncate min-w-0 text-left">{visible.join(", ")}</span>
 				{extraCount > 0 && (


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

When creating a new automation for flow run state, the deployments multi select is showing plus +1 to the extreme right.

**before**
<img width="1620" height="82" alt="image" src="https://github.com/user-attachments/assets/75b48a39-9ec4-424e-bb1e-8cd0acdb01a3" /> 


**after**
<img width="1618" height="77" alt="image" src="https://github.com/user-attachments/assets/7b4752a4-40d9-435a-abf2-793185d74148" /> 


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
