### PR TITLE
Fix Prefect task retention in Dask scheduler

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/client.py
+++ b/src/integrations/prefect-dask/prefect_dask/client.py
@@ -1,5 +1,4 @@
 import asyncio
-from functools import wraps
 from uuid import uuid4
 
 from distributed import Client, Future
@@ -11,7 +10,28 @@ from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.engine import collect_task_run_inputs_sync
 
 
+def _run_prefect_task(*args, **kwargs):
+    task = kwargs["task"]
+    if task.isasync:
+        return asyncio.run(run_task_async(*args, **kwargs))
+    else:
+        return run_task_sync(*args, **kwargs)
+
+
 class PrefectDaskClient(Client):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._prefect_task_futures: dict[int, Future] = {}
+
+    def _get_prefect_task_future(self, task: Task) -> Future:
+        task_id = id(task)
+        if task_id not in self._prefect_task_futures:
+            self._prefect_task_futures[task_id] = self.scatter(
+                task, broadcast=True, hash=False
+            )
+
+        return self._prefect_task_futures[task_id]
+
     def submit(
         self,
         func,
@@ -30,7 +50,7 @@ class PrefectDaskClient(Client):
     ):
         if isinstance(func, Task):
             run_task_kwargs = {}
-            run_task_kwargs["task"] = func
+            run_task_kwargs["task"] = self._get_prefect_task_future(func)
             task_run_id = uuid4()
             run_task_kwargs["task_run_id"] = task_run_id
 
@@ -62,17 +82,14 @@ class PrefectDaskClient(Client):
                     "copy_to_child_ctx": True,
                 }
             )
-            run_task_kwargs["context"] = context
+            context_future = self.scatter(context, broadcast=False, hash=False)
+            run_task_kwargs["context"] = context_future
 
-            @wraps(func)
-            def wrapper_func(*args, **kwargs):
-                if func.isasync:
-                    return asyncio.run(run_task_async(*args, **kwargs))
-                else:
-                    return run_task_sync(*args, **kwargs)
+            if key is None:
+                key = f"{func.name}-{uuid4().hex}"
 
             future = super().submit(
-                wrapper_func,
+                _run_prefect_task,
                 key=key,
                 workers=workers,
                 resources=resources,
@@ -87,6 +104,7 @@ class PrefectDaskClient(Client):
             )
 
             future.task_run_id = run_task_kwargs["task_run_id"]
