### PR TITLE
Allow flow names with surrounding whitespace to complete

### DIFF
--- a/src/prefect/client/attribution.py
+++ b/src/prefect/client/attribution.py
@@ -67,4 +67,10 @@ def get_attribution_headers() -> dict[str, str]:
         if deployment_name := os.environ.get("PREFECT__DEPLOYMENT_NAME"):
             headers["X-Prefect-Deployment-Name"] = deployment_name
 
-    return headers
+    # HTTP header values cannot start or end with spaces or tabs. Normalize only
+    # the attribution values, leaving the actual flow/deployment/worker names intact.
+    return {
+        name: stripped
+        for name, value in headers.items()
+        if (stripped := value.strip(" \t"))
+    }

--- a/tests/client/test_attribution.py
+++ b/tests/client/test_attribution.py
@@ -17,8 +17,6 @@ from prefect.client.attribution import get_attribution_headers
 from prefect.client.base import PrefectHttpxAsyncClient, PrefectHttpxSyncClient
 from prefect.settings import PREFECT_CLIENT_MAX_RETRIES, temporary_settings
 
-pytestmark = pytest.mark.clear_db
-
 RESPONSE_200 = Response(
     status.HTTP_200_OK,
     request=Request("a test request", "fake.url/fake/route"),
@@ -319,6 +317,7 @@ class TestSyncClientAttributionHeaders:
 def test_environment_attribution_whitespace(
     monkeypatch: pytest.MonkeyPatch, kind: str, name: str, expected: str | None
 ):
+    """Normalize optional header values without changing the source environment."""
     monkeypatch.setenv(f"PREFECT__{kind}_NAME", name)
     headers = get_attribution_headers()
     header = f"X-Prefect-{kind.title()}-Name"
@@ -332,6 +331,8 @@ def test_environment_attribution_whitespace(
 @pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.parametrize("name", ["my flow ", " my flow", "\t my flow \t", " \t "])
 def test_flow_with_surrounding_whitespace_completes(name: str, is_async: bool):
+    """Accepted flow names must not prevent terminal state reporting over HTTP."""
+
     def sync_body() -> str:
         return "done"
 

--- a/tests/client/test_attribution.py
+++ b/tests/client/test_attribution.py
@@ -2,6 +2,7 @@
 Tests for attribution headers functionality.
 """
 
+import asyncio
 import os
 from unittest import mock
 from uuid import uuid4
@@ -10,9 +11,11 @@ import httpx
 import pytest
 from httpx import Request, Response
 
+from prefect import flow
 from prefect._internal.compatibility.starlette import status
 from prefect.client.attribution import get_attribution_headers
 from prefect.client.base import PrefectHttpxAsyncClient, PrefectHttpxSyncClient
+from prefect.settings import PREFECT_CLIENT_MAX_RETRIES, temporary_settings
 
 pytestmark = pytest.mark.clear_db
 
@@ -301,3 +304,50 @@ class TestSyncClientAttributionHeaders:
                 assert request.headers["X-Prefect-Worker-Name"] == worker_name
                 assert request.headers["X-Prefect-Flow-Id"] == flow_id
                 assert request.headers["X-Prefect-Flow-Name"] == flow_name
+
+
+@pytest.mark.parametrize("kind", ["FLOW", "DEPLOYMENT", "WORKER"])
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("my flow ", "my flow"),
+        (" my flow", "my flow"),
+        ("\t my flow \t", "my flow"),
+        (" \t ", None),
+    ],
+)
+def test_environment_attribution_whitespace(
+    monkeypatch: pytest.MonkeyPatch, kind: str, name: str, expected: str | None
+):
+    monkeypatch.setenv(f"PREFECT__{kind}_NAME", name)
+    headers = get_attribution_headers()
+    header = f"X-Prefect-{kind.title()}-Name"
+    if expected is None:
+        assert header not in headers
+    else:
+        assert headers[header] == expected
+    assert os.environ[f"PREFECT__{kind}_NAME"] == name
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("name", ["my flow ", " my flow", "\t my flow \t", " \t "])
+def test_flow_with_surrounding_whitespace_completes(name: str, is_async: bool):
+    def sync_body() -> str:
+        return "done"
+
+    async def async_body() -> str:
+        return "done"
+
+    # Use the hosted API so real HTTP serialization validates the headers.
+    # In-process ASGI transports do not reject leading/trailing whitespace.
+    with temporary_settings({PREFECT_CLIENT_MAX_RETRIES: 0}):
+        if is_async:
+            example = flow(name=name)(async_body)
+            state = asyncio.run(example(return_state=True))
+        else:
+            example = flow(name=name)(sync_body)
+            state = example(return_state=True)
+
+    assert state.is_completed()
+    assert state.result() == "done"
+    assert example.name == name


### PR DESCRIPTION
A flow name with a leading or trailing space can prevent final-state reporting and leave the run in `Running`. This PR trims spaces and tabs from optional attribution headers so these flows complete, while preserving their names.

Values that become empty are omitted. The same normalization serves sync and async clients, including environment-sourced flow, deployment, and worker attribution.

<details>
<summary>Validation and contribution checklist</summary>

The regression tests exercise real HTTP serialization and flow completion, without mocking orchestration. They cover sync and async flows, surrounding spaces and tabs, and whitespace-only names. All 34 attribution tests pass. Repository hooks pass.

The test file also passes without database clearing, so its unnecessary `clear_db` marker is removed per `tests/AGENTS.md`.

- [ ] This pull request references any related issue by including "closes `<link to issue>`". No matching issue was found; this is a small fix.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue. Not applicable.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed. This restores accepted flow names; no configuration or usage change requires documentation.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`. Not applicable.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

</details>

<details>
<summary>Session context</summary>

An async flow called through `asyncio.run` reproduced the reported `LocalProtocolError` after its body completed. Removing the trailing space avoided the failure. The regression tests failed before the fix, and the original reproduction completes after it. Attribution headers were introduced in [#20508](https://github.com/PrefectHQ/prefect/pull/20508).

</details>

generated with Codex (GPT-6)
