### PR TITLE
make date range span relative instead of absolute

### DIFF
--- a/ui-v2/src/routes/-dashboard.test.ts
+++ b/ui-v2/src/routes/-dashboard.test.ts
@@ -30,6 +30,7 @@ describe("getDateRangeFromSearch", () => {
 	it("honors explicit from/to when no range type is set", () => {
 		expect(
 			getDateRangeFromSearch({
+				seconds: -3600,
 				from: "2020-01-01T00:00:00.000Z",
 				to: "2020-01-01T01:00:00.000Z",
 			}),

--- a/ui-v2/src/routes/-dashboard.test.ts
+++ b/ui-v2/src/routes/-dashboard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getDateRangeFromSearch } from "./dashboard";
+
+describe("getDateRangeFromSearch", () => {
+	it("recomputes relative spans instead of using stale from/to", () => {
+		const { from, to } = getDateRangeFromSearch({
+			rangeType: "span",
+			seconds: -3600,
+			from: "2020-01-01T00:00:00.000Z",
+			to: "2020-01-01T01:00:00.000Z",
+		});
+
+		expect(new Date(to).getTime() - new Date(from).getTime()).toBe(3600 * 1000);
+		expect(new Date(to).getTime()).toBeGreaterThan(Date.now() - 2 * 60 * 1000);
+	});
+
+	it("honors explicit from/to when no range type is set", () => {
+		expect(
+			getDateRangeFromSearch({
+				from: "2020-01-01T00:00:00.000Z",
+				to: "2020-01-01T01:00:00.000Z",
+			}),
+		).toEqual({
+			from: "2020-01-01T00:00:00.000Z",
+			to: "2020-01-01T01:00:00.000Z",
+		});
+	});
+});

--- a/ui-v2/src/routes/-dashboard.test.ts
+++ b/ui-v2/src/routes/-dashboard.test.ts
@@ -1,17 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDateRangeFromSearch } from "./dashboard";
 
-describe("getDateRangeFromSearch", () => {
-	it("recomputes relative spans instead of using stale from/to", () => {
-		const { from, to } = getDateRangeFromSearch({
-			rangeType: "span",
-			seconds: -3600,
-			from: "2020-01-01T00:00:00.000Z",
-			to: "2020-01-01T01:00:00.000Z",
-		});
+const NOW = new Date("2024-06-01T12:00:00.000Z");
 
-		expect(new Date(to).getTime() - new Date(from).getTime()).toBe(3600 * 1000);
-		expect(new Date(to).getTime()).toBeGreaterThan(Date.now() - 2 * 60 * 1000);
+describe("getDateRangeFromSearch", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("recomputes relative spans instead of using stale from/to", () => {
+		expect(
+			getDateRangeFromSearch({
+				rangeType: "span",
+				seconds: -3600,
+				from: "2020-01-01T00:00:00.000Z",
+				to: "2020-01-01T01:00:00.000Z",
+			}),
+		).toEqual({
+			from: "2024-06-01T11:00:00.000Z",
+			to: "2024-06-01T12:00:00.000Z",
+		});
 	});
 
 	it("honors explicit from/to when no range type is set", () => {

--- a/ui-v2/src/routes/dashboard.tsx
+++ b/ui-v2/src/routes/dashboard.tsx
@@ -142,8 +142,7 @@ const searchParams = z.object({
 	rangeType: z
 		.enum(["span", "range", "around", "period"])
 		.optional()
-		.default("span")
-		.catch("span"),
+		.catch(undefined),
 	seconds: z.number().optional().default(-86400).catch(-86400), // default 24h
 	start: z.string().datetime().optional(), // for range
 	end: z.string().datetime().optional(),
@@ -171,14 +170,10 @@ function roundToMinute(date: Date): Date {
 	return rounded;
 }
 
-function getDateRangeFromSearch(search: DashboardSearch): {
+export function getDateRangeFromSearch(search: DashboardSearch): {
 	from: string;
 	to: string;
 } {
-	if (search.from && search.to) {
-		return { from: search.from, to: search.to };
-	}
-
 	switch (search.rangeType) {
 		case "span": {
 			const now = roundToMinute(new Date());
@@ -217,6 +212,10 @@ function getDateRangeFromSearch(search: DashboardSearch): {
 			end.setHours(23, 59, 59, 999);
 			return { from: start.toISOString(), to: end.toISOString() };
 		}
+	}
+
+	if (search.from && search.to) {
+		return { from: search.from, to: search.to };
 	}
 
 	const now = roundToMinute(new Date());
@@ -963,19 +962,12 @@ export function RouteComponent() {
 					let toIso: string | undefined;
 					switch (next.type) {
 						case "span": {
-							const now = new Date();
-							const then = new Date(now.getTime() + next.seconds * 1000);
-							const [a, b] = [now, then].sort(
-								(x, y) => x.getTime() - y.getTime(),
-							);
-							fromIso = a.toISOString();
-							toIso = b.toISOString();
 							return {
 								...prev,
 								rangeType: "span",
 								seconds: next.seconds,
-								from: fromIso,
-								to: toIso,
+								from: undefined,
+								to: undefined,
 								flow: undefined,
 								page: undefined,
 							};
@@ -1020,20 +1012,14 @@ export function RouteComponent() {
 							};
 						}
 						case "period": {
-							// Only Today supported; normalize to today's start/end
-							const now = new Date();
-							const start = new Date(now);
-							start.setHours(0, 0, 0, 0);
-							const end = new Date(now);
-							end.setHours(23, 59, 59, 999);
-							fromIso = start.toISOString();
-							toIso = end.toISOString();
+							// Only Today supported; is relative so revisiting the URL
+							// on a later day resolves to that day
 							return {
 								...prev,
 								rangeType: "period",
 								period: next.period,
-								from: fromIso,
-								to: toIso,
+								from: undefined,
+								to: undefined,
 								flow: undefined,
 								page: undefined,
 							};


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
<!-- Whether or not AI tools helped draft this PR, you are responsible for understanding the change, keeping it scoped, validating it locally, and explaining the approach. -->
<!-- Maintainers may close PRs that appear low-effort, likely AI-generated, and substantially far from the expected implementation. -->

Due to url `http://localhost:5173/dashboard?rangeType=span&seconds=-3600&from=2026-09-11T03%3A35%3A22.436Z&to=2026-09-11T04%3A35%3A22.436Z` when using the `past hour` on time selector on dashboard show that date's hour (because of `from` `to` query params) instead of the just previous hour.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.
- [ ] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.
- [ ] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
