### PR TITLE
fix: resolve $PREFECT_HOME-relative defaults on settings submodels

### DIFF
--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -279,6 +279,17 @@ class Settings(PrefectBaseSettings):
         to use default_factory. The remaining items here require access to the full Settings instance
         or have complex interdependencies that will be migrated in future PRs.
         """
+        for model, field, relative_path in (
+            (self.results, "local_storage_path", "storage"),
+            (self.logging, "config_path", "logging.yml"),
+            (self.server, "memo_store_path", "memo_store.toml"),
+        ):
+            # These live on submodels, so their default_factory cannot see `home`,
+            # which is a field of this model. Resolve them here, leaving any value
+            # the user set explicitly untouched.
+            if field not in model.__pydantic_fields_set__:
+                setattr(model, field, self.home / relative_path)
+                model.__pydantic_fields_set__.remove(field)
         if self.ui_url is None:
             self.ui_url = default_ui_url(self)
             self.__pydantic_fields_set__.remove("ui_url")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2226,6 +2226,79 @@ class TestSettingsSources:
         assert Settings().profiles_path == profile_path
         assert (k := Settings().api.key) and k.get_secret_value() == "test_key"
 
+    HOME_DERIVED_PATH_ENV_VARS = (
+        "PREFECT_RESULTS_LOCAL_STORAGE_PATH",
+        "PREFECT_LOCAL_STORAGE_PATH",
+        "PREFECT_LOGGING_CONFIG_PATH",
+        "PREFECT_LOGGING_SETTINGS_PATH",
+        "PREFECT_SERVER_MEMO_STORE_PATH",
+        "PREFECT_MEMO_STORE_PATH",
+    )
+
+    def test_prefect_home_determines_home_derived_paths(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """
+        this is a regression test for https://github.com/PrefectHQ/prefect/issues/23046
+
+        Each of these settings documents a default relative to $PREFECT_HOME, so with
+        no explicit value set they must follow PREFECT_HOME rather than the user's
+        real home directory.
+        """
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        for env_var in self.HOME_DERIVED_PATH_ENV_VARS:
+            monkeypatch.delenv(env_var, raising=False)
+
+        home_dir = tmp_path / "custom_home"
+        home_dir.mkdir()
+        monkeypatch.setenv("PREFECT_HOME", str(home_dir))
+
+        settings = Settings()
+
+        assert settings.home == home_dir
+        assert settings.results.local_storage_path == home_dir / "storage"
+        assert settings.logging.config_path == home_dir / "logging.yml"
+        assert settings.server.memo_store_path == home_dir / "memo_store.toml"
+
+    def test_explicit_paths_are_kept_when_prefect_home_is_set(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """
+        Setting PREFECT_HOME must not override a path the user set explicitly.
+        """
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        for env_var in self.HOME_DERIVED_PATH_ENV_VARS:
+            monkeypatch.delenv(env_var, raising=False)
+
+        home_dir = tmp_path / "custom_home"
+        elsewhere = tmp_path / "elsewhere"
+        home_dir.mkdir()
+        elsewhere.mkdir()
+
+        monkeypatch.setenv("PREFECT_HOME", str(home_dir))
+        monkeypatch.setenv(
+            "PREFECT_RESULTS_LOCAL_STORAGE_PATH", str(elsewhere / "storage")
+        )
+        monkeypatch.setenv(
+            "PREFECT_LOGGING_CONFIG_PATH", str(elsewhere / "logging.yml")
+        )
+        monkeypatch.setenv(
+            "PREFECT_SERVER_MEMO_STORE_PATH", str(elsewhere / "memo_store.toml")
+        )
+
+        settings = Settings()
+
+        assert settings.home == home_dir
+        assert settings.results.local_storage_path == elsewhere / "storage"
+        assert settings.logging.config_path == elsewhere / "logging.yml"
+        assert settings.server.memo_store_path == elsewhere / "memo_store.toml"
+
 
 class TestLoadProfiles:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
`results.local_storage_path`, `logging.config_path` and `server.memo_store_path` each document a
default relative to `$PREFECT_HOME`, but they ignore it and resolve against the real user home
directory instead. Reported in #23046 for `local_storage_path`; the other two fail the same way.

Before, with `PREFECT_HOME=/tmp/custom-prefect-home` and none of the three set explicitly:

```
home                       : /tmp/custom-prefect-home
profiles_path              : /tmp/custom-prefect-home/profiles.toml
results.local_storage_path : /Users/<me>/.prefect/storage
logging.config_path        : /Users/<me>/.prefect/logging.yml
server.memo_store_path     : /Users/<me>/.prefect/memo_store.toml
```

After, all four follow `PREFECT_HOME`.

### Why it happens

The three defaults come from helpers in `settings/models/_defaults.py` that read
`values.get("home")`, but they are used as `default_factory` on fields of submodels, and `home`
is a field of the root `Settings`. The factory only ever sees the validated data of its own
model, so `home` is absent and each helper falls through to `Path("~/.prefect").expanduser()`.
`profiles_path` uses the identical pattern and works, because it lives on the root model beside
`home`. The three moved out of the root model in #18029, where they had been resolved from
`self.home` in `post_hoc_settings`.

### Approach

Resolve them back in `post_hoc_settings`, which is where the other defaults that need the full
`Settings` instance are already handled, and guard on `__pydantic_fields_set__` so a value the
user set explicitly is never overwritten. Environment variables, `prefect.toml` and profile
values continue to win.

This keeps the field types, validation aliases and generated schema unchanged: `just
generate-settings` produces no diff.

### Validation

- `tests/test_settings.py::TestSettingsSources::test_prefect_home_determines_home_derived_paths`
  fails before this change and passes after, covering all three paths.
- `test_explicit_paths_are_kept_when_prefect_home_is_set` covers the other direction, that
  `PREFECT_HOME` does not override an explicitly configured path.
- `tests/test_settings.py` (1863 passed, 3 skipped), plus `tests/test_context.py`,
  `tests/test_logging.py`, `tests/results` and `tests/logging` (417 passed).
- `uv run pre-commit run` and the `pre-push` stage on the changed files, all green.

### Checklist

- [x] This pull request references any related issue by including "closes https://github.com/PrefectHQ/prefect/issues/23046"
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
  - Not a complex change: an 11-line fix in one validator. The diagnosis and the approach are written up on the issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
  - No documentation change: the settings reference already documents all three as `$PREFECT_HOME`-relative, so this makes the behavior match the existing docs.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
  - No docs files removed.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
  - No new functions or classes.
