### PR TITLE
docs: document the automation action template context

### DIFF
--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -137,19 +137,84 @@ Templated variables enable you to dynamically include details from an automation
 
 Jinja templated variable syntax wraps the variable name in double curly brackets, like this: `{{ variable }}`.
 
-You can access properties of the underlying flow run objects including:
+### Always-available variables
 
-- [flow_run](https://reference.prefect.io/prefect/server/schemas/core/#prefect.server.schemas.core.FlowRun)
-- [flow](https://reference.prefect.io/prefect/server/schemas/core/#prefect.server.schemas.core.Flow)
-- [deployment](https://reference.prefect.io/prefect/server/schemas/core/#prefect.server.schemas.core.Deployment)
-- [work_queue](https://reference.prefect.io/prefect/server/schemas/core/#prefect.server.schemas.core.WorkQueue)
-- [work_pool](https://reference.prefect.io/prefect/server/schemas/core/#prefect.server.schemas.core.WorkPool)
+These variables describe the automation and the event that triggered it. They are present in
+every action template:
 
-In addition to its native properties, each object includes an `id` along with `created` and `updated` timestamps.
+| Variable | What it is |
+| --- | --- |
+| `automation` | The automation that fired, including `name`, `description`, `trigger`, and `actions`. |
+| `event` | The event that triggered the action. For reactive triggers this is the matching event; for proactive triggers it is the last event that matched the automation, and it may be empty. |
+| `labels` | The subset of event labels named by the trigger's `for_each`, accessible by attribute — for example `{{ labels.prefect.resource.id }}`. Empty when the trigger has no `for_each`. |
+| `firing` | The firing of the trigger that prompted this action, including `trigger`, `triggered`, and `triggering_labels`. |
+| `firings` | All firings that contributed to this action — more than one for compound and sequence triggers. |
+| `events` | All events that contributed to this action, in the same situations as `firings`. |
 
-The `flow_run|ui_url` token returns the URL to view the flow run in the UI.
+### Objects loaded from the API
 
-Use `{{ value | tojson }}` to serialize any template variable to a JSON string. The filter handles Pydantic model objects such as `flow_run`, `deployment`, and `event` directly — for example, `{{ flow_run | tojson(indent=2) }}` renders the full flow run as formatted JSON. The optional `indent` argument controls pretty-printing.
+The following variables are convenience shortcuts. When the name appears in a template, Prefect
+looks for a matching resource on the triggering event and fetches a fresh copy of that object from
+the API when it renders the action:
+
+| Variable | Object | Loaded when the event references |
+| --- | --- | --- |
+| `flow_run` | Flow run, including its `state` | `prefect.flow-run.<id>` |
+| `flow` | Flow | `prefect.flow.<id>` |
+| `deployment` | Deployment | `prefect.deployment.<id>` |
+| `task_run` | Task run, including its `state` | `prefect.task-run.<id>` |
+| `work_queue` | Work queue, including its `status` | `prefect.work-queue.<id>` |
+| `work_pool` | Work pool | `prefect.work-pool.<id>` |
+| `concurrency_limit` | Global concurrency limit | `prefect.concurrency-limit.<id>` |
+| `variables` | A dictionary of all [variables](/v3/concepts/variables) in the workspace, for example `{{ variables.my_variable }}` | n/a — always loaded when referenced |
+
+In addition to its native properties, each object includes an `id` along with `created` and
+`updated` timestamps.
+
+Because the objects are read at render time, they reflect the current state of the object rather
+than its state when the event occurred. The one exception is `state` on `flow_run` and `task_run`,
+which Prefect rebuilds from the triggering event so a notification reports the state that actually
+fired the automation.
+
+<Note>
+Undefined values render as an empty string instead of raising an error, and attribute access on
+them chains safely. If the triggering event has no deployment, `{{ deployment.name }}` renders
+nothing rather than failing the action — so an unexpectedly empty notification usually means the
+object was not available on the event, not that the property is wrong.
+</Note>
+
+### Filters
+
+Standard Jinja [filters](https://jinja.palletsprojects.com/en/stable/templates/#builtin-filters)
+are available, along with the human-friendly date and time filters from the
+[`jinja2-humanize-extension` package](https://pypi.org/project/jinja2-humanize-extension/) (for
+example `{{ event.occurred | humanize_naturaltime }}`) and these Prefect-specific filters:
+
+| Filter | Result |
+| --- | --- |
+| `tojson` | Serializes any template value to a JSON string, including Pydantic objects such as `flow_run`, `deployment`, and `event`. The optional `indent` argument pretty-prints: `{{ flow_run | tojson(indent=2) }}`. |
+| `ui_url` | The URL to view the given object in the UI, for example `{{ flow_run | ui_url }}`. |
+| `ui_resource_events_url` | The URL of the UI event feed filtered to the given object or event resource. |
+| `flow_run_id` | Extracts a flow run ID from a string that contains a flow run URL, such as a pull request body. |
+
+<Note>
+The `ui_url` and `ui_resource_events_url` filters render the literal string `None` when the object
+type has no UI page. On a self-hosted Prefect server they also need
+[`PREFECT_UI_URL`](/v3/api-ref/settings-ref#ui-url) to be set on the server; otherwise `ui_url`
+renders `None` and `ui_resource_events_url` renders a path with no host.
+</Note>
+
+### Sandbox limits
+
+User templates are rendered in a sandbox, so a template that fails these limits fails the action
+rather than the server:
+
+- `range()` may produce at most 100 items. Exceeding it fails the action at render time with a
+  template rendering error.
+- A template may contain at most 10 `for` loops, nested no more than 2 levels deep. Both limits are
+  checked when the automation is saved, so the API rejects the automation instead of failing later.
+
+### Examples
 
 Here's an example relevant to a flow run state-based notification:
 
@@ -192,19 +257,22 @@ In addition to those shortcuts for flows, deployments, and work pools, you have 
 event that triggered the automation. See the [Automations API](https://app.prefect.cloud/api/docs#tag/Automations)
 for additional details.
 
+Iterate a resource's labels through its `labels` attribute — iterating the resource itself yields the
+resource's whole label dictionary as a single item, not one `label`/`value` pair per label:
+
 ```
 Automation: {{ automation.name }}
 Description: {{ automation.description }}
 
 Event: {{ event.id }}
 Resource:
-{% for label, value in event.resource %}
+{% for label, value in event.resource.labels %}
 {{ label }}: {{ value }}
 {% endfor %}
 Related Resources:
 {% for related in event.related %}
     Role: {{ related.role }}
-    {% for label, value in related %}
+    {% for label, value in related.labels %}
     {{ label }}: {{ value }}
     {% endfor %}
 {% endfor %}

--- a/docs/v3/concepts/automations.mdx
+++ b/docs/v3/concepts/automations.mdx
@@ -192,8 +192,8 @@ example `{{ event.occurred | humanize_naturaltime }}`) and these Prefect-specifi
 
 | Filter | Result |
 | --- | --- |
-| `tojson` | Serializes any template value to a JSON string, including Pydantic objects such as `flow_run`, `deployment`, and `event`. The optional `indent` argument pretty-prints: `{{ flow_run | tojson(indent=2) }}`. |
-| `ui_url` | The URL to view the given object in the UI, for example `{{ flow_run | ui_url }}`. |
+| `tojson` | Serializes any template value to a JSON string, including Pydantic objects such as `flow_run`, `deployment`, and `event`. The optional `indent` argument pretty-prints: `{{ flow_run \| tojson(indent=2) }}`. |
+| `ui_url` | The URL to view the given object in the UI, for example `{{ flow_run \| ui_url }}`. |
 | `ui_resource_events_url` | The URL of the UI event feed filtered to the given object or event resource. |
 | `flow_run_id` | Extracts a flow run ID from a string that contains a flow run URL, such as a pull request body. |
 


### PR DESCRIPTION
Fixes #14031.

## Problem

`docs/v3/concepts/automations.mdx` listed five objects an automation action template can use
(`flow_run`, `flow`, `deployment`, `work_queue`, `work_pool`) and nothing about where they come
from. The renderer actually exposes more than that, and the page does not say which names are
always present versus fetched on demand, which filters exist, or what the sandbox forbids. #14031
also asks for the Jinja filters to be documented.

While checking the page against the code I found a second, concrete bug: the resource-iteration
example does not work. `Resource` is a pydantic `RootModel`, so iterating it yields one
`("root", {...})` pair, not one pair per label.

## Approach

Everything documented was read out of the code, then rendered through the real renderer
(`prefect.server.utilities.user_templates`) rather than assumed:

* Always-present names, from `JinjaTemplateAction._template_context`: `automation`, `event`,
  `labels`, `firing`, `firings`, `events`. `event` and `firing` are `Optional` on
  `TriggeredAction`, and the field description says proactive triggers carry the last matching
  event, so the page says it may be empty.
* Names fetched from the API when referenced, from `_relevant_native_objects` +
  `_get_object_from_prefect_api`'s `kind_to_model_and_methods` map. This adds `task_run`,
  `concurrency_limit` and `variables`, none of which were documented, and states the resource kind
  each one is resolved from. `matching_types_in_templates` is what makes the lookup
  reference-driven, so the page says "when the name appears in a template".
* The freshness caveat and its one exception: `instantiate_object` rebuilds `state` on
  `FlowRunResponse`/`TaskRun` from the event's `prefect.state-*` labels, so `state` reflects the
  triggering event while the rest of the object is current.
* Undefined behavior: the environment uses `ChainableUndefined`, so a missing object renders empty
  instead of failing. This is worth stating because an empty notification looks like a bug.
* Filters, from `jinja_filters.all_filters` plus the `tojson` override and the
  `jinja2_humanize_extension` extension in `UserTemplateEnvironment`.
* Sandbox limits from `MAX_TEMPLATE_RANGE` / `MAX_LOOP_COUNT` / `MAX_NESTED_LOOP_DEPTH`, split by
  *when* they bite: loop limits fail `validate_user_template` (save time), `range()` fails at render
  time.
* Fixed the two loop examples to iterate `event.resource.labels` and `related.labels`.

The prose sections are also broken into subheadings so the reference tables are linkable.

## Verification

Rendered through `render_user_template` on this branch (Prefect 3.8.4.dev6):

```
# the example currently in the docs
{% for label, value in event.resource %}{{ label }}={{ value }}
{% endfor %}
-> "root={'prefect.resource.id': 'prefect.flow-run.7dd4e0d0-...', 'prefect.resource.name': 'chartreuse-otter'}\n"

# the example in this PR
{% for label, value in event.resource.labels %}{{ label }}={{ value }}
{% endfor %}
-> 'prefect.resource.id=prefect.flow-run.7dd4e0d0-...\nprefect.resource.name=chartreuse-otter\n'
```

Same result for `{% for l, v in related %}` vs `{% for l, v in related.labels %}`.

Other claims, each rendered/validated the same way:

* `matching_types_in_templates` on `{{ flow_run.name }}{{ task_run.id }}{{ concurrency_limit.name }}{{ variables.x }}`
  returns `['concurrency_limit', 'flow_run', 'task_run', 'variables']` — the on-demand names are
  reference-driven.
* `{{ deployment.name }}` with no `deployment` in the context renders `''`; so does a deep chain
  such as `{{ event.resource.labels.nope.deeper }}`.
* `ui_url`, `ui_resource_events_url`, `flow_run_id`, `tojson` and `humanize_naturaltime` are all in
  `_template_environment.filters` after `JinjaTemplateAction._register_filters_if_needed()`;
  `{{ event | tojson }}` serializes the model.
* `{% for i in range(101) %}` → `TemplateRenderError: OverflowError('Range too big. The sandbox
  blocks ranges larger than MAX_TEMPLATE_RANGE=100.')` at render time, while 3-deep nesting and 11
  loops raise `TemplateSecurityError` from `validate_user_template`, i.e. at save time.
* With `PREFECT_UI_URL` unset, `{{ flow_run | ui_url }}` renders the literal `'None'` and
  `ui_resource_events_url` renders `'events?resource=prefect.flow-run.<id>'` with no host; with it
  set, both render absolute URLs. An unsupported input (`{{ 'hi' | ui_url }}`) renders `'None'`
  either way.

`pre-commit run --files docs/v3/concepts/automations.mdx` passes (codespell; the ruff/mypy hooks
have no files to check). No python code fences were added or changed, so the
`pytest docs/ --markdown-docs` job sees no new cases.

## Deliberately left out

* No change to the Cloud-only `flow_run_log_summary` section.
* Did not document `event.payload` shapes or webhook templating — different renderer, own page.
* Did not add per-field links into the API reference for each object; the reference pages are
  auto-generated and the old links on this page pointed at `reference.prefect.io` server schemas
  that do not match the response models actually placed in the context
  (`DeploymentResponse`, `FlowRunResponse`, `WorkQueueWithStatus`, `ConcurrencyLimitV2`), so the
  table names the object instead of linking a possibly-wrong schema.

## Note on prior work

PR #22488 (a different contributor) targeted this issue, received review from @desertaxle, and was
auto-closed by the stale bot on 2026-09-02. This PR was written from the code rather than from that
branch, but their review thread confirmed the `.labels` iteration problem independently — credit to
@youdie006 for getting there first.

AI assistance disclosure, per `docs/contribute/dev-contribute.mdx`: this change was drafted with an
AI coding agent. Every documented behavior was executed against the renderer on this branch, with
the outputs above.
