### PR TITLE
Do not revoke a concurrency lease that was renewed after being listed

### DIFF
--- a/src/prefect/server/concurrency/lease_storage/memory.py
+++ b/src/prefect/server/concurrency/lease_storage/memory.py
@@ -72,7 +72,12 @@ class ConcurrencyLeaseStorage(_ConcurrencyLeaseStorage):
             self.expirations.pop(lease_id, None)
             return False
 
-        self.expirations[lease_id] = datetime.now(timezone.utc) + ttl
+        new_expiration = datetime.now(timezone.utc) + ttl
+        # Keep the lease itself in step with the index, otherwise `read_lease`
+        # reports the pre-renewal expiration and callers cannot tell that the
+        # lease is still live.
+        self.leases[lease_id].expiration = new_expiration
+        self.expirations[lease_id] = new_expiration
         return True
 
     async def revoke_lease(self, lease_id: UUID) -> None:

--- a/src/prefect/server/services/repossessor.py
+++ b/src/prefect/server/services/repossessor.py
@@ -40,6 +40,15 @@ async def revoke_expired_lease(
         logger.warning(f"Lease {lease_id} should be revoked but was not found")
         return
 
+    if expired_lease.expiration >= datetime.now(timezone.utc):
+        # The holder renewed between `monitor_expired_leases` listing this lease
+        # and this task running, so it is live again and must not be revoked.
+        logger.debug(
+            f"Lease {lease_id} was renewed after being listed as expired; "
+            "skipping revocation"
+        )
+        return
+
     if expired_lease.metadata is None:
         logger.warning(f"Lease {lease_id} should be revoked but has no metadata")
         return

--- a/tests/server/services/test_repossessor.py
+++ b/tests/server/services/test_repossessor.py
@@ -139,6 +139,40 @@ class TestRevokeExpiredLease:
         # Verify lease was not processed due to missing metadata
         assert len(lease_storage.leases) == 1  # Lease should still exist
 
+    async def test_revoke_expired_lease_skips_lease_renewed_after_listing(
+        self, lease_storage, concurrency_limit, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A lease renewed between listing and revocation must not be revoked."""
+        lease = await lease_storage.create_lease(
+            resource_ids=[concurrency_limit.id],
+            ttl=timedelta(seconds=-1),  # Already expired, so it gets listed
+            metadata=ConcurrencyLimitLeaseMetadata(slots=2),
+        )
+
+        # The holder renews before the scheduled revocation task runs
+        assert await lease_storage.renew_lease(lease.id, timedelta(minutes=5)) is True
+
+        decrement_calls: list[int] = []
+
+        async def spy_decrement(*args: object, slots: int, **kwargs: object) -> None:
+            decrement_calls.append(slots)
+
+        monkeypatch.setattr(
+            "prefect.server.services.repossessor.bulk_decrement_active_slots",
+            spy_decrement,
+        )
+
+        db = provide_database_interface()
+        await revoke_expired_lease(
+            lease.id,
+            db=db,
+            lease_storage=lease_storage,
+        )
+
+        # The renewed lease survives and its slots are left alone
+        assert lease.id in lease_storage.leases
+        assert decrement_calls == []
+
 
 class TestMonitorExpiredLeases:
     @pytest.fixture


### PR DESCRIPTION
Closes #22983

`monitor_expired_leases` lists expired leases and schedules one `revoke_expired_lease` task per lease. That task re-read the lease but never rechecked whether it was still expired, so a holder that renewed in the scheduling gap had its slots decremented and its lease deleted while alive — surfacing on its next renewal as a `410 Gone`.

This adds the missing check: after reading the lease, skip revocation if its expiration is now in the future.

### The in-memory storage needed fixing too

The guard alone does not work on the memory backend. `ConcurrencyLeaseStorage.renew_lease` updated only the expiration index:

```python
self.expirations[lease_id] = datetime.now(timezone.utc) + ttl
```

`self.leases[lease_id].expiration` was left at its pre-renewal value, so `read_lease` reports a renewed lease as still expired and the new check never fires. The filesystem backend does not have this problem — `renew_lease` there rewrites the lease file's `expiration` alongside the index — which is why the divergence is easy to miss.

So `renew_lease` now updates both. That is also a fix in its own right: `read_lease` was returning a stale expiration to any caller, not just to this service.

### Tests

`test_revoke_expired_lease_skips_lease_renewed_after_listing` creates an expired lease, renews it, then runs `revoke_expired_lease`, asserting the lease survives and that `bulk_decrement_active_slots` is never called. The test fails if **either** fix is reverted on its own, so it pins both.

`tests/server/services/test_repossessor.py` and `tests/server/concurrency/` pass — 60 tests.

I asserted on a spy over `bulk_decrement_active_slots` rather than reading `active_slots` back from the database. In my environment `bulk_increment_active_slots` followed by `session.commit()` leaves `active_slots` at 0 when read back through the test session, so a database-level assertion here would not have distinguished the fixed and unfixed code. Worth noting that the existing `test_revoke_expired_lease` asserts `active_slots == 0` after revocation, which passes for that reason rather than because the decrement was observed — I have left that test alone, but it may be worth a look separately.

`ruff check` and `ruff format` clean at the pinned 0.15.19.
