### PR TITLE
remove "todo additional fields" being rendered in create automation page

### DIFF
--- a/ui-v2/src/components/automations/automations-wizard/actions-step/select-deployments-fields.tsx
+++ b/ui-v2/src/components/automations/automations-wizard/actions-step/select-deployments-fields.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import type { DeploymentWithFlow } from "@/api/deployments";
 import { useListDeploymentsWithFlows } from "@/api/deployments/use-list-deployments-with-flows";
 import {
@@ -56,10 +56,6 @@ export const SelectDeploymentsFields = ({
 }: SelectDeploymentsFieldsProps) => {
 	const [search, setSearch] = useState("");
 	const form = useFormContext<AutomationWizardSchema>();
-	const actionType = form.watch(`actions.${index}.type`);
-	const deploymentId = useWatch<AutomationWizardSchema>({
-		name: `actions.${index}.deployment_id`,
-	});
 
 	const debouncedSearch = useDebounce(search, 500);
 	const { data } = useListDeploymentsWithFlows({
@@ -140,8 +136,6 @@ export const SelectDeploymentsFields = ({
 					);
 				}}
 			/>
-			{deploymentId !== INFER_OPTION.value &&
-				actionType === "run-deployment" && <div>TODO: Additional fields</div>}
 		</>
 	);
 };


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

The "TODO: Additional Fields" was being shown in /automations/create page.


**before**
<img width="701" height="453" alt="image" src="https://github.com/user-attachments/assets/89f4038a-120b-4d23-90f7-02f89a9de554" />

**after**
<img width="575" height="451" alt="image" src="https://github.com/user-attachments/assets/b707cb41-4c65-4617-803d-3ce6782d65a4" />


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