+            future.add_done_callback(lambda _: context_future.release())
             return future
         else:
             return super().submit(

--- a/src/integrations/prefect-dask/prefect_dask/client.py
+++ b/src/integrations/prefect-dask/prefect_dask/client.py
@@ -10,6 +10,10 @@ from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.engine import collect_task_run_inputs_sync
 
 
+def _materialize_payload(value):
+    return value
+
+
 def _run_prefect_task(*args, **kwargs):
     task = kwargs["task"]
     if task.isasync:
@@ -19,18 +23,121 @@ def _run_prefect_task(*args, **kwargs):
 
 
 class PrefectDaskClient(Client):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._prefect_task_futures: dict[int, Future] = {}
+    def _submit_payload(self, value, key_prefix: str) -> Future:
+        """Submit payload data as a dependency without waiting for a worker."""
+        return super().submit(
+            _materialize_payload,
+            value,
+            key=f"{key_prefix}-{uuid4().hex}",
+            pure=False,
+        )
 
-    def _get_prefect_task_future(self, task: Task) -> Future:
-        task_id = id(task)
-        if task_id not in self._prefect_task_futures:
-            self._prefect_task_futures[task_id] = self.scatter(
-                task, broadcast=True, hash=False
+    def _submit_prefect_run(
+        self,
+        run_task_kwargs,
+        *,
+        key,
+        workers,
+        resources,
+        retries,
+        priority,
+        fifo_timeout,
+        allow_other_workers,
+        actor,
+        actors,
+        pure,
+    ) -> Future:
+        return super().submit(
+            _run_prefect_task,
+            key=key,
+            workers=workers,
+            resources=resources,
+            retries=retries,
+            priority=priority,
+            fifo_timeout=fifo_timeout,
+            allow_other_workers=allow_other_workers,
+            actor=actor,
+            actors=actors,
+            pure=pure,
+            **run_task_kwargs,
+        )
+
+    def _submit_prefect_task(
+        self,
+        func: Task,
+        task_future: Future,
+        args,
+        *,
+        key,
+        workers,
+        resources,
+        retries,
+        priority,
+        fifo_timeout,
+        allow_other_workers,
+        actor,
+        actors,
+        pure,
+        kwargs,
+    ) -> Future:
+        kwargs = kwargs.copy()
+        run_task_kwargs = {"task": task_future}
+        task_run_id = uuid4()
+        run_task_kwargs["task_run_id"] = task_run_id
+
+        passed_dependencies = kwargs.pop("dependencies", None)
+        run_task_kwargs["wait_for"] = kwargs.pop("wait_for", None)
+        run_task_kwargs["return_type"] = kwargs.pop("return_type", "result")
+        if (parameters := kwargs.get("parameters")) is None:
+            # If parameters are not provided, we need to extract them from the function.
+            # This case is when the PrefectDistributedClient is used directly without
+            # the DaskTaskRunner.
+            parameters = get_call_parameters(func, args, kwargs)
+        run_task_kwargs["parameters"] = parameters
+        dependencies = {
+            k: collect_task_run_inputs_sync(v, future_cls=Future)
+            for k, v in parameters.items()
+        }
+        if passed_dependencies:
+            dependencies = {
+                k: v.union(passed_dependencies.get(k, set()))
+                for k, v in dependencies.items()
+            }
+        run_task_kwargs["dependencies"] = dependencies
+
+        context = serialize_context(
+            asset_ctx_kwargs={
+                "task": func,
+                "task_run_id": task_run_id,
+                "task_inputs": dependencies,
+                "copy_to_child_ctx": True,
+            }
+        )
+        context_future = self._submit_payload(context, "prefect-context")
+        run_task_kwargs["context"] = context_future
+
+        if key is None:
+            key = f"{func.name}-{uuid4().hex}"
+
+        try:
+            future = self._submit_prefect_run(
+                run_task_kwargs,
+                key=key,
+                workers=workers,
+                resources=resources,
+                retries=retries,
+                priority=priority,
+                fifo_timeout=fifo_timeout,
+                allow_other_workers=allow_other_workers,
+                actor=actor,
+                actors=actors,
+                pure=pure,
             )
+        finally:
+            context_future.release()
 
-        return self._prefect_task_futures[task_id]
+        future.task_run_id = task_run_id
+        return future
 
     def submit(
         self,
@@ -49,63 +156,26 @@ class PrefectDaskClient(Client):
         **kwargs,
     ):
         if isinstance(func, Task):
-            run_task_kwargs = {}
-            run_task_kwargs["task"] = self._get_prefect_task_future(func)
-            task_run_id = uuid4()
-            run_task_kwargs["task_run_id"] = task_run_id
-
-            passed_dependencies = kwargs.pop("dependencies", None)
-            run_task_kwargs["wait_for"] = kwargs.pop("wait_for", None)
-            run_task_kwargs["return_type"] = kwargs.pop("return_type", "result")
-            if (parameters := kwargs.get("parameters")) is None:
-                # If parameters are not provided, we need to extract them from the function.
-                # This case is when the PrefectDistributedClient is used directly without
-                # the DaskTaskRunner.
-                parameters = get_call_parameters(func, args, kwargs)
-            run_task_kwargs["parameters"] = parameters
-            dependencies = {
-                k: collect_task_run_inputs_sync(v, future_cls=Future)
-                for k, v in parameters.items()
-            }
-            if passed_dependencies:
-                dependencies = {
-                    k: v.union(passed_dependencies.get(k, set()))
-                    for k, v in dependencies.items()
-                }
-            run_task_kwargs["dependencies"] = dependencies
-
-            context = serialize_context(
-                asset_ctx_kwargs={
-                    "task": func,
-                    "task_run_id": task_run_id,
-                    "task_inputs": dependencies,
-                    "copy_to_child_ctx": True,
-                }
-            )
-            context_future = self.scatter(context, broadcast=False, hash=False)
-            run_task_kwargs["context"] = context_future
-
-            if key is None:
-                key = f"{func.name}-{uuid4().hex}"
-
-            future = super().submit(
-                _run_prefect_task,
-                key=key,
-                workers=workers,
-                resources=resources,
-                retries=retries,
-                priority=priority,
-                fifo_timeout=fifo_timeout,
-                allow_other_workers=allow_other_workers,
-                actor=actor,
-                actors=actors,
-                pure=pure,
-                **run_task_kwargs,
-            )
-
-            future.task_run_id = run_task_kwargs["task_run_id"]
-            future.add_done_callback(lambda _: context_future.release())
-            return future
+            task_future = self._submit_payload(func, "prefect-task")
+            try:
+                return self._submit_prefect_task(
+                    func,
+                    task_future,
+                    args,
+                    key=key,
+                    workers=workers,
+                    resources=resources,
+                    retries=retries,
+                    priority=priority,
+                    fifo_timeout=fifo_timeout,
+                    allow_other_workers=allow_other_workers,
+                    actor=actor,
+                    actors=actors,
+                    pure=pure,
+                    kwargs=kwargs,
+                )
+            finally:
+                task_future.release()
         else:
             return super().submit(
                 func,
@@ -141,27 +211,31 @@ class PrefectDaskClient(Client):
         **kwargs,
     ):
         if isinstance(func, Task):
-            args_list = zip(*iterables)
-            futures = []
-            for args in args_list:
-                futures.append(
-                    self.submit(
-                        func,
-                        *args,
-                        key=key,
-                        workers=workers,
-                        resources=resources,
-                        retries=retries,
-                        priority=priority,
-                        fifo_timeout=fifo_timeout,
-                        allow_other_workers=allow_other_workers,
-                        actor=actor,
-                        actors=actors,
-                        pure=pure,
-                        **kwargs,
+            task_future = self._submit_payload(func, "prefect-task")
+            try:
+                futures = []
+                for args in zip(*iterables):
+                    futures.append(
+                        self._submit_prefect_task(
+                            func,
+                            task_future,
+                            args,
+                            key=key,
+                            workers=workers,
+                            resources=resources,
+                            retries=retries,
+                            priority=priority,
+                            fifo_timeout=fifo_timeout,
+                            allow_other_workers=allow_other_workers,
+                            actor=actor,
+                            actors=actors,
+                            pure=pure,
+                            kwargs=kwargs,
+                        )
                     )
-                )
-            return futures
+                return futures
+            finally:
+                task_future.release()
         else:
             return super().map(
                 func,

--- a/src/integrations/prefect-dask/prefect_dask/client.py
+++ b/src/integrations/prefect-dask/prefect_dask/client.py
@@ -1,4 +1,6 @@
 import asyncio
+
+import cloudpickle
 from uuid import uuid4
 
 from distributed import Client, Future
@@ -10,8 +12,8 @@ from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.engine import collect_task_run_inputs_sync
 
 
-def _materialize_payload(value):
-    return value
+def _materialize_payload(payload: bytes):
+    return cloudpickle.loads(payload)
 
 
 def _run_prefect_task(*args, **kwargs):
@@ -25,9 +27,10 @@ def _run_prefect_task(*args, **kwargs):
 class PrefectDaskClient(Client):
     def _submit_payload(self, value, key_prefix: str) -> Future:
         """Submit payload data as a dependency without waiting for a worker."""
+        payload = cloudpickle.dumps(value)
         return super().submit(
             _materialize_payload,
-            value,
+            payload,
             key=f"{key_prefix}-{uuid4().hex}",
             pure=False,
         )

--- a/src/integrations/prefect-dask/prefect_dask/client.py
+++ b/src/integrations/prefect-dask/prefect_dask/client.py
@@ -1,8 +1,7 @@
 import asyncio
-
-import cloudpickle
 from uuid import uuid4
 
+import cloudpickle
 from distributed import Client, Future
 
 from prefect.context import serialize_context

--- a/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
+++ b/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
@@ -9,26 +9,33 @@ from prefect_dask.client import PrefectDaskClient
 from prefect import flow, task
 
 
-def _count_prefect_tasks_in_scheduler_process(dask_scheduler) -> int:
+def _count_named_prefect_tasks_in_scheduler_process(dask_scheduler, task_names) -> int:
     import gc
 
     gc.collect()
+    names = set(task_names)
     return sum(
         1
         for obj in gc.get_objects()
-        if type(obj).__module__ == "prefect.tasks" and type(obj).__name__ == "Task"
+        if type(obj).__module__ == "prefect.tasks"
+        and type(obj).__name__ == "Task"
+        and getattr(obj, "name", None) in names
     )
 
 
 def test_scheduler_does_not_retain_prefect_tasks():
     with distributed.LocalCluster(dashboard_address=None) as cluster:
         task_runner = DaskTaskRunner(address=cluster.scheduler_address)
+        tracked_task_names = {
+            "scheduler-retention-make-range",
+            "scheduler-retention-identity",
+        }
 
-        @task
+        @task(name="scheduler-retention-make-range")
         def make_range(n: int) -> list[int]:
             return list(range(n))
 
-        @task
+        @task(name="scheduler-retention-identity")
         def identity(x: int) -> int:
             return x
 
@@ -38,12 +45,22 @@ def test_scheduler_does_not_retain_prefect_tasks():
             futures = identity.map(values)
             return [future.result() for future in futures]
 
+        with distributed.Client(cluster) as client:
+            assert (
+                client.run_on_scheduler(
+                    _count_named_prefect_tasks_in_scheduler_process,
+                    tracked_task_names,
+                )
+                == 0
+            )
+
         assert test_flow(10) == list(range(10))
 
         with distributed.Client(cluster) as client:
             for _ in range(20):
                 retained_prefect_tasks = client.run_on_scheduler(
-                    _count_prefect_tasks_in_scheduler_process
+                    _count_named_prefect_tasks_in_scheduler_process,
+                    tracked_task_names,
                 )
                 if retained_prefect_tasks == 0:
                     break

--- a/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
+++ b/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
@@ -1,0 +1,71 @@
+import distributed
+from prefect_dask import DaskTaskRunner
+
+from prefect import flow, task
+
+
+def _count_retained_prefect_tasks_in_dask_specs(dask_scheduler) -> int:
+    import gc
+
+    def is_prefect_task(obj) -> bool:
+        obj_type = type(obj)
+        return obj_type.__module__ == "prefect.tasks" and obj_type.__name__ == "Task"
+
+    def contains_prefect_task(obj) -> bool:
+        seen: set[int] = set()
+        stack = [obj]
+
+        while stack:
+            current = stack.pop()
+            current_id = id(current)
+            if current_id in seen:
+                continue
+            seen.add(current_id)
+
+            if is_prefect_task(current):
+                return True
+            elif isinstance(current, dict):
+                stack.extend(current.keys())
+                stack.extend(current.values())
+            elif isinstance(current, (list, tuple, set, frozenset)):
+                stack.extend(current)
+
+        return False
+
+    return sum(
+        1
+        for obj in gc.get_objects()
+        if type(obj).__module__ == "dask._task_spec"
+        and type(obj).__name__ == "Task"
+        and contains_prefect_task(
+            (getattr(obj, "args", ()), getattr(obj, "kwargs", {}))
+        )
+    )
+
+
+def test_scheduler_does_not_retain_prefect_tasks():
+    with distributed.LocalCluster(dashboard_address=None) as cluster:
+        task_runner = DaskTaskRunner(address=cluster.scheduler_address)
+
+        @task
+        def make_range(n: int) -> list[int]:
+            return list(range(n))
+
+        @task
+        def identity(x: int) -> int:
+            return x
+
+        @flow(task_runner=task_runner)
+        def test_flow(n: int):
+            values = make_range.submit(n)
+            futures = identity.map(values)
+            return [future.result() for future in futures]
+
+        assert test_flow(10) == list(range(10))
+
+        with distributed.Client(cluster) as client:
+            retained_prefect_tasks = client.run_on_scheduler(
+                _count_retained_prefect_tasks_in_dask_specs
+            )
+
+        assert retained_prefect_tasks == 0

--- a/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
+++ b/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
@@ -1,45 +1,22 @@
+import time
+from unittest.mock import MagicMock, patch
+
 import distributed
+import pytest
 from prefect_dask import DaskTaskRunner
+from prefect_dask.client import PrefectDaskClient
 
 from prefect import flow, task
 
 
-def _count_retained_prefect_tasks_in_dask_specs(dask_scheduler) -> int:
+def _count_prefect_tasks_in_scheduler_process(dask_scheduler) -> int:
     import gc
 
-    def is_prefect_task(obj) -> bool:
-        obj_type = type(obj)
-        return obj_type.__module__ == "prefect.tasks" and obj_type.__name__ == "Task"
-
-    def contains_prefect_task(obj) -> bool:
-        seen: set[int] = set()
-        stack = [obj]
-
-        while stack:
-            current = stack.pop()
-            current_id = id(current)
-            if current_id in seen:
-                continue
-            seen.add(current_id)
-
-            if is_prefect_task(current):
-                return True
-            elif isinstance(current, dict):
-                stack.extend(current.keys())
-                stack.extend(current.values())
-            elif isinstance(current, (list, tuple, set, frozenset)):
-                stack.extend(current)
-
-        return False
-
+    gc.collect()
     return sum(
         1
         for obj in gc.get_objects()
-        if type(obj).__module__ == "dask._task_spec"
-        and type(obj).__name__ == "Task"
-        and contains_prefect_task(
-            (getattr(obj, "args", ()), getattr(obj, "kwargs", {}))
-        )
+        if type(obj).__module__ == "prefect.tasks" and type(obj).__name__ == "Task"
     )
 
 
@@ -64,8 +41,56 @@ def test_scheduler_does_not_retain_prefect_tasks():
         assert test_flow(10) == list(range(10))
 
         with distributed.Client(cluster) as client:
-            retained_prefect_tasks = client.run_on_scheduler(
-                _count_retained_prefect_tasks_in_dask_specs
-            )
+            for _ in range(20):
+                retained_prefect_tasks = client.run_on_scheduler(
+                    _count_prefect_tasks_in_scheduler_process
+                )
+                if retained_prefect_tasks == 0:
+                    break
+                time.sleep(0.05)
 
         assert retained_prefect_tasks == 0
+
+
+def test_zero_worker_adaptive_cluster_can_run_prefect_task():
+    with distributed.LocalCluster(n_workers=0, dashboard_address=None) as cluster:
+        cluster.adapt(minimum=0, maximum=1)
+        task_runner = DaskTaskRunner(address=cluster.scheduler_address)
+
+        @task
+        def increment(value: int) -> int:
+            return value + 1
+
+        @flow(task_runner=task_runner)
+        def test_flow() -> int:
+            return increment.submit(1).result()
+
+        assert test_flow() == 2
+
+
+def test_payload_futures_are_released_when_run_submission_fails():
+    client = PrefectDaskClient.__new__(PrefectDaskClient)
+    task_future = MagicMock()
+    context_future = MagicMock()
+
+    @task
+    def noop() -> None:
+        return None
+
+    with (
+        patch.object(
+            PrefectDaskClient,
+            "_submit_payload",
+            side_effect=[task_future, context_future],
+        ),
+        patch.object(
+            PrefectDaskClient,
+            "_submit_prefect_run",
+            side_effect=RuntimeError("submission failed"),
+        ),
+        pytest.raises(RuntimeError, match="submission failed"),
+    ):
+        client.submit(noop, parameters={}, wait_for=[])
+
+    task_future.release.assert_called_once_with()
+    context_future.release.assert_called_once_with()

--- a/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
+++ b/src/integrations/prefect-dask/tests/test_scheduler_task_retention.py
@@ -9,7 +9,7 @@ from prefect_dask.client import PrefectDaskClient
 from prefect import flow, task
 
 
-def _count_named_prefect_tasks_in_scheduler_process(dask_scheduler, task_names) -> int:
+def _count_named_prefect_tasks_in_scheduler_process(task_names, dask_scheduler=None) -> int:
     import gc
 
     gc.collect()


### PR DESCRIPTION
Closes #21697.

This revives and revalidates the approach from the closed draft #21703 against current `main`. Credit to @zzstoatzz for the original investigation and patch direction.

## Problem

When `DaskTaskRunner` connects to an existing/shared Dask scheduler, historical Dask task specs can retain heavy Prefect `Task` objects and serialized per-run context. Repeated flow runs can therefore grow scheduler memory even after active tasks/groups are gone.

## Changes

- use a module-level runner function instead of creating a per-submit wrapper closure
- transport Prefect `Task` and serialized context as temporary Dask dependency futures instead of embedding them in every task spec
- avoid `scatter()` so zero-worker adaptive clusters can scale from submitted work
- avoid long-lived `id(task)` caching; direct submissions capture the current Task definition and `map()` shares a payload only within that map call
- release task/context payload futures on success and failure paths
- preserve generated Dask key prefixes based on the Prefect task name
- add regression coverage for scheduler retention, zero-worker adaptive clusters, and failed-submission cleanup

## Validation

Focused regression coverage is included in `src/integrations/prefect-dask/tests/test_scheduler_task_retention.py`. The initial automated review findings have been addressed and resolved; CI/repository review will provide final validation.