### PR TITLE
Warn when a task run outlives its timeout

### DIFF
--- a/docs/v3/how-to-guides/workflows/write-and-run.mdx
+++ b/docs/v3/how-to-guides/workflows/write-and-run.mdx
@@ -126,6 +126,10 @@ Task timeouts work differently depending on how the task is executed:
 
 **Sync tasks via `.submit()` with ThreadPoolTaskRunner**: When a sync task is submitted using to a `ThreadPoolTaskRunner` (the default), it runs in a worker thread. In this context, timeouts **cannot interrupt blocking operations** like `time.sleep()`, network requests, or file I/O. The timeout will only take effect after the blocking operation completes naturally.
 
+A task is also on a worker thread when it is called from inside another submitted or mapped task, even if the inner task is called directly.
+
+When a task run passes its timeout and is still running, Prefect logs a warning to the task run logger. The run continues until its blocking operation finishes and is only then marked `TimedOut`, so this warning is the first indication that the timeout was exceeded.
+
 <Warning>
 If you need reliable timeout behavior for sync tasks that perform blocking operations, consider:
 1. Using `ProcessPoolTaskRunner` instead of the default `ThreadPoolTaskRunner`

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -129,6 +129,10 @@ R = TypeVar("R")
 
 BACKOFF_MAX = 10
 
+# Grace period before warning that a run has outlived its timeout, so an enforced
+# timeout can unwind the run first rather than race the watchdog into a warning
+TIMEOUT_WATCHDOG_GRACE_SECONDS = 0.5
+
 
 def _create_task_run_locally(
     task: "Task[Any, Any]",
@@ -267,6 +271,47 @@ class BaseTaskRunEngine(Generic[P, R]):
         ):
             return self.context["cancel_event"].is_set()
         return False
+
+    def _warn_timeout_exceeded(self) -> None:
+        """Report a run that is still going after its timeout has elapsed."""
+        try:
+            self.logger.warning(
+                "Task run has exceeded its timeout of %s second(s) but is still "
+                "running. The timeout could not interrupt the operation in progress; "
+                "the run will continue until it finishes on its own and only then be "
+                "marked `TimedOut`. Blocking operations like `time.sleep()`, network "
+                "requests, or file I/O cannot be interrupted. See "
+                "https://docs.prefect.io/v3/how-to-guides/workflows/"
+                "write-and-run#task-timeout-behavior for more information.",
+                self.task.timeout_seconds,
+            )
+        except Exception:  # pragma: no cover
+            # Advisory only, and raised on a watchdog thread where nothing would catch
+            # it; log shipping fails here for a run with no flow run to attach to
+            pass
+
+    @contextmanager
+    def timeout_watchdog(self) -> Generator[None, None, None]:
+        """
+        Warn if the run outlives its timeout.
+
+        A timeout cannot interrupt a run blocked in a syscall, so the run overruns its
+        deadline and is only marked `TimedOut` once that call returns on its own.
+        """
+        watchdog: Optional[threading.Timer] = None
+        if self.task.timeout_seconds is not None:
+            watchdog = threading.Timer(
+                self.task.timeout_seconds + TIMEOUT_WATCHDOG_GRACE_SECONDS,
+                self._warn_timeout_exceeded,
+            )
+            watchdog.daemon = True
+            watchdog.start()
+
+        try:
+            yield
+        finally:
+            if watchdog is not None:
+                watchdog.cancel()
 
     def compute_transaction_key(self) -> Optional[str]:
         key: Optional[str] = None
@@ -990,7 +1035,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     @contextmanager
     def run_context(self):
         # reenter the run context to ensure it is up to date for every run
