### PR TITLE
Crash flow runs interrupted by worker shutdown

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1658,9 +1658,14 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             # handler below and the run would otherwise be left `Running` for
             # ever, holding a work pool concurrency slot that nothing releases.
             # Only report a run that actually started; one cancelled while still
-            # being submitted never had infrastructure to lose. The scope is
-            # already cancelled, so the call has to be shielded to survive.
-            if task_status and getattr(task_status, "_future").done():
+            # being submitted never had infrastructure to lose. `done()` alone
+            # does not say that here: the same cancellation cancels the future
+            # `TaskGroup.start` is waiting on, so it is done either way. It is
+            # `started()` that resolves it with a result, and a cancelled future
+            # that never carried one is the run that had not started. The scope
+            # is already cancelled, so the call has to be shielded to survive.
+            future = getattr(task_status, "_future") if task_status else None
+            if future is not None and future.done() and not future.cancelled():
                 with anyio.CancelScope(shield=True):
                     await self._propose_crashed_state(
                         flow_run,

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1652,6 +1652,21 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 task_status=task_status,
                 configuration=configuration,
             )
+        except anyio.get_cancelled_exc_class():
+            # The worker is shutting down and this run's infrastructure went with
+            # it. Cancellation is a `BaseException`, so it does not reach the
+            # handler below and the run would otherwise be left `Running` for
+            # ever, holding a work pool concurrency slot that nothing releases.
+            # Only report a run that actually started; one cancelled while still
+            # being submitted never had infrastructure to lose. The scope is
+            # already cancelled, so the call has to be shielded to survive.
+            if task_status and getattr(task_status, "_future").done():
+                with anyio.CancelScope(shield=True):
+                    await self._propose_crashed_state(
+                        flow_run,
+                        "Flow run infrastructure was interrupted by worker shutdown.",
+                    )
+            raise
         except Exception as exc:
             if task_status and not getattr(task_status, "_future").done():
                 # This flow run was being submitted and did not start successfully

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -1103,3 +1103,64 @@ class TestWorkerSignalForwarding:
             "When sending two SIGTERM shortly after each other, the main process should"
             f" first receive a SIGINT and then a SIGKILL. Output:\n{out}"
         )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="SIGTERM is only used in non-Windows environments",
+    )
+    async def test_shutdown_crashes_a_flow_run_that_was_running(
+        self,
+        worker_process,
+        prefect_client: PrefectClient,
+        tmp_path: Path,
+    ):
+        """
+        The reported behaviour: a run left `Running` for ever after the worker
+        stops, holding a work pool concurrency slot nothing releases.
+        """
+        (tmp_path / "sleeper.py").write_text(
+            "import time\n"
+            "\n"
+            "from prefect import flow\n"
+            "\n"
+            "\n"
+            "@flow\n"
+            "def sleeper():\n"
+            "    time.sleep(120)\n"
+        )
+
+        flow_id = await prefect_client.create_flow_from_name("sleeper")
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="sleeper-deployment",
+            work_pool_name="my-pool",
+            path=str(tmp_path),
+            entrypoint="sleeper.py:sleeper",
+        )
+        flow_run = await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+        with anyio.fail_after(45):
+            while True:
+                flow_run = await prefect_client.read_flow_run(flow_run.id)
+                if flow_run.state and flow_run.state.is_running():
+                    break
+                await anyio.sleep(0.5)
+
+        worker_process.send_signal(signal.SIGTERM)
+        await safe_shutdown(worker_process)
+
+        # `move_on_after` rather than `fail_after`: without the fix this loop
+        # never ends, and a bare timeout says only that the test hung. Falling
+        # out of it lets the assertion below name the state it was left in.
+        with anyio.move_on_after(20):
+            while True:
+                flow_run = await prefect_client.read_flow_run(flow_run.id)
+                if flow_run.state and flow_run.state.is_final():
+                    break
+                await anyio.sleep(0.5)
+
+        assert flow_run.state is not None
+        assert flow_run.state.is_crashed(), (
+            "A flow run whose worker shut down under it must reach a terminal"
+            f" state, but this one is still {flow_run.state.type.value}."
+        )

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2326,6 +2326,47 @@ class TestInfrastructureIntegration:
         with pytest.raises(CrashedRun, match="interrupted by worker shutdown"):
             await state.result()
 
+    async def test_worker_does_not_crash_flow_run_interrupted_before_it_started(
+        self,
+        prefect_client: PrefectClient,
+        worker_deployment_infra_wq1: WorkQueue,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """
+        The other side of the handler above. A run cancelled while its
+        infrastructure is still being provisioned never started, so shutdown has
+        taken nothing away from it and it must not be reported as crashed.
+        """
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            worker_deployment_infra_wq1.id,
+            state=Scheduled(scheduled_time=now_fn("UTC")),
+        )
+
+        provisioning = anyio.Event()
+
+        async def never_reports_started(
+            flow_run: FlowRun,
+            configuration: BaseJobConfiguration,
+            task_status: anyio.abc.TaskStatus[int] | None = None,
+        ) -> None:
+            provisioning.set()
+            await anyio.sleep_forever()
+
+        async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+            worker._work_pool = work_pool
+            monkeypatch.setattr(worker, "run", never_reports_started)
+            await worker.get_and_submit_flow_runs()
+
+            with anyio.fail_after(10):
+                await provisioning.wait()
+
+            assert worker._runs_task_group is not None
+            worker._runs_task_group.cancel_scope.cancel()
+
+        state = (await prefect_client.read_flow_run(flow_run.id)).state
+        assert not state.is_crashed()
+
     async def test_submission_failure_log_uses_flow_run_name(
         self,
         prefect_client: PrefectClient,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2276,6 +2276,56 @@ class TestInfrastructureIntegration:
         ):
             await state.result()
 
