### PR TITLE
fix(prefect-dbt): raise on skipped dbt nodes in PrefectDbtRunner

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -123,6 +123,10 @@ def execute_dbt_node(
 
         if node_status in FAILURE_STATUSES:
             raise Exception(f"Node {node_id} finished with status {node_status}")
+        if node_status in SKIPPED_STATUSES:
+            raise Exception(
+                f"Node {node_id} was skipped, likely due to an upstream failure"
+            )
 
 
 class PrefectDbtRunner(DbtHookMixin):

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -1446,6 +1446,28 @@ class TestExecuteDbtNode:
         # Should complete without error when no status is available
         mock_task_state.wait_for_node_completion.assert_called_once_with(node_id)
 
+    @pytest.mark.parametrize("skipped_status", ["skipped"])
+    def test_execute_dbt_node_raises_on_skipped_status(
+        self, mock_task_state, skipped_status
+    ):
+        """Test that execute_dbt_node raises when a node is skipped.
+
+        Nodes can be skipped when an upstream node fails (e.g. a pre-hook
+        error in strict static analysis mode where dbt emits NodeStart before
+        the upstream Run phase completes).  Without this check, the task
+        function would return normally and Prefect would record the task as
+        successful even though nothing ran.
+        """
+        node_id = "model.test_project.test_model"
+        asset_id = "test_asset"
+
+        mock_task_state.get_node_status.return_value = {
+            "event_data": {"node_info": {"node_status": skipped_status}}
+        }
+
+        with pytest.raises(Exception, match="Node .* was skipped"):
+            execute_dbt_node(mock_task_state, node_id, asset_id)
+
     def test_execute_dbt_node_with_asset_context(self, mock_task_state):
         """Test that execute_dbt_node works with asset context."""
         node_id = "model.test_project.test_model"


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

This PR fixes PrefectDbtRunner incorrectly marking dbt nodes as successful when they were actually skipped due to upstream failure.
I didn't create issue, because AI bot creates a duplicate PR and noise.
   
**What was happening**

In strict static analysis mode, dbt's task graph splits node execution into phases (Render → Analyze → Run). Downstream nodes can complete their Render and Analyze phases before an upstream node's Run phase finishes. This means dbt emits NodeStart for a downstream node before it knows the upstream will fail.

When the upstream fails (e.g. in a pre-hook), dbt propagates the skip and emits NodeFinished for the downstream node with node_status = "skipped".

PrefectDbtRunner correctly creates a Prefect task on NodeStart. But execute_dbt_node only checked FAILURE_STATUSES when the node finished — it never checked SKIPPED_STATUSES. So the task function returned normally and Prefect recorded it as success, even though the node never executed.

**The fix**

Added a SKIPPED_STATUSES check in execute_dbt_node. When a node finishes with a skipped status, the task now raises an exception with a clear message, so Prefect marks the task as failed rather than succeeded.

Prefect has no SKIPPED task state (the terminal states are COMPLETED, FAILED, CANCELLED, CRASHED), so FAILED is the most accurate representation of "this node did not run because something upstream broke."