### PR TITLE
Migrate 2.x PyPI publishing to OIDC

### DIFF
--- a/.github/workflows/prefect-client-publish.yaml
+++ b/.github/workflows/prefect-client-publish.yaml
@@ -19,6 +19,8 @@ jobs:
     environment: "prod"
     needs: [verify-prefect-client-build]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Download build artifacts
@@ -29,6 +31,3 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PREFECT_CLIENT_PYPI_API_TOKEN }}
-          name: ci

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -60,6 +60,8 @@ jobs:
     environment: "prod"
     needs: [build-pypi-dists]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Download build artifacts
@@ -70,6 +72,3 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          name: ci


### PR DESCRIPTION
this PR migrates Prefect 2.x PyPI publication for `prefect` and `prefect-client` from long-lived API tokens to OIDC trusted publishing.

<details>
<summary>Details</summary>

- Grants `id-token: write` only to the two PyPI publishing jobs.
- Removes both explicit PyPI token inputs so `pypa/gh-action-pypi-publish` can exchange the workflow identity for short-lived credentials.
- Retains the protected `prod` environment and matches the authentication pattern used by current Prefect releases.
- Confirms both changed workflow files parse as valid YAML.

</details>

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - No issue exists; this is a narrowly scoped release fix.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
  - This changes release authentication only; no product functionality is added.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.