-        with self.setup_run_context():
+        with self.setup_run_context(), self.timeout_watchdog():
             try:
                 # Warn if timeout is set but we're not on the main thread
                 if (
@@ -1621,22 +1666,25 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     async def run_context(self):
         # reenter the run context to ensure it is up to date for every run
         async with self.setup_run_context():
-            try:
-                with timeout_async(
-                    seconds=self.task.timeout_seconds,
-                    timeout_exc_type=TaskRunTimeoutError,
-                ):
-                    self.logger.debug(
-                        f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
-                    )
-                    if self.is_cancelled():
-                        raise CancelledError("Task run cancelled by the task runner")
+            with self.timeout_watchdog():
+                try:
+                    with timeout_async(
+                        seconds=self.task.timeout_seconds,
+                        timeout_exc_type=TaskRunTimeoutError,
+                    ):
+                        self.logger.debug(
+                            f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
+                        )
+                        if self.is_cancelled():
+                            raise CancelledError(
+                                "Task run cancelled by the task runner"
+                            )
 
-                    yield self
-            except TimeoutError as exc:
-                await self.handle_timeout(exc)
-            except Exception as exc:
-                await self.handle_exception(exc)
+                        yield self
+                except TimeoutError as exc:
+                    await self.handle_timeout(exc)
+                except Exception as exc:
+                    await self.handle_exception(exc)
 
     async def call_task_fn(
         self, transaction: AsyncTransaction

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -300,12 +300,18 @@ class BaseTaskRunEngine(Generic[P, R]):
         """
         watchdog: Optional[threading.Timer] = None
         if self.task.timeout_seconds is not None:
-            watchdog = threading.Timer(
-                self.task.timeout_seconds + TIMEOUT_WATCHDOG_GRACE_SECONDS,
-                self._warn_timeout_exceeded,
-            )
-            watchdog.daemon = True
-            watchdog.start()
+            try:
+                watchdog = threading.Timer(
+                    self.task.timeout_seconds + TIMEOUT_WATCHDOG_GRACE_SECONDS,
+                    self._warn_timeout_exceeded,
+                )
+                watchdog.daemon = True
+                watchdog.start()
+            except Exception:
+                # The warning is advisory, so a run that cannot spare a thread for it
+                # goes without rather than failing. `start` raises once the process
+                # cannot allocate more, which a wide enough mapped run can reach.
+                watchdog = None
 
         try:
             yield
@@ -1035,7 +1041,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     @contextmanager
     def run_context(self):
         # reenter the run context to ensure it is up to date for every run
-        with self.setup_run_context(), self.timeout_watchdog():
+        with self.setup_run_context():
             try:
                 # Warn if timeout is set but we're not on the main thread
                 if (
@@ -1053,9 +1059,16 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                         "write-and-run#task-timeout-behavior for more information.",
                         self.task.timeout_seconds,
                     )
-                with timeout(
-                    seconds=self.task.timeout_seconds,
-                    timeout_exc_type=TaskRunTimeoutError,
+                # The watchdog is entered outside the timeout scope so that it is
+                # disarmed the moment execution leaves it, before `handle_timeout`
+                # evaluates retry conditions. An enforced timeout has already
+                # interrupted the run by then and there is no overrun to report.
+                with (
+                    self.timeout_watchdog(),
+                    timeout(
+                        seconds=self.task.timeout_seconds,
+                        timeout_exc_type=TaskRunTimeoutError,
+                    ),
                 ):
                     self.logger.debug(
                         f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
@@ -1666,25 +1679,29 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     async def run_context(self):
         # reenter the run context to ensure it is up to date for every run
         async with self.setup_run_context():
-            with self.timeout_watchdog():
-                try:
-                    with timeout_async(
+            try:
+                # The watchdog is entered outside the timeout scope so that it is
+                # disarmed the moment execution leaves it, before `handle_timeout`
+                # evaluates retry conditions. An enforced timeout has already
+                # interrupted the run by then and there is no overrun to report.
+                with (
+                    self.timeout_watchdog(),
+                    timeout_async(
                         seconds=self.task.timeout_seconds,
                         timeout_exc_type=TaskRunTimeoutError,
-                    ):
-                        self.logger.debug(
-                            f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
-                        )
-                        if self.is_cancelled():
-                            raise CancelledError(
-                                "Task run cancelled by the task runner"
-                            )
+                    ),
+                ):
+                    self.logger.debug(
+                        f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
+                    )
+                    if self.is_cancelled():
+                        raise CancelledError("Task run cancelled by the task runner")
 
-                        yield self
-                except TimeoutError as exc:
-                    await self.handle_timeout(exc)
-                except Exception as exc:
-                    await self.handle_exception(exc)
+                    yield self
+            except TimeoutError as exc:
+                await self.handle_timeout(exc)
+            except Exception as exc:
+                await self.handle_exception(exc)
 
     async def call_task_fn(
         self, transaction: AsyncTransaction

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -2092,15 +2092,94 @@ class TestSyncTaskTimeoutWarning:
         assert result == "result"
 
 
+class TestTaskTimeoutWatchdog:
+    """Tests for the watchdog itself, without racing a real deadline."""
+
+    def test_arms_a_timer_for_the_deadline_plus_grace(self):
+        """Test that the watchdog arms for the deadline and disarms on exit."""
+
+        @task(timeout_seconds=30)
+        def timed_task():
+            return "result"
+
+        engine = SyncTaskRunEngine(task=timed_task)
+
+        with mock.patch("threading.Timer") as timer_cls:
+            with engine.timeout_watchdog():
+                timer_cls.assert_called_once_with(
+                    30 + TIMEOUT_WATCHDOG_GRACE_SECONDS,
+                    engine._warn_timeout_exceeded,
+                )
+                timer_cls.return_value.start.assert_called_once()
+                timer_cls.return_value.cancel.assert_not_called()
+
+            timer_cls.return_value.cancel.assert_called_once()
+
+    def test_does_not_arm_when_the_task_has_no_timeout(self):
+        """Test that a task without a timeout gets no watchdog thread."""
+
+        @task
+        def untimed_task():
+            return "result"
+
+        engine = SyncTaskRunEngine(task=untimed_task)
+
+        with mock.patch("threading.Timer") as timer_cls:
+            with engine.timeout_watchdog():
+                pass
+
+            timer_cls.assert_not_called()
+
+    def test_run_survives_a_watchdog_thread_that_cannot_start(self):
+        """Test that a run continues when no thread is available for the warning.
+
+        A wide enough mapped run can exhaust the process's threads. The warning is
+        advisory, so failing to arm it must not take the run down with it.
+        """
+
+        @task(timeout_seconds=30)
+        def timed_task():
+            return "result"
+
+        engine = SyncTaskRunEngine(task=timed_task)
+
+        with mock.patch("threading.Timer") as timer_cls:
+            timer_cls.return_value.start.side_effect = RuntimeError(
+                "can't start new thread"
+            )
+
+            with engine.timeout_watchdog():
+                pass
+
+            # Nothing to cancel, since the timer never started
+            timer_cls.return_value.cancel.assert_not_called()
+
+    def test_warning_names_the_configured_timeout(self, caplog):
+        """Test that the warning reports the timeout the task was given."""
+
+        @task(timeout_seconds=30)
+        def timed_task():
+            return "result"
+
+        engine = SyncTaskRunEngine(task=timed_task)
+
+        with caplog.at_level(logging.WARNING):
+            engine._warn_timeout_exceeded()
+
+        assert (
+            "exceeded its timeout of 30.0 second(s) but is still running" in caplog.text
+        )
+
+
 class TestTaskTimeoutExceededWarning:
-    """Tests for the warning emitted when a run outlives its timeout."""
+    """Tests for the warning reaching a run that actually outlives its timeout."""
 
     def test_warning_emitted_when_run_outlives_its_timeout(self, caplog):
         """Test that a warning is emitted while the run is still overrunning."""
 
         @task(timeout_seconds=0.1)
         def blocking_task():
-            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 2)
             return "result"
 
         @flow
@@ -2118,45 +2197,6 @@ class TestTaskTimeoutExceededWarning:
             for record in caplog.records
         )
 
-    def test_no_warning_when_run_finishes_within_its_timeout(self, caplog):
-        """Test that no warning is emitted when the run stays inside its timeout."""
-
-        @task(timeout_seconds=10)
-        def quick_task():
-            return "result"
-
-        @flow
-        def my_flow():
-            return quick_task.submit().result()
-
-        with caplog.at_level(logging.WARNING):
-            result = my_flow()
-
-        assert not any(
-            "but is still running" in record.message for record in caplog.records
-        )
-        assert result == "result"
-
-    def test_no_warning_when_task_has_no_timeout(self, caplog):
-        """Test that no warning is emitted when the task sets no timeout."""
-
-        @task
-        def blocking_task():
-            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
-            return "result"
-
-        @flow
-        def my_flow():
-            return blocking_task.submit().result()
-
-        with caplog.at_level(logging.WARNING):
-            result = my_flow()
-
-        assert not any(
-            "but is still running" in record.message for record in caplog.records
-        )
-        assert result == "result"
-
     async def test_warning_emitted_for_async_run_that_blocks_past_its_timeout(
         self, caplog
     ):
@@ -2165,7 +2205,7 @@ class TestTaskTimeoutExceededWarning:
         @task(timeout_seconds=0.1)
         async def blocking_async_task():
             # Blocks the event loop, so there is no await point to cancel at
-            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 2)
             return "result"
 
         @flow
@@ -2181,6 +2221,25 @@ class TestTaskTimeoutExceededWarning:
             for record in caplog.records
         )
 
+    def test_no_warning_when_run_finishes_within_its_timeout(self, caplog):
+        """Test that no warning is emitted when the run stays inside its timeout."""
+
+        @task(timeout_seconds=30)
+        def quick_task():
+            return "result"
+
+        @flow
+        def my_flow():
+            return quick_task.submit().result()
+
+        with caplog.at_level(logging.WARNING):
+            result = my_flow()
+
+        assert not any(
+            "but is still running" in record.message for record in caplog.records
+        )
+        assert result == "result"
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="Timeouts are not enforced on Windows, so the run never reaches TimedOut",
@@ -2190,7 +2249,7 @@ class TestTaskTimeoutExceededWarning:
 
         @task(timeout_seconds=0.1)
         def blocking_task():
-            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 2)
             return "result"
 
         @flow

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -2240,6 +2240,24 @@ class TestTaskTimeoutExceededWarning:
         )
         assert result == "result"
 
+    def test_watchdog_does_not_alter_an_ordinary_failure(self):
+        """Test that a run failing for its own reasons resolves with a watchdog armed."""
+
+        @task(timeout_seconds=30)
+        def failing_task():
+            raise ValueError("boom")
+
+        @flow
+        def my_flow():
+            future = failing_task.submit()
+            future.wait()
+            return future.state.name, future.state.is_failed()
+
+        state_name, is_failed = my_flow()
+
+        assert is_failed
+        assert state_name == "Failed"
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="Timeouts are not enforced on Windows, so the run never reaches TimedOut",
@@ -2255,15 +2273,17 @@ class TestTaskTimeoutExceededWarning:
         @flow
         def my_flow():
             future = blocking_task.submit()
-            # `wait` resolves the future without returning the state
+            # `wait` resolves the future without returning the state. Returning the
+            # state itself would make the flow adopt it and fail its own run, so
+            # report it as plain data instead.
             future.wait()
-            return future.state
+            return future.state.name, future.state.is_failed()
 
         with caplog.at_level(logging.WARNING):
-            state = my_flow()
+            state_name, is_failed = my_flow()
 
-        assert state.is_failed()
-        assert state.name == "TimedOut"
+        assert is_failed
+        assert state_name == "TimedOut"
 
 
 class TestPersistence:

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import logging
 import os
 import random
+import sys
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -47,6 +48,7 @@ from prefect.states import (
     Suspended,
 )
 from prefect.task_engine import (
+    TIMEOUT_WATCHDOG_GRACE_SECONDS,
     AsyncTaskRunEngine,
     SyncTaskRunEngine,
     run_task_async,
@@ -2088,6 +2090,118 @@ class TestSyncTaskTimeoutWarning:
             "running in a worker thread" in record.message for record in caplog.records
         )
         assert result == "result"
+
+
+class TestTaskTimeoutExceededWarning:
+    """Tests for the warning emitted when a run outlives its timeout."""
+
+    def test_warning_emitted_when_run_outlives_its_timeout(self, caplog):
+        """Test that a warning is emitted while the run is still overrunning."""
+
+        @task(timeout_seconds=0.1)
+        def blocking_task():
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            return "result"
+
+        @flow
+        def my_flow():
+            # Submit runs the task in a worker thread, where the timeout cannot
+            # interrupt a blocking call
+            return blocking_task.submit().result(raise_on_failure=False)
+
+        with caplog.at_level(logging.WARNING):
+            my_flow()
+
+        assert any(
+            "exceeded its timeout of 0.1 second(s) but is still running"
+            in record.message
+            for record in caplog.records
+        )
+
+    def test_no_warning_when_run_finishes_within_its_timeout(self, caplog):
+        """Test that no warning is emitted when the run stays inside its timeout."""
+
+        @task(timeout_seconds=10)
+        def quick_task():
+            return "result"
+
+        @flow
+        def my_flow():
+            return quick_task.submit().result()
+
+        with caplog.at_level(logging.WARNING):
+            result = my_flow()
+
+        assert not any(
+            "but is still running" in record.message for record in caplog.records
+        )
+        assert result == "result"
+
+    def test_no_warning_when_task_has_no_timeout(self, caplog):
+        """Test that no warning is emitted when the task sets no timeout."""
+
+        @task
+        def blocking_task():
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            return "result"
+
+        @flow
+        def my_flow():
+            return blocking_task.submit().result()
+
+        with caplog.at_level(logging.WARNING):
+            result = my_flow()
+
+        assert not any(
+            "but is still running" in record.message for record in caplog.records
+        )
+        assert result == "result"
+
+    async def test_warning_emitted_for_async_run_that_blocks_past_its_timeout(
+        self, caplog
+    ):
+        """Test that an async run blocking the event loop is warned about too."""
+
+        @task(timeout_seconds=0.1)
+        async def blocking_async_task():
+            # Blocks the event loop, so there is no await point to cancel at
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            return "result"
+
+        @flow
+        async def my_flow():
+            return await blocking_async_task(return_state=True)
+
+        with caplog.at_level(logging.WARNING):
+            await my_flow()
+
+        assert any(
+            "exceeded its timeout of 0.1 second(s) but is still running"
+            in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Timeouts are not enforced on Windows, so the run never reaches TimedOut",
+    )
+    def test_warning_does_not_change_terminal_state(self, caplog):
+        """Test that the watchdog reports without altering how the run resolves."""
+
+        @task(timeout_seconds=0.1)
+        def blocking_task():
+            time.sleep(TIMEOUT_WATCHDOG_GRACE_SECONDS + 1)
+            return "result"
+
+        @flow
+        def my_flow():
+            return blocking_task.submit().wait()
+
+        with caplog.at_level(logging.WARNING):
+            state = my_flow()
+
+        assert state.is_failed()
+        assert state.name == "TimedOut"
 
 
 class TestPersistence:

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -2254,7 +2254,10 @@ class TestTaskTimeoutExceededWarning:
 
         @flow
         def my_flow():
-            return blocking_task.submit().wait()
+            future = blocking_task.submit()
+            # `wait` resolves the future without returning the state
+            future.wait()
+            return future.state
 
         with caplog.at_level(logging.WARNING):
             state = my_flow()


### PR DESCRIPTION
refs [#18542](https://github.com/PrefectHQ/prefect/issues/18542)

A task with a 4 hour timeout ran over 9 hours before landing in `TimedOut`. A timeout can't interrupt a task blocked in a sleep, a network call, or file I/O, so the run continues past its deadline and nothing is reported until it ends.

Prefect already notices the deadline on time. `WatcherThreadCancelScope._timeout_enforcer` logs it the moment it elapses, but at `DEBUG` on the internal concurrency logger, which defaults to `ERROR`. This warns on the task run logger instead, so you find out at hour 4 rather than hour 9.

**It reports the overrun, it doesn't stop it.** You can't interrupt a thread blocked in a syscall. Use `ProcessPoolTaskRunner` or an async task if you need a timeout that can interrupt.

`BaseTaskRunEngine.timeout_watchdog()` starts a daemon `threading.Timer` for `timeout_seconds + 0.5s` and cancels it when the run context exits. The grace keeps an enforced timeout, which unwinds at almost exactly the deadline, from racing the watchdog into a spurious warning. It's on the base class so the sync and async engines stay in lockstep.

Repro is a `timeout_seconds=3` task called from inside a `.map()`'d task, sleeping 10s. Before, nothing happens between 3s and 10s. After:

```
13:59:08.557 | WARNING | Task run 'timeout_task-9b0' - Task run has exceeded its timeout of 3.0
                         second(s) but is still running. The timeout could not interrupt the
                         operation in progress...
```

Five tests in `TestTaskTimeoutExceededWarning`. Developed on Windows, where `cancel_sync_after` returns a `NullCancelScope` and timeouts aren't enforced at all, so one test is skipped there and I haven't exercised the enforced-timeout paths locally.

Docs updated, including a note that a task called from inside a submitted or mapped task is on a worker thread too. That's how the directly called task in #18542 ends up without an interruptible timeout, despite the docs saying direct calls run on the main thread.

Not here: releasing dependents at the deadline (they currently wait out the whole overrun, then land in `NotReady`), and emitting an event so automations can act rather than needing someone to read logs. Both need decisions I'd rather not assume. Happy to open issues if wanted.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - Uses `refs`, not `closes`. This doesn't resolve #18542: the task still runs past its deadline, it's only reported while doing so.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
