### PR TITLE
Add 2.x Docker release recovery path

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -23,15 +23,21 @@ on:
       - ".github/workflows/docker-images.yaml"
       - "ui/**"
 
-  # On workflow_dispatch, push sha and branch patterns to prefect-dev
+  # On workflow_dispatch, push sha and branch patterns to prefect-dev or recover an existing stable release
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing stable release tag to publish to prefecthq/prefect"
+        required: false
+        type: string
 
 jobs:
   publish-docker-images:
     name: Build and publish to DockerHub
     runs-on: ubuntu-latest
-    environment: ${{ ( github.event_name == 'release' && 'prod' ) || 'dev' }}
+    environment: ${{ ( (github.event_name == 'release' || inputs.tag != '') && 'prod' ) || 'dev' }}
     strategy:
+      fail-fast: false
       matrix:
         flavor:
           - ""
@@ -57,18 +63,19 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_RW }}
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Generate tags for prefecthq/prefect-dev
         id: metadata-dev
         uses: docker/metadata-action@v5
         # do not generate the development tags on release events
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ github.event_name != 'release' && inputs.tag == '' }}
         with:
           images: prefecthq/prefect-dev
           tags: |
@@ -90,18 +97,18 @@ jobs:
       - name: Generate tags for prefecthq/prefect
         id: metadata-prod
         uses: docker/metadata-action@v5
-        # only generate the production tags on release events
-        if: ${{ github.event_name == 'release' }}
+        # generate production tags on release events or when recovering an existing stable release
+        if: ${{ github.event_name == 'release' || inputs.tag != '' }}
         with:
           images: prefecthq/prefect
           # push `latest`, `X.Y` and `X` tags only when the release is not marked as prerelease
           # push `latest` and `X` tags only when the release is marked as latest
           # push `2-latest` tags on any non-prerelease 2.x release
           tags: |
-            type=pep440,pattern={{version}},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }}
-            type=pep440,pattern={{major}}.{{minor}},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ github.event.release.prerelease == false }}
-            type=pep440,pattern={{major}},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ github.event.release.prerelease == false && github.ref_name == env.LATEST_TAG }}
-            type=raw,value=2-latest${{ matrix.flavor }},enable=${{ matrix.python-version == '3.10' && github.event.release.prerelease == false }}
+            type=pep440,pattern={{version}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }}
+            type=pep440,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ (github.event_name == 'release' && github.event.release.prerelease == false) || inputs.tag != '' }}
+            type=pep440,pattern={{major}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ github.event.release.prerelease == false && github.ref_name == env.LATEST_TAG }}
+            type=raw,value=2-latest${{ matrix.flavor }},enable=${{ matrix.python-version == '3.10' && ((github.event_name == 'release' && github.event.release.prerelease == false) || inputs.tag != '') }}
           flavor: |
             latest=false
 

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -32,8 +32,53 @@ on:
         type: string
 
 jobs:
+  prepare-release-recovery:
+    name: Prepare release recovery
+    runs-on: ubuntu-latest
+    outputs:
+      publish_minor: ${{ steps.recovery.outputs.publish_minor }}
+      publish_2_latest: ${{ steps.recovery.outputs.publish_2_latest }}
+    steps:
+      - name: Resolve release recovery aliases
+        id: recovery
+        if: ${{ inputs.tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release recovery requires a stable 2.x tag, got: $TAG" >&2
+            exit 1
+          fi
+
+          stable_tags="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^2\.[0-9]+\.[0-9]+$' \
+            | sort -V
+          )"
+
+          if ! grep -Fxq "$TAG" <<< "$stable_tags"; then
+            echo "Release recovery requires a published stable 2.x release, got: $TAG" >&2
+            exit 1
+          fi
+
+          IFS=. read -r major minor _ <<< "$TAG"
+          latest_minor="$(grep -E "^${major}\\.${minor}\\.[0-9]+$" <<< "$stable_tags" | tail -n 1)"
+          latest_2x="$(tail -n 1 <<< "$stable_tags")"
+
+          [[ "$TAG" == "$latest_minor" ]] && publish_minor=true || publish_minor=false
+          [[ "$TAG" == "$latest_2x" ]] && publish_2_latest=true || publish_2_latest=false
+
+          echo "publish_minor=$publish_minor" >> "$GITHUB_OUTPUT"
+          echo "publish_2_latest=$publish_2_latest" >> "$GITHUB_OUTPUT"
+
   publish-docker-images:
     name: Build and publish to DockerHub
+    needs: prepare-release-recovery
     runs-on: ubuntu-latest
     environment: ${{ ( (github.event_name == 'release' || inputs.tag != '') && 'prod' ) || 'dev' }}
     strategy:
@@ -106,9 +151,9 @@ jobs:
           # push `2-latest` tags on any non-prerelease 2.x release
           tags: |
             type=pep440,pattern={{version}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }}
-            type=pep440,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ (github.event_name == 'release' && github.event.release.prerelease == false) || inputs.tag != '' }}
+            type=pep440,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ (github.event_name == 'release' && github.event.release.prerelease == false) || needs.prepare-release-recovery.outputs.publish_minor == 'true' }}
             type=pep440,pattern={{major}},value=${{ inputs.tag || github.ref_name }},suffix=-python${{ matrix.python-version }}${{ matrix.flavor }},enable=${{ github.event.release.prerelease == false && github.ref_name == env.LATEST_TAG }}
-            type=raw,value=2-latest${{ matrix.flavor }},enable=${{ matrix.python-version == '3.10' && ((github.event_name == 'release' && github.event.release.prerelease == false) || inputs.tag != '') }}
+            type=raw,value=2-latest${{ matrix.flavor }},enable=${{ matrix.python-version == '3.10' && ((github.event_name == 'release' && github.event.release.prerelease == false) || needs.prepare-release-recovery.outputs.publish_2_latest == 'true') }}
           flavor: |
             latest=false
 


### PR DESCRIPTION
Updates the 2.x Docker workflow to use `DOCKERHUB_TOKEN_RW` and allows maintainers to publish images for an existing stable release tag. The recovery path checks out the immutable tag and publishes the same version, minor, and `2-latest` aliases as a normal stable release.

Disables matrix fail-fast so one image failure does not cancel the remaining variants. Normal release events and development dispatches retain their existing behavior.

### Example

```bash
gh workflow run docker-images.yaml --repo PrefectHQ/prefect --ref 2.x -f tag=2.20.26
```

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.