### PR TITLE
Limit worker polling to a deployment's available concurrency slots

### DIFF
--- a/docs/v3/concepts/deployments.mdx
+++ b/docs/v3/concepts/deployments.mdx
@@ -342,6 +342,10 @@ deployment can be active at once. To enable this behavior, deployments have the 
   slot is released. This is useful for deployments with slow-starting infrastructure. Must be between 60 and
   86400 seconds. If not set, falls back to the server setting (default 300 seconds / 5 minutes).
 
+Workers only receive as many runs as the deployment has free concurrency slots, so an `ENQUEUE` deployment
+with a large backlog does not repeatedly cycle runs through `AwaitingConcurrencySlot`. The limit is still
+enforced when a run is submitted, which is what settles races between workers.
+
 <CodeGroup>
 
 ```sh prefect deploy

--- a/src/prefect/server/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/server/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
@@ -30,13 +30,50 @@ queue_slots AS (
         AND wq.concurrency_limit IS NOT NULL
     GROUP BY
         wq.id
-)
+),
+
+-- compute available slots under deployment concurrency limits
+--
+-- Unlike pool and queue limits, deployment slots are held in
+-- concurrency_limit_v2.active_slots rather than counted from flow_run, because
+-- they are acquired by SecureFlowConcurrencySlots at the Scheduled -> Pending
+-- transition and released by lease expiry. Mirroring that rule:
+--   * an inactive limit can never be acquired, so it offers no slots
+--   * slot decay is not modeled here; deployment-backed limits are created
+--     with slot_decay_per_second = 0
+-- Only ENQUEUE deployments are eligible: a CANCEL_NEW run must still be handed
+-- to a worker so the transition can cancel it rather than leaving it Scheduled.
+deployment_slots AS (
+    SELECT
+        d.id,
+        CASE WHEN cl.active THEN
+            GREATEST (0, cl."limit" - cl.active_slots)
+        ELSE
+            0
+        END AS available_slots
+    FROM
+        deployment d
+        JOIN concurrency_limit_v2 cl ON cl.id = d.concurrency_limit_id
+    WHERE
+        COALESCE(d.concurrency_options ->> 'collision_strategy', 'ENQUEUE') = 'ENQUEUE'
+),
 
 -- get all flow runs that match criteria
+candidate_runs AS (
 SELECT
     wp.id AS run_work_pool_id,
     fr_outer.work_queue_id AS run_work_queue_id,
-    fr_outer.*
+    fr_outer.*,
+    deployment_slots.available_slots AS available_deployment_slots,
+    -- rank each run within its deployment so a deployment with some capacity
+    -- left contributes only that many runs, rather than being excluded
+    -- entirely or flooding the response
+    ROW_NUMBER() OVER (PARTITION BY fr_outer.deployment_id
+        ORDER BY
+            {% if respect_queue_priorities %}
+            fr_outer.work_queue_priority ASC,
+            {% endif %}
+            fr_outer.next_scheduled_start_time ASC) AS deployment_rank
 FROM
     work_pool wp
     LEFT JOIN pool_slots ON wp.id = pool_slots.id
@@ -66,6 +103,18 @@ FROM
                     fr.work_queue_id = wq.id
                     AND fr.state_type = 'SCHEDULED'
                     AND (fr.empirical_policy->>'retry_type' IS NULL OR fr.empirical_policy->>'retry_type' != 'in_process')
+                    -- skip deployments that are entirely out of slots so their
+                    -- runs don't consume queue or pool slots another deployment
+                    -- could use. A correlated subquery rather than a join
+                    -- because FOR UPDATE cannot be applied to the nullable side
+                    -- of an outer join.
+                    AND COALESCE((
+                        SELECT
+                            ds.available_slots
+                        FROM
+                            deployment_slots ds
+                        WHERE
+                            ds.id = fr.deployment_id), 1) > 0
                     {% if scheduled_after %}
                     AND fr.next_scheduled_start_time >= :scheduled_after
                     {% endif %}
@@ -97,6 +146,8 @@ FROM
 
         LIMIT LEAST (:worker_limit, pool_slots.available_slots)) fr_outer
 
+    LEFT JOIN deployment_slots ON deployment_slots.id = fr_outer.deployment_id
+
 WHERE
     wp.is_paused IS FALSE 
 
@@ -104,6 +155,17 @@ WHERE
     -- optionally filter for specific worker pool IDs
     AND wp.id IN :work_pool_ids
     {% endif %}
+)
+
+SELECT
+    *
+FROM
+    candidate_runs
+WHERE
+    -- hold back the runs a deployment has no room for; the transition-time
+    -- check in SecureFlowConcurrencySlots remains the authority for races
+    available_deployment_slots IS NULL
+    OR deployment_rank <= available_deployment_slots
 
 ORDER BY 
 {% if respect_queue_priorities %}

--- a/src/prefect/server/database/sql/sqlite/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/server/database/sql/sqlite/get-runs-from-worker-queues.sql.jinja
@@ -33,6 +33,33 @@ GROUP BY
 ),
 
 
+-- compute available slots under deployment concurrency limits
+--
+-- Unlike pool and queue limits, deployment slots are held in
+-- concurrency_limit_v2.active_slots rather than counted from flow_run, because
+-- they are acquired by SecureFlowConcurrencySlots at the Scheduled -> Pending
+-- transition and released by lease expiry. Mirroring that rule:
+--   * an inactive limit can never be acquired, so it offers no slots
+--   * slot decay is not modeled here; deployment-backed limits are created
+--     with slot_decay_per_second = 0
+-- Only ENQUEUE deployments are eligible: a CANCEL_NEW run must still be handed
+-- to a worker so the transition can cancel it rather than leaving it Scheduled.
+deployment_slots AS (
+    SELECT
+        d.id,
+        CASE WHEN cl.active THEN
+            MAX(0, cl."limit" - cl.active_slots)
+        ELSE
+            0
+        END AS available_slots
+    FROM
+        deployment d
+        JOIN concurrency_limit_v2 cl ON cl.id = d.concurrency_limit_id
+    WHERE
+        COALESCE(json_extract(d.concurrency_options, '$.collision_strategy'), 'ENQUEUE') = 'ENQUEUE'
+),
+
+
 -- CTE that loads flow runs and applies worker pool queue limits
 scheduled_flow_runs AS (
     SELECT
@@ -40,6 +67,7 @@ scheduled_flow_runs AS (
         wq.id AS run_work_queue_id,
         fr.*,
         worker_slots.available_slots as available_worker_slots,
+        deployment_slots.available_slots as available_deployment_slots,
         ROW_NUMBER() OVER (PARTITION BY wp.id ORDER BY {% if respect_queue_priorities %}wq.priority ASC, {% endif %}fr.next_scheduled_start_time) AS work_pool_rank
     FROM
         work_pool wp
@@ -50,10 +78,17 @@ scheduled_flow_runs AS (
         JOIN (
             SELECT 
                 fr.*,
-                ROW_NUMBER() OVER (PARTITION BY work_queue_id ORDER BY next_scheduled_start_time) AS work_queue_rank
+                ROW_NUMBER() OVER (PARTITION BY work_queue_id ORDER BY next_scheduled_start_time) AS work_queue_rank,
+                -- rank each run within its deployment so that a deployment with
+                -- some capacity left contributes only that many runs, rather
+                -- than being excluded entirely or flooding the response
+                ROW_NUMBER() OVER (PARTITION BY deployment_id ORDER BY next_scheduled_start_time) AS deployment_rank
             FROM flow_run fr
             WHERE fr.state_type = 'SCHEDULED'
             AND (json_extract(fr.empirical_policy, '$.retry_type') IS NULL OR json_extract(fr.empirical_policy, '$.retry_type') != 'in_process')
+            -- skip deployments that are entirely out of slots so their runs
+            -- don't consume queue or pool slots another deployment could use
+            AND COALESCE((SELECT ds.available_slots FROM deployment_slots ds WHERE ds.id = fr.deployment_id), 1) > 0
             {% if scheduled_after %}
             AND fr.next_scheduled_start_time >= :scheduled_after
             {% endif %}
@@ -64,6 +99,8 @@ scheduled_flow_runs AS (
         ON 
             fr.work_queue_id = wq.id 
             AND work_queue_rank <= MIN(COALESCE(queue_slots.available_slots, :queue_limit), :queue_limit)
+
+        LEFT JOIN deployment_slots ON deployment_slots.id = fr.deployment_id
 
     WHERE
         wp.is_paused IS FALSE
@@ -83,6 +120,10 @@ SELECT
 FROM scheduled_flow_runs
 WHERE
     work_pool_rank <= MIN(COALESCE(available_worker_slots, :worker_limit), :worker_limit)
+    -- hold back the runs a deployment has no room for; the transition-time
+    -- check in SecureFlowConcurrencySlots remains the authority for races
+    AND (available_deployment_slots IS NULL
+        OR deployment_rank <= available_deployment_slots)
 ORDER BY 
     {% if respect_queue_priorities %}
     

--- a/tests/server/models/test_workers.py
+++ b/tests/server/models/test_workers.py
@@ -1571,3 +1571,152 @@ class TestGetWorkQueueSlotHolders:
         )
         assert len(holders) == 1
         assert holders[0][0].id == run.id
+
+
+class TestGetScheduledRunsWithDeploymentConcurrency:
+    """
+    The work pool scheduler withholds runs that a deployment has no concurrency
+    slot for, instead of handing them to a worker only for the
+    Scheduled -> Pending transition to reject and reschedule them.
+    """
+
+    @pytest.fixture
+    async def work_queue(self, session):
+        work_pool = await models.workers.create_work_pool(
+            session=session,
+            work_pool=schemas.actions.WorkPoolCreate(name="deployment-limits"),
+        )
+        return await models.workers.create_work_queue(
+            session=session,
+            work_pool_id=work_pool.id,
+            work_queue=schemas.actions.WorkQueueCreate(name="runs"),
+        )
+
+    async def create_deployment(
+        self,
+        session: AsyncSession,
+        flow,
+        name: str,
+        limit: int | None = None,
+        active_slots: int = 0,
+        collision_strategy: schemas.core.ConcurrencyLimitStrategy | None = None,
+        limit_is_active: bool = True,
+    ):
+        deployment = await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name=name,
+                flow_id=flow.id,
+                concurrency_limit=limit,
+                concurrency_options=(
+                    schemas.core.ConcurrencyOptions(
+                        collision_strategy=collision_strategy
+                    )
+                    if collision_strategy is not None
+                    else None
+                ),
+            ),
+        )
+        if deployment.global_concurrency_limit is not None:
+            deployment.global_concurrency_limit.active_slots = active_slots
+            deployment.global_concurrency_limit.active = limit_is_active
+        return deployment
+
+    async def create_runs(
+        self, session: AsyncSession, flow, work_queue, deployment, count: int
+    ):
+        runs = []
+        for i in range(count):
+            runs.append(
+                await models.flow_runs.create_flow_run(
+                    session=session,
+                    flow_run=schemas.core.FlowRun(
+                        flow_id=flow.id,
+                        deployment_id=deployment.id if deployment else None,
+                        work_queue_id=work_queue.id,
+                        state=schemas.states.Scheduled(
+                            scheduled_time=now("UTC") + datetime.timedelta(minutes=i)
+                        ),
+                    ),
+                )
+            )
+        return runs
+
+    async def scheduled_run_ids(self, session: AsyncSession):
+        runs = await models.workers.get_scheduled_flow_runs(session=session)
+        return {r.flow_run.id for r in runs}
+
+    async def test_deployment_without_a_limit_is_unaffected(
+        self, session, flow, work_queue
+    ):
+        deployment = await self.create_deployment(session, flow, "unlimited")
+        runs = await self.create_runs(session, flow, work_queue, deployment, 3)
+        await session.commit()
+
+        assert await self.scheduled_run_ids(session) == {r.id for r in runs}
+
+    async def test_runs_without_a_deployment_are_unaffected(
+        self, session, flow, work_queue
+    ):
+        runs = await self.create_runs(session, flow, work_queue, None, 3)
+        await session.commit()
+
+        assert await self.scheduled_run_ids(session) == {r.id for r in runs}
+
+    async def test_available_slots_bound_the_number_of_runs_returned(
+        self, session, flow, work_queue
+    ):
+        deployment = await self.create_deployment(
+            session, flow, "one-slot-left", limit=3, active_slots=2
+        )
+        runs = await self.create_runs(session, flow, work_queue, deployment, 5)
+        await session.commit()
+
+        # the single remaining slot goes to the earliest scheduled run
+        assert await self.scheduled_run_ids(session) == {runs[0].id}
+
+    async def test_saturated_deployment_yields_no_runs(self, session, flow, work_queue):
+        deployment = await self.create_deployment(
+            session, flow, "saturated", limit=2, active_slots=2
+        )
+        await self.create_runs(session, flow, work_queue, deployment, 5)
+        await session.commit()
+
+        assert await self.scheduled_run_ids(session) == set()
+
+    async def test_saturated_deployment_does_not_block_its_neighbors(
+        self, session, flow, work_queue
+    ):
+        saturated = await self.create_deployment(
+            session, flow, "saturated", limit=1, active_slots=1
+        )
+        idle = await self.create_deployment(session, flow, "idle", limit=5)
+        await self.create_runs(session, flow, work_queue, saturated, 5)
+        idle_runs = await self.create_runs(session, flow, work_queue, idle, 3)
+        await session.commit()
+
+        assert await self.scheduled_run_ids(session) == {r.id for r in idle_runs}
+
+    async def test_cancel_new_runs_are_still_delivered(self, session, flow, work_queue):
+        deployment = await self.create_deployment(
+            session,
+            flow,
+            "cancel-new",
+            limit=1,
+            active_slots=1,
+            collision_strategy=schemas.core.ConcurrencyLimitStrategy.CANCEL_NEW,
+        )
+        runs = await self.create_runs(session, flow, work_queue, deployment, 3)
+        await session.commit()
+
+        # a CANCEL_NEW run must reach a worker so the transition can cancel it
+        assert await self.scheduled_run_ids(session) == {r.id for r in runs}
+
+    async def test_inactive_limit_offers_no_slots(self, session, flow, work_queue):
+        deployment = await self.create_deployment(
+            session, flow, "inactive-limit", limit=5, limit_is_active=False
+        )
+        await self.create_runs(session, flow, work_queue, deployment, 3)
+        await session.commit()
+
+        assert await self.scheduled_run_ids(session) == set()


### PR DESCRIPTION
Deployment concurrency limits are enforced at the `Scheduled -> Pending` transition, but the work-pool polling query knows nothing about them. So a deployment with 300 queued runs and 1 free slot has all 300 runs handed to a worker, 299 get rejected into `AwaitingConcurrencySlot` and rescheduled ~30s out, and the same set is re-selected on the next poll. Two consequences:

- a poll/reject/reschedule loop on every spike, which loads the API and the database
- FIFO inversion within a tier, because a bumped run loses its place to runs that were scheduled later

This adds a `deployment_slots` term to `get-runs-from-worker-queues.sql.jinja` alongside `pool_slots` and `queue_slots`, in both the Postgres and SQLite templates:

- runs of a deployment with no slots left are skipped in the innermost lateral, so they don't consume queue or pool slots another deployment could use
- a deployment with partial capacity contributes at most `limit - active_slots` runs, earliest scheduled first — the "one slot left, hundreds eligible" case selects one run, not zero and not hundreds
- `CANCEL_NEW` deployments are exempt: those runs must reach a worker so the transition can cancel them instead of leaving them `Scheduled`
- an inactive limit offers no slots, mirroring `bulk_increment_active_slots`

`SecureFlowConcurrencySlots` is untouched and stays the authority for races between concurrent workers — this only stops handing out runs that the transition would certainly reject.

### Notes for review

- Slot decay is not modeled in the query. Deployment-backed limits are created with `slot_decay_per_second = 0`, so `limit - active_slots` is exact for them; a decaying limit would just be treated conservatively for one poll interval.
- The per-deployment cap is applied after the pool-level `LIMIT` in the Postgres template, so a poll can return fewer runs than the pool has capacity for when a deployment is partially saturated. Pushing it further in would mean a window function inside the `FOR UPDATE SKIP LOCKED` subquery, which Postgres disallows. Happy to restructure if you'd prefer the pool always filled.
- `deployment.concurrency_limit_id` has no index. The CTE is cheap at a few hundred limited deployments; an index may be worth adding for larger installations.
- Context: this came out of a support thread with Prefect about wanting per-deployment admission control, a small number of shared priority tiers, and FIFO within a tier at the same time. Poll-time deployment filtering was called a reasonable enhancement request there. Opened as a draft — glad to take the design session that was offered and reshape this.

### Validation

- New `TestGetScheduledRunsWithDeploymentConcurrency` in `tests/server/models/test_workers.py` covers no limit, no deployment, partial capacity, saturation, a saturated deployment not blocking its neighbors, `CANCEL_NEW`, and an inactive limit. The four behavioral cases fail on `main`.
- Ran on SQLite: `tests/server/models/test_workers.py`, `tests/server/models/test_work_queues.py`, `tests/server/database/test_queries.py`, `tests/server/orchestration/api/test_workers.py`, `tests/workers/test_base_worker.py`, and the concurrency tests in `tests/server/orchestration/test_core_policy.py`.
- Ran the same scenarios against PostgreSQL 16 to exercise the Postgres template.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
