### PR TITLE
fix(settings): default local_storage_path to PREFECT_HOME/storage (#23046)

### DIFF
--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -449,10 +449,20 @@ class Settings(PrefectBaseSettings):
         for setting, value in updates.items():
             set_in_dict(updates_obj, _get_setting_accessor(setting), value)
 
+        current_values = self.model_dump(exclude_unset=True)
+        if "profiles_path" not in self.model_fields_set:
+            current_values.pop("profiles_path", None)
+        if "local_storage_path" not in self.results.model_fields_set:
+            current_values.get("results", {}).pop("local_storage_path", None)
+        if "config_path" not in self.logging.model_fields_set:
+            current_values.get("logging", {}).pop("config_path", None)
+        if "memo_store_path" not in self.server.model_fields_set:
+            current_values.get("server", {}).pop("memo_store_path", None)
+
         new_settings = self.__class__.model_validate(
             deep_merge_dicts(
                 set_defaults_obj,
-                self.model_dump(exclude_unset=True),
+                current_values,
                 restore_defaults_obj,
                 updates_obj,
             )

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -279,6 +279,15 @@ class Settings(PrefectBaseSettings):
         to use default_factory. The remaining items here require access to the full Settings instance
         or have complex interdependencies that will be migrated in future PRs.
         """
+        if "profiles_path" not in self.model_fields_set:
+            self.profiles_path = self.home / "profiles.toml"
+        if "local_storage_path" not in self.results.model_fields_set:
+            self.results.local_storage_path = self.home / "storage"
+        if "config_path" not in self.logging.model_fields_set:
+            self.logging.config_path = self.home / "logging.yml"
+        if "memo_store_path" not in self.server.model_fields_set:
+            self.server.memo_store_path = self.home / "memo_store.toml"
+
         if self.ui_url is None:
             self.ui_url = default_ui_url(self)
             self.__pydantic_fields_set__.remove("ui_url")

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -281,12 +281,16 @@ class Settings(PrefectBaseSettings):
         """
         if "profiles_path" not in self.model_fields_set:
             self.profiles_path = self.home / "profiles.toml"
+            self.__pydantic_fields_set__.remove("profiles_path")
         if "local_storage_path" not in self.results.model_fields_set:
             self.results.local_storage_path = self.home / "storage"
+            self.results.__pydantic_fields_set__.remove("local_storage_path")
         if "config_path" not in self.logging.model_fields_set:
             self.logging.config_path = self.home / "logging.yml"
+            self.logging.__pydantic_fields_set__.remove("config_path")
         if "memo_store_path" not in self.server.model_fields_set:
             self.server.memo_store_path = self.home / "memo_store.toml"
+            self.server.__pydantic_fields_set__.remove("memo_store_path")
 
         if self.ui_url is None:
             self.ui_url = default_ui_url(self)
@@ -449,20 +453,10 @@ class Settings(PrefectBaseSettings):
         for setting, value in updates.items():
             set_in_dict(updates_obj, _get_setting_accessor(setting), value)
 
-        current_values = self.model_dump(exclude_unset=True)
-        if "profiles_path" not in self.model_fields_set:
-            current_values.pop("profiles_path", None)
-        if "local_storage_path" not in self.results.model_fields_set:
-            current_values.get("results", {}).pop("local_storage_path", None)
-        if "config_path" not in self.logging.model_fields_set:
-            current_values.get("logging", {}).pop("config_path", None)
-        if "memo_store_path" not in self.server.model_fields_set:
-            current_values.get("server", {}).pop("memo_store_path", None)
-
         new_settings = self.__class__.model_validate(
             deep_merge_dicts(
                 set_defaults_obj,
-                current_values,
+                self.model_dump(exclude_unset=True),
                 restore_defaults_obj,
                 updates_obj,
             )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3258,7 +3258,9 @@ class TestHomeDependentDefaults:
         assert updated.logging.config_path == new_home / "logging.yml"
         assert updated.server.memo_store_path == new_home / "memo_store.toml"
 
-    def test_local_storage_path_defaults_to_prefect_home_storage(self, monkeypatch, tmp_path):
+    def test_local_storage_path_defaults_to_prefect_home_storage(
+        self, monkeypatch, tmp_path
+    ):
         custom_home = tmp_path / "custom_prefect_home"
         monkeypatch.setenv("PREFECT_HOME", str(custom_home))
         settings = Settings()
@@ -3276,4 +3278,3 @@ class TestHomeDependentDefaults:
         settings = Settings()
         assert settings.home == custom_home
         assert settings.results.local_storage_path == override_path
-

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3259,8 +3259,8 @@ class TestHomeDependentDefaults:
         assert updated.server.memo_store_path == new_home / "memo_store.toml"
 
     def test_local_storage_path_defaults_to_prefect_home_storage(
-        self, monkeypatch, tmp_path
-    ):
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         custom_home = tmp_path / "custom_prefect_home"
         monkeypatch.setenv("PREFECT_HOME", str(custom_home))
         settings = Settings()
@@ -3270,7 +3270,9 @@ class TestHomeDependentDefaults:
         assert settings.server.memo_store_path == custom_home / "memo_store.toml"
         assert settings.logging.config_path == custom_home / "logging.yml"
 
-    def test_local_storage_path_explicit_override(self, monkeypatch, tmp_path):
+    def test_local_storage_path_explicit_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         custom_home = tmp_path / "custom_prefect_home"
         override_path = tmp_path / "override_storage"
         monkeypatch.setenv("PREFECT_HOME", str(custom_home))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3245,6 +3245,19 @@ class TestWorkerDebugMode:
 
 
 class TestHomeDependentDefaults:
+    def test_copy_with_update_recomputes_home_dependent_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        settings = Settings(home=tmp_path / "old")
+        new_home = tmp_path / "new"
+
+        updated = settings.copy_with_update(updates={PREFECT_HOME: new_home})
+
+        assert updated.profiles_path == new_home / "profiles.toml"
+        assert updated.results.local_storage_path == new_home / "storage"
+        assert updated.logging.config_path == new_home / "logging.yml"
+        assert updated.server.memo_store_path == new_home / "memo_store.toml"
+
     def test_local_storage_path_defaults_to_prefect_home_storage(self, monkeypatch, tmp_path):
         custom_home = tmp_path / "custom_prefect_home"
         monkeypatch.setenv("PREFECT_HOME", str(custom_home))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3242,3 +3242,25 @@ class TestWorkerDebugMode:
         with temporary_settings({PREFECT_DEBUG_MODE: True}):
             env = get_current_settings().to_environment_variables(exclude_unset=True)
             assert "PREFECT_DEBUG_MODE" in env
+
+
+class TestHomeDependentDefaults:
+    def test_local_storage_path_defaults_to_prefect_home_storage(self, monkeypatch, tmp_path):
+        custom_home = tmp_path / "custom_prefect_home"
+        monkeypatch.setenv("PREFECT_HOME", str(custom_home))
+        settings = Settings()
+        assert settings.home == custom_home
+        assert settings.results.local_storage_path == custom_home / "storage"
+        assert settings.profiles_path == custom_home / "profiles.toml"
+        assert settings.server.memo_store_path == custom_home / "memo_store.toml"
+        assert settings.logging.config_path == custom_home / "logging.yml"
+
+    def test_local_storage_path_explicit_override(self, monkeypatch, tmp_path):
+        custom_home = tmp_path / "custom_prefect_home"
+        override_path = tmp_path / "override_storage"
+        monkeypatch.setenv("PREFECT_HOME", str(custom_home))
+        monkeypatch.setenv("PREFECT_RESULTS_LOCAL_STORAGE_PATH", str(override_path))
+        settings = Settings()
+        assert settings.home == custom_home
+        assert settings.results.local_storage_path == override_path
+


### PR DESCRIPTION
### Summary
Fixes #23046 where `local_storage_path` (and other home-dependent settings like `memo_store_path` and `logging_config_path`) failed to default to `$PREFECT_HOME/...` when `PREFECT_HOME` was customized and the respective setting environment variables/kwargs were left unset.

### Root Cause
`local_storage_path` is defined on `ResultsSettings`, `memo_store_path` on `ServerSettings`, and `config_path` on `LoggingSettings`. When Pydantic settings constructs these sub-settings models, `values` only contains fields for that specific nested model (not `home`, which lives on the root `Settings` model). Consequently, default factories fall back to `~/.prefect` instead of using `settings.home`.

### Fix
Added home-dependent default resolution to `Settings.post_hoc_settings` (`@model_validator(mode="after")`). If a path setting (`local_storage_path`, `profiles_path`, `memo_store_path`, `config_path`) was not explicitly set during initialization, `post_hoc_settings` resolves it using `self.home`.

### Verification
- Added `TestHomeDependentDefaults` in `tests/test_settings.py` verifying that custom `PREFECT_HOME` correctly sets `local_storage_path`, `profiles_path`, `memo_store_path`, and `config_path`.
- Verified explicit overrides continue to take precedence.
- All new tests pass green.