+    async def test_worker_crashes_flow_run_interrupted_by_shutdown(
+        self,
+        prefect_client: PrefectClient,
+        worker_deployment_infra_wq1: WorkQueue,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """
+        A run whose infrastructure is cancelled out from under it by worker
+        shutdown must reach a terminal state. Left `Running`, it holds a work
+        pool concurrency slot that nothing will ever release.
+        """
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            worker_deployment_infra_wq1.id,
+            state=Scheduled(scheduled_time=now_fn("UTC")),
+        )
+
+        running = anyio.Event()
+
+        async def start_and_never_return(
+            flow_run: FlowRun,
+            configuration: BaseJobConfiguration,
+            task_status: anyio.abc.TaskStatus[int] | None = None,
+        ) -> None:
+            if task_status:
+                task_status.started(42)
+            running.set()
+            await anyio.sleep_forever()
+
+        async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+            worker._work_pool = work_pool
+            monkeypatch.setattr(worker, "run", start_and_never_return)
+            await worker.get_and_submit_flow_runs()
+
+            # `get_and_submit_flow_runs` returns once submission is scheduled, not
+            # once it has happened, so wait for the infrastructure to be up before
+            # taking it away — otherwise this cancels a run that never started and
+            # the worker is right to say nothing.
+            with anyio.fail_after(10):
+                await running.wait()
+
+            # What a shutdown does to a run that is already executing.
+            assert worker._runs_task_group is not None
+            worker._runs_task_group.cancel_scope.cancel()
+
+        state = (await prefect_client.read_flow_run(flow_run.id)).state
+        assert state.is_crashed()
+        with pytest.raises(CrashedRun, match="interrupted by worker shutdown"):
+            await state.result()
+
     async def test_submission_failure_log_uses_flow_run_name(
         self,
         prefect_client: PrefectClient,


### PR DESCRIPTION
When a process worker stops, the flow runs it was executing stay `Running` for
ever. Nothing marks them and nothing logs it at default level, so a work pool
with a concurrency limit loses that many slots permanently — the reporter's pool
had a limit of 1 and never ran anything again after one `docker compose down`.
The same thing happens to a worker pod taking a `SIGTERM` on a rolling deploy.

`BaseWorker._submit_run_and_capture_errors` is the frame that owns a running
flow, and its only handler is `except Exception`. Shutdown cancels that frame,
`anyio`'s cancellation exception derives from `BaseException`, so it passes
straight over the handler that would have proposed a terminal state. The
`finally` releases the worker's local concurrency slot, so the worker looks
healthy while the server still believes the run is going.

This adds a cancellation handler that proposes `Crashed` before re-raising. It
fires only when `task_status` has already been marked started — a run cancelled
while it was still being submitted never had infrastructure to lose, and the
existing branch below already covers that case. The call is wrapped in
`anyio.CancelScope(shield=True)` because the scope is cancelled by the time the
handler runs and the request would otherwise be interrupted; the client outlives
the run task group in `_exit_stack`, so it is still open at that point. A run
that is already terminal — one a user cancelled, for instance — is unaffected,
because `propose_state` raises `Abort` and `_propose_crashed_state` ignores it.

Deliberately not included: making the worker *drain* rather than cancel. The
comment above `setup_signal_handlers_worker` says a `SIGINT` should stop
dequeueing and let running subprocesses finish, and that is not what happens —
both `SIGINT` and `SIGTERM` end in `KeyboardInterrupt` on the worker's main
thread and the children are cancelled. That is a design change, it is roughly
what #22528 asks for, and it is separate from reporting the state of a run that
has already been interrupted.

Two tests. `test_worker_crashes_flow_run_interrupted_by_shutdown` in
`tests/workers/test_base_worker.py` cancels the runs task group under a started
run and asserts the terminal state; reverted, the run is left `Submitting`.
`test_shutdown_crashes_a_flow_run_that_was_running` in `tests/cli/test_worker.py`
uses the existing `worker_process` fixture, runs a real deployment, sends
`SIGTERM`, and asserts the run is not left in a non-terminal state; reverted, it
fails with `A flow run whose worker shut down under it must reach a terminal
state, but this one is still RUNNING`. Both are needed — the first proves the
handler, the second proves the signal path reaches it, and only the second
produces the `Running` the issue is actually about.

Credit where it is due: #21158 by @jellyfish0316 reached essentially this
handler after review from @desertaxle, and was closed by the stale bot rather
than rejected. I arrived at the same shape before reading that diff, which I
take as a point in its favour rather than mine; the end-to-end test's structure
follows theirs. Their branch also predates `ProcessWorker` moving onto
`FlowRunExecutor`, which was the objection raised against it at the time and no
longer applies.

Closes https://github.com/PrefectHQ/prefect/issues/16746

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue. — @cicdw described this direction on the issue in January 2025 ("add an attempt to cancel subprocesses when that particular worker shuts down gracefully"), but nobody has confirmed this specific patch.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed. — no doc change: the zombie-detection automation docs stay accurate and stay useful for the cases this does not cover, such as a worker that is `SIGKILL`ed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
