### PR TITLE
Enhancement: allow transitioning to cancelling from paused

### DIFF
--- a/docs/v3/concepts/states.mdx
+++ b/docs/v3/concepts/states.mdx
@@ -191,6 +191,7 @@ flowchart TD
 
     Running --> |Manual pause| Paused
     Paused --> |Resume| Running
+    Paused --> |User cancels| Cancelling
     
     Cancelling -.-> |Cleanup complete| Cancelled
 

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1431,7 +1431,14 @@ class HandlePausingFlows(FlowRunOrchestrationRule):
 
 class HandleResumingPausedFlows(FlowRunOrchestrationRule):
     """
-    Governs runs attempting to leave a Paused state
+    Governs runs attempting to leave a Paused state.
+
+    A paused run may resume (Running), be rescheduled (Scheduled), be
+    cancelled (Cancelling), or be written directly into a terminal state.
+    Every other exit is rejected. Suspended runs never reach this rule with a
+    Cancelling proposal: `BypassCancellingFlowRunsWithNoInfra` runs earlier
+    and rewrites their cancel to Cancelled, because they have no process to
+    tear down.
     """
 
     FROM_STATES = {StateType.PAUSED}
@@ -1451,6 +1458,7 @@ class HandleResumingPausedFlows(FlowRunOrchestrationRule):
             and (
                 proposed_state.is_running()
                 or proposed_state.is_scheduled()
+                or proposed_state.is_cancelling()
                 or proposed_state.is_final()
             )
         ):

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1432,13 +1432,6 @@ class HandlePausingFlows(FlowRunOrchestrationRule):
 class HandleResumingPausedFlows(FlowRunOrchestrationRule):
     """
     Governs runs attempting to leave a Paused state.
-
-    A paused run may resume (Running), be rescheduled (Scheduled), be
-    cancelled (Cancelling), or be written directly into a terminal state.
-    Every other exit is rejected. Suspended runs never reach this rule with a
-    Cancelling proposal: `BypassCancellingFlowRunsWithNoInfra` runs earlier
-    and rewrites their cancel to Cancelled, because they have no process to
-    tear down.
     """
 
     FROM_STATES = {StateType.PAUSED}

--- a/tests/server/orchestration/api/test_flow_runs.py
+++ b/tests/server/orchestration/api/test_flow_runs.py
@@ -1860,6 +1860,70 @@ class TestSetFlowRunState:
         assert run.state.type == StateType.RUNNING
         assert run.state.name == "Test State"
 
+    async def test_cancelling_a_paused_flow_run_is_accepted(
+        self, flow, client, session
+    ):
+        """A blocking pause keeps its process alive, so a user cancel goes
+        through Cancelling the same way it does for a running flow run."""
+        flow_run = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id,
+                flow_version="1.0",
+                state=schemas.states.Paused(timeout_seconds=300),
+            ),
+        )
+        await session.commit()
+
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(state=dict(type="CANCELLING", name="Cancelling")),
+        )
+        assert response.status_code == 201, response.text
+
+        api_response = OrchestrationResult.model_validate(response.json())
+        assert api_response.status == responses.SetStateStatus.ACCEPT
+        assert api_response.state.type == StateType.CANCELLING
+
+        flow_run_id = flow_run.id
+        session.expire(flow_run)
+        run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert run.state.type == StateType.CANCELLING
+
+    async def test_cancelling_a_suspended_flow_run_writes_cancelled(
+        self, flow, client, session
+    ):
+        """A suspended run has no process to tear down. The bypass rule runs
+        before the pause rule and turns the cancel into Cancelled."""
+        flow_run = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id,
+                flow_version="1.0",
+                state=schemas.states.Suspended(timeout_seconds=300),
+            ),
+        )
+        await session.commit()
+
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(state=dict(type="CANCELLING", name="Cancelling")),
+        )
+        assert response.status_code == 201, response.text
+
+        api_response = OrchestrationResult.model_validate(response.json())
+        assert api_response.status == responses.SetStateStatus.REJECT
+        assert api_response.state.type == StateType.CANCELLED
+
+        flow_run_id = flow_run.id
+        session.expire(flow_run)
+        run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert run.state.type == StateType.CANCELLED
+
     async def test_set_flow_run_state_allows_cancelling_when_timeout_schedule_fails(
         self,
         app: FastAPI,

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -3264,6 +3264,7 @@ class TestResumingFlows:
             states.StateType.FAILED,
             states.StateType.CRASHED,
             states.StateType.CANCELLED,
+            states.StateType.CANCELLING,
         ]
 
         if proposed_state_type in permitted_resuming_states:
@@ -3324,6 +3325,32 @@ class TestResumingFlows:
             await ctx.validate_proposed_state()
 
         assert ctx.response_status == SetStateStatus.ACCEPT
+
+    async def test_allows_cancelling_a_paused_flow_run(
+        self,
+        session,
+        initialize_orchestration,
+    ):
+        """A blocking pause keeps the flow process alive, so a user cancel
+        must reach Cancelling for the worker to tear that process down."""
+        initial_state_type = states.StateType.PAUSED
+        proposed_state_type = states.StateType.CANCELLING
+        intended_transition = (initial_state_type, proposed_state_type)
+        ctx = await initialize_orchestration(
+            session,
+            "flow",
+            *intended_transition,
+        )
+        the_future = now("UTC") + timedelta(minutes=5)
+        ctx.initial_state.state_details = states.StateDetails(pause_timeout=the_future)
+
+        state_protection = HandleResumingPausedFlows(ctx, *intended_transition)
+
+        async with state_protection as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.ACCEPT
+        assert ctx.validated_state_type == states.StateType.CANCELLING
 
     async def test_marks_flow_run_as_resuming_upon_leaving_paused_state(
         self,


### PR DESCRIPTION
Updates the `HandleResumingPausedFlows` orchestration rule to allow transitioning to `Cancelling` from `Paused`